### PR TITLE
feat(management): expose the routing prefix in the auth-files listing

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -251,6 +251,9 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				if projectID := strings.TrimSpace(gjson.GetBytes(data, "project_id").String()); projectID != "" {
 					fileData["project_id"] = projectID
 				}
+				if prefix := strings.TrimSpace(gjson.GetBytes(data, "prefix").String()); prefix != "" {
+					fileData["prefix"] = prefix
+				}
 				if pv := gjson.GetBytes(data, "priority"); pv.Exists() {
 					switch pv.Type {
 					case gjson.Number:
@@ -353,6 +356,11 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	}
 	if projectID := authProjectID(auth); projectID != "" {
 		entry["project_id"] = projectID
+	}
+	// Routing prefix, so the console can show which credential a prefixed
+	// request reaches without downloading the whole credential file.
+	if prefix := strings.TrimSpace(auth.Prefix); prefix != "" {
+		entry["prefix"] = prefix
 	}
 	if accountType, account := auth.AccountInfo(); accountType != "" || account != "" {
 		if accountType != "" {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -17,6 +17,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -251,7 +252,7 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				if projectID := strings.TrimSpace(gjson.GetBytes(data, "project_id").String()); projectID != "" {
 					fileData["project_id"] = projectID
 				}
-				if prefix := strings.TrimSpace(gjson.GetBytes(data, "prefix").String()); prefix != "" {
+				if prefix := synthesizer.NormalizeCredentialPrefix(gjson.GetBytes(data, "prefix").String()); prefix != "" {
 					fileData["prefix"] = prefix
 				}
 				if pv := gjson.GetBytes(data, "priority"); pv.Exists() {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -71,6 +71,25 @@ func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) ([]
 	return synthesizeFileAuths(ctx, fullPath, data)
 }
 
+// NormalizeCredentialPrefix reduces a raw `prefix` field to the value routing
+// actually uses, or an empty string when the credential carries no usable
+// prefix.
+//
+// Surrounding slashes are stripped, so `/team/` and `team` address the same
+// credential. A prefix with an interior slash is rejected rather than repaired:
+// it would be ambiguous against the `prefix/model` split, and a credential
+// carrying one is not reachable by prefix at all.
+//
+// Exported because the management API reports this field, and a second copy of
+// the rule would drift from the routing it is meant to describe.
+func NormalizeCredentialPrefix(raw string) string {
+	trimmed := strings.Trim(strings.TrimSpace(raw), "/")
+	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return ""
+	}
+	return trimmed
+}
+
 func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) ([]*coreauth.Auth, error) {
 	if ctx == nil || len(data) == 0 {
 		return nil, nil
@@ -165,11 +184,7 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) ([
 
 	prefix := ""
 	if rawPrefix, ok := metadata["prefix"].(string); ok {
-		trimmed := strings.TrimSpace(rawPrefix)
-		trimmed = strings.Trim(trimmed, "/")
-		if trimmed != "" && !strings.Contains(trimmed, "/") {
-			prefix = trimmed
-		}
+		prefix = NormalizeCredentialPrefix(rawPrefix)
 	}
 
 	disabled, _ := metadata["disabled"].(bool)

--- a/internal/watcher/synthesizer/prefix_test.go
+++ b/internal/watcher/synthesizer/prefix_test.go
@@ -1,0 +1,30 @@
+package synthesizer
+
+import "testing"
+
+// The management API reports this value, so it must agree with what routing
+// uses; the cases below are the ones where a naive trim would disagree.
+func TestNormalizeCredentialPrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "team", "team"},
+		{"surrounding whitespace", "  team  ", "team"},
+		{"surrounding slashes", "/team/", "team"},
+		{"whitespace and slashes", "  /team/  ", "team"},
+		{"interior slash is rejected", "team/sub", ""},
+		{"interior slash after trimming", "/team/sub/", ""},
+		{"empty", "", ""},
+		{"only whitespace", "   ", ""},
+		{"only slashes", "///", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeCredentialPrefix(tc.in); got != tc.want {
+				t.Fatalf("NormalizeCredentialPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`GET /v0/management/auth-files` reports everything needed to identify a
credential except the one field that determines how a request reaches it.

With `force-model-prefix` enabled, `personal/claude-opus-5` and
`ag/gemini-3.5-flash` are answered by different credentials. The console has no
way to show which card owns which prefix, because the only way to read it today
is `GET /auth-files/:name` and parsing the raw credential — which pulls the
access and refresh tokens into the browser. That is fine for a details sheet the
user opened deliberately; it is not fine for a listing that renders every
credential on page load.

Both branches of the handler are covered: the in-memory one reads `auth.Prefix`,
the directory-scan fallback reads `prefix` from the file with `gjson`, mirroring
how `project_id` is already handled a few lines above. The field is omitted when
empty, so existing consumers see no change.

The console side is a separate PR against
`router-for-me/Cli-Proxy-API-Management-Center`, and it degrades cleanly on
servers that do not send the field.

## Testing

- `gofmt` clean, `go build ./cmd/server` OK, `go test ./internal/api/handlers/management/...` passes.
- Built from `v7.2.142` with only this change and run against a copy of a real
  auth dir: the listing reports `prefix` for the credentials that set one and
  omits it for the rest, and `GET /v1/models` returns a byte-identical model list
  (83 models across 5 prefixes), confirming routing is untouched.
