### PR TITLE
feat(alias): support wildcard patterns in oauth-model-alias

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -695,12 +695,12 @@ nonstream-keepalive-interval: 0
 # unique aliases/prefixes or avoid overlapping names.
 # You can repeat the same name with different aliases to expose multiple client model names.
 # An alias may contain '*', which matches zero or more characters (case-insensitive).
-# Wildcard aliases are routing-only: they are never listed in /v1/models, because a
-# pattern is not a model id, so `fork` has no effect on a wildcard entry. A matching
-# request is routed to whatever catalog entry the upstream model currently has: its
-# own id, or the exact alias that replaced it when the same name is also mapped
-# without `fork`. Exact aliases always win; wildcards are consulted only when no
-# exact alias matched, and the first matching pattern is used.
+# Wildcard aliases are routing-only: the pattern itself is never listed in /v1/models,
+# because a pattern is not a model id, so `fork` has no effect on a wildcard entry.
+# The model a wildcard targets always keeps its own catalog entry, even when the same
+# name is also mapped to an exact alias without `fork`, because routing resolves the
+# pattern to that upstream id. Exact aliases always win; wildcards are consulted only
+# when no exact alias matched, and the first matching pattern is used.
 # This is useful for clients that send dated model ids, for example:
 #   - name: "gpt-5.6-luna"
 #     alias: "claude-haiku-4-5-*"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -696,12 +696,18 @@ nonstream-keepalive-interval: 0
 # You can repeat the same name with different aliases to expose multiple client model names.
 # An alias may contain '*', which matches zero or more characters (case-insensitive).
 # Wildcard aliases are routing-only: they are never listed in /v1/models, because a
-# pattern is not a model id, and the upstream model keeps its own catalog entry (so
-# `fork` has no effect on a wildcard entry). Exact aliases always win; wildcards are
-# consulted only when no exact alias matched, and the first matching pattern is used.
+# pattern is not a model id, so `fork` has no effect on a wildcard entry. A matching
+# request is routed to whatever catalog entry the upstream model currently has: its
+# own id, or the exact alias that replaced it when the same name is also mapped
+# without `fork`. Exact aliases always win; wildcards are consulted only when no
+# exact alias matched, and the first matching pattern is used.
 # This is useful for clients that send dated model ids, for example:
 #   - name: "gpt-5.6-luna"
 #     alias: "claude-haiku-4-5-*"
+# Wildcards must be declared here, in the global configuration: only these entries
+# make a matching model routable. A wildcard placed in an auth file's "model_aliases"
+# resolves after a credential is selected but is not enough on its own, so it is
+# reported with a warning at load time.
 # Optional per-entry fields:
 #   fork: true                  # keep the upstream model and also expose the alias as a separate client-visible model
 #   display-name: "Model Name" # override the human-readable name shown in model catalogs

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -694,6 +694,14 @@ nonstream-keepalive-interval: 0
 # client-visible names can become ambiguous across providers. For strict backend pinning, use
 # unique aliases/prefixes or avoid overlapping names.
 # You can repeat the same name with different aliases to expose multiple client model names.
+# An alias may contain '*', which matches zero or more characters (case-insensitive).
+# Wildcard aliases are routing-only: they are never listed in /v1/models, because a
+# pattern is not a model id, and the upstream model keeps its own catalog entry (so
+# `fork` has no effect on a wildcard entry). Exact aliases always win; wildcards are
+# consulted only when no exact alias matched, and the first matching pattern is used.
+# This is useful for clients that send dated model ids, for example:
+#   - name: "gpt-5.6-luna"
+#     alias: "claude-haiku-4-5-*"
 # Optional per-entry fields:
 #   fork: true                  # keep the upstream model and also expose the alias as a separate client-visible model
 #   display-name: "Model Name" # override the human-readable name shown in model catalogs

--- a/internal/registry/model_alias_pattern.go
+++ b/internal/registry/model_alias_pattern.go
@@ -1,0 +1,112 @@
+package registry
+
+import "strings"
+
+// ModelAliasPattern maps a wildcard client-visible model pattern to the upstream
+// model that serves it.
+//
+// Patterns are routing hints only. They are deliberately never registered as
+// models, because a pattern is not a model id and must not surface in the model
+// catalog. Provider lookups fall back to them only after an exact model id misses.
+type ModelAliasPattern struct {
+	// Pattern is the client-visible alias pattern, for example "claude-haiku-4-5-*".
+	Pattern string
+	// Target is the upstream model id the pattern resolves to.
+	Target string
+}
+
+// MatchModelPattern reports whether value matches pattern, where '*' matches zero
+// or more characters. A pattern without '*' compares for equality.
+//
+// Matching is case-insensitive to line up with the model id comparisons used
+// elsewhere in the registry and with OAuth model alias resolution.
+func MatchModelPattern(pattern, value string) bool {
+	pattern = strings.TrimSpace(pattern)
+	value = strings.TrimSpace(value)
+	if pattern == "" {
+		return false
+	}
+	if !strings.Contains(pattern, "*") {
+		return strings.EqualFold(pattern, value)
+	}
+
+	pattern = strings.ToLower(pattern)
+	value = strings.ToLower(value)
+	parts := strings.Split(pattern, "*")
+
+	if prefix := parts[0]; prefix != "" {
+		if !strings.HasPrefix(value, prefix) {
+			return false
+		}
+		value = value[len(prefix):]
+	}
+	if suffix := parts[len(parts)-1]; suffix != "" {
+		if !strings.HasSuffix(value, suffix) {
+			return false
+		}
+		value = value[:len(value)-len(suffix)]
+	}
+	for i := 1; i < len(parts)-1; i++ {
+		segment := parts[i]
+		if segment == "" {
+			continue
+		}
+		idx := strings.Index(value, segment)
+		if idx < 0 {
+			return false
+		}
+		value = value[idx+len(segment):]
+	}
+
+	return true
+}
+
+// SetModelAliasPatterns replaces the routing-only alias patterns consulted when an
+// exact model id lookup finds no provider. Entries without a pattern or a target
+// are dropped. Order is preserved: the first matching pattern wins.
+func (r *ModelRegistry) SetModelAliasPatterns(patterns []ModelAliasPattern) {
+	if r == nil {
+		return
+	}
+
+	clean := make([]ModelAliasPattern, 0, len(patterns))
+	for _, entry := range patterns {
+		pattern := strings.TrimSpace(entry.Pattern)
+		target := strings.TrimSpace(entry.Target)
+		if pattern == "" || target == "" {
+			continue
+		}
+		if !strings.Contains(pattern, "*") {
+			continue
+		}
+		clean = append(clean, ModelAliasPattern{Pattern: pattern, Target: target})
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if len(clean) == 0 {
+		r.modelAliasPatterns = nil
+		return
+	}
+	r.modelAliasPatterns = clean
+}
+
+// resolveModelAliasPatternLocked returns the target model for the first alias
+// pattern matching modelID, or an empty string when nothing matches.
+//
+// Callers must hold at least a read lock on the registry mutex.
+func (r *ModelRegistry) resolveModelAliasPatternLocked(modelID string) string {
+	if r == nil || len(r.modelAliasPatterns) == 0 {
+		return ""
+	}
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return ""
+	}
+	for _, entry := range r.modelAliasPatterns {
+		if MatchModelPattern(entry.Pattern, modelID) {
+			return entry.Target
+		}
+	}
+	return ""
+}

--- a/internal/registry/model_alias_pattern.go
+++ b/internal/registry/model_alias_pattern.go
@@ -110,3 +110,31 @@ func (r *ModelRegistry) resolveModelAliasPatternLocked(modelID string) string {
 	}
 	return ""
 }
+
+// modelRegistrationForTargetLocked resolves an alias pattern target to its
+// registration.
+//
+// Registered model ids keep the casing their client supplied, while a pattern
+// target comes from configuration. An exact lookup is tried first and a
+// case-insensitive scan only backs it up, so wildcard routing stays consistent
+// with the case-insensitive matching used everywhere else on the alias path.
+//
+// Callers must hold at least a read lock on the registry mutex.
+func (r *ModelRegistry) modelRegistrationForTargetLocked(target string) *ModelRegistration {
+	target = strings.TrimSpace(target)
+	if r == nil || target == "" {
+		return nil
+	}
+	if registration, exists := r.models[target]; exists && registration != nil {
+		return registration
+	}
+	for modelID, registration := range r.models {
+		if registration == nil {
+			continue
+		}
+		if strings.EqualFold(modelID, target) {
+			return registration
+		}
+	}
+	return nil
+}

--- a/internal/registry/model_alias_pattern_test.go
+++ b/internal/registry/model_alias_pattern_test.go
@@ -1,0 +1,106 @@
+package registry
+
+import "testing"
+
+func TestMatchModelPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		want    bool
+	}{
+		{"exact match without wildcard", "gpt-5.6-luna", "gpt-5.6-luna", true},
+		{"exact mismatch without wildcard", "gpt-5.6-luna", "gpt-5.6-sol", false},
+		{"exact match is case insensitive", "GPT-5.6-Luna", "gpt-5.6-luna", true},
+		{"trailing wildcard", "claude-haiku-4-5-*", "claude-haiku-4-5-20251001", true},
+		{"trailing wildcard is case insensitive", "Claude-Haiku-4-5-*", "CLAUDE-HAIKU-4-5-20251001", true},
+		{"trailing wildcard requires the prefix", "claude-haiku-4-5-*", "claude-haiku-4-5", false},
+		{"trailing wildcard matches empty remainder", "claude-haiku-4-5*", "claude-haiku-4-5", true},
+		{"leading wildcard", "*-20251001", "claude-haiku-4-5-20251001", true},
+		{"middle wildcard", "claude-*-20251001", "claude-haiku-4-5-20251001", true},
+		{"middle wildcard mismatch", "claude-*-20260101", "claude-haiku-4-5-20251001", false},
+		{"bare wildcard matches anything", "*", "anything", true},
+		{"unrelated model", "claude-haiku-4-5-*", "gpt-5.6-sol", false},
+		{"empty pattern never matches", "", "gpt-5.6-sol", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := MatchModelPattern(tc.pattern, tc.value); got != tc.want {
+				t.Errorf("MatchModelPattern(%q, %q) = %v, want %v", tc.pattern, tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetModelAliasPatterns_DropsEntriesWithoutWildcard(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "gpt-5.6-luna"},
+		{Pattern: "claude-opus-5", Target: "gpt-5.6-sol"},
+		{Pattern: "", Target: "gpt-5.6-sol"},
+		{Pattern: "claude-*", Target: ""},
+	})
+
+	if len(r.modelAliasPatterns) != 1 {
+		t.Fatalf("modelAliasPatterns length = %d, want 1", len(r.modelAliasPatterns))
+	}
+	if r.modelAliasPatterns[0].Target != "gpt-5.6-luna" {
+		t.Errorf("kept pattern target = %q, want %q", r.modelAliasPatterns[0].Target, "gpt-5.6-luna")
+	}
+}
+
+func TestGetModelProviders_FallsBackToAliasPattern(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: "gpt-5.6-luna"}})
+
+	// Without a pattern the dated id is unroutable, which is the reported failure.
+	if providers := r.GetModelProviders("claude-haiku-4-5-20251001"); len(providers) != 0 {
+		t.Fatalf("providers before pattern = %v, want none", providers)
+	}
+
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "gpt-5.6-luna"},
+	})
+
+	providers := r.GetModelProviders("claude-haiku-4-5-20251001")
+	if len(providers) != 1 || providers[0] != "codex" {
+		t.Fatalf("providers after pattern = %v, want [codex]", providers)
+	}
+}
+
+func TestGetModelProviders_AliasPatternDoesNotShadowRegisteredModel(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	r.RegisterClient("client-2", "claude", []*ModelInfo{{ID: "claude-haiku-4-5-20251001"}})
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "gpt-5.6-luna"},
+	})
+
+	providers := r.GetModelProviders("claude-haiku-4-5-20251001")
+	if len(providers) != 1 || providers[0] != "claude" {
+		t.Fatalf("providers = %v, want [claude] because the exact model is registered", providers)
+	}
+}
+
+func TestGetModelProviders_AliasPatternWithUnregisteredTarget(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "gpt-5.6-luna"},
+	})
+
+	if providers := r.GetModelProviders("claude-haiku-4-5-20251001"); len(providers) != 0 {
+		t.Fatalf("providers = %v, want none when the target is not registered", providers)
+	}
+}

--- a/internal/registry/model_alias_pattern_test.go
+++ b/internal/registry/model_alias_pattern_test.go
@@ -104,3 +104,37 @@ func TestGetModelProviders_AliasPatternWithUnregisteredTarget(t *testing.T) {
 		t.Fatalf("providers = %v, want none when the target is not registered", providers)
 	}
 }
+
+func TestGetModelProviders_AliasPatternTargetIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	// The configured target casing does not have to match the registered model id,
+	// which is how exact aliases already behave.
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "GPT-5.6-LUNA"},
+	})
+
+	providers := r.GetModelProviders("claude-haiku-4-5-20251001")
+	if len(providers) != 1 || providers[0] != "codex" {
+		t.Fatalf("providers = %v, want [codex]", providers)
+	}
+}
+
+func TestGetModelProviders_RegisteredModelIsNotRedirectedByPattern(t *testing.T) {
+	t.Parallel()
+
+	r := newTestModelRegistry()
+	r.RegisterClient("client-1", "codex", []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	// A registered model whose providers have all gone away must report nothing
+	// rather than being rerouted to an unrelated wildcard target.
+	r.models["claude-haiku-4-5-20251001"] = &ModelRegistration{Providers: map[string]int{}}
+	r.SetModelAliasPatterns([]ModelAliasPattern{
+		{Pattern: "claude-haiku-4-5-*", Target: "gpt-5.6-luna"},
+	})
+
+	if providers := r.GetModelProviders("claude-haiku-4-5-20251001"); len(providers) != 0 {
+		t.Fatalf("providers = %v, want none for a registered model with no providers", providers)
+	}
+}

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -1342,17 +1342,23 @@ func (r *ModelRegistry) GetModelProviders(modelID string) []string {
 	defer r.mutex.RUnlock()
 
 	registration, exists := r.models[modelID]
-	if !exists || registration == nil || len(registration.Providers) == 0 {
-		// A wildcard OAuth model alias never registers a model of its own, so fall
-		// back to the pattern table and report the providers of its target model.
+	if !exists || registration == nil {
+		// A wildcard OAuth model alias never registers a model of its own, so an
+		// unknown id falls back to the pattern table and reports the providers of its
+		// target model. A registered id is never redirected this way, not even while
+		// it temporarily has no providers, so the fallback cannot shadow a model the
+		// operator registered on purpose.
 		target := r.resolveModelAliasPatternLocked(modelID)
 		if target == "" {
 			return nil
 		}
-		registration, exists = r.models[target]
-		if !exists || registration == nil || len(registration.Providers) == 0 {
+		registration = r.modelRegistrationForTargetLocked(target)
+		if registration == nil {
 			return nil
 		}
+	}
+	if len(registration.Providers) == 0 {
+		return nil
 	}
 
 	type providerCount struct {

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -159,6 +159,9 @@ type ModelRegistry struct {
 	generation uint64
 	// hook is an optional callback sink for model registration changes
 	hook ModelRegistryHook
+	// modelAliasPatterns holds routing-only wildcard alias patterns consulted when
+	// an exact model id lookup finds no provider. See model_alias_pattern.go.
+	modelAliasPatterns []ModelAliasPattern
 }
 
 // Global model registry instance
@@ -1340,7 +1343,16 @@ func (r *ModelRegistry) GetModelProviders(modelID string) []string {
 
 	registration, exists := r.models[modelID]
 	if !exists || registration == nil || len(registration.Providers) == 0 {
-		return nil
+		// A wildcard OAuth model alias never registers a model of its own, so fall
+		// back to the pattern table and report the providers of its target model.
+		target := r.resolveModelAliasPatternLocked(modelID)
+		if target == "" {
+			return nil
+		}
+		registration, exists = r.models[target]
+		if !exists || registration == nil || len(registration.Providers) == 0 {
+			return nil
+		}
 	}
 
 	type providerCount struct {

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -3,10 +3,12 @@ package auth
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	log "github.com/sirupsen/logrus"
 )
 
 const oauthModelAliasesAttributeKey = "model_aliases"
@@ -347,6 +349,7 @@ func SetOAuthModelAliasesAttribute(auth *Auth, aliases []internalconfig.OAuthMod
 	if len(aliases) == 0 {
 		return
 	}
+	warnUnroutablePerAuthWildcardAliases(auth, aliases)
 	data, errMarshal := json.Marshal(aliases)
 	if errMarshal != nil {
 		return
@@ -425,7 +428,15 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 				} else if !registry.MatchModelPattern(alias, key) {
 					continue
 				}
-				if result, stop := oauthModelAliasResultFor(entry.Name, alias, entry.ForceMapping, requestedModel, baseModel, requestResult); stop {
+				// A wildcard alias is a pattern, not a client-visible model id, so a
+				// force-mapped response must echo the concrete model the client asked
+				// for rather than the configured pattern. The thinking suffix is
+				// dropped the same way an exact alias never carries one.
+				responseAlias := alias
+				if !exactPass {
+					responseAlias = baseModel
+				}
+				if result, stop := oauthModelAliasResultFor(entry.Name, responseAlias, entry.ForceMapping, requestedModel, baseModel, requestResult); stop {
 					return result
 				}
 			}
@@ -495,7 +506,10 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 			if !registry.MatchModelPattern(wildcard.pattern, value) {
 				continue
 			}
-			if result, stop := oauthModelAliasResultFor(wildcard.entry.upstreamModel, wildcard.entry.configAlias, wildcard.entry.forceMapping, requestedModel, baseModel, requestResult); stop {
+			// The configured alias is a pattern here, so a force-mapped response echoes
+			// the concrete requested model instead of the pattern itself. The thinking
+			// suffix is dropped the same way an exact alias never carries one.
+			if result, stop := oauthModelAliasResultFor(wildcard.entry.upstreamModel, baseModel, wildcard.entry.forceMapping, requestedModel, baseModel, requestResult); stop {
 				return result
 			}
 		}
@@ -552,4 +566,39 @@ func normalizeOAuthModelAliasAuthKind(authKind string) string {
 	default:
 		return authKind
 	}
+}
+
+// warnedPerAuthWildcardAliases remembers the pattern list already reported for an
+// auth ID. Auth files are re-synthesized on every watcher event, including the
+// rewrite that follows a token refresh, so without this the warning would repeat on
+// every reload for the lifetime of the process.
+var warnedPerAuthWildcardAliases sync.Map // auth ID -> joined pattern list
+
+// warnUnroutablePerAuthWildcardAliases reports per-auth wildcard aliases that the
+// handler-level provider lookup cannot see.
+//
+// Only the global oauth-model-alias configuration feeds the registry pattern table,
+// so a wildcard declared in an auth file resolves once a credential is selected but
+// never makes the matching model routable on its own. Saying so keeps the gap
+// visible instead of surfacing as an opaque model_not_found.
+func warnUnroutablePerAuthWildcardAliases(auth *Auth, aliases []internalconfig.OAuthModelAlias) {
+	if auth == nil {
+		return
+	}
+	patterns := make([]string, 0, len(aliases))
+	for _, entry := range aliases {
+		alias := strings.TrimSpace(entry.Alias)
+		if alias != "" && strings.Contains(alias, "*") {
+			patterns = append(patterns, alias)
+		}
+	}
+	if len(patterns) == 0 {
+		return
+	}
+	joined := strings.Join(patterns, ",")
+	if previous, reported := warnedPerAuthWildcardAliases.Load(auth.ID); reported && previous == joined {
+		return
+	}
+	warnedPerAuthWildcardAliases.Store(auth.ID, joined)
+	log.Warnf("auth %s: per-auth wildcard model aliases %v are not published for routing; declare them under oauth-model-alias so requests matching the pattern can reach a provider", auth.ID, patterns)
 }

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 )
 
@@ -26,6 +27,16 @@ type oauthModelAliasEntry struct {
 type oauthModelAliasTable struct {
 	// reverse maps channel -> alias (lower) -> entry with upstream model and flags.
 	reverse map[string]map[string]oauthModelAliasEntry
+	// wildcards maps channel -> ordered alias patterns containing '*'. Patterns are
+	// consulted only after the exact lookup misses, so existing configurations that
+	// use plain aliases keep their behaviour unchanged.
+	wildcards map[string][]oauthModelAliasWildcard
+}
+
+// oauthModelAliasWildcard pairs a wildcard alias pattern with the entry it resolves to.
+type oauthModelAliasWildcard struct {
+	pattern string
+	entry   oauthModelAliasEntry
 }
 
 // OAuthModelAliasResult contains the resolved upstream model and mapping metadata.
@@ -40,7 +51,8 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 		return &oauthModelAliasTable{}
 	}
 	out := &oauthModelAliasTable{
-		reverse: make(map[string]map[string]oauthModelAliasEntry, len(aliases)),
+		reverse:   make(map[string]map[string]oauthModelAliasEntry, len(aliases)),
+		wildcards: make(map[string][]oauthModelAliasWildcard, len(aliases)),
 	}
 	for rawChannel, entries := range aliases {
 		channel := strings.ToLower(strings.TrimSpace(rawChannel))
@@ -48,6 +60,8 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 			continue
 		}
 		rev := make(map[string]oauthModelAliasEntry, len(entries))
+		var wild []oauthModelAliasWildcard
+		seenPattern := make(map[string]struct{})
 		for _, entry := range entries {
 			name := strings.TrimSpace(entry.Name)
 			alias := strings.TrimSpace(entry.Alias)
@@ -57,24 +71,70 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 			if strings.EqualFold(name, alias) {
 				continue
 			}
-			aliasKey := strings.ToLower(alias)
-			if _, exists := rev[aliasKey]; exists {
-				continue
-			}
-			rev[aliasKey] = oauthModelAliasEntry{
+			resolved := oauthModelAliasEntry{
 				upstreamModel: name,
 				configAlias:   alias,
 				forceMapping:  entry.ForceMapping,
 			}
+			aliasKey := strings.ToLower(alias)
+			if strings.Contains(alias, "*") {
+				// Wildcard aliases keep configuration order: the first match wins.
+				if _, exists := seenPattern[aliasKey]; exists {
+					continue
+				}
+				seenPattern[aliasKey] = struct{}{}
+				wild = append(wild, oauthModelAliasWildcard{pattern: alias, entry: resolved})
+				continue
+			}
+			if _, exists := rev[aliasKey]; exists {
+				continue
+			}
+			rev[aliasKey] = resolved
 		}
 		if len(rev) > 0 {
 			out.reverse[channel] = rev
+		}
+		if len(wild) > 0 {
+			out.wildcards[channel] = wild
 		}
 	}
 	if len(out.reverse) == 0 {
 		out.reverse = nil
 	}
+	if len(out.wildcards) == 0 {
+		out.wildcards = nil
+	}
 	return out
+}
+
+// oauthModelAliasResultFor builds the alias result for a matched alias entry.
+//
+// The boolean reports whether the match is terminal. A matched alias always stops
+// the search, including the case where it deliberately resolves to no rewrite.
+func oauthModelAliasResultFor(upstreamModel, configAlias string, forceMapping bool, requestedModel, baseModel string, requestResult thinking.SuffixResult) (OAuthModelAliasResult, bool) {
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if upstreamModel == "" {
+		return OAuthModelAliasResult{}, false
+	}
+	if strings.EqualFold(upstreamModel, baseModel) {
+		if !forceMapping {
+			return OAuthModelAliasResult{}, true
+		}
+		return OAuthModelAliasResult{
+			UpstreamModel: preserveResolvedModelSuffix(upstreamModel, requestResult),
+			ForceMapping:  true,
+			OriginalAlias: oauthModelAliasForceMappingResponseModel(configAlias),
+		}, true
+	}
+	originalAlias := requestedModel
+	if forceMapping {
+		originalAlias = oauthModelAliasForceMappingResponseModel(configAlias)
+	}
+	return OAuthModelAliasResult{
+		UpstreamModel: preserveResolvedModelSuffix(upstreamModel, requestResult),
+		ForceMapping:  forceMapping,
+		OriginalAlias: originalAlias,
+	}, true
 }
 
 // SetOAuthModelAlias updates the OAuth model name alias table used during execution.
@@ -342,35 +402,32 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 	if baseModel == "" {
 		baseModel = strings.TrimSpace(requestedModel)
 	}
-	for _, candidate := range candidates {
-		key := strings.TrimSpace(candidate)
-		if key == "" {
-			continue
-		}
-		for _, entry := range aliases {
-			original := strings.TrimSpace(entry.Name)
-			alias := strings.TrimSpace(entry.Alias)
-			if original == "" || alias == "" || !strings.EqualFold(alias, key) {
+	// Exact aliases are resolved first; wildcard patterns are consulted only when no
+	// exact alias matched any candidate, so plain configurations are unaffected.
+	for _, exactPass := range []bool{true, false} {
+		for _, candidate := range candidates {
+			key := strings.TrimSpace(candidate)
+			if key == "" {
 				continue
 			}
-			if strings.EqualFold(original, baseModel) {
-				if !entry.ForceMapping {
-					return OAuthModelAliasResult{}
+			for _, entry := range aliases {
+				alias := strings.TrimSpace(entry.Alias)
+				if alias == "" {
+					continue
 				}
-				return OAuthModelAliasResult{
-					UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
-					ForceMapping:  entry.ForceMapping,
-					OriginalAlias: oauthModelAliasForceMappingResponseModel(alias),
+				if strings.Contains(alias, "*") == exactPass {
+					continue
 				}
-			}
-			originalAlias := requestedModel
-			if entry.ForceMapping {
-				originalAlias = oauthModelAliasForceMappingResponseModel(alias)
-			}
-			return OAuthModelAliasResult{
-				UpstreamModel: preserveResolvedModelSuffix(original, requestResult),
-				ForceMapping:  entry.ForceMapping,
-				OriginalAlias: originalAlias,
+				if exactPass {
+					if !strings.EqualFold(alias, key) {
+						continue
+					}
+				} else if !registry.MatchModelPattern(alias, key) {
+					continue
+				}
+				if result, stop := oauthModelAliasResultFor(entry.Name, alias, entry.ForceMapping, requestedModel, baseModel, requestResult); stop {
+					return result
+				}
 			}
 		}
 	}
@@ -398,11 +455,18 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 
 	raw := m.oauthModelAlias.Load()
 	table, _ := raw.(*oauthModelAliasTable)
-	if table == nil || table.reverse == nil {
+	if table == nil {
 		return OAuthModelAliasResult{}
 	}
-	rev := table.reverse[channel]
-	if rev == nil {
+	var rev map[string]oauthModelAliasEntry
+	if table.reverse != nil {
+		rev = table.reverse[channel]
+	}
+	var wild []oauthModelAliasWildcard
+	if table.wildcards != nil {
+		wild = table.wildcards[channel]
+	}
+	if len(rev) == 0 && len(wild) == 0 {
 		return OAuthModelAliasResult{}
 	}
 
@@ -415,40 +479,25 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 		if !exists {
 			continue
 		}
+		if result, stop := oauthModelAliasResultFor(entry.upstreamModel, entry.configAlias, entry.forceMapping, requestedModel, baseModel, requestResult); stop {
+			return result
+		}
+	}
 
-		targetModel := entry.upstreamModel
-		if targetModel == "" {
+	// Wildcard patterns are consulted only after every exact candidate missed, which
+	// keeps an exact alias authoritative whenever both could match.
+	for _, candidate := range candidates {
+		value := strings.TrimSpace(candidate)
+		if value == "" {
 			continue
 		}
-
-		if strings.EqualFold(targetModel, baseModel) {
-			if !entry.forceMapping {
-				return OAuthModelAliasResult{}
+		for _, wildcard := range wild {
+			if !registry.MatchModelPattern(wildcard.pattern, value) {
+				continue
 			}
-			return OAuthModelAliasResult{
-				UpstreamModel: preserveResolvedModelSuffix(targetModel, requestResult),
-				ForceMapping:  entry.forceMapping,
-				OriginalAlias: oauthModelAliasForceMappingResponseModel(entry.configAlias),
+			if result, stop := oauthModelAliasResultFor(wildcard.entry.upstreamModel, wildcard.entry.configAlias, wildcard.entry.forceMapping, requestedModel, baseModel, requestResult); stop {
+				return result
 			}
-		}
-
-		var upstreamModel string
-		if thinking.ParseSuffix(targetModel).HasSuffix {
-			upstreamModel = targetModel
-		} else if requestResult.HasSuffix && requestResult.RawSuffix != "" {
-			upstreamModel = targetModel + "(" + requestResult.RawSuffix + ")"
-		} else {
-			upstreamModel = targetModel
-		}
-
-		originalAlias := requestedModel
-		if entry.forceMapping {
-			originalAlias = oauthModelAliasForceMappingResponseModel(entry.configAlias)
-		}
-		return OAuthModelAliasResult{
-			UpstreamModel: upstreamModel,
-			ForceMapping:  entry.forceMapping,
-			OriginalAlias: originalAlias,
 		}
 	}
 

--- a/sdk/cliproxy/auth/oauth_model_alias_wildcard_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_wildcard_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"strings"
 	"testing"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -174,5 +175,118 @@ func TestApplyOAuthModelAliasWithResult_WildcardForceMappingUsesRequestedModel(t
 	}
 	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
 		t.Errorf("OriginalAlias = %q, want the requested model", result.OriginalAlias)
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_WildcardForceMappingEchoesRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*", ForceMapping: true}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001")
+	if result.UpstreamModel != "gpt-5.6-luna" {
+		t.Errorf("UpstreamModel = %q, want %q", result.UpstreamModel, "gpt-5.6-luna")
+	}
+	if !result.ForceMapping {
+		t.Errorf("ForceMapping = false, want true")
+	}
+	// The pattern is not a model id, so it must never reach a response model field.
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the concrete requested model", result.OriginalAlias)
+	}
+	if strings.Contains(result.OriginalAlias, "*") {
+		t.Errorf("OriginalAlias = %q, must not contain the wildcard pattern", result.OriginalAlias)
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_PerAuthWildcardForceMappingEchoesRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+	SetOAuthModelAliasesAttribute(auth, []internalconfig.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*", ForceMapping: true},
+	})
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001")
+	if result.UpstreamModel != "gpt-5.6-luna" {
+		t.Errorf("UpstreamModel = %q, want %q", result.UpstreamModel, "gpt-5.6-luna")
+	}
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the concrete requested model", result.OriginalAlias)
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_ExactForceMappingStillUsesConfiguredAlias(t *testing.T) {
+	t.Parallel()
+
+	// The wildcard fix must not change how an exact alias reports itself.
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-20251001", ForceMapping: true}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001")
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the configured alias", result.OriginalAlias)
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_WildcardForceMappingDropsThinkingSuffix(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*", ForceMapping: true}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001(high)")
+	if result.UpstreamModel != "gpt-5.6-luna(high)" {
+		t.Errorf("UpstreamModel = %q, want %q", result.UpstreamModel, "gpt-5.6-luna(high)")
+	}
+	// OriginalAlias is written verbatim into the response model field, so it must be a
+	// model id, exactly as an exact alias would report.
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the suffix-free requested model", result.OriginalAlias)
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_PerAuthWildcardForceMappingDropsThinkingSuffix(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+
+	auth := &Auth{ID: "test-auth-suffix", Provider: "codex"}
+	SetOAuthModelAliasesAttribute(auth, []internalconfig.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*", ForceMapping: true},
+	})
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001(high)")
+	if result.UpstreamModel != "gpt-5.6-luna(high)" {
+		t.Errorf("UpstreamModel = %q, want %q", result.UpstreamModel, "gpt-5.6-luna(high)")
+	}
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the suffix-free requested model", result.OriginalAlias)
 	}
 }

--- a/sdk/cliproxy/auth/oauth_model_alias_wildcard_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_wildcard_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestApplyOAuthModelAlias_WildcardAliasMatchesDatedModelID(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20251001"); got != "gpt-5.6-luna" {
+		t.Errorf("applyOAuthModelAlias() model = %q, want %q", got, "gpt-5.6-luna")
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20260401"); got != "gpt-5.6-luna" {
+		t.Errorf("later dated id: model = %q, want %q", got, "gpt-5.6-luna")
+	}
+}
+
+func TestApplyOAuthModelAlias_WildcardAliasIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "Claude-Haiku-4-5-*"}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	if got := mgr.applyOAuthModelAlias(auth, "CLAUDE-HAIKU-4-5-20251001"); got != "gpt-5.6-luna" {
+		t.Errorf("applyOAuthModelAlias() model = %q, want %q", got, "gpt-5.6-luna")
+	}
+}
+
+func TestApplyOAuthModelAlias_WildcardAliasPreservesThinkingSuffix(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20251001(high)"); got != "gpt-5.6-luna(high)" {
+		t.Errorf("applyOAuthModelAlias() model = %q, want %q", got, "gpt-5.6-luna(high)")
+	}
+}
+
+func TestApplyOAuthModelAlias_ExactAliasWinsOverWildcard(t *testing.T) {
+	t.Parallel()
+
+	// The wildcard is declared first on purpose: precedence must come from the match
+	// kind, not from configuration order.
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-terra", Alias: "claude-haiku-4-5-20251001"},
+		},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20251001"); got != "gpt-5.6-terra" {
+		t.Errorf("exact alias should win: model = %q, want %q", got, "gpt-5.6-terra")
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20260401"); got != "gpt-5.6-luna" {
+		t.Errorf("wildcard should still cover other ids: model = %q, want %q", got, "gpt-5.6-luna")
+	}
+}
+
+func TestApplyOAuthModelAlias_WildcardFirstMatchWins(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-*"},
+			{Name: "gpt-5.6-terra", Alias: "claude-*"},
+		},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20251001"); got != "gpt-5.6-luna" {
+		t.Errorf("first matching pattern should win: model = %q, want %q", got, "gpt-5.6-luna")
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "claude-sonnet-5"); got != "gpt-5.6-terra" {
+		t.Errorf("broader pattern should still apply: model = %q, want %q", got, "gpt-5.6-terra")
+	}
+}
+
+func TestApplyOAuthModelAlias_WildcardAliasDoesNotMatchOtherModels(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	// A bare id without the trailing segment must not match, and neither must an
+	// unrelated model.
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5"); got != "claude-haiku-4-5" {
+		t.Errorf("bare id should not match: model = %q, want unchanged", got)
+	}
+	if got := mgr.applyOAuthModelAlias(auth, "gpt-5.6-sol"); got != "gpt-5.6-sol" {
+		t.Errorf("unrelated model should not match: model = %q, want unchanged", got)
+	}
+}
+
+func TestApplyOAuthModelAlias_PerAuthWildcardAlias(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+	SetOAuthModelAliasesAttribute(auth, []internalconfig.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+	})
+
+	if got := mgr.applyOAuthModelAlias(auth, "claude-haiku-4-5-20251001"); got != "gpt-5.6-luna" {
+		t.Errorf("applyOAuthModelAlias() model = %q, want %q", got, "gpt-5.6-luna")
+	}
+}
+
+func TestApplyOAuthModelAliasWithResult_WildcardForceMappingUsesRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string][]internalconfig.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"}},
+	}
+
+	mgr := NewManager(nil, nil, nil)
+	mgr.SetConfig(&internalconfig.Config{})
+	mgr.SetOAuthModelAlias(aliases)
+
+	auth := &Auth{ID: "test-auth-id", Provider: "codex"}
+
+	result := mgr.applyOAuthModelAliasWithResult(auth, "claude-haiku-4-5-20251001")
+	if result.UpstreamModel != "gpt-5.6-luna" {
+		t.Errorf("UpstreamModel = %q, want %q", result.UpstreamModel, "gpt-5.6-luna")
+	}
+	if result.ForceMapping {
+		t.Errorf("ForceMapping = true, want false")
+	}
+	if result.OriginalAlias != "claude-haiku-4-5-20251001" {
+		t.Errorf("OriginalAlias = %q, want the requested model", result.OriginalAlias)
+	}
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -260,6 +260,7 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
+	applyModelAliasPatterns(b.cfg.OAuthModelAlias)
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
 	}

--- a/sdk/cliproxy/model_alias_pattern_test.go
+++ b/sdk/cliproxy/model_alias_pattern_test.go
@@ -1,0 +1,78 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestApplyOAuthModelAliasEntries_WildcardAliasIsNotPublished(t *testing.T) {
+	t.Parallel()
+
+	aliases := []config.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+	}
+	models := []*ModelInfo{{ID: "gpt-5.6-luna"}}
+
+	out := applyOAuthModelAliasEntries(aliases, models)
+	if len(out) != 1 {
+		t.Fatalf("model count = %d, want 1", len(out))
+	}
+	if out[0].ID != "gpt-5.6-luna" {
+		t.Errorf("model id = %q, want the upstream model to keep its catalog entry", out[0].ID)
+	}
+}
+
+func TestApplyOAuthModelAliasEntries_ExactAliasStillPublished(t *testing.T) {
+	t.Parallel()
+
+	aliases := []config.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-20251001"},
+	}
+	models := []*ModelInfo{{ID: "gpt-5.6-luna"}}
+
+	out := applyOAuthModelAliasEntries(aliases, models)
+	if len(out) != 1 {
+		t.Fatalf("model count = %d, want 1", len(out))
+	}
+	if out[0].ID != "claude-haiku-4-5-20251001" {
+		t.Errorf("model id = %q, want the exact alias", out[0].ID)
+	}
+}
+
+func TestCollectModelAliasPatterns(t *testing.T) {
+	t.Parallel()
+
+	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{
+		"codex": {
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-sol", Alias: "claude-opus-5"},
+		},
+		"antigravity": {
+			{Name: "gemini-pro-agent", Alias: "gemini-*-preview"},
+			{Name: "", Alias: "broken-*"},
+		},
+	})
+
+	if len(patterns) != 2 {
+		t.Fatalf("pattern count = %d, want 2", len(patterns))
+	}
+	// Channels are walked in sorted order, so antigravity comes first.
+	if patterns[0].Pattern != "gemini-*-preview" || patterns[0].Target != "gemini-pro-agent" {
+		t.Errorf("first pattern = %+v, want the antigravity entry", patterns[0])
+	}
+	if patterns[1].Pattern != "claude-haiku-4-5-*" || patterns[1].Target != "gpt-5.6-luna" {
+		t.Errorf("second pattern = %+v, want the codex entry", patterns[1])
+	}
+}
+
+func TestCollectModelAliasPatterns_NoWildcards(t *testing.T) {
+	t.Parallel()
+
+	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{
+		"codex": {{Name: "gpt-5.6-sol", Alias: "claude-opus-5"}},
+	})
+	if patterns != nil {
+		t.Errorf("patterns = %+v, want nil when no wildcard alias is configured", patterns)
+	}
+}

--- a/sdk/cliproxy/model_alias_pattern_test.go
+++ b/sdk/cliproxy/model_alias_pattern_test.go
@@ -1,6 +1,7 @@
 package cliproxy
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -77,11 +78,48 @@ func TestCollectModelAliasPatterns_NoWildcards(t *testing.T) {
 	}
 }
 
-func TestCollectModelAliasPatterns_TargetFollowsTheExactAliasThatReplacedIt(t *testing.T) {
+func TestApplyOAuthModelAliasEntries_WildcardTargetSurvivesExactReplacement(t *testing.T) {
 	t.Parallel()
 
-	// The exact alias removes "gpt-5.6-luna" from the catalog because it does not set
-	// fork, so the wildcard has to target the surviving id or it can never route.
+	// The exact alias sets no fork, so on its own it would replace "gpt-5.6-luna" in
+	// the catalog. The wildcard resolves to that upstream name, so it has to stay
+	// published or nothing can serve the pattern.
+	aliases := []config.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+		{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+	}
+
+	published := applyOAuthModelAliasEntries(aliases, []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	ids := make([]string, 0, len(published))
+	for _, model := range published {
+		ids = append(ids, model.ID)
+	}
+
+	if !slices.Contains(ids, "gpt-5.6-luna") {
+		t.Errorf("published ids = %v, want the wildcard target to remain", ids)
+	}
+	if !slices.Contains(ids, "my-friendly-name") {
+		t.Errorf("published ids = %v, want the exact alias as well", ids)
+	}
+}
+
+func TestApplyOAuthModelAliasEntries_ExactAliasStillReplacesWithoutWildcard(t *testing.T) {
+	t.Parallel()
+
+	// Without a wildcard on the same model the non-fork replacement is unchanged.
+	aliases := []config.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+	}
+
+	published := applyOAuthModelAliasEntries(aliases, []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	if len(published) != 1 || published[0].ID != "my-friendly-name" {
+		t.Fatalf("published = %v, want only the exact alias", published)
+	}
+}
+
+func TestCollectModelAliasPatterns_TargetIsTheUpstreamModel(t *testing.T) {
+	t.Parallel()
+
 	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{
 		"codex": {
 			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
@@ -92,8 +130,8 @@ func TestCollectModelAliasPatterns_TargetFollowsTheExactAliasThatReplacedIt(t *t
 	if len(patterns) != 1 {
 		t.Fatalf("pattern count = %d, want 1", len(patterns))
 	}
-	if patterns[0].Target != "my-friendly-name" {
-		t.Errorf("target = %q, want the published alias id", patterns[0].Target)
+	if patterns[0].Target != "gpt-5.6-luna" {
+		t.Errorf("target = %q, want the upstream model", patterns[0].Target)
 	}
 }
 
@@ -115,22 +153,44 @@ func TestCollectModelAliasPatterns_ForkKeepsTheUpstreamTarget(t *testing.T) {
 	}
 }
 
-func TestCollectModelAliasPatterns_TargetMatchesTheAppliedCatalog(t *testing.T) {
+func TestCollectModelAliasPatterns_TargetIsAlwaysAPublishedCatalogID(t *testing.T) {
 	t.Parallel()
 
-	// Guard the two halves against drifting apart: whatever id the catalog ends up
-	// publishing for the upstream model must be the id the pattern targets.
-	aliases := []config.OAuthModelAlias{
-		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
-		{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+	// The pattern target is also the value OAuth alias resolution returns for a
+	// wildcard, so this one invariant covers both gates: the handler provider lookup
+	// and the per-credential support check. If the catalog ever stops publishing the
+	// target, a matching request dies as model_not_found or auth_not_found.
+	cases := [][]config.OAuthModelAlias{
+		{
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+		},
+		{
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+		},
+		{
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-luna", Alias: "my-friendly-name", Fork: true},
+		},
+		{
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-luna", Alias: "one"},
+			{Name: "gpt-5.6-luna", Alias: "two"},
+		},
 	}
-	published := applyOAuthModelAliasEntries(aliases, []*ModelInfo{{ID: "gpt-5.6-luna"}})
-	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{"codex": aliases})
 
-	if len(published) != 1 || len(patterns) != 1 {
-		t.Fatalf("published = %d models, patterns = %d, want 1 each", len(published), len(patterns))
-	}
-	if published[0].ID != patterns[0].Target {
-		t.Errorf("catalog id = %q but pattern target = %q", published[0].ID, patterns[0].Target)
+	for i, aliases := range cases {
+		published := applyOAuthModelAliasEntries(aliases, []*ModelInfo{{ID: "gpt-5.6-luna"}})
+		ids := make([]string, 0, len(published))
+		for _, model := range published {
+			ids = append(ids, model.ID)
+		}
+		patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{"codex": aliases})
+		if len(patterns) != 1 {
+			t.Fatalf("case %d: pattern count = %d, want 1", i, len(patterns))
+		}
+		if !slices.Contains(ids, patterns[0].Target) {
+			t.Errorf("case %d: pattern target %q is not published; catalog has %v", i, patterns[0].Target, ids)
+		}
 	}
 }

--- a/sdk/cliproxy/model_alias_pattern_test.go
+++ b/sdk/cliproxy/model_alias_pattern_test.go
@@ -76,3 +76,61 @@ func TestCollectModelAliasPatterns_NoWildcards(t *testing.T) {
 		t.Errorf("patterns = %+v, want nil when no wildcard alias is configured", patterns)
 	}
 }
+
+func TestCollectModelAliasPatterns_TargetFollowsTheExactAliasThatReplacedIt(t *testing.T) {
+	t.Parallel()
+
+	// The exact alias removes "gpt-5.6-luna" from the catalog because it does not set
+	// fork, so the wildcard has to target the surviving id or it can never route.
+	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{
+		"codex": {
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+		},
+	})
+
+	if len(patterns) != 1 {
+		t.Fatalf("pattern count = %d, want 1", len(patterns))
+	}
+	if patterns[0].Target != "my-friendly-name" {
+		t.Errorf("target = %q, want the published alias id", patterns[0].Target)
+	}
+}
+
+func TestCollectModelAliasPatterns_ForkKeepsTheUpstreamTarget(t *testing.T) {
+	t.Parallel()
+
+	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{
+		"codex": {
+			{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+			{Name: "gpt-5.6-luna", Alias: "my-friendly-name", Fork: true},
+		},
+	})
+
+	if len(patterns) != 1 {
+		t.Fatalf("pattern count = %d, want 1", len(patterns))
+	}
+	if patterns[0].Target != "gpt-5.6-luna" {
+		t.Errorf("target = %q, want the upstream model kept by fork", patterns[0].Target)
+	}
+}
+
+func TestCollectModelAliasPatterns_TargetMatchesTheAppliedCatalog(t *testing.T) {
+	t.Parallel()
+
+	// Guard the two halves against drifting apart: whatever id the catalog ends up
+	// publishing for the upstream model must be the id the pattern targets.
+	aliases := []config.OAuthModelAlias{
+		{Name: "gpt-5.6-luna", Alias: "claude-haiku-4-5-*"},
+		{Name: "gpt-5.6-luna", Alias: "my-friendly-name"},
+	}
+	published := applyOAuthModelAliasEntries(aliases, []*ModelInfo{{ID: "gpt-5.6-luna"}})
+	patterns := collectModelAliasPatterns(map[string][]config.OAuthModelAlias{"codex": aliases})
+
+	if len(published) != 1 || len(patterns) != 1 {
+		t.Fatalf("published = %d models, patterns = %d, want 1 each", len(published), len(patterns))
+	}
+	if published[0].ID != patterns[0].Target {
+		t.Errorf("catalog id = %q but pattern target = %q", published[0].ID, patterns[0].Target)
+	}
+}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -216,6 +216,7 @@ func (s *Service) applyManagerConfig(ctx context.Context, commit configCommit) b
 		return false
 	}
 	s.coreManager.SetOAuthModelAlias(commit.cfg.OAuthModelAlias)
+	applyModelAliasPatterns(commit.cfg.OAuthModelAlias)
 	return true
 }
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -947,6 +947,9 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 	}
 
 	forward := make(map[string][]aliasEntry, len(aliases))
+	// wildcardTargets holds the upstream models a wildcard alias resolves to, keyed
+	// the same way as forward.
+	wildcardTargets := make(map[string]struct{})
 	for i := range aliases {
 		name := strings.TrimSpace(aliases[i].Name)
 		alias := strings.TrimSpace(aliases[i].Alias)
@@ -958,8 +961,10 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 		}
 		if strings.Contains(alias, "*") {
 			// A wildcard alias is a routing pattern, not a model id, so it must never
-			// reach the catalog. The upstream model keeps its own entry and requests
-			// matching the pattern are resolved during routing instead.
+			// reach the catalog itself. Its target does have to stay published: routing
+			// resolves the pattern to this upstream name, and both the provider lookup
+			// and the credential support check compare against registered model ids.
+			wildcardTargets[strings.ToLower(name)] = struct{}{}
 			continue
 		}
 		key := strings.ToLower(name)
@@ -995,6 +1000,11 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 		}
 
 		keepOriginal := false
+		if _, isWildcardTarget := wildcardTargets[key]; isWildcardTarget {
+			// An exact alias would otherwise replace this model, which would strand the
+			// wildcard on an id no client registers.
+			keepOriginal = true
+		}
 		for _, entry := range entries {
 			if entry.fork {
 				keepOriginal = true
@@ -1062,8 +1072,7 @@ func collectModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) []re
 
 	var out []registry.ModelAliasPattern
 	for _, channel := range channels {
-		entries := aliases[channel]
-		for _, entry := range entries {
+		for _, entry := range aliases[channel] {
 			name := strings.TrimSpace(entry.Name)
 			alias := strings.TrimSpace(entry.Alias)
 			if name == "" || alias == "" {
@@ -1072,46 +1081,10 @@ func collectModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) []re
 			if !strings.Contains(alias, "*") {
 				continue
 			}
-			out = append(out, registry.ModelAliasPattern{
-				Pattern: alias,
-				Target:  catalogModelIDForAliasTarget(entries, name),
-			})
+			out = append(out, registry.ModelAliasPattern{Pattern: alias, Target: name})
 		}
 	}
 	return out
-}
-
-// catalogModelIDForAliasTarget returns the model id the registry actually holds for
-// an upstream model name inside one alias channel.
-//
-// applyOAuthModelAliasEntries drops the upstream model from the published catalog
-// when the channel also maps it to exact aliases and none of them sets fork. A
-// wildcard whose target is that model must therefore point at a surviving alias id,
-// otherwise the registry lookup misses and the pattern silently never routes.
-func catalogModelIDForAliasTarget(entries []config.OAuthModelAlias, name string) string {
-	replacement := ""
-	for _, entry := range entries {
-		entryName := strings.TrimSpace(entry.Name)
-		alias := strings.TrimSpace(entry.Alias)
-		if entryName == "" || alias == "" || !strings.EqualFold(entryName, name) {
-			continue
-		}
-		// Mirror the skips applyOAuthModelAliasEntries performs before it reads fork.
-		if strings.EqualFold(entryName, alias) || strings.Contains(alias, "*") {
-			continue
-		}
-		if entry.Fork {
-			// The upstream model keeps its own catalog entry.
-			return name
-		}
-		if replacement == "" {
-			replacement = alias
-		}
-	}
-	if replacement == "" {
-		return name
-	}
-	return replacement
 }
 
 // applyModelAliasPatterns publishes wildcard alias patterns to the global model

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -1060,9 +1060,10 @@ func collectModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) []re
 	}
 	sort.Strings(channels)
 
-	out := make([]registry.ModelAliasPattern, 0)
+	var out []registry.ModelAliasPattern
 	for _, channel := range channels {
-		for _, entry := range aliases[channel] {
+		entries := aliases[channel]
+		for _, entry := range entries {
 			name := strings.TrimSpace(entry.Name)
 			alias := strings.TrimSpace(entry.Alias)
 			if name == "" || alias == "" {
@@ -1071,13 +1072,46 @@ func collectModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) []re
 			if !strings.Contains(alias, "*") {
 				continue
 			}
-			out = append(out, registry.ModelAliasPattern{Pattern: alias, Target: name})
+			out = append(out, registry.ModelAliasPattern{
+				Pattern: alias,
+				Target:  catalogModelIDForAliasTarget(entries, name),
+			})
 		}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
+}
+
+// catalogModelIDForAliasTarget returns the model id the registry actually holds for
+// an upstream model name inside one alias channel.
+//
+// applyOAuthModelAliasEntries drops the upstream model from the published catalog
+// when the channel also maps it to exact aliases and none of them sets fork. A
+// wildcard whose target is that model must therefore point at a surviving alias id,
+// otherwise the registry lookup misses and the pattern silently never routes.
+func catalogModelIDForAliasTarget(entries []config.OAuthModelAlias, name string) string {
+	replacement := ""
+	for _, entry := range entries {
+		entryName := strings.TrimSpace(entry.Name)
+		alias := strings.TrimSpace(entry.Alias)
+		if entryName == "" || alias == "" || !strings.EqualFold(entryName, name) {
+			continue
+		}
+		// Mirror the skips applyOAuthModelAliasEntries performs before it reads fork.
+		if strings.EqualFold(entryName, alias) || strings.Contains(alias, "*") {
+			continue
+		}
+		if entry.Fork {
+			// The upstream model keeps its own catalog entry.
+			return name
+		}
+		if replacement == "" {
+			replacement = alias
+		}
+	}
+	if replacement == "" {
+		return name
+	}
+	return replacement
 }
 
 // applyModelAliasPatterns publishes wildcard alias patterns to the global model

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -2,6 +2,7 @@ package cliproxy
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -955,6 +956,12 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 		if strings.EqualFold(name, alias) {
 			continue
 		}
+		if strings.Contains(alias, "*") {
+			// A wildcard alias is a routing pattern, not a model id, so it must never
+			// reach the catalog. The upstream model keeps its own entry and requests
+			// matching the pattern are resolved during routing instead.
+			continue
+		}
 		key := strings.ToLower(name)
 		forward[key] = append(forward[key], aliasEntry{
 			alias:       alias,
@@ -1036,4 +1043,45 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 		}
 	}
 	return out
+}
+
+// collectModelAliasPatterns extracts routing-only wildcard alias patterns from the
+// OAuth model alias configuration. Exact aliases are published as models by
+// applyOAuthModelAliasEntries and are therefore not included here.
+//
+// Channels are walked in sorted order so a reload produces a stable pattern order.
+func collectModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) []registry.ModelAliasPattern {
+	if len(aliases) == 0 {
+		return nil
+	}
+	channels := make([]string, 0, len(aliases))
+	for channel := range aliases {
+		channels = append(channels, channel)
+	}
+	sort.Strings(channels)
+
+	out := make([]registry.ModelAliasPattern, 0)
+	for _, channel := range channels {
+		for _, entry := range aliases[channel] {
+			name := strings.TrimSpace(entry.Name)
+			alias := strings.TrimSpace(entry.Alias)
+			if name == "" || alias == "" {
+				continue
+			}
+			if !strings.Contains(alias, "*") {
+				continue
+			}
+			out = append(out, registry.ModelAliasPattern{Pattern: alias, Target: name})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// applyModelAliasPatterns publishes wildcard alias patterns to the global model
+// registry so provider lookups can resolve model ids that no client registers.
+func applyModelAliasPatterns(aliases map[string][]config.OAuthModelAlias) {
+	registry.GetGlobalRegistry().SetModelAliasPatterns(collectModelAliasPatterns(aliases))
 }


### PR DESCRIPTION
Closes #5366

## Description

`oauth-model-alias` matched the client-visible model name for equality only, so a client that sends **dated** model ids needed a configuration edit every time the upstream id changed.

Claude Code is the concrete case: it sends its native ids on every path, including a dated id for background side queries (`claude-haiku-4-5-20251001`). Without a matching alias the request fails with `unknown provider for model …` (reported in #1596), and for the background model slot the failure is worse than an error — recent Claude Code versions do not surface one, they quietly answer those queries with the main model instead. A single date-suffix bump is enough to trigger it, with no signal until someone inspects per-model request counts.

This PR lets an alias contain `*`:

```yaml
oauth-model-alias:
  codex:
    - name: "gpt-5.6-luna"
      alias: "claude-haiku-4-5-*"
```

## Type of Change

- [x] Feature (non-breaking change that adds functionality)

## Implementation Details

**Resolution** (`sdk/cliproxy/auth/oauth_model_alias.go`)

- `compileOAuthModelAliasTable` splits entries: aliases without `*` keep the existing O(1) lowercase map, aliases with `*` go to a per-channel ordered slice.
- Both resolvers — the compiled table (global `oauth-model-alias`) and the per-auth `model_aliases` attribute — run the **existing exact pass unchanged first**, and only consult wildcards when it matched nothing. Existing configurations therefore cannot change behaviour.
- Among wildcards the first match in configuration order wins.
- The duplicated result-building blocks in the two resolvers were folded into one `oauthModelAliasResultFor` helper so the exact and wildcard paths cannot drift. `force-mapping`, thinking-suffix preservation and the "alias resolves to its own upstream name" case are all unchanged.

**Routing** (`internal/registry/`)

A wildcard alias registers no model of its own, so `GetModelProviders` — which backs the handler-level `unknown provider for model` check — would still reject the request. The registry now keeps a routing-only pattern table (`SetModelAliasPatterns`) and falls back to it **only after an exact model id lookup finds no provider**, returning the providers of the pattern's target model. A registered model id always shadows a pattern.

**Catalog** (`sdk/cliproxy/service_models.go`)

`applyOAuthModelAliasEntries` skips wildcard aliases: a pattern is not a model id and must not be published in `/v1/models`. The upstream model keeps its own catalog entry, which also means `fork` has no effect on a wildcard entry. `collectModelAliasPatterns` feeds the registry table from config, walking channels in sorted order so a hot reload produces a stable pattern order.

**Matching**

`registry.MatchModelPattern` mirrors the semantics of the existing `matchWildcard` / `matchModelPattern` helpers (prefix, suffix, ordered middle segments) but compares case-insensitively, which is what alias resolution already does. I did not unify the three matchers in this PR to keep the diff reviewable — happy to follow up separately if you want them collapsed into one helper.

## Scope

- Applies to `oauth-model-alias` and the per-auth `model_aliases` attribute.
- Provider `models:` alias lists (`openai-compatibility` and friends) are unchanged.
- The registry pattern table is fed from the global `oauth-model-alias` config, so it is aware of neither the individual auth nor its prefix. Three consequences follow, all of them fail-closed — a request either resolves correctly or is rejected, never silently routed to the wrong upstream:
  - **Per-auth patterns.** A wildcard declared only in an auth's `model_aliases` attribute resolves during execution but adds no handler-level provider entry, so a matching request is rejected before credential selection. `warnUnroutablePerAuthWildcardAliases` logs a warning when this is configured.
  - **`force-model-prefix: true`.** Aliases are applied before prefixes (`service_models.go:263` then `:276`), and `applyModelPrefixes` emits only `<prefix>/<id>` under force mode. A wildcard's target is therefore not registered under its bare name and the pattern resolves to nothing. This matches the existing behaviour of exact aliases, which are likewise reachable only under their prefixed id — but it does mean there is currently no way to write a wildcard that serves prefixed requests.
  - **Responses WebSocket passthrough.** `responsesWebsocketAuthMatchesModel` filters credentials with an exact `ClientSupportsModel` check, which cannot see a routing-only pattern. A wildcard-matched request is served over HTTP instead of native upstream WebSocket. This is not a regression: before this change the same request did not reach that code at all, because the empty provider set returned at the `len(providerSet) == 0` guard.

  All three would be resolved by the same follow-up: registering patterns per-auth alongside `applyModelPrefixes` rather than globally from config. I left that out here because it moves the change from a routing-lookup fallback into every auth's registration path, which is a different risk profile for an already sizeable diff. Happy to do it as a follow-up, or to defer to your own implementation if you would rather own that path.

## Testing

```
gofmt -l .            # clean
go build ./...
go build -o test-output ./cmd/server && rm test-output
go test ./...         # full suite passes
```

New tests:

- `internal/registry/model_alias_pattern_test.go` — matcher table (prefix/suffix/middle/case/empty), `SetModelAliasPatterns` dropping non-wildcard entries, provider fallback, a registered id shadowing a pattern, and an unregistered target resolving to nothing.
- `sdk/cliproxy/auth/oauth_model_alias_wildcard_test.go` — dated id matching, case-insensitivity, thinking-suffix preservation, exact-beats-wildcard (with the wildcard declared first, so precedence cannot come from ordering), first-wildcard-wins, non-matching ids left untouched, per-auth wildcard aliases, and `force-mapping` defaults.
- `sdk/cliproxy/model_alias_pattern_test.go` — wildcard aliases absent from the catalog while exact aliases still publish, plus `collectModelAliasPatterns` ordering and filtering.

Verification was unit-level; I have not exercised it against a live upstream account.

