### PR TITLE
fix(claude): recover hybrid MCP tool names and fail open on alias restore

### DIFF
--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1774,12 +1774,31 @@ type claudeMCPAliasEntry struct {
 	parts    claudeMCPAliasParts
 }
 
-type claudeMCPAliasResolver struct {
-	exact   map[string]string
-	aliases []claudeMCPAliasEntry
-	servers map[string]struct{}
+// claudeMCPPassthroughEntry is a caller-owned MCP tool that was forwarded to the
+// upstream untouched, split into its server and tool components. Such tools are
+// recorded in the reverse map as identity entries and are deliberately kept out
+// of resolver.aliases so they cannot contaminate fuzzy alias recovery, but the
+// split is still needed to recognise a response name that glued the request's
+// virtual server component onto a real MCP tool.
+type claudeMCPPassthroughEntry struct {
+	name   string
+	server string
+	tool   string
 }
 
+type claudeMCPAliasResolver struct {
+	exact       map[string]string
+	aliases     []claudeMCPAliasEntry
+	servers     map[string]struct{}
+	passthrough []claudeMCPPassthroughEntry
+}
+
+// claudeMCPAliasRestoreError marks a restore failure as request-scoped rather
+// than credential-scoped. resolve no longer constructs one -- an unrestorable
+// tool name now fails open -- but the type is retained deliberately: it is part
+// of the executor's error-classification contract (cliproxyexecutor.RequestScopedError),
+// it costs nothing at runtime, and keeping it means a future upstream call site
+// that returns it still compiles against this fork.
 type claudeMCPAliasRestoreError struct {
 	error
 }
@@ -1801,7 +1820,16 @@ func newClaudeMCPAliasResolver(reverseMap map[string]string) claudeMCPAliasResol
 	for alias, original := range reverseMap {
 		if alias == original {
 			// Caller-owned MCP tool recorded for exact passthrough only. It must not
-			// register a virtual server or take part in fuzzy alias recovery.
+			// register a virtual server or take part in fuzzy alias recovery, but its
+			// server/tool split is kept so resolve can recognise a response name that
+			// glued the virtual server component onto this tool.
+			if server, tool, split := splitClaudeMCPToolName(alias); split {
+				resolver.passthrough = append(resolver.passthrough, claudeMCPPassthroughEntry{
+					name:   alias,
+					server: server,
+					tool:   tool,
+				})
+			}
 			continue
 		}
 		parts, ok := parseClaudeMCPAlias(alias)
@@ -1835,6 +1863,22 @@ func parseClaudeMCPAlias(name string) (claudeMCPAliasParts, bool) {
 		return claudeMCPAliasParts{}, false
 	}
 	return claudeMCPAliasParts{server: server, toolID: toolID, semantic: semantic}, true
+}
+
+// splitClaudeMCPToolName splits a genuine mcp__<server>__<tool> name into its
+// two components. Unlike parseClaudeMCPAlias it does not require the generated
+// "<word>_<semantic>" tool shape, because a caller-owned MCP tool carries an
+// arbitrary tool component that need not contain an underscore at all.
+func splitClaudeMCPToolName(name string) (string, string, bool) {
+	rest, cut := strings.CutPrefix(name, "mcp__")
+	if !cut {
+		return "", "", false
+	}
+	server, tool, ok := strings.Cut(rest, "__")
+	if !ok || server == "" || tool == "" {
+		return "", "", false
+	}
+	return server, tool, true
 }
 
 func claudeMCPAliasServer(name string) string {
@@ -1893,6 +1937,32 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		}
 	}
 
+	// Hybrid recovery, shape (a): the model kept the whole caller-owned MCP name
+	// and merely prefixed it with the request's virtual server, producing
+	// mcp__<virtual>__inventory__inventory_lookup_by_id for mcp__inventory__inventory_lookup_by_id.
+	// Re-adding the "mcp__" prefix to the remaining suffix reconstructs the exact
+	// declared name. The reverse-map entry for a passthrough tool is an IDENTITY
+	// entry, so this must report matched=true even though original equals the map
+	// key: the name that arrived on the wire is not the name the client declared,
+	// and returning the no-change form would leave the virtual prefix in place.
+	// Two variants are reconstructed, because the model may either drop the real
+	// name's leading "mcp__" (mcp__<virtual>__inventory__inventory_lookup_by_id) or keep it
+	// (mcp__<virtual>__mcp__inventory__inventory_lookup_by_id). Both are exact lookups
+	// against names the client literally declared, never partial matches, so
+	// neither can select a tool the caller did not send.
+	if suffix != "" {
+		candidates := []string{"mcp__" + suffix}
+		if strings.HasPrefix(suffix, "mcp__") {
+			candidates = append(candidates, suffix)
+		}
+		for _, candidate := range candidates {
+			if original, exact := resolver.exact[candidate]; exact {
+				log.Debugf("claude oauth mcp alias: recovered tool name %q as %q by stripping the virtual server prefix", name, original)
+				return original, true, nil
+			}
+		}
+	}
+
 	matchedOriginal := ""
 	matchCount := 0
 	for _, entry := range resolver.aliases {
@@ -1905,7 +1975,7 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)}
+		return claudeMCPAliasFailOpen(name, "matched multiple declared aliases")
 	}
 
 	parts, validAlias := parseClaudeMCPAlias(normalizedName)
@@ -1960,10 +2030,67 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)}
+		return claudeMCPAliasFailOpen(name, "semantic suffix matches multiple declared tools")
 	}
 
-	return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)}
+	// Hybrid recovery, shape (b): the model kept the virtual server but dropped
+	// the caller's real server segment, producing mcp__<virtual>__inventory_lookup_by_id
+	// for mcp__inventory__inventory_lookup_by_id. Match the remaining suffix against the
+	// tool component of the recorded passthrough tools, and restore only when it
+	// is unique. Two caller MCP servers exposing the same tool name is a genuine
+	// ambiguity: guessing there would invoke the wrong server, which is worse than
+	// letting the name through unrestored, so that case falls through.
+	//
+	// This runs LAST, after every pre-existing alias path, and the ordering is
+	// load-bearing rather than incidental. Unlike shape (a) this is a partial
+	// match on the tool component alone, so it can collide with a generated alias
+	// whose semantic field happens to equal a caller tool component: a request
+	// declaring both a client tool "Bash" and a caller tool mcp__shell__Bash makes
+	// mcp__<virtual>__Bash ambiguous across the two namespaces. Running earlier
+	// resolved that to the caller's MCP server and silently invoked the wrong
+	// tool, which is exactly the wrong-tool outcome this patch exists to avoid.
+	// Placed here it can only ever claim names that would otherwise be abandoned,
+	// so it cannot change any answer v7.2.142 already produced.
+	if suffix != "" {
+		matchedPassthrough := ""
+		passthroughServer := ""
+		passthroughMatches := 0
+		for _, entry := range resolver.passthrough {
+			if entry.tool == suffix {
+				matchedPassthrough = entry.name
+				passthroughServer = entry.server
+				passthroughMatches++
+			}
+		}
+		if passthroughMatches == 1 {
+			// Logged at Info, not Debug: this crosses the alias/passthrough
+			// namespace boundary on a partial match, so the successful guess is
+			// the outcome an operator most needs to be able to see.
+			log.Infof("claude oauth mcp alias: recovered tool name %q as %q on caller MCP server %q", name, matchedPassthrough, passthroughServer)
+			return matchedPassthrough, true, nil
+		}
+		if passthroughMatches > 1 {
+			log.Warnf("claude oauth mcp alias: tool component %q of %q matches %d caller MCP tools, refusing to guess a server", suffix, name, passthroughMatches)
+		}
+	}
+
+	return claudeMCPAliasFailOpen(name, "no unique request-local match")
+}
+
+// claudeMCPAliasFailOpen abandons one tool-name restore instead of failing the
+// whole response. A proxy must never destroy an entire in-flight response
+// because it could not restore a single tool name: on the streaming path the
+// error reaches the client after message_start has already been flushed, so it
+// terminates the SSE stream and cannot be retried -- and a retry replays
+// identical context, so the model re-emits the same name and the conversation is
+// stuck permanently. Forwarding the name unchanged instead makes the client
+// answer with an ordinary tool-not-found tool_result, which the model
+// self-corrects on the next turn: a recoverable blip rather than a dead session.
+// The warning is the only record that a restore was abandoned, so it names both
+// the unrecoverable tool and the reason.
+func claudeMCPAliasFailOpen(name, reason string) (string, bool, error) {
+	log.Warnf("claude oauth mcp alias: cannot restore tool name %q: %s; forwarding it unchanged", name, reason)
+	return "", false, nil
 }
 
 // reverseRemapOAuthToolNames reverses the tool name mapping for non-stream responses

--- a/internal/runtime/executor/claude_executor_request_aliasfailopen_test.go
+++ b/internal/runtime/executor/claude_executor_request_aliasfailopen_test.go
@@ -1,0 +1,252 @@
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// The real tool that triggered the incident: a deferred MCP tool the model
+// loaded through ToolSearch mid-conversation and then referred to by a hybrid
+// name that mixed the request's virtual MCP server with the real one.
+const (
+	failOpenRealMCPTool   = "mcp__inventory__inventory_lookup_by_id"
+	failOpenRealMCPServer = "inventory"
+	failOpenRealToolPart  = "inventory_lookup_by_id"
+)
+
+// failOpenVirtualServer returns the two-word virtual MCP server component that
+// remapOAuthToolNamesWithOptions derives for this caller secret. Tests build
+// drifted names against the real derivation rather than a hand-written string so
+// they keep testing the shipped alias format.
+func failOpenVirtualServer(t *testing.T, secret string) string {
+	t.Helper()
+	parts := strings.SplitN(helps.ClaudeMCPToolAlias(secret, "probe", 0), "__", 3)
+	if len(parts) != 3 || parts[1] == "" {
+		t.Fatalf("cannot derive virtual server from alias %q", helps.ClaudeMCPToolAlias(secret, "probe", 0))
+	}
+	return parts[1]
+}
+
+// failOpenRequest drives the real request path: one ordinary client tool (which
+// forces alias allocation, without which passthrough tools are not recorded at
+// all) plus the caller-owned MCP tools named by mcpTools. It returns the derived
+// virtual server, the alias allocated for the ordinary tool, and the per-request
+// reverse map that the response path consumes.
+func failOpenRequest(t *testing.T, secret string, mcpTools ...string) (string, string, map[string]string) {
+	t.Helper()
+	declarations := []string{`{"name":"Read","input_schema":{"type":"object"}}`}
+	for _, name := range mcpTools {
+		declarations = append(declarations, fmt.Sprintf(`{"name":%q}`, name))
+	}
+	body := []byte(fmt.Sprintf(`{"tools":[%s]}`, strings.Join(declarations, ",")))
+
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: secret})
+
+	readAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+	if readAlias == "Read" || !helps.IsClaudeMCPToolName(readAlias) {
+		t.Fatalf("ordinary tool was not aliased: %q", readAlias)
+	}
+	for index, name := range mcpTools {
+		if got := gjson.GetBytes(remapped, fmt.Sprintf("tools.%d.name", index+1)).String(); got != name {
+			t.Fatalf("caller MCP tool sent upstream as %q, want %q unchanged", got, name)
+		}
+		if original, ok := reverseMap[name]; !ok || original != name {
+			t.Fatalf("caller MCP tool %q was not recorded as an identity entry (got %q, ok=%v)", name, original, ok)
+		}
+	}
+	return failOpenVirtualServer(t, secret), readAlias, reverseMap
+}
+
+func failOpenRestoreToolUse(t *testing.T, name string, reverseMap map[string]string) string {
+	t.Helper()
+	response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, name))
+	restored, err := restoreClaudeOAuthToolNamesFromResponse(response, reverseMap)
+	if err != nil {
+		t.Fatalf("restoreClaudeOAuthToolNamesFromResponse(%q) error = %v, want fail-open nil", name, err)
+	}
+	return gjson.GetBytes(restored, "content.0.name").String()
+}
+
+// Shape (a) of the incident: the model prefixed the complete caller-owned MCP
+// name with the request's virtual server, dropping only the leading "mcp__".
+// Recovery must strip the virtual prefix and restore the real declared name.
+func TestClaudeMCPAliasFailOpenRecoversVirtualServerPrefixedRealName(t *testing.T) {
+	server, _, reverseMap := failOpenRequest(t, "failopen-shape-a-caller", failOpenRealMCPTool)
+
+	hybrid := "mcp__" + server + "__" + failOpenRealMCPServer + "__" + failOpenRealToolPart
+	if got := failOpenRestoreToolUse(t, hybrid, reverseMap); got != failOpenRealMCPTool {
+		t.Fatalf("hybrid name %q restored as %q, want %q", hybrid, got, failOpenRealMCPTool)
+	}
+}
+
+// Shape (b) of the incident: the model kept the virtual server but dropped the
+// caller's real server segment entirely, leaving only the tool component. The
+// reverse-map entry for a passthrough tool is an identity entry, so this must
+// still report a change: the name on the wire is not the declared name.
+func TestClaudeMCPAliasFailOpenRecoversDroppedServerSegment(t *testing.T) {
+	server, _, reverseMap := failOpenRequest(t, "failopen-shape-b-caller", failOpenRealMCPTool)
+
+	hybrid := "mcp__" + server + "__" + failOpenRealToolPart
+	if got := failOpenRestoreToolUse(t, hybrid, reverseMap); got != failOpenRealMCPTool {
+		t.Fatalf("hybrid name %q restored as %q, want %q", hybrid, got, failOpenRealMCPTool)
+	}
+}
+
+// Two caller MCP servers exposing the same tool component is a genuine
+// ambiguity. Recovering shape (b) there would pick a server at random and call
+// the wrong one, so the name must be forwarded untouched instead -- and still
+// without an error.
+func TestClaudeMCPAliasFailOpenDoesNotGuessAmbiguousPassthroughTool(t *testing.T) {
+	const sharedTool = "lookup_by_ip"
+	server, _, reverseMap := failOpenRequest(t, "failopen-ambiguous-caller",
+		"mcp__inventory__"+sharedTool, "mcp__catalog__"+sharedTool)
+
+	hybrid := "mcp__" + server + "__" + sharedTool
+	if got := failOpenRestoreToolUse(t, hybrid, reverseMap); got != hybrid {
+		t.Fatalf("ambiguous tool component restored as %q, want %q forwarded unchanged", got, hybrid)
+	}
+}
+
+// An alias-shaped name under the known virtual server that maps to nothing at
+// all must fail OPEN: no restore, and critically no error, because on the
+// streaming path an error here destroys the whole response.
+func TestClaudeMCPAliasFailOpenOnUnmappableAliasShapedName(t *testing.T) {
+	server, _, reverseMap := failOpenRequest(t, "failopen-unmappable-caller", failOpenRealMCPTool)
+
+	unmappable := "mcp__" + server + "__abandon_no_such_tool_at_all"
+	if got := failOpenRestoreToolUse(t, unmappable, reverseMap); got != unmappable {
+		t.Fatalf("unmappable name restored as %q, want %q forwarded unchanged", got, unmappable)
+	}
+}
+
+// A name belonging to some other MCP server entirely was never ours to restore
+// and must not be touched by any of the new recovery paths.
+func TestClaudeMCPAliasFailOpenLeavesUnknownServerNameUntouched(t *testing.T) {
+	_, _, reverseMap := failOpenRequest(t, "failopen-unknown-server-caller", failOpenRealMCPTool)
+
+	const foreign = "mcp__external__query"
+	if got := failOpenRestoreToolUse(t, foreign, reverseMap); got != foreign {
+		t.Fatalf("foreign MCP name restored as %q, want %q unchanged", got, foreign)
+	}
+}
+
+// The passthrough tool quoted exactly as declared keeps taking the identity
+// path, and the ordinary aliased tool keeps restoring through both the exact map
+// and the pre-existing repeated-server drift fallback. The recovery paths must
+// not have displaced either.
+func TestClaudeMCPAliasFailOpenPreservesExistingRestorePaths(t *testing.T) {
+	server, readAlias, reverseMap := failOpenRequest(t, "failopen-existing-paths-caller", failOpenRealMCPTool)
+
+	if got := failOpenRestoreToolUse(t, failOpenRealMCPTool, reverseMap); got != failOpenRealMCPTool {
+		t.Fatalf("declared MCP tool restored as %q, want %q unchanged", got, failOpenRealMCPTool)
+	}
+	if got := failOpenRestoreToolUse(t, readAlias, reverseMap); got != "Read" {
+		t.Fatalf("generated alias restored as %q, want Read", got)
+	}
+
+	aliasToolPart := strings.SplitN(readAlias, "__", 3)[2]
+	repeatedServer := "mcp__" + server + "__" + server + "__" + aliasToolPart
+	if got := failOpenRestoreToolUse(t, repeatedServer, reverseMap); got != "Read" {
+		t.Fatalf("repeated-server alias %q restored as %q, want Read", repeatedServer, got)
+	}
+}
+
+// The whole point of the change: the streaming path. content_block_start is
+// emitted after message_start has already been flushed, so an error here closes
+// the SSE stream unretryably. Both hybrid shapes must be repaired in place, and
+// nothing may error.
+func TestClaudeMCPAliasFailOpenStreamLineRecoversHybridNames(t *testing.T) {
+	server, _, reverseMap := failOpenRequest(t, "failopen-stream-caller", failOpenRealMCPTool)
+
+	shapes := map[string]string{
+		"virtual server prefixed real name": "mcp__" + server + "__" + failOpenRealMCPServer + "__" + failOpenRealToolPart,
+		"dropped server segment":            "mcp__" + server + "__" + failOpenRealToolPart,
+	}
+	for label, name := range shapes {
+		t.Run(label, func(t *testing.T) {
+			line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, name))
+			restored, err := restoreClaudeOAuthToolNamesFromStreamLine(line, reverseMap)
+			if err != nil {
+				t.Fatalf("restoreClaudeOAuthToolNamesFromStreamLine(%q) error = %v, want nil", name, err)
+			}
+			if got := gjson.GetBytes(helps.JSONPayload(restored), "content_block.name").String(); got != failOpenRealMCPTool {
+				t.Fatalf("stream name restored as %q, want %q", got, failOpenRealMCPTool)
+			}
+		})
+	}
+}
+
+// An unrecoverable name on the streaming path must leave the line byte-identical
+// and return no error, so the stream survives and the client simply answers with
+// an ordinary tool-not-found tool_result.
+func TestClaudeMCPAliasFailOpenStreamLineSurvivesUnmappableName(t *testing.T) {
+	server, _, reverseMap := failOpenRequest(t, "failopen-stream-unmappable-caller", failOpenRealMCPTool)
+
+	unmappable := "mcp__" + server + "__abandon_no_such_tool_at_all"
+	line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, unmappable))
+	restored, err := restoreClaudeOAuthToolNamesFromStreamLine(line, reverseMap)
+	if err != nil {
+		t.Fatalf("restoreClaudeOAuthToolNamesFromStreamLine() error = %v, want fail-open nil", err)
+	}
+	if !bytes.Equal(restored, line) {
+		t.Fatalf("stream line = %s, want it forwarded unchanged", restored)
+	}
+}
+
+// claudeMCPAliasRestoreError is no longer constructed by resolve, but it is kept
+// as part of the executor's error-classification contract. Pin that it still
+// exists and still classifies as request-scoped, so a future rebase that
+// reintroduces a call site does not silently get credential-scoped behaviour.
+func TestClaudeMCPAliasFailOpenRestoreErrorStaysRequestScoped(t *testing.T) {
+	var requestErr cliproxyexecutor.RequestScopedError = claudeMCPAliasRestoreError{fmt.Errorf("probe")}
+	if !requestErr.IsRequestScoped() {
+		t.Fatal("claudeMCPAliasRestoreError.IsRequestScoped() = false, want true")
+	}
+}
+
+// A request that declares BOTH a client tool and a caller MCP tool ending in the
+// same component makes the drifted name ambiguous ACROSS the two namespaces. The
+// pre-existing v7.2.142 alias paths resolve it to the client tool; the shape (b)
+// passthrough recovery must not be allowed to preempt that and silently invoke
+// the caller's MCP server instead. This pins the ordering, not just the outcome.
+func TestClaudeMCPAliasFailOpenPassthroughRecoveryNeverPreemptsAliasMatch(t *testing.T) {
+	secret := "failopen-cross-namespace"
+	body := []byte(`{"tools":[{"name":"Bash","input_schema":{"type":"object"}},{"name":"mcp__shell__Bash"}]}`)
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: secret})
+
+	bashAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+	if bashAlias == "Bash" {
+		t.Fatalf("client tool was not aliased")
+	}
+	if got := gjson.GetBytes(remapped, "tools.1.name").String(); got != "mcp__shell__Bash" {
+		t.Fatalf("caller MCP tool mangled on the way out: %q", got)
+	}
+
+	// Exactly the drift v7.2.142 resolved to the client tool "Bash".
+	drifted := "mcp__" + failOpenVirtualServer(t, secret) + "__Bash"
+	if got := failOpenRestoreToolUse(t, drifted, reverseMap); got != "Bash" {
+		t.Fatalf("cross-namespace drift restored as %q, want the client tool %q (v7.2.142 behaviour)", got, "Bash")
+	}
+	// And the exact alias still restores normally.
+	if got := failOpenRestoreToolUse(t, bashAlias, reverseMap); got != "Bash" {
+		t.Fatalf("exact alias restored as %q, want %q", got, "Bash")
+	}
+}
+
+// The model may keep the real name's leading "mcp__" instead of dropping it.
+// This is an exact lookup of a declared name, so it must restore, not fail open.
+func TestClaudeMCPAliasFailOpenRecoversFullyQualifiedRealName(t *testing.T) {
+	const real = "mcp__inventory__inventory_lookup_by_id"
+	server, _, reverseMap := failOpenRequest(t, "failopen-fully-qualified", real)
+
+	hybrid := "mcp__" + server + "__" + real // mcp__<virtual>__mcp__inventory__inventory_lookup_by_id
+	if got := failOpenRestoreToolUse(t, hybrid, reverseMap); got != real {
+		t.Fatalf("fully-qualified hybrid restored as %q, want %q", got, real)
+	}
+}

--- a/internal/runtime/executor/claude_executor_request_remap_test.go
+++ b/internal/runtime/executor/claude_executor_request_remap_test.go
@@ -2,14 +2,12 @@ package executor
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"maps"
 	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
-	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 )
 
@@ -300,7 +298,13 @@ func TestReverseRemapOAuthToolNamesWithBIP39Aliases(t *testing.T) {
 	}
 }
 
-func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
+// Contract change: an alias that cannot be restored unambiguously used to be a
+// fail-closed, request-scoped error. It now fails OPEN -- the name is forwarded
+// to the client untouched -- because the streaming caller turns any error here
+// into a terminated SSE stream after message_start has already been flushed,
+// which is unretryable and permanently wedges the conversation. The important
+// property is unchanged: an ambiguous name is never guessed at.
+func TestReverseRemapOAuthToolNamesFailsOpenOnUnsafeMangledAliases(t *testing.T) {
 	body := []byte(`{"tools":[{"name":"tool.name"},{"name":"tool/name"}]}`)
 	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "ambiguous-alias-caller"})
 	firstAlias := gjson.GetBytes(remapped, "tools.0.name").String()
@@ -322,46 +326,40 @@ func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
 		unknownToolID = "bbbbbbbbbbbb"
 	}
 	tests := []struct {
-		name      string
-		alias     string
-		wantError string
+		name  string
+		alias string
 	}{
 		{
-			name:      "ambiguous semantic suffix",
-			alias:     "mcp__" + firstParts.server + "__" + unknownToolID + "_" + firstParts.semantic,
-			wantError: "semantic suffix matches multiple declared tools",
+			name:  "ambiguous semantic suffix",
+			alias: "mcp__" + firstParts.server + "__" + unknownToolID + "_" + firstParts.semantic,
 		},
 		{
-			name:      "ambiguous semantic suffix with malformed tool ID",
-			alias:     "mcp__" + firstParts.server + "__" + unknownToolID[:len(unknownToolID)-1] + "_" + firstParts.semantic,
-			wantError: "semantic suffix matches multiple declared tools",
+			name:  "ambiguous semantic suffix with malformed tool ID",
+			alias: "mcp__" + firstParts.server + "__" + unknownToolID[:len(unknownToolID)-1] + "_" + firstParts.semantic,
 		},
 		{
-			name:      "unrecoverable semantic suffix",
-			alias:     "mcp__" + firstParts.server + "__" + unknownToolID + "_missing_tool",
-			wantError: "no unique request-local match",
+			name:  "unrecoverable semantic suffix",
+			alias: "mcp__" + firstParts.server + "__" + unknownToolID + "_missing_tool",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, test.alias))
-			_, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
-			if errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
-				t.Fatalf("reverseRemapOAuthToolNames() error = %v, want %q", errReverse, test.wantError)
+			restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+			if errReverse != nil {
+				t.Fatalf("reverseRemapOAuthToolNames() error = %v, want fail-open nil", errReverse)
 			}
-			var requestErr cliproxyexecutor.RequestScopedError
-			if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
-				t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
+			if got := gjson.GetBytes(restored, "content.0.name").String(); got != test.alias {
+				t.Fatalf("unrestorable name = %q, want %q forwarded unchanged", got, test.alias)
 			}
 
 			line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, test.alias))
-			_, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
-			if errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
-				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want %q", errStream, test.wantError)
+			restoredLine, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+			if errStream != nil {
+				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want fail-open nil", errStream)
 			}
-			requestErr = nil
-			if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
-				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
+			if !bytes.Equal(restoredLine, line) {
+				t.Fatalf("stream line = %s, want it forwarded unchanged", restoredLine)
 			}
 		})
 	}
@@ -555,35 +553,31 @@ func TestRemapKeepsReverseMapEmptyWhenOnlyCallerMCPToolsArePresent(t *testing.T)
 	}
 }
 
-func TestReverseRemapOAuthToolNamesMarksTrailingMarkupFailureRequestScoped(t *testing.T) {
+// Same contract change as above: an alias with trailing prompt markup glued to
+// it is still never restored, but it is now forwarded verbatim instead of
+// failing the response. The body and the SSE line must both come back
+// byte-identical.
+func TestReverseRemapOAuthToolNamesFailsOpenOnTrailingMarkup(t *testing.T) {
 	const alias = "mcp__hmzqrngkulqv__xuo7jlxlpzee_clear_thinking"
 	malformedAlias := alias + "</parameter>\n<parameter name=\"merge\""
 	reverseMap := map[string]string{alias: "clear_thinking"}
 
 	response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, malformedAlias))
 	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
-	if errReverse == nil {
-		t.Fatal("reverseRemapOAuthToolNames() error = nil, want fail-closed alias error")
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v, want fail-open nil", errReverse)
 	}
 	if !bytes.Equal(restored, response) {
 		t.Fatalf("reverseRemapOAuthToolNames() returned modified response: %s", restored)
 	}
-	var requestErr cliproxyexecutor.RequestScopedError
-	if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
-		t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
-	}
 
 	line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, malformedAlias))
 	restoredLine, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
-	if errStream == nil {
-		t.Fatal("reverseRemapOAuthToolNamesFromStreamLine() error = nil, want fail-closed alias error")
+	if errStream != nil {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want fail-open nil", errStream)
 	}
 	if !bytes.Equal(restoredLine, line) {
 		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() returned modified line: %s", restoredLine)
-	}
-	requestErr = nil
-	if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
-		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
 	}
 }
 


### PR DESCRIPTION
## Problem

`claudeMCPAliasResolver.resolve` fails the entire response when it cannot restore a streamed tool name. On the streaming path that error is raised **after `message_start` has already been flushed**, so it terminates the SSE stream, cannot be retried, and a client retry replays identical context and reproduces it exactly. One drifted tool name ends the conversation permanently instead of costing it a turn.

This is reachable in normal use. On a cloaked request every non-`mcp__` tool is aliased under the request's virtual server, while genuine `mcp__<server>__<tool>` names pass through untouched and are recorded as identity entries. The model sees that mixed namespace — especially after a deferred tool is loaded mid-conversation via tool search, when both the virtual server and the real MCP name are in context — and emits hybrids of the two. For a real tool `mcp__inventory__inventory_lookup_by_id`:

```
mcp__<virtual>__inventory__inventory_lookup_by_id     virtual prefix + whole real name
mcp__<virtual>__inventory_lookup_by_id                virtual prefix + tool part only
```

Both parse as an alias under a *known* virtual server, so neither takes the unknown-server passthrough at `resolve`'s second branch. Both then miss the exact map, the repeated-server strip loop and every fuzzy path, and both reach the final `no unique request-local match` return.

Observed in production on a self-hosted deployment (2026-08-29): three occurrences in one session, each killing the response, with `Try again` reproducing it every time because the replayed context makes the model emit the same name.

## Change

**Two recoveries, both exact lookups of names the client actually declared.**

- **(a)** re-prefixes the remaining suffix with `mcp__` and looks it up in the exact map, covering both the variant that drops the real name's leading `mcp__` and the one that keeps it. Since a passthrough tool's map entry is an *identity* entry, this must report `matched=true` even though value equals key — the name on the wire is not the name the client declared, and the no-change form would leave the virtual prefix in place.
- **(b)** matches the remaining suffix against the tool component of the recorded passthrough tools, which now survive resolver construction in a `passthrough` slice. It restores **only on a unique match**: two caller servers exposing the same tool component is a real ambiguity where guessing would invoke the wrong server.

**Ordering is load-bearing.** Recovery (b) runs *last*, after every pre-existing alias path, because unlike (a) it is a partial match on the tool component alone. Run earlier it steals cross-namespace collisions: a request declaring both a client tool `Bash` and a caller tool `mcp__shell__Bash` makes `mcp__<virtual>__Bash` ambiguous across the two namespaces, and an earlier (b) resolved it to the caller's MCP server — silently invoking the wrong tool. Placed last it can only claim names that would otherwise be abandoned, so it cannot change any answer the resolver already produced. A regression test pins the ordering, not just the outcome.

**Everything still unresolved fails open.** All three `claudeMCPAliasRestoreError` returns now log a warning naming the tool and the reason, and return the no-change form. A proxy should not destroy an in-flight response because it could not restore one tool name: forwarding it unchanged makes the client answer with an ordinary tool-not-found `tool_result`, which the model self-corrects next turn. This also covers shapes not enumerated here — including the trailing-markup names in #4979 that remained fatal after #4965 and #5082.

## Compatibility

- **No call-site changes needed.** `resolve` has always returned the no-change form for unknown-server names, and all seven call sites (four in `reverseRemapOAuthToolNames`, three in `reverseRemapOAuthToolNamesFromStreamLine`) already treat `matched == false` as leave-alone and emit the original bytes unmodified.
- **`claudeMCPAliasRestoreError` is kept**, not deleted, so a future call site returning it still compiles; a test pins that it still classifies as `RequestScopedError`.
- **Two existing tests changed contract** and are updated and renamed to assert fail-open. The property they protected is intact — an ambiguous name is still never guessed at, merely forwarded rather than raised.
- A differential harness over 25 drifted names against two reverse maps confirms the net effect: 12 input classes go from fatal error to fail-open, 3 go from no-match to correct recovery, and **every class the resolver already resolved returns a byte-identical answer** (exact alias, exact identity passthrough, repeated-server strip, semantic drift, extra-word tool components, unknown servers).

## Tests

13 tests pass on `dev`, including a repro of each production shape through both `restoreClaudeOAuthToolNamesFromResponse` and `restoreClaudeOAuthToolNamesFromStreamLine`:

```
go test ./internal/runtime/executor/ -run 'ClaudeMCPAliasFailOpen|ReverseRemapOAuthToolNamesFailsOpenOn'
```

Refs #4979, #5035, #5044