### PR TITLE
fix(translator): skip truncated/corrupt PNG in Claude→Codex

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -6,7 +6,9 @@
 package claude
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strconv"
@@ -196,11 +198,12 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 								if mediaType == "" {
 									mediaType = sourceResult.Get("mime_type").String()
 								}
-								if mediaType == "" {
-									mediaType = "application/octet-stream"
+								dataURL, corrupt := sanitizeImageData(mediaType, data)
+								if corrupt {
+									appendTextContent(corruptImagePlaceholder)
+								} else {
+									appendImageContent(dataURL)
 								}
-								dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
-								appendImageContent(dataURL)
 							}
 						}
 					case "document":
@@ -257,14 +260,16 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 											if mediaType == "" {
 												mediaType = sourceResult.Get("mime_type").String()
 											}
-											if mediaType == "" {
-												mediaType = "application/octet-stream"
+											dataURL, corrupt := sanitizeImageData(mediaType, data)
+											if corrupt {
+												toolResultContent := []byte(`{"type":"input_text","text":""}`)
+												toolResultContent, _ = sjson.SetBytes(toolResultContent, "text", corruptImagePlaceholder)
+												toolResultContentItems = append(toolResultContentItems, toolResultContent)
+											} else {
+												toolResultContent := []byte(`{"type":"input_image","image_url":""}`)
+												toolResultContent, _ = sjson.SetBytes(toolResultContent, "image_url", dataURL)
+												toolResultContentItems = append(toolResultContentItems, toolResultContent)
 											}
-											dataURL := fmt.Sprintf("data:%s;base64,%s", mediaType, data)
-
-											toolResultContent := []byte(`{"type":"input_image","image_url":""}`)
-											toolResultContent, _ = sjson.SetBytes(toolResultContent, "image_url", dataURL)
-											toolResultContentItems = append(toolResultContentItems, toolResultContent)
 										}
 									}
 								} else if toolResultContentType == "text" {
@@ -638,4 +643,54 @@ func normalizeToolParameters(raw string) string {
 		schema, _ = sjson.SetRawBytes(schema, "properties", []byte(`{}`))
 	}
 	return string(schema)
+}
+
+const corruptImagePlaceholder = "[image data truncated or corrupt; skipped]"
+
+// sanitizeImageData validates base64 image payload integrity. Truncated or
+// corrupt images (for example a screenshot written before IEND was flushed)
+// are rejected so callers can emit a text placeholder instead of forwarding
+// a bad data URL that some upstreams reject with 400 (e.g. Grok "Invalid PNG image").
+func sanitizeImageData(mediaType, data string) (safeDataURL string, corrupt bool) {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return "", true
+	}
+	raw, err := decodeImageBase64(data)
+	if err != nil {
+		return "", true
+	}
+	if len(raw) < 8 {
+		return "", true
+	}
+	isPNG := strings.Contains(strings.ToLower(mediaType), "png") || bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n"))
+	if isPNG && !pngHasIEND(raw) {
+		return "", true
+	}
+	if mediaType == "" {
+		mediaType = "application/octet-stream"
+	}
+	return fmt.Sprintf("data:%s;base64,%s", mediaType, data), false
+}
+
+func decodeImageBase64(data string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(data)
+	if err == nil {
+		return raw, nil
+	}
+	return base64.RawStdEncoding.DecodeString(strings.TrimRight(data, "="))
+}
+
+// pngHasIEND looks for an IEND chunk only near the file tail. Searching the
+// whole buffer with Contains can treat coincidental "IEND" bytes inside IDAT
+// as a complete image; a well-formed PNG ends with a 12-byte IEND chunk.
+func pngHasIEND(raw []byte) bool {
+	if len(raw) < 12 {
+		return false
+	}
+	tail := raw
+	if len(raw) > 24 {
+		tail = raw[len(raw)-24:]
+	}
+	return bytes.Contains(tail, []byte("IEND"))
 }

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1,7 +1,9 @@
 package claude
 
 import (
+	"bytes"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -561,7 +563,7 @@ func TestConvertClaudeRequestToCodex_PreservesContentOrderAcrossToolAndReasoning
 			{"role":"user","content":[
 				{"type":"tool_result","tool_use_id":"toolu_1","content":[
 					{"type":"text","text":"tool output"},
-					{"type":"image","source":{"media_type":"image/png","data":"aW1hZ2U="}}
+					{"type":"image","source":{"media_type":"image/png","data":"` + validPNG1x1Base64 + `"}}
 				]},
 				{"type":"text","text":"continue"}
 			]}
@@ -594,7 +596,7 @@ func TestConvertClaudeRequestToCodex_PreservesContentOrderAcrossToolAndReasoning
 	if got := inputs[6].Get("output.0.type").String(); got != "input_text" {
 		t.Fatalf("tool result output.0.type = %q, want input_text", got)
 	}
-	if got := inputs[6].Get("output.1.image_url").String(); got != "data:image/png;base64,aW1hZ2U=" {
+	if got := inputs[6].Get("output.1.image_url").String(); got != "data:image/png;base64,"+validPNG1x1Base64 {
 		t.Fatalf("tool result image_url = %q, want data URL", got)
 	}
 	if got := inputs[7].Get("content.0.text").String(); got != "continue" {
@@ -817,4 +819,65 @@ func TestConvertClaudeRequestToCodex_OutputConfigFormat(t *testing.T) {
 			t.Errorf("expected reasoning.effort to be 'high', got %q", got)
 		}
 	})
+}
+
+// Tiny valid 1x1 PNG (includes trailing IEND).
+const validPNG1x1Base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+// Same idea as a screenshot flushed before IEND was written.
+const corruptPNGMissingIENDBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9aw=="
+
+func TestConvertClaudeRequestToCodex_SanitizesCorruptedPNG(t *testing.T) {
+	translated := ConvertClaudeRequestToCodex("grok-4.6", claudePNGPayload(corruptPNGMissingIENDBase64), false)
+	content := string(translated)
+	if strings.Contains(content, "input_image") {
+		t.Fatalf("expected corrupted PNG to be skipped, but got input_image in payload: %s", content)
+	}
+	if !strings.Contains(content, corruptImagePlaceholder) {
+		t.Fatalf("expected placeholder for corrupted PNG, but got: %s", content)
+	}
+}
+
+func TestConvertClaudeRequestToCodex_KeepsValidPNG(t *testing.T) {
+	translated := ConvertClaudeRequestToCodex("grok-4.6", claudePNGPayload(validPNG1x1Base64), false)
+	content := string(translated)
+	if !strings.Contains(content, "input_image") {
+		t.Fatalf("expected valid PNG to stay input_image, got: %s", content)
+	}
+	if strings.Contains(content, corruptImagePlaceholder) {
+		t.Fatalf("valid PNG must not be treated as corrupt: %s", content)
+	}
+
+	unpadded := strings.TrimRight(validPNG1x1Base64, "=")
+	url, corrupt := sanitizeImageData("image/png", unpadded)
+	if corrupt || !strings.Contains(url, "data:image/png;base64,") {
+		t.Fatalf("unpadded valid PNG must pass, url=%q corrupt=%v", url, corrupt)
+	}
+}
+
+func TestPngHasIEND_LooksAtTailOnly(t *testing.T) {
+	fake := append([]byte("\x89PNG\r\n\x1a\nIEND"), bytes.Repeat([]byte{0x00}, 32)...)
+	if pngHasIEND(fake) {
+		t.Fatal("IEND in the middle of a truncated PNG must not count")
+	}
+	complete := append([]byte("\x89PNG\r\n\x1a\n"), []byte{0, 0, 0, 0, 'I', 'E', 'N', 'D', 0xae, 0x42, 0x60, 0x82}...)
+	if !pngHasIEND(complete) {
+		t.Fatal("canonical trailing IEND chunk must count")
+	}
+}
+
+func claudePNGPayload(data string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"messages":[
+			{
+				"role":"user",
+				"content":[
+					{
+						"type":"image",
+						"source":{"type":"base64","media_type":"image/png","data":"%s"}
+					}
+				]
+			}
+		]
+	}`, data))
 }


### PR DESCRIPTION
## Problem

Truncated or corrupt PNG payloads (missing IEND, illegal base64) were still assembled into `data:` URLs and forwarded to Grok/Codex, which then 400d.

## Change

In the Claude→Codex translator, skip truncated/corrupt images instead of emitting `input_image`:

- `sanitizeImageData` / `decodeImageBase64` / `pngHasIEND` (only inspects the last ~24 bytes)
- Wired for message `image` and `tool_result` image
- On damage, emit `[image data truncated or corrupt; skipped]` as `input_text`

Based on official `dev`. No Aster session self-heal.

## Tests

`go test -count=1 ./internal/translator/codex/claude/`
`go build ./cmd/server`

- PNG missing IEND → no `input_image`, placeholder text
- Valid 1×1 PNG still `input_image`
- Valid PNG base64 without padding still accepted
- A mid-stream `IEND` substring is not treated as complete
