### PR TITLE
Improve test reliability by avoiding wall-clock time

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -151,6 +151,7 @@ func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, selected *au
 }
 
 type codexSearchHomeDispatcher struct {
+	authID string
 	calls  atomic.Int32
 	policy atomic.Value
 }
@@ -199,18 +200,22 @@ func (*codexSearchHomeDispatcher) HeartbeatOK() bool { return true }
 
 func (d *codexSearchHomeDispatcher) RPopAuth(_ context.Context, model string, _ string, _ http.Header, _ int) ([]byte, error) {
 	d.calls.Add(1)
+	authID := d.authID
+	if authID == "" {
+		authID = "home-codex-search"
+	}
 	return json.Marshal(map[string]any{
 		"model":      model,
-		"auth_index": "home-codex-search",
+		"auth_index": authID,
 		"auth": map[string]any{
-			"id":       "home-codex-search",
+			"id":       authID,
 			"provider": "codex",
 			"status":   "active",
 			"metadata": map[string]any{"access_token": "home-search-token"},
 		},
 		"concurrency": map[string]any{
 			"accounted":     true,
-			"credential_id": "home-codex-search",
+			"credential_id": authID,
 			"model":         model,
 		},
 	})
@@ -467,7 +472,8 @@ func TestHomeCodexAlphaSearchReportsUnauthorizedBeforeEarlyReturn(t *testing.T) 
 			server := newTestServer(t)
 			registry := executionregistry.New()
 			server.handlers.AuthManager.SetConfig(&proxyconfig.Config{Home: proxyconfig.HomeConfig{Enabled: true}})
-			server.handlers.AuthManager.PublishHomeDispatch(&codexSearchHomeDispatcher{}, registry, 1)
+			testAuthID := "home-codex-search-" + strings.ReplaceAll(test.name, " ", "-")
+			server.handlers.AuthManager.PublishHomeDispatch(&codexSearchHomeDispatcher{authID: testAuthID}, registry, 1)
 			executor := &codexSearchCaptureExecutor{
 				statuses:     []int{http.StatusUnauthorized},
 				responseBody: test.responseBody(),
@@ -476,7 +482,7 @@ func TestHomeCodexAlphaSearchReportsUnauthorizedBeforeEarlyReturn(t *testing.T) 
 				executor.beforeReturn = func() { test.beforeReturn(registry) }
 			}
 			server.handlers.AuthManager.RegisterExecutor(executor)
-			usageCapture := registerHomeUnauthorizedUsageCapture(t, t.Name(), "home-codex-search")
+			usageCapture := registerHomeUnauthorizedUsageCapture(t, t.Name(), testAuthID)
 
 			recorder := httptest.NewRecorder()
 			request := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"model":"gpt-5-codex","query":"test"}`))

--- a/internal/cache/antigravity_reasoning_replay_cache_test.go
+++ b/internal/cache/antigravity_reasoning_replay_cache_test.go
@@ -259,6 +259,12 @@ func TestAntigravityReasoningReplayUnrelatedEvictionDoesNotBlockAbsentSnapshot(t
 	if !CacheAntigravityReasoningReplayItems(model, "older-live-entry", [][]byte{liveItem}) {
 		t.Fatal("live entry write failed")
 	}
+	antigravityReasoningReplayMu.Lock()
+	if entry, ok := antigravityReasoningReplayEntries[antigravityReasoningReplayCacheKey(model, "older-live-entry")]; ok {
+		entry.Timestamp = time.Now().Add(-time.Minute)
+		antigravityReasoningReplayEntries[antigravityReasoningReplayCacheKey(model, "older-live-entry")] = entry
+	}
+	antigravityReasoningReplayMu.Unlock()
 	_, snapshot, found, errGet := GetAntigravityReasoningReplayItemsWithSnapshotRequired(context.Background(), model, "untouched-absent-session")
 	if errGet != nil || found {
 		t.Fatalf("initial absent snapshot = found %v, err %v", found, errGet)


### PR DESCRIPTION
Enhance the reliability of TTL and cache-eviction tests by eliminating reliance on wall-clock time. This change introduces a more consistent approach to testing, ensuring that tests do not fail due to timing issues. Additionally, refactor the `codexSearchHomeDispatcher` to utilize a dynamic `authID`.