### PR TITLE
fix(home): map user limit errors to HTTP status codes 🤖🤖🤖

### DIFF
--- a/sdk/cliproxy/auth/home_concurrency.go
+++ b/sdk/cliproxy/auth/home_concurrency.go
@@ -253,6 +253,10 @@ func decodeHomeDispatchError(raw []byte) error {
 	case "credential_concurrency_exceeded", "credential_model_concurrency_exceeded":
 		result.HTTPStatus = http.StatusTooManyRequests
 		return newHomeConcurrencyBusyError(result, time.Duration(detail.RetryAfterMS)*time.Millisecond)
+	case "user_credits_insufficient":
+		result.HTTPStatus = http.StatusPaymentRequired
+	case "user_period_limit_exceeded":
+		result.HTTPStatus = http.StatusTooManyRequests
 	case "auth_not_found", "auth_unavailable", "refresh_temporarily_unavailable", "home_unavailable",
 		"concurrency_protocol_required", "concurrency_tracker_unavailable", "concurrency_node_unavailable":
 		result.HTTPStatus = http.StatusServiceUnavailable

--- a/sdk/cliproxy/auth/home_concurrency_test.go
+++ b/sdk/cliproxy/auth/home_concurrency_test.go
@@ -396,6 +396,25 @@ func TestHomeNoCandidateErrorsMapToServiceUnavailable(t *testing.T) {
 	}
 }
 
+func TestHomeUserLimitErrorsMapToExpectedStatus(t *testing.T) {
+	tests := []struct {
+		code       string
+		wantStatus int
+	}{
+		{code: "user_credits_insufficient", wantStatus: http.StatusPaymentRequired},
+		{code: "user_period_limit_exceeded", wantStatus: http.StatusTooManyRequests},
+	}
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			errDispatch := decodeHomeDispatchError([]byte(fmt.Sprintf(`{"error":{"type":%q,"message":"limit reached"}}`, test.code)))
+			var authErr *Error
+			if !errors.As(errDispatch, &authErr) || authErr.Code != test.code || authErr.HTTPStatus != test.wantStatus {
+				t.Fatalf("decodeHomeDispatchError(%s) = %#v, want status %d", test.code, errDispatch, test.wantStatus)
+			}
+		})
+	}
+}
+
 func TestHomeConcurrencyTupleAuthMismatchEndsScope(t *testing.T) {
 	dispatcher := &fixtureHomeDispatcher{payload: []byte(`{"concurrency":{"accounted":true,"credential_id":"cred-1","model":"gpt"},"auth_index":"other","auth":{"id":"cred-1","provider":"codex"}}`)}
 	manager := newHomeSelectionTestManager(t, dispatcher)


### PR DESCRIPTION
## Summary

- Map Home's `user_credits_insufficient` error to HTTP 402 (`Payment Required`).
- Map Home's `user_period_limit_exceeded` error to HTTP 429 (`Too Many Requests`).
- Add table-driven coverage for both mappings.

Home already returns these structured error codes, but `decodeHomeDispatchError` fell through to its default 502 response. This preserves the upstream error code/message while returning the status downstream clients can act on.

Closes #5170

## Verification

- Reviewed the existing status mapping in `decodeHomeDispatchError` and the issue's proposed cases.
- Added tests for both error codes and expected statuses.
- `git diff --check` passed.
- The Go toolchain is not installed in this environment, so `gofmt`, `go test ./...`, and `go build -o test-output ./cmd/server` could not be run locally. The patch follows the surrounding gofmt style and is scoped to the existing Home error decoder plus its unit test; repository CI should provide the full Go validation.

## AI assistance disclosure

AI assistance was used for the complete two-file patch and for drafting this description. I reviewed the issue, the repository's contribution guidance, the current decoder, and nearby tests independently. This change is based on a real failure mode in the CLIProxyAPI Home-mode topology I use. No credentials, private configuration, or copied private material is included.
