### PR TITLE
fix(aistudio): normalize thinking levels for upstream requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ PackyCode provides special discounts for our software users: register using <a h
 - Multiple accounts with round-robin load balancing (Gemini, OpenAI, Claude, Grok)
 - Simple CLI authentication flows (Gemini, OpenAI, Claude, Grok)
 - Generative Language API Key support
-- AI Studio Build multi-account load balancing
+- AI Studio Build multi-account load balancing, with Gemini thinking levels normalized to the canonical enum casing required by the Google AI Studio upstream
 - Claude Code multi-account load balancing
 - OpenAI Codex multi-account load balancing
 - Grok Build multi-account load balancing

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -473,6 +473,8 @@ func (e *AIStudioExecutor) translateRequest(ctx context.Context, req cliproxyexe
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	payload = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", payload, originalTranslated, requestedModel, requestPath, opts.Headers)
+	// AI Studio requires canonical Google enum casing; keep shared Gemini translation unchanged.
+	payload = normalizeAIStudioThinkingLevel(payload)
 	payload, _ = sjson.DeleteBytes(payload, "generationConfig.maxOutputTokens")
 	payload, _ = sjson.DeleteBytes(payload, "generationConfig.responseMimeType")
 	payload, _ = sjson.DeleteBytes(payload, "generationConfig.responseJsonSchema")
@@ -489,6 +491,30 @@ func (e *AIStudioExecutor) translateRequest(ctx context.Context, req cliproxyexe
 	payload, _ = sjson.DeleteBytes(payload, "session_id")
 	payload = helps.EnsureGeminiLeadingUserContent(payload, "contents")
 	return payload, translatedPayload{payload: payload, action: action, toFormat: to}, nil
+}
+
+func normalizeAIStudioThinkingLevel(payload []byte) []byte {
+	const path = "generationConfig.thinkingConfig.thinkingLevel"
+	level := gjson.GetBytes(payload, path)
+	if level.Type != gjson.String {
+		return payload
+	}
+
+	normalized := strings.ToUpper(level.String())
+	switch normalized {
+	case "MINIMAL", "LOW", "MEDIUM", "HIGH":
+	default:
+		return payload
+	}
+	if normalized == level.String() {
+		return payload
+	}
+
+	result, err := sjson.SetBytes(payload, path, normalized)
+	if err != nil {
+		return payload
+	}
+	return result
 }
 
 func (e *AIStudioExecutor) buildEndpoint(model, action, alt string) string {

--- a/internal/runtime/executor/aistudio_executor_test.go
+++ b/internal/runtime/executor/aistudio_executor_test.go
@@ -39,6 +39,89 @@ func TestAIStudioTranslateRequestPreservesSummaryFromOriginalRequest(t *testing.
 	}
 }
 
+func TestAIStudioTranslateRequestNormalizesThinkingLevel(t *testing.T) {
+	executor := NewAIStudioExecutor(&config.Config{}, "aistudio", nil)
+	req := cliproxyexecutor.Request{
+		Model: "gemini-3.7-flash",
+		Payload: []byte(`{
+			"contents":[{"role":"user","parts":[{"text":"Human: Hi"}]}],
+			"model":"gemini-3.7-flash",
+			"generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":true}},
+			"safetySettings":[
+				{"category":"HARM_CATEGORY_HARASSMENT","threshold":"OFF"},
+				{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"OFF"},
+				{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"OFF"},
+				{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"OFF"},
+				{"category":"HARM_CATEGORY_CIVIC_INTEGRITY","threshold":"BLOCK_NONE"}
+			]
+		}`),
+	}
+
+	_, body, err := executor.translateRequest(context.Background(), req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}, false)
+	if err != nil {
+		t.Fatalf("translateRequest() error = %v", err)
+	}
+	if got := gjson.GetBytes(body.payload, "generationConfig.thinkingConfig.thinkingLevel").String(); got != "HIGH" {
+		t.Fatalf("thinkingLevel = %q, want HIGH; payload=%s", got, body.payload)
+	}
+	if !gjson.GetBytes(body.payload, "generationConfig.thinkingConfig.includeThoughts").Bool() {
+		t.Fatalf("includeThoughts was lost: %s", body.payload)
+	}
+}
+
+func TestAIStudioTranslateRequestNormalizesThinkingLevelAfterPayloadOverride(t *testing.T) {
+	executor := NewAIStudioExecutor(&config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+		Models: []config.PayloadModelRule{{Name: "gemini-3.7-flash", Protocol: "gemini"}},
+		Params: map[string]any{"generationConfig.thinkingConfig.thinkingLevel": "medium"},
+	}}}}, "aistudio", nil)
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"model":"gemini-3.7-flash"}`),
+	}
+
+	_, body, err := executor.translateRequest(context.Background(), req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}, false)
+	if err != nil {
+		t.Fatalf("translateRequest() error = %v", err)
+	}
+	if got := gjson.GetBytes(body.payload, "generationConfig.thinkingConfig.thinkingLevel").String(); got != "MEDIUM" {
+		t.Fatalf("thinkingLevel = %q, want MEDIUM; payload=%s", got, body.payload)
+	}
+}
+
+func TestNormalizeAIStudioThinkingLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		levelJSON string
+		want      string
+		unchanged bool
+	}{
+		{name: "minimal", levelJSON: `"minimal"`, want: "MINIMAL"},
+		{name: "low", levelJSON: `"low"`, want: "LOW"},
+		{name: "medium", levelJSON: `"medium"`, want: "MEDIUM"},
+		{name: "mixed case high", levelJSON: `"hIgH"`, want: "HIGH"},
+		{name: "already uppercase", levelJSON: `"HIGH"`, want: "HIGH", unchanged: true},
+		{name: "none", levelJSON: `"none"`, want: "none", unchanged: true},
+		{name: "xhigh", levelJSON: `"xhigh"`, want: "xhigh", unchanged: true},
+		{name: "max", levelJSON: `"max"`, want: "max", unchanged: true},
+		{name: "custom", levelJSON: `"custom"`, want: "custom", unchanged: true},
+		{name: "non-string", levelJSON: `1`, want: "1", unchanged: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := []byte(fmt.Sprintf(`{"generationConfig":{"thinkingConfig":{"thinkingLevel":%s}},"marker":true}`, test.levelJSON))
+			output := normalizeAIStudioThinkingLevel(input)
+			level := gjson.GetBytes(output, "generationConfig.thinkingConfig.thinkingLevel")
+			if got := level.String(); got != test.want {
+				t.Fatalf("thinkingLevel = %q, want %q; payload=%s", got, test.want, output)
+			}
+			if test.unchanged && string(output) != string(input) {
+				t.Fatalf("payload changed from %s to %s", input, output)
+			}
+		})
+	}
+}
+
 func TestAIStudioTranslateRequestPrependsLeadingUserForIssue4959ResponsesHistory(t *testing.T) {
 	executor := NewAIStudioExecutor(&config.Config{}, "aistudio", nil)
 	_, body, err := executor.translateRequest(context.Background(), cliproxyexecutor.Request{


### PR DESCRIPTION
## Problem

When CPA routes a Gemini request through the AI Studio provider, the shared Gemini thinking pipeline can emit lowercase `generationConfig.thinkingConfig.thinkingLevel` values. The AI Studio upstream validates this field case-sensitively and can return:

```text
400 Request contains an invalid argument
```

For example, this representative `gemini-3.7-flash` payload fails when routed through AI Studio:

```json
{
  "contents": [
    {
      "role": "user",
      "parts": [
        {
          "text": "Human: Hi"
        }
      ]
    }
  ],
  "model": "gemini-3.7-flash",
  "generationConfig": {
    "thinkingConfig": {
      "thinkingLevel": "high",
      "includeThoughts": true
    }
  },
  "safetySettings": [
    {
      "category": "HARM_CATEGORY_HARASSMENT",
      "threshold": "OFF"
    },
    {
      "category": "HARM_CATEGORY_HATE_SPEECH",
      "threshold": "OFF"
    },
    {
      "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
      "threshold": "OFF"
    },
    {
      "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
      "threshold": "OFF"
    },
    {
      "category": "HARM_CATEGORY_CIVIC_INTEGRITY",
      "threshold": "BLOCK_NONE"
    }
  ]
}
```

Changing `high` to `HIGH` makes the request succeed. The same AI Studio casing discrepancy has been independently reported for `low`, `medium`, and `high`.

Google's [API reference](https://ai.google.dev/api/generate-content#ThinkingLevel), live [v1beta Discovery schema](https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta), and generated [Go SDK constants](https://github.com/googleapis/go-genai/blob/main/types.go#L2561-L2584) define the canonical enum values as uppercase. The [AI Studio reproduction](https://discuss.ai.google.dev/t/bug-report-discrepancy-in-thinkinglevel-parameter-case-sensitivity-google-ai-studio-vs-production-api/113466) also documents lowercase values being rejected while uppercase values succeed.

## Change

Normalize recognized thinking levels at the final AI Studio outbound boundary, after payload rules have been applied:

- `minimal` → `MINIMAL`
- `low` → `LOW`
- `medium` → `MEDIUM`
- `high` → `HIGH`

`MINIMAL` is included because it is part of Google's enum and is supported by some Gemini models; this change does not alter model capability rules. Unknown values and non-string inputs remain untouched.

The shared Gemini translator and applier are unchanged, so ordinary Gemini and Gemini-compatible request paths retain their existing behavior.

## Verification

```sh
go test ./internal/runtime/executor -run 'Test(AIStudio|NormalizeAIStudio)' -count=1
go test ./internal/runtime/executor -count=1
go test ./...
go build -o test-output ./cmd/server && rm test-output
gofmt -l internal/runtime/executor/aistudio_executor.go internal/runtime/executor/aistudio_executor_test.go
git diff --check
```

Coverage verifies:

- The reported `gemini-3.7-flash` payload produces `HIGH` while preserving `includeThoughts`.
- Payload overrides are normalized before dispatch.
- `MINIMAL`, `LOW`, `MEDIUM`, and `HIGH` use canonical casing.
- Already canonical values remain unchanged.
- Unsupported, custom, and non-string values are not rewritten.
