### PR TITLE
feat: add display names for static API key providers

### DIFF
--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -191,6 +191,7 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	type geminiKeyPatch struct {
 		APIKey              *string                          `json:"api-key"`
+		DisplayName         *string                          `json:"display-name"`
 		Weight              json.RawMessage                  `json:"weight"`
 		Prefix              *string                          `json:"prefix"`
 		BaseURL             *string                          `json:"base-url"`
@@ -249,6 +250,9 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	entry := h.cfg.GeminiKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -393,6 +397,7 @@ func (h *Handler) PutInteractionsKeys(c *gin.Context) {
 func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 	type geminiKeyPatch struct {
 		APIKey              *string                          `json:"api-key"`
+		DisplayName         *string                          `json:"display-name"`
 		Weight              json.RawMessage                  `json:"weight"`
 		Prefix              *string                          `json:"prefix"`
 		BaseURL             *string                          `json:"base-url"`
@@ -452,6 +457,9 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 	entry := h.cfg.InteractionsKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -599,6 +607,7 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	type claudeKeyPatch struct {
 		APIKey                  *string                          `json:"api-key"`
+		DisplayName             *string                          `json:"display-name"`
 		FingerprintProfile      *string                          `json:"fingerprint-profile"`
 		Weight                  json.RawMessage                  `json:"weight"`
 		Prefix                  *string                          `json:"prefix"`
@@ -645,6 +654,9 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	entry := h.cfg.ClaudeKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if body.Value.FingerprintProfile != nil {
 		if rejectInvalidFingerprintProfile(c, "fingerprint-profile", *body.Value.FingerprintProfile) {
@@ -955,6 +967,7 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	type vertexCompatPatch struct {
 		APIKey         *string                     `json:"api-key"`
+		DisplayName    *string                     `json:"display-name"`
 		Weight         json.RawMessage             `json:"weight"`
 		Prefix         *string                     `json:"prefix"`
 		BaseURL        *string                     `json:"base-url"`
@@ -1007,6 +1020,9 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 			return
 		}
 		entry.APIKey = trimmed
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -1421,6 +1437,7 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 func (h *Handler) PatchCodexKey(c *gin.Context) {
 	type codexKeyPatch struct {
 		APIKey              *string                          `json:"api-key"`
+		DisplayName         *string                          `json:"display-name"`
 		Weight              json.RawMessage                  `json:"weight"`
 		Prefix              *string                          `json:"prefix"`
 		BaseURL             *string                          `json:"base-url"`
@@ -1466,6 +1483,9 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	entry := h.cfg.CodexKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -1615,6 +1635,7 @@ func (h *Handler) PutXAIKeys(c *gin.Context) {
 func (h *Handler) PatchXAIKey(c *gin.Context) {
 	type xaiKeyPatch struct {
 		APIKey              *string                          `json:"api-key"`
+		DisplayName         *string                          `json:"display-name"`
 		Priority            *int                             `json:"priority"`
 		Weight              json.RawMessage                  `json:"weight"`
 		Prefix              *string                          `json:"prefix"`
@@ -1661,6 +1682,9 @@ func (h *Handler) PatchXAIKey(c *gin.Context) {
 	entry := h.cfg.XAIKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if body.Value.DisplayName != nil {
+		entry.DisplayName = strings.TrimSpace(*body.Value.DisplayName)
 	}
 	if body.Value.Priority != nil {
 		entry.Priority = *body.Value.Priority

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -201,6 +201,7 @@ func sanitizeCodexKeyEntries(entries []CodexKey) []CodexKey {
 	out := make([]CodexKey, 0, len(entries))
 	for i := range entries {
 		e := entries[i]
+		e.DisplayName = strings.TrimSpace(e.DisplayName)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
 		e.Headers = NormalizeHeaders(e.Headers)
@@ -220,6 +221,7 @@ func (cfg *Config) SanitizeClaudeKeys() {
 	}
 	for i := range cfg.ClaudeKey {
 		entry := &cfg.ClaudeKey[i]
+		entry.DisplayName = strings.TrimSpace(entry.DisplayName)
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
@@ -240,6 +242,7 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 	for i := range entries {
 		entry := entries[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		entry.DisplayName = strings.TrimSpace(entry.DisplayName)
 		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		if entry.APIKey == "" && entry.BaseURL == "" {
 			continue

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -343,6 +343,9 @@ type ClaudeKey struct {
 	// APIKey is the authentication key for accessing Claude API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// DisplayName is an optional human-readable name for this provider credential.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -458,6 +461,9 @@ type CodexKey struct {
 	// APIKey is the authentication key for accessing Codex API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// DisplayName is an optional human-readable name for this provider credential.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -561,6 +567,9 @@ type XAIModel = CodexModel
 type GeminiKey struct {
 	// APIKey is the authentication key for accessing Gemini API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// DisplayName is an optional human-readable name for this provider credential.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
 
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.

--- a/internal/config/display_name_test.go
+++ b/internal/config/display_name_test.go
@@ -1,0 +1,65 @@
+package config
+
+import "testing"
+
+func TestStaticProviderDisplayNameRoundTrip(t *testing.T) {
+	configBytes := []byte(`gemini-api-key:
+  - api-key: gemini-key
+    display-name: Gemini account
+interactions-api-key:
+  - api-key: interactions-key
+    display-name: Interactions account
+codex-api-key:
+  - api-key: codex-key
+    display-name: Codex account
+    base-url: https://codex.example.com/v1
+xai-api-key:
+  - api-key: xai-key
+    display-name: xAI account
+    base-url: https://xai.example.com/v1
+claude-api-key:
+  - api-key: claude-key
+    display-name: Claude account
+vertex-api-key:
+  - api-key: vertex-key
+    display-name: Vertex account
+`)
+
+	cfg, err := ParseConfigBytes(configBytes)
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+
+	if got := cfg.GeminiKey[0].DisplayName; got != "Gemini account" {
+		t.Fatalf("Gemini display name = %q, want %q", got, "Gemini account")
+	}
+	if got := cfg.InteractionsKey[0].DisplayName; got != "Interactions account" {
+		t.Fatalf("Interactions display name = %q, want %q", got, "Interactions account")
+	}
+	if got := cfg.CodexKey[0].DisplayName; got != "Codex account" {
+		t.Fatalf("Codex display name = %q, want %q", got, "Codex account")
+	}
+	if got := cfg.XAIKey[0].DisplayName; got != "xAI account" {
+		t.Fatalf("xAI display name = %q, want %q", got, "xAI account")
+	}
+	if got := cfg.ClaudeKey[0].DisplayName; got != "Claude account" {
+		t.Fatalf("Claude display name = %q, want %q", got, "Claude account")
+	}
+	if got := cfg.VertexCompatAPIKey[0].DisplayName; got != "Vertex account" {
+		t.Fatalf("Vertex display name = %q, want %q", got, "Vertex account")
+	}
+}
+
+func TestStaticProviderDisplayNameIsTrimmed(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`codex-api-key:
+  - api-key: codex-key
+    display-name: "  Codex account  "
+    base-url: https://codex.example.com/v1
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if got := cfg.CodexKey[0].DisplayName; got != "Codex account" {
+		t.Fatalf("trimmed display name = %q, want %q", got, "Codex account")
+	}
+}

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -17,6 +17,9 @@ type VertexCompatKey struct {
 	// Maps to the x-goog-api-key header.
 	APIKey string `yaml:"api-key" json:"api-key"`
 
+	// DisplayName is an optional human-readable name for this provider credential.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
@@ -98,6 +101,7 @@ func (cfg *Config) SanitizeVertexCompatKeys() {
 	for i := range cfg.VertexCompatAPIKey {
 		entry := cfg.VertexCompatAPIKey[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
+		entry.DisplayName = strings.TrimSpace(entry.DisplayName)
 		if entry.APIKey == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

- add optional `display-name` to Gemini, Interactions, Codex, xAI, Claude, and Vertex Compatibility API-key entries
- expose and patch the field through the management API
- trim values during config normalization and cover YAML/JSON round trips
- keep provider identity, auth-index, routing, load balancing, statistics, and OpenAI Compatibility unchanged

This change is intended to provide a stable human-readable label for management UIs without changing runtime behavior.