### PR TITLE
fix(executor): recover truncated streamed tool calls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -614,6 +614,9 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
+#     # Workaround for upstreams that truncate streamed tool-call arguments. Tool-bearing
+#     # requests are sent non-streamed and converted back to downstream SSE locally.
+#     non-stream-tool-calls: false
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -48,6 +48,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Models                []config.OpenAICompatibilityModel        `json:"models,omitempty"`
 	Headers               map[string]string                        `json:"headers,omitempty"`
 	SupportPromptCacheKey bool                                     `json:"support-prompt-cache-key,omitempty"`
+	NonStreamToolCalls    bool                                     `json:"non-stream-tool-calls,omitempty"`
 	DisableCooling        *bool                                    `json:"disable-cooling,omitempty"`
 	RequestRetry          *int                                     `json:"request-retry,omitempty"`
 	RequestScopedErrors   []config.RequestScopedErrorRule          `json:"request-scoped-errors,omitempty"`
@@ -309,6 +310,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Models:                entry.Models,
 			Headers:               entry.Headers,
 			SupportPromptCacheKey: entry.SupportPromptCacheKey,
+			NonStreamToolCalls:    entry.NonStreamToolCalls,
 			DisableCooling:        entry.DisableCooling,
 			RequestRetry:          entry.RequestRetry,
 			RequestScopedErrors:   entry.RequestScopedErrors,

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -801,6 +801,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Models                *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers               *map[string]string                  `json:"headers"`
 		SupportPromptCacheKey *bool                               `json:"support-prompt-cache-key"`
+		NonStreamToolCalls    *bool                               `json:"non-stream-tool-calls"`
 		RequestRetry          *int                                `json:"request-retry"`
 		RequestScopedErrors   *[]config.RequestScopedErrorRule    `json:"request-scoped-errors"`
 	}
@@ -877,6 +878,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if body.Value.SupportPromptCacheKey != nil {
 		entry.SupportPromptCacheKey = *body.Value.SupportPromptCacheKey
+	}
+	if body.Value.NonStreamToolCalls != nil {
+		entry.NonStreamToolCalls = *body.Value.NonStreamToolCalls
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -675,6 +675,10 @@ type OpenAICompatibility struct {
 	// SupportPromptCacheKey enables derived prompt_cache_key injection for supported requests.
 	SupportPromptCacheKey bool `yaml:"support-prompt-cache-key,omitempty" json:"support-prompt-cache-key,omitempty"`
 
+	// NonStreamToolCalls sends tool-bearing stream requests upstream without
+	// streaming and synthesizes downstream SSE frames from the complete response.
+	NonStreamToolCalls bool `yaml:"non-stream-tool-calls,omitempty" json:"non-stream-tool-calls,omitempty"`
+
 	// DisableCooling overrides the global cooling policy for this provider when set.
 	// True disables auth/model cooldowns; false explicitly enables them.
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/tidwall/gjson"
@@ -34,6 +35,9 @@ func ShouldForceNonStreamToolCalls(compat *config.OpenAICompatibility, payload [
 // used by the provider response cache.
 func SynthesizeOpenAIStreamFrames(body []byte) []string {
 	if len(body) == 0 {
+		return nil
+	}
+	if !gjson.ValidBytes(body) {
 		return nil
 	}
 	root := gjson.ParseBytes(body)
@@ -177,6 +181,13 @@ func hasUsableToolCalls(toolCalls gjson.Result) bool {
 	usable := true
 	toolCalls.ForEach(func(_, call gjson.Result) bool {
 		if !call.IsObject() || call.Get("function.name").String() == "" {
+			usable = false
+			return false
+		}
+		// The truncation this option recovers from shows up as empty or partial
+		// arguments, so a call is only usable when it carries valid JSON.
+		arguments := strings.TrimSpace(call.Get("function.arguments").String())
+		if arguments == "" || !gjson.Valid(arguments) {
 			usable = false
 			return false
 		}

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -105,7 +105,13 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		}
 		contentEmitted := false
 		if content := message.Get("content"); content.Exists() && content.String() != "" {
-			emit(index, fmt.Sprintf(`{"content":%s}`, content.Raw), gjson.Result{}, logprobs, false)
+			delta := fmt.Sprintf(`{"content":%s}`, content.Raw)
+			if annotations := message.Get("annotations"); annotations.Exists() && annotations.Type != gjson.Null {
+				if updated, errSet := sjson.SetRaw(delta, "annotations", annotations.Raw); errSet == nil {
+					delta = updated
+				}
+			}
+			emit(index, delta, gjson.Result{}, logprobs, false)
 			contentEmitted = true
 		}
 		if !contentEmitted && logprobs.Exists() && logprobs.Type != gjson.Null {
@@ -152,9 +158,24 @@ func hasUsableAssistantChoice(choice gjson.Result) bool {
 		return true
 	}
 	if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() && len(toolCalls.Array()) > 0 {
-		return true
+		return hasUsableToolCalls(toolCalls)
 	}
 	return choice.Get("finish_reason").String() != ""
+}
+
+// hasUsableToolCalls reports whether every reported call carries function data
+// the client can act on. Placeholder entries such as tool_calls:[{}] are treated
+// as an unusable reply so the caller can fall back to another credential.
+func hasUsableToolCalls(toolCalls gjson.Result) bool {
+	usable := true
+	toolCalls.ForEach(func(_, call gjson.Result) bool {
+		if !call.IsObject() || call.Get("function.name").String() == "" {
+			usable = false
+			return false
+		}
+		return true
+	})
+	return usable
 }
 
 // buildToolCallsDelta rewrites a non-streaming tool_calls array into a single

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -38,8 +38,16 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 	}
 	root := gjson.ParseBytes(body)
 	choices := root.Get("choices")
-	if !choices.Exists() || !choices.IsArray() {
+	if !choices.Exists() || !choices.IsArray() || len(choices.Array()) == 0 {
 		return nil
+	}
+	// Every choice must carry a usable assistant message. Rejecting placeholder
+	// entries such as {"choices":[{}]} keeps the caller's bootstrap error path
+	// intact so credential and model fallback can still run.
+	for _, choice := range choices.Array() {
+		if !hasUsableAssistantChoice(choice) {
+			return nil
+		}
 	}
 
 	id := root.Get("id").String()
@@ -123,13 +131,44 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 	return append(frames, "[DONE]")
 }
 
+// hasUsableAssistantChoice reports whether a non-streaming choice carries
+// something the synthesizer can replay as streaming deltas. A choice with an
+// empty message is still accepted when the upstream reported a terminal reason,
+// because an empty assistant reply is a legitimate completion.
+func hasUsableAssistantChoice(choice gjson.Result) bool {
+	message := choice.Get("message")
+	if !message.Exists() || !message.IsObject() {
+		return false
+	}
+	if content := message.Get("content"); content.Exists() && content.String() != "" {
+		return true
+	}
+	for _, field := range []string{"reasoning_content", "reasoning"} {
+		if value := message.Get(field); value.Exists() && value.String() != "" {
+			return true
+		}
+	}
+	if refusal := message.Get("refusal"); refusal.Exists() && refusal.Type != gjson.Null {
+		return true
+	}
+	if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() && len(toolCalls.Array()) > 0 {
+		return true
+	}
+	return choice.Get("finish_reason").String() != ""
+}
+
 // buildToolCallsDelta rewrites a non-streaming tool_calls array into a single
 // streaming delta that carries the complete arguments for every call.
 func buildToolCallsDelta(toolCalls gjson.Result) string {
 	delta := []byte(`{"tool_calls":[]}`)
 	position := 0
 	toolCalls.ForEach(func(_, call gjson.Result) bool {
-		entry := []byte(`{}`)
+		// Start from the upstream call so provider metadata such as Gemini's
+		// extra_content.google.thought_signature survives the rewrite.
+		entry := []byte(call.Raw)
+		if !call.IsObject() {
+			entry = []byte(`{}`)
+		}
 		entry, _ = sjson.SetBytes(entry, "index", position)
 		if id := call.Get("id"); id.Exists() {
 			entry, _ = sjson.SetBytes(entry, "id", id.String())

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -114,6 +114,10 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 			emit(index, delta, gjson.Result{}, logprobs, false)
 			contentEmitted = true
 		}
+		if audio := message.Get("audio"); audio.Exists() && audio.Type != gjson.Null {
+			emit(index, fmt.Sprintf(`{"audio":%s}`, audio.Raw), gjson.Result{}, gjson.Result{}, false)
+			contentEmitted = true
+		}
 		if !contentEmitted && logprobs.Exists() && logprobs.Type != gjson.Null {
 			emit(index, "", gjson.Result{}, logprobs, false)
 		}
@@ -153,6 +157,9 @@ func hasUsableAssistantChoice(choice gjson.Result) bool {
 		if value := message.Get(field); value.Exists() && value.String() != "" {
 			return true
 		}
+	}
+	if audio := message.Get("audio"); audio.Exists() && audio.Type != gjson.Null {
+		return true
 	}
 	if refusal := message.Get("refusal"); refusal.Exists() && refusal.Type != gjson.Null {
 		return true

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -30,9 +30,11 @@ func ShouldForceNonStreamToolCalls(compat *config.OpenAICompatibility, payload [
 // SynthesizeOpenAIStreamBootstrapFrame builds the assistant-role opening chunk
 // used to release downstream bootstrap while a non-streaming upstream body is
 // still being generated.
-func SynthesizeOpenAIStreamBootstrapFrame(model string) string {
+func SynthesizeOpenAIStreamBootstrapFrame(id, model string, created int64) string {
 	frame := []byte(`{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`)
+	frame, _ = sjson.SetBytes(frame, "id", id)
 	frame, _ = sjson.SetBytes(frame, "model", model)
+	frame, _ = sjson.SetBytes(frame, "created", created)
 	return string(frame)
 }
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -46,16 +46,20 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 	model := root.Get("model").String()
 	created := root.Get("created").Int()
 	serviceTier := root.Get("service_tier")
+	systemFingerprint := root.Get("system_fingerprint")
 	usage := root.Get("usage")
 
 	frames := make([]string, 0, 8)
-	emit := func(index int64, delta string, finishReason gjson.Result, withUsage bool) {
+	emit := func(index int64, delta string, finishReason, logprobs gjson.Result, withUsage bool) {
 		frame := []byte(`{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]}`)
 		frame, _ = sjson.SetBytes(frame, "id", id)
 		frame, _ = sjson.SetBytes(frame, "model", model)
 		frame, _ = sjson.SetBytes(frame, "created", created)
 		if serviceTier.Exists() && serviceTier.Type != gjson.Null {
 			frame, _ = sjson.SetRawBytes(frame, "service_tier", []byte(serviceTier.Raw))
+		}
+		if systemFingerprint.Exists() && systemFingerprint.Type != gjson.Null {
+			frame, _ = sjson.SetRawBytes(frame, "system_fingerprint", []byte(systemFingerprint.Raw))
 		}
 		frame, _ = sjson.SetBytes(frame, "choices.0.index", index)
 		if delta != "" {
@@ -65,6 +69,9 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 			frame, _ = sjson.SetBytes(frame, "choices.0.finish_reason", finishReason.String())
 		} else {
 			frame, _ = sjson.SetRawBytes(frame, "choices.0.finish_reason", []byte("null"))
+		}
+		if logprobs.Exists() && logprobs.Type != gjson.Null {
+			frame, _ = sjson.SetRawBytes(frame, "choices.0.logprobs", []byte(logprobs.Raw))
 		}
 		if withUsage && usage.Exists() {
 			frame, _ = sjson.SetRawBytes(frame, "usage", []byte(usage.Raw))
@@ -76,21 +83,29 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		index := choice.Get("index").Int()
 		message := choice.Get("message")
 		finishReason := choice.Get("finish_reason")
+		logprobs := choice.Get("logprobs")
 
-		emit(index, `{"role":"assistant"}`, gjson.Result{}, false)
+		emit(index, `{"role":"assistant"}`, gjson.Result{}, gjson.Result{}, false)
 
 		if reasoning := message.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
-			emit(index, fmt.Sprintf(`{"reasoning_content":%s}`, reasoning.Raw), gjson.Result{}, false)
+			emit(index, fmt.Sprintf(`{"reasoning_content":%s}`, reasoning.Raw), gjson.Result{}, gjson.Result{}, false)
+		} else if reasoning = message.Get("reasoning"); reasoning.Exists() && reasoning.String() != "" {
+			emit(index, fmt.Sprintf(`{"reasoning":%s}`, reasoning.Raw), gjson.Result{}, gjson.Result{}, false)
 		}
 		if refusal := message.Get("refusal"); refusal.Exists() && refusal.Type != gjson.Null {
-			emit(index, fmt.Sprintf(`{"refusal":%s}`, refusal.Raw), gjson.Result{}, false)
+			emit(index, fmt.Sprintf(`{"refusal":%s}`, refusal.Raw), gjson.Result{}, gjson.Result{}, false)
 		}
+		contentEmitted := false
 		if content := message.Get("content"); content.Exists() && content.String() != "" {
-			emit(index, fmt.Sprintf(`{"content":%s}`, content.Raw), gjson.Result{}, false)
+			emit(index, fmt.Sprintf(`{"content":%s}`, content.Raw), gjson.Result{}, logprobs, false)
+			contentEmitted = true
+		}
+		if !contentEmitted && logprobs.Exists() && logprobs.Type != gjson.Null {
+			emit(index, "", gjson.Result{}, logprobs, false)
 		}
 		if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
 			if delta := buildToolCallsDelta(toolCalls); delta != "" {
-				emit(index, delta, gjson.Result{}, false)
+				emit(index, delta, gjson.Result{}, gjson.Result{}, false)
 			}
 		}
 
@@ -98,7 +113,7 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		// the usage block that stream_options.include_usage would have appended.
 		// Keying on the array position instead of the reported index keeps usage
 		// single even when an upstream omits the index field on every choice.
-		emit(index, "", finishReason, position.Int() == 0)
+		emit(index, "", finishReason, gjson.Result{}, position.Int() == 0)
 		return true
 	})
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -45,6 +45,7 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 	id := root.Get("id").String()
 	model := root.Get("model").String()
 	created := root.Get("created").Int()
+	serviceTier := root.Get("service_tier")
 	usage := root.Get("usage")
 
 	frames := make([]string, 0, 8)
@@ -53,6 +54,9 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		frame, _ = sjson.SetBytes(frame, "id", id)
 		frame, _ = sjson.SetBytes(frame, "model", model)
 		frame, _ = sjson.SetBytes(frame, "created", created)
+		if serviceTier.Exists() && serviceTier.Type != gjson.Null {
+			frame, _ = sjson.SetRawBytes(frame, "service_tier", []byte(serviceTier.Raw))
+		}
 		frame, _ = sjson.SetBytes(frame, "choices.0.index", index)
 		if delta != "" {
 			frame, _ = sjson.SetRawBytes(frame, "choices.0.delta", []byte(delta))

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -27,17 +27,6 @@ func ShouldForceNonStreamToolCalls(compat *config.OpenAICompatibility, payload [
 	return tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
 }
 
-// SynthesizeOpenAIStreamBootstrapFrame builds the assistant-role opening chunk
-// used to release downstream bootstrap while a non-streaming upstream body is
-// still being generated.
-func SynthesizeOpenAIStreamBootstrapFrame(id, model string, created int64) string {
-	frame := []byte(`{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`)
-	frame, _ = sjson.SetBytes(frame, "id", id)
-	frame, _ = sjson.SetBytes(frame, "model", model)
-	frame, _ = sjson.SetBytes(frame, "created", created)
-	return string(frame)
-}
-
 // SynthesizeOpenAIStreamFrames converts a non-streaming OpenAI chat completion
 // response into the sequence of SSE data frames an equivalent streaming call
 // would have produced. The returned frames are raw JSON payloads without the
@@ -83,6 +72,8 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		index := choice.Get("index").Int()
 		message := choice.Get("message")
 		finishReason := choice.Get("finish_reason")
+
+		emit(index, `{"role":"assistant"}`, gjson.Result{}, false)
 
 		if reasoning := message.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
 			emit(index, fmt.Sprintf(`{"reasoning_content":%s}`, reasoning.Raw), gjson.Result{}, false)

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -1,0 +1,135 @@
+package helps
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ShouldForceNonStreamToolCalls reports whether a streaming request must be sent
+// to the upstream as a non-streaming call.
+//
+// Some OpenAI-compatible aggregators truncate tool call arguments when streaming:
+// they emit the tool name with an empty "arguments" string and then close the
+// stream, which leaves the client with an unusable tool call. The same request
+// answered without streaming returns complete arguments, so the request is routed
+// through the non-streaming endpoint and the SSE frames are synthesized locally.
+//
+// The rewrite only applies when the payload actually declares tools, so plain
+// chat completions keep their native token-by-token streaming.
+func ShouldForceNonStreamToolCalls(compat *config.OpenAICompatibility, payload []byte) bool {
+	if compat == nil || !compat.NonStreamToolCalls {
+		return false
+	}
+	tools := gjson.GetBytes(payload, "tools")
+	return tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+}
+
+// SynthesizeOpenAIStreamFrames converts a non-streaming OpenAI chat completion
+// response into the sequence of SSE data frames an equivalent streaming call
+// would have produced. The returned frames are raw JSON payloads without the
+// "data: " prefix, terminated by a "[DONE]" sentinel, matching the frame format
+// used by the provider response cache.
+func SynthesizeOpenAIStreamFrames(body []byte) []string {
+	if len(body) == 0 {
+		return nil
+	}
+	root := gjson.ParseBytes(body)
+	choices := root.Get("choices")
+	if !choices.Exists() || !choices.IsArray() {
+		return nil
+	}
+
+	id := root.Get("id").String()
+	model := root.Get("model").String()
+	created := root.Get("created").Int()
+	usage := root.Get("usage")
+
+	frames := make([]string, 0, 8)
+	emit := func(index int64, delta string, finishReason gjson.Result, withUsage bool) {
+		frame := []byte(`{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]}`)
+		frame, _ = sjson.SetBytes(frame, "id", id)
+		frame, _ = sjson.SetBytes(frame, "model", model)
+		frame, _ = sjson.SetBytes(frame, "created", created)
+		frame, _ = sjson.SetBytes(frame, "choices.0.index", index)
+		if delta != "" {
+			frame, _ = sjson.SetRawBytes(frame, "choices.0.delta", []byte(delta))
+		}
+		if finishReason.Exists() && finishReason.String() != "" {
+			frame, _ = sjson.SetBytes(frame, "choices.0.finish_reason", finishReason.String())
+		} else {
+			frame, _ = sjson.SetRawBytes(frame, "choices.0.finish_reason", []byte("null"))
+		}
+		if withUsage && usage.Exists() {
+			frame, _ = sjson.SetRawBytes(frame, "usage", []byte(usage.Raw))
+		}
+		frames = append(frames, string(frame))
+	}
+
+	choices.ForEach(func(position, choice gjson.Result) bool {
+		index := choice.Get("index").Int()
+		message := choice.Get("message")
+		finishReason := choice.Get("finish_reason")
+
+		emit(index, `{"role":"assistant"}`, gjson.Result{}, false)
+
+		if reasoning := message.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
+			emit(index, fmt.Sprintf(`{"reasoning_content":%s}`, reasoning.Raw), gjson.Result{}, false)
+		}
+		if content := message.Get("content"); content.Exists() && content.String() != "" {
+			emit(index, fmt.Sprintf(`{"content":%s}`, content.Raw), gjson.Result{}, false)
+		}
+		if toolCalls := message.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {
+			if delta := buildToolCallsDelta(toolCalls); delta != "" {
+				emit(index, delta, gjson.Result{}, false)
+			}
+		}
+
+		// The terminal chunk carries the finish reason and, for the first choice,
+		// the usage block that stream_options.include_usage would have appended.
+		// Keying on the array position instead of the reported index keeps usage
+		// single even when an upstream omits the index field on every choice.
+		emit(index, "", finishReason, position.Int() == 0)
+		return true
+	})
+
+	if len(frames) == 0 {
+		return nil
+	}
+	return append(frames, "[DONE]")
+}
+
+// buildToolCallsDelta rewrites a non-streaming tool_calls array into a single
+// streaming delta that carries the complete arguments for every call.
+func buildToolCallsDelta(toolCalls gjson.Result) string {
+	delta := []byte(`{"tool_calls":[]}`)
+	position := 0
+	toolCalls.ForEach(func(_, call gjson.Result) bool {
+		entry := []byte(`{}`)
+		entry, _ = sjson.SetBytes(entry, "index", position)
+		if id := call.Get("id"); id.Exists() {
+			entry, _ = sjson.SetBytes(entry, "id", id.String())
+		}
+		callType := call.Get("type").String()
+		if callType == "" {
+			callType = "function"
+		}
+		entry, _ = sjson.SetBytes(entry, "type", callType)
+		entry, _ = sjson.SetBytes(entry, "function.name", call.Get("function.name").String())
+		entry, _ = sjson.SetBytes(entry, "function.arguments", call.Get("function.arguments").String())
+
+		updated, err := sjson.SetRawBytes(delta, "tool_calls.-1", entry)
+		if err != nil {
+			return true
+		}
+		delta = updated
+		position++
+		return true
+	})
+	if position == 0 {
+		return ""
+	}
+	return string(delta)
+}

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream.go
@@ -27,6 +27,15 @@ func ShouldForceNonStreamToolCalls(compat *config.OpenAICompatibility, payload [
 	return tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
 }
 
+// SynthesizeOpenAIStreamBootstrapFrame builds the assistant-role opening chunk
+// used to release downstream bootstrap while a non-streaming upstream body is
+// still being generated.
+func SynthesizeOpenAIStreamBootstrapFrame(model string) string {
+	frame := []byte(`{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`)
+	frame, _ = sjson.SetBytes(frame, "model", model)
+	return string(frame)
+}
+
 // SynthesizeOpenAIStreamFrames converts a non-streaming OpenAI chat completion
 // response into the sequence of SSE data frames an equivalent streaming call
 // would have produced. The returned frames are raw JSON payloads without the
@@ -73,10 +82,11 @@ func SynthesizeOpenAIStreamFrames(body []byte) []string {
 		message := choice.Get("message")
 		finishReason := choice.Get("finish_reason")
 
-		emit(index, `{"role":"assistant"}`, gjson.Result{}, false)
-
 		if reasoning := message.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
 			emit(index, fmt.Sprintf(`{"reasoning_content":%s}`, reasoning.Raw), gjson.Result{}, false)
+		}
+		if refusal := message.Get("refusal"); refusal.Exists() && refusal.Type != gjson.Null {
+			emit(index, fmt.Sprintf(`{"refusal":%s}`, refusal.Raw), gjson.Result{}, false)
 		}
 		if content := message.Get("content"); content.Exists() && content.String() != "" {
 			emit(index, fmt.Sprintf(`{"content":%s}`, content.Raw), gjson.Result{}, false)

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -141,6 +141,17 @@ func TestSynthesizeOpenAIStreamFramesRejectsUnusableChoices(t *testing.T) {
 	}
 }
 
+func TestSynthesizeOpenAIStreamFramesPreservesAudio(t *testing.T) {
+	body := []byte(`{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":null,"audio":{"id":"audio_1","data":"AAAA","transcript":"hello","expires_at":1}}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	joined := strings.Join(frames, "\n")
+	for _, want := range []string{`"audio":{`, `"transcript":"hello"`, `"data":"AAAA"`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("audio metadata %s missing: %s", want, joined)
+		}
+	}
+}
+
 func TestSynthesizeOpenAIStreamFramesPreservesAnnotations(t *testing.T) {
 	body := []byte(`{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"cited","annotations":[{"type":"url_citation","url_citation":{"url":"https://example.com","start_index":0,"end_index":5}}]}}]}`)
 	frames := SynthesizeOpenAIStreamFrames(body)

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -125,6 +125,43 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 	}
 }
 
+func TestSynthesizeOpenAIStreamFramesRejectsUnusableChoices(t *testing.T) {
+	cases := map[string]string{
+		"empty choice":  `{"id":"x","model":"m","created":1,"choices":[{}]}`,
+		"empty array":   `{"id":"x","model":"m","created":1,"choices":[]}`,
+		"empty message": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`,
+		"mixed choices": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}},{"index":1,"message":{}}]}`,
+	}
+	for name, body := range cases {
+		if frames := SynthesizeOpenAIStreamFrames([]byte(body)); frames != nil {
+			t.Fatalf("%s: expected rejection, got %v", name, frames)
+		}
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesAcceptsEmptyReplyWithFinishReason(t *testing.T) {
+	body := []byte(`{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":""}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	if len(frames) == 0 {
+		t.Fatal("expected frames for empty assistant reply with terminal reason")
+	}
+	if !strings.Contains(strings.Join(frames, "\n"), `"finish_reason":"stop"`) {
+		t.Fatalf("missing terminal reason: %v", frames)
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesPreservesToolCallProviderMetadata(t *testing.T) {
+	body := []byte(`{"id":"chatcmpl-g","model":"gemini","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"f","arguments":"{}"},"extra_content":{"google":{"thought_signature":"sig-123"}}}]}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	joined := strings.Join(frames, "\n")
+	if !strings.Contains(joined, `"thought_signature":"sig-123"`) {
+		t.Fatalf("thought signature dropped: %s", joined)
+	}
+	if !strings.Contains(joined, `"arguments":"{}"`) {
+		t.Fatalf("arguments missing: %s", joined)
+	}
+}
+
 func TestSynthesizeOpenAIStreamFramesPreservesReasoningAliasLogprobsAndFingerprint(t *testing.T) {
 	body := []byte(`{"id":"chatcmpl-meta","model":"m","created":1,"system_fingerprint":"fp_test","choices":[{"index":0,"finish_reason":"stop","logprobs":{"content":[{"token":"ok","logprob":-0.1}]},"message":{"reasoning":"alternate reasoning","content":"ok"}}]}`)
 	frames := SynthesizeOpenAIStreamFrames(body)

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -125,6 +125,19 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 	}
 }
 
+func TestSynthesizeOpenAIStreamFramesPreservesServiceTier(t *testing.T) {
+	body := []byte(`{"id":"chatcmpl-tier","model":"m","created":1,"service_tier":"priority","choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	if len(frames) < 2 {
+		t.Fatalf("expected synthesized frames, got %v", frames)
+	}
+	for _, frame := range frames[:len(frames)-1] {
+		if !strings.Contains(frame, `"service_tier":"priority"`) {
+			t.Fatalf("service tier missing from frame: %s", frame)
+		}
+	}
+}
+
 func TestSynthesizeOpenAIStreamFramesEmitsRoleForEveryChoice(t *testing.T) {
 	body := []byte(`{"id":"chatcmpl-n","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"a"}},{"index":1,"finish_reason":"stop","message":{"content":"b"}}]}`)
 	frames := SynthesizeOpenAIStreamFrames(body)

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -127,15 +127,29 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 
 func TestSynthesizeOpenAIStreamFramesRejectsUnusableChoices(t *testing.T) {
 	cases := map[string]string{
-		"empty choice":  `{"id":"x","model":"m","created":1,"choices":[{}]}`,
-		"empty array":   `{"id":"x","model":"m","created":1,"choices":[]}`,
-		"empty message": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`,
-		"mixed choices": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}},{"index":1,"message":{}}]}`,
+		"empty choice":      `{"id":"x","model":"m","created":1,"choices":[{}]}`,
+		"empty array":       `{"id":"x","model":"m","created":1,"choices":[]}`,
+		"empty message":     `{"id":"x","model":"m","created":1,"choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`,
+		"mixed choices":     `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}},{"index":1,"message":{}}]}`,
+		"empty tool call":   `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{}]}}]}`,
+		"unnamed tool call": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"","arguments":"{}"}}]}}]}`,
 	}
 	for name, body := range cases {
 		if frames := SynthesizeOpenAIStreamFrames([]byte(body)); frames != nil {
 			t.Fatalf("%s: expected rejection, got %v", name, frames)
 		}
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesPreservesAnnotations(t *testing.T) {
+	body := []byte(`{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"cited","annotations":[{"type":"url_citation","url_citation":{"url":"https://example.com","start_index":0,"end_index":5}}]}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	joined := strings.Join(frames, "\n")
+	if !strings.Contains(joined, `"annotations":[{"type":"url_citation"`) {
+		t.Fatalf("annotations dropped: %s", joined)
+	}
+	if !strings.Contains(joined, `"content":"cited"`) {
+		t.Fatalf("content missing: %s", joined)
 	}
 }
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -57,15 +57,6 @@ func decodeFrames(t *testing.T, frames []string) []map[string]any {
 	return out
 }
 
-func TestSynthesizeOpenAIStreamBootstrapFrame(t *testing.T) {
-	frame := SynthesizeOpenAIStreamBootstrapFrame("chatcmpl-stable", "alias-model", 1700000000)
-	for _, want := range []string{`"role":"assistant"`, `"model":"alias-model"`, `"id":"chatcmpl-stable"`, `"created":1700000000`} {
-		if !strings.Contains(frame, want) {
-			t.Fatalf("bootstrap frame missing %s: %s", want, frame)
-		}
-	}
-}
-
 func TestSynthesizeOpenAIStreamFramesToolCalls(t *testing.T) {
 	body := []byte(`{
 		"id":"msg_1","model":"claude-opus-5","created":1700000000,
@@ -131,6 +122,17 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 	decodeFrames(t, frames)
 	if !strings.Contains(strings.Join(frames, "\n"), `"refusal":"I cannot help with that."`) {
 		t.Fatalf("refusal missing from frames: %v", frames)
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesEmitsRoleForEveryChoice(t *testing.T) {
+	body := []byte(`{"id":"chatcmpl-n","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"a"}},{"index":1,"finish_reason":"stop","message":{"content":"b"}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	joined := strings.Join(frames, "\n")
+	for _, want := range []string{`"index":0,"delta":{"role":"assistant"}`, `"index":1,"delta":{"role":"assistant"}`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing role frame %s in %s", want, joined)
+		}
 	}
 }
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -127,12 +127,14 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 
 func TestSynthesizeOpenAIStreamFramesRejectsUnusableChoices(t *testing.T) {
 	cases := map[string]string{
-		"empty choice":      `{"id":"x","model":"m","created":1,"choices":[{}]}`,
-		"empty array":       `{"id":"x","model":"m","created":1,"choices":[]}`,
-		"empty message":     `{"id":"x","model":"m","created":1,"choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`,
-		"mixed choices":     `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}},{"index":1,"message":{}}]}`,
-		"empty tool call":   `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{}]}}]}`,
-		"unnamed tool call": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"","arguments":"{}"}}]}}]}`,
+		"empty choice":             `{"id":"x","model":"m","created":1,"choices":[{}]}`,
+		"empty array":              `{"id":"x","model":"m","created":1,"choices":[]}`,
+		"empty message":            `{"id":"x","model":"m","created":1,"choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`,
+		"mixed choices":            `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}},{"index":1,"message":{}}]}`,
+		"empty tool call":          `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{}]}}]}`,
+		"unnamed tool call":        `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"","arguments":"{}"}}]}}]}`,
+		"empty tool arguments":     `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":""}}]}}]}`,
+		"malformed tool arguments": `{"id":"x","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls","message":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{\"city\":"}}]}}]}`,
 	}
 	for name, body := range cases {
 		if frames := SynthesizeOpenAIStreamFrames([]byte(body)); frames != nil {
@@ -262,7 +264,10 @@ func TestSynthesizeOpenAIStreamFramesUsageOnceWithMultipleChoices(t *testing.T) 
 }
 
 func TestSynthesizeOpenAIStreamFramesRejectsUnusableBodies(t *testing.T) {
-	for _, body := range []string{``, `{}`, `{"choices":[]}`, `not json`} {
+	for _, body := range []string{``, `{}`, `{"choices":[]}`, `not json`,
+		`{"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}}]`,
+		`{"choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}}]} trailing`,
+	} {
 		if frames := SynthesizeOpenAIStreamFrames([]byte(body)); len(frames) != 0 {
 			t.Fatalf("body %q produced frames %v, want none", body, frames)
 		}

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -57,6 +57,13 @@ func decodeFrames(t *testing.T, frames []string) []map[string]any {
 	return out
 }
 
+func TestSynthesizeOpenAIStreamBootstrapFrame(t *testing.T) {
+	frame := SynthesizeOpenAIStreamBootstrapFrame("alias-model")
+	if !strings.Contains(frame, `"role":"assistant"`) || !strings.Contains(frame, `"model":"alias-model"`) {
+		t.Fatalf("invalid bootstrap frame: %s", frame)
+	}
+}
+
 func TestSynthesizeOpenAIStreamFramesToolCalls(t *testing.T) {
 	body := []byte(`{
 		"id":"msg_1","model":"claude-opus-5","created":1700000000,
@@ -112,6 +119,16 @@ func TestSynthesizeOpenAIStreamFramesContentOnly(t *testing.T) {
 	choice := last["choices"].([]any)[0].(map[string]any)
 	if choice["finish_reason"] != "stop" {
 		t.Fatalf("finish_reason = %v, want stop", choice["finish_reason"])
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
+	body := []byte(`{"id":"msg_r","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop",
+		"message":{"role":"assistant","content":null,"refusal":"I cannot help with that."}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	decodeFrames(t, frames)
+	if !strings.Contains(strings.Join(frames, "\n"), `"refusal":"I cannot help with that."`) {
+		t.Fatalf("refusal missing from frames: %v", frames)
 	}
 }
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -58,9 +58,11 @@ func decodeFrames(t *testing.T, frames []string) []map[string]any {
 }
 
 func TestSynthesizeOpenAIStreamBootstrapFrame(t *testing.T) {
-	frame := SynthesizeOpenAIStreamBootstrapFrame("alias-model")
-	if !strings.Contains(frame, `"role":"assistant"`) || !strings.Contains(frame, `"model":"alias-model"`) {
-		t.Fatalf("invalid bootstrap frame: %s", frame)
+	frame := SynthesizeOpenAIStreamBootstrapFrame("chatcmpl-stable", "alias-model", 1700000000)
+	for _, want := range []string{`"role":"assistant"`, `"model":"alias-model"`, `"id":"chatcmpl-stable"`, `"created":1700000000`} {
+		if !strings.Contains(frame, want) {
+			t.Fatalf("bootstrap frame missing %s: %s", want, frame)
+		}
 	}
 }
 

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -1,0 +1,163 @@
+package helps
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestShouldForceNonStreamToolCalls(t *testing.T) {
+	withTools := []byte(`{"model":"m","tools":[{"type":"function","function":{"name":"read"}}]}`)
+	withoutTools := []byte(`{"model":"m"}`)
+	emptyTools := []byte(`{"model":"m","tools":[]}`)
+
+	tests := []struct {
+		name    string
+		compat  *config.OpenAICompatibility
+		payload []byte
+		want    bool
+	}{
+		{"nil compat", nil, withTools, false},
+		{"disabled", &config.OpenAICompatibility{}, withTools, false},
+		{"enabled with tools", &config.OpenAICompatibility{NonStreamToolCalls: true}, withTools, true},
+		{"enabled without tools", &config.OpenAICompatibility{NonStreamToolCalls: true}, withoutTools, false},
+		{"enabled empty tools", &config.OpenAICompatibility{NonStreamToolCalls: true}, emptyTools, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShouldForceNonStreamToolCalls(tc.compat, tc.payload); got != tc.want {
+				t.Fatalf("ShouldForceNonStreamToolCalls = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// decodeFrames parses every synthesized frame except the [DONE] sentinel.
+func decodeFrames(t *testing.T, frames []string) []map[string]any {
+	t.Helper()
+	if len(frames) == 0 {
+		t.Fatal("no frames produced")
+	}
+	if frames[len(frames)-1] != "[DONE]" {
+		t.Fatalf("last frame = %q, want [DONE]", frames[len(frames)-1])
+	}
+	out := make([]map[string]any, 0, len(frames)-1)
+	for _, frame := range frames[:len(frames)-1] {
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(frame), &parsed); err != nil {
+			t.Fatalf("frame %q is not valid JSON: %v", frame, err)
+		}
+		if parsed["object"] != "chat.completion.chunk" {
+			t.Fatalf("frame object = %v, want chat.completion.chunk", parsed["object"])
+		}
+		out = append(out, parsed)
+	}
+	return out
+}
+
+func TestSynthesizeOpenAIStreamFramesToolCalls(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1","model":"claude-opus-5","created":1700000000,
+		"choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[
+			{"id":"call_1","type":"function","function":{"name":"read","arguments":"{\"path\":\"config.yaml\"}"}}
+		]}}],
+		"usage":{"prompt_tokens":10,"completion_tokens":4,"total_tokens":14}
+	}`)
+
+	frames := SynthesizeOpenAIStreamFrames(body)
+	parsed := decodeFrames(t, frames)
+
+	joined := strings.Join(frames, "\n")
+	if !strings.Contains(joined, `"arguments":"{\"path\":\"config.yaml\"}"`) {
+		t.Fatalf("tool call arguments missing from frames: %s", joined)
+	}
+
+	for _, frame := range parsed {
+		if frame["id"] != "msg_1" || frame["model"] != "claude-opus-5" {
+			t.Fatalf("frame lost id/model: %v", frame)
+		}
+	}
+
+	last := parsed[len(parsed)-1]
+	choice := last["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "tool_calls" {
+		t.Fatalf("finish_reason = %v, want tool_calls", choice["finish_reason"])
+	}
+	if _, ok := last["usage"]; !ok {
+		t.Fatal("terminal frame is missing the usage block")
+	}
+
+	// Only the terminal frame may carry the finish reason.
+	for _, frame := range parsed[:len(parsed)-1] {
+		ch := frame["choices"].([]any)[0].(map[string]any)
+		if ch["finish_reason"] != nil {
+			t.Fatalf("intermediate frame carries finish_reason: %v", frame)
+		}
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesContentOnly(t *testing.T) {
+	body := []byte(`{"id":"msg_2","model":"m","created":1,"choices":[{"index":0,"finish_reason":"stop",
+		"message":{"role":"assistant","content":"hola"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+
+	frames := SynthesizeOpenAIStreamFrames(body)
+	parsed := decodeFrames(t, frames)
+
+	if !strings.Contains(strings.Join(frames, "\n"), `"content":"hola"`) {
+		t.Fatalf("content missing from frames: %v", frames)
+	}
+	last := parsed[len(parsed)-1]
+	choice := last["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "stop" {
+		t.Fatalf("finish_reason = %v, want stop", choice["finish_reason"])
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesMultipleToolCalls(t *testing.T) {
+	body := []byte(`{"id":"msg_3","model":"m","created":1,"choices":[{"index":0,"finish_reason":"tool_calls",
+		"message":{"role":"assistant","tool_calls":[
+			{"id":"a","type":"function","function":{"name":"read","arguments":"{}"}},
+			{"id":"b","type":"function","function":{"name":"bash","arguments":"{\"command\":\"ls\"}"}}
+		]}}]}`)
+
+	frames := SynthesizeOpenAIStreamFrames(body)
+	decodeFrames(t, frames)
+
+	joined := strings.Join(frames, "\n")
+	for _, want := range []string{`"name":"read"`, `"name":"bash"`, `"index":0`, `"index":1`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("frames missing %s: %s", want, joined)
+		}
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesUsageOnceWithMultipleChoices(t *testing.T) {
+	body := []byte(`{"id":"msg_5","model":"m","created":1,"choices":[
+		{"finish_reason":"stop","message":{"role":"assistant","content":"a"}},
+		{"finish_reason":"stop","message":{"role":"assistant","content":"b"}}
+	],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`)
+
+	frames := SynthesizeOpenAIStreamFrames(body)
+	parsed := decodeFrames(t, frames)
+
+	usageFrames := 0
+	for _, frame := range parsed {
+		if _, ok := frame["usage"]; ok {
+			usageFrames++
+		}
+	}
+	// Both choices omit "index", so a value-based guard would emit usage twice.
+	if usageFrames != 1 {
+		t.Fatalf("usage appears in %d frames, want exactly 1", usageFrames)
+	}
+}
+
+func TestSynthesizeOpenAIStreamFramesRejectsUnusableBodies(t *testing.T) {
+	for _, body := range []string{``, `{}`, `{"choices":[]}`, `not json`} {
+		if frames := SynthesizeOpenAIStreamFrames([]byte(body)); len(frames) != 0 {
+			t.Fatalf("body %q produced frames %v, want none", body, frames)
+		}
+	}
+}

--- a/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
+++ b/internal/runtime/executor/helps/openai_compat_nonstream_stream_test.go
@@ -125,6 +125,17 @@ func TestSynthesizeOpenAIStreamFramesPreservesRefusal(t *testing.T) {
 	}
 }
 
+func TestSynthesizeOpenAIStreamFramesPreservesReasoningAliasLogprobsAndFingerprint(t *testing.T) {
+	body := []byte(`{"id":"chatcmpl-meta","model":"m","created":1,"system_fingerprint":"fp_test","choices":[{"index":0,"finish_reason":"stop","logprobs":{"content":[{"token":"ok","logprob":-0.1}]},"message":{"reasoning":"alternate reasoning","content":"ok"}}]}`)
+	frames := SynthesizeOpenAIStreamFrames(body)
+	joined := strings.Join(frames, "\n")
+	for _, want := range []string{`"system_fingerprint":"fp_test"`, `"reasoning":"alternate reasoning"`, `"logprobs":{"content":[{"token":"ok","logprob":-0.1}]}`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing metadata %s in %s", want, joined)
+		}
+	}
+}
+
 func TestSynthesizeOpenAIStreamFramesPreservesServiceTier(t *testing.T) {
 	body := []byte(`{"id":"chatcmpl-tier","model":"m","created":1,"service_tier":"priority","choices":[{"index":0,"finish_reason":"stop","message":{"content":"ok"}}]}`)
 	frames := SynthesizeOpenAIStreamFrames(body)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -350,6 +350,10 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		}
 	}
 
+	if helps.ShouldForceNonStreamToolCalls(e.resolveCompatConfig(auth), translated) {
+		return e.executeStreamViaNonStream(ctx, auth, req, opts, reporter, baseURL, apiKey, to, responseFormat, translated, originalPayload)
+	}
+
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
 	translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
@@ -564,6 +568,94 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			}
 		}
 		// Ensure we record the request if no usage chunk was ever seen.
+		streamUsage.Publish(ctx, reporter)
+		reporter.EnsurePublished(ctx)
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// executeStreamViaNonStream sends tool-bearing requests upstream as a single
+// JSON response and translates synthesized OpenAI chunks through the existing
+// downstream stream pipeline.
+func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, reporter *helps.UsageReporter, baseURL, apiKey string, to, responseFormat sdktranslator.Format, translated, originalPayload []byte) (*cliproxyexecutor.StreamResult, error) {
+	translated = helps.SetBoolIfDifferent(translated, "stream", false)
+	translated = helps.DeleteJSONField(translated, "stream_options")
+	reporter.SetTranslatedReasoningEffort(translated, to.String())
+
+	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs, opts.Headers)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL: url, Method: http.MethodPost, Headers: httpReq.Header.Clone(), Body: translated,
+		Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue,
+	})
+
+	httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("openai compat executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		body, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
+	}
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	frames := helps.SynthesizeOpenAIStreamFrames(body)
+	if len(frames) == 0 {
+		errSynth := statusErr{code: http.StatusBadGateway, msg: "upstream non-streaming reply could not be converted to a stream"}
+		helps.RecordAPIResponseError(ctx, e.cfg, errSynth)
+		return nil, errSynth
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
+		var param any
+		var streamUsage helps.StreamUsageBuffer
+		for _, frame := range frames {
+			streamLine := append([]byte("data: "), frame...)
+			streamUsage.ObserveOpenAIStream(streamLine)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
 		streamUsage.Publish(ctx, reporter)
 		reporter.EnsurePublished(ctx)
 	}()

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -626,22 +626,9 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
 	}
 
-	bootstrapID := "chatcmpl-" + uuid.NewString()
-	bootstrapCreated := time.Now().Unix()
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
-		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
-		var param any
-		bootstrapLine := []byte("data: " + helps.SynthesizeOpenAIStreamBootstrapFrame(bootstrapID, req.Model, bootstrapCreated))
-		bootstrapChunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bootstrapLine, &param, claudeInputTokens)
-		for i := range bootstrapChunks {
-			select {
-			case out <- cliproxyexecutor.StreamChunk{Payload: bootstrapChunks[i]}:
-			case <-ctx.Done():
-				return
-			}
-		}
 		defer func() {
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
@@ -658,8 +645,6 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			return
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
-		body, _ = sjson.SetBytes(body, "id", bootstrapID)
-		body, _ = sjson.SetBytes(body, "created", bootstrapCreated)
 		frames := helps.SynthesizeOpenAIStreamFrames(body)
 		if len(frames) == 0 {
 			errSynth := statusErr{code: http.StatusBadGateway, msg: "upstream non-streaming reply could not be converted to a stream"}
@@ -672,6 +657,8 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			return
 		}
 
+		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
+		var param any
 		var streamUsage helps.StreamUsageBuffer
 		defer func() {
 			streamUsage.Publish(ctx, reporter)
@@ -690,8 +677,8 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			}
 		}
 	}()
-	// Headers and status are available synchronously, while body buffering runs
-	// behind the stream so the handler can emit keep-alives during generation.
+	// Status and headers are available synchronously. The first payload is sent
+	// only after the complete body is validated, preserving bootstrap fallback.
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -608,37 +608,43 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 		Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue,
 	})
 
+	httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("openai compat executor: close response body error: %v", errClose)
+			}
+		}()
+		body, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
+	}
+
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
-		httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
-		httpResp, errDo := httpClient.Do(httpReq)
-		if errDo != nil {
-			helps.RecordAPIResponseError(ctx, e.cfg, errDo)
-			reporter.PublishFailure(ctx, errDo)
+		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
+		var param any
+		bootstrapLine := []byte("data: " + helps.SynthesizeOpenAIStreamBootstrapFrame(req.Model))
+		bootstrapChunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bootstrapLine, &param, claudeInputTokens)
+		for i := range bootstrapChunks {
 			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: errDo}:
+			case out <- cliproxyexecutor.StreamChunk{Payload: bootstrapChunks[i]}:
 			case <-ctx.Done():
+				return
 			}
-			return
 		}
 		defer func() {
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
 		}()
-		helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-		if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-			body, _ := io.ReadAll(httpResp.Body)
-			helps.AppendAPIResponseChunk(ctx, e.cfg, body)
-			streamErr := statusErr{code: httpResp.StatusCode, msg: string(body)}
-			reporter.PublishFailure(ctx, streamErr)
-			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
-			case <-ctx.Done():
-			}
-			return
-		}
 		body, errRead := io.ReadAll(httpResp.Body)
 		if errRead != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
@@ -662,8 +668,6 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			return
 		}
 
-		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
-		var param any
 		var streamUsage helps.StreamUsageBuffer
 		defer func() {
 			streamUsage.Publish(ctx, reporter)
@@ -682,9 +686,9 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			}
 		}
 	}()
-	// Return before connecting/reading so the streaming handler can start its
-	// response and configured keep-alives while the non-stream upstream runs.
-	return &cliproxyexecutor.StreamResult{Chunks: out}, nil
+	// Headers and status are available synchronously, while body buffering runs
+	// behind the stream so the handler can emit keep-alives during generation.
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -626,12 +626,14 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
 	}
 
+	bootstrapID := "chatcmpl-" + uuid.NewString()
+	bootstrapCreated := time.Now().Unix()
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
 		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
 		var param any
-		bootstrapLine := []byte("data: " + helps.SynthesizeOpenAIStreamBootstrapFrame(req.Model))
+		bootstrapLine := []byte("data: " + helps.SynthesizeOpenAIStreamBootstrapFrame(bootstrapID, req.Model, bootstrapCreated))
 		bootstrapChunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bootstrapLine, &param, claudeInputTokens)
 		for i := range bootstrapChunks {
 			select {
@@ -656,6 +658,8 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 			return
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+		body, _ = sjson.SetBytes(body, "id", bootstrapID)
+		body, _ = sjson.SetBytes(body, "created", bootstrapCreated)
 		frames := helps.SynthesizeOpenAIStreamFrames(body)
 		if len(frames) == 0 {
 			errSynth := statusErr{code: http.StatusBadGateway, msg: "upstream non-streaming reply could not be converted to a stream"}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -608,42 +608,67 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 		Provider: e.Identifier(), AuthID: authID, AuthLabel: authLabel, AuthType: authType, AuthValue: authValue,
 	})
 
-	httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
-	httpResp, err := httpClient.Do(httpReq)
-	if err != nil {
-		helps.RecordAPIResponseError(ctx, e.cfg, err)
-		return nil, err
-	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
-			log.Errorf("openai compat executor: close response body error: %v", errClose)
-		}
-	}()
-	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
-	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		body, _ := io.ReadAll(httpResp.Body)
-		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
-	}
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		helps.RecordAPIResponseError(ctx, e.cfg, err)
-		return nil, err
-	}
-	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
-	frames := helps.SynthesizeOpenAIStreamFrames(body)
-	if len(frames) == 0 {
-		errSynth := statusErr{code: http.StatusBadGateway, msg: "upstream non-streaming reply could not be converted to a stream"}
-		helps.RecordAPIResponseError(ctx, e.cfg, errSynth)
-		return nil, errSynth
-	}
-
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
+		httpClient := reporter.TrackHTTPClient(helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0))
+		httpResp, errDo := httpClient.Do(httpReq)
+		if errDo != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+			reporter.PublishFailure(ctx, errDo)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errDo}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("openai compat executor: close response body error: %v", errClose)
+			}
+		}()
+		helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+		if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+			body, _ := io.ReadAll(httpResp.Body)
+			helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+			streamErr := statusErr{code: httpResp.StatusCode, msg: string(body)}
+			reporter.PublishFailure(ctx, streamErr)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		body, errRead := io.ReadAll(httpResp.Body)
+		if errRead != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+			reporter.PublishFailure(ctx, errRead)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errRead}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+		frames := helps.SynthesizeOpenAIStreamFrames(body)
+		if len(frames) == 0 {
+			errSynth := statusErr{code: http.StatusBadGateway, msg: "upstream non-streaming reply could not be converted to a stream"}
+			helps.RecordAPIResponseError(ctx, e.cfg, errSynth)
+			reporter.PublishFailure(ctx, errSynth)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errSynth}:
+			case <-ctx.Done():
+			}
+			return
+		}
+
 		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, originalPayload)
 		var param any
 		var streamUsage helps.StreamUsageBuffer
+		defer func() {
+			streamUsage.Publish(ctx, reporter)
+			reporter.EnsurePublished(ctx)
+		}()
 		for _, frame := range frames {
 			streamLine := append([]byte("data: "), frame...)
 			streamUsage.ObserveOpenAIStream(streamLine)
@@ -656,10 +681,10 @@ func (e *OpenAICompatExecutor) executeStreamViaNonStream(ctx context.Context, au
 				}
 			}
 		}
-		streamUsage.Publish(ctx, reporter)
-		reporter.EnsurePublished(ctx)
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	// Return before connecting/reading so the streaming handler can start its
+	// response and configured keep-alives while the non-stream upstream runs.
+	return &cliproxyexecutor.StreamResult{Chunks: out}, nil
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {


### PR DESCRIPTION
## Summary

Add an opt-in workaround for OpenAI-compatible upstreams that truncate tool-call arguments in streaming mode.

## Problem

Some aggregator gateways intermittently emit a tool name with an empty `function.arguments` string and immediately finish the stream with `tool_calls`. The identical request sent with `stream: false` returns complete arguments, leaving streaming agent clients with an unusable call.

## Changes

- Add `openai-compatibility[].non-stream-tool-calls` (disabled by default).
- When enabled and a streaming request declares non-empty `tools`:
  1. Send the translated upstream request with `stream: false` and remove `stream_options`.
  2. Validate the complete JSON response.
  3. Synthesize equivalent OpenAI `chat.completion.chunk` frames.
  4. Feed those frames through the existing stream translation pipeline.
- Requests without tools preserve native upstream streaming.
- Preserve dynamic custom headers and upstream response headers.
- Expose the option through management API GET/PATCH.

Synthesized frames preserve role, content, `reasoning_content`, complete tool calls, finish reason, usage (once), and `[DONE]`. The normal translation pipeline provides downstream OpenAI, Anthropic Messages, and Responses API compatibility.

## Safety

- Opt-in only; no behavior change by default.
- No timeout or deadline is introduced after upstream connection establishment.
- Invalid/non-convertible upstream bodies return HTTP 502 rather than producing a partial tool call.
- Request cancellation stops downstream frame delivery.

## Verification

- `go test ./...`
- `go build -o test-output ./cmd/server`
- `git diff --check`

All pass locally.
