### PR TITLE
fix(pluginhost): preserve Prefix and Disabled in host.auth.save upsert

### DIFF
--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -326,6 +326,29 @@ func (h *Host) buildAuthFromFileData(path string, data []byte) (*coreauth.Auth, 
 	if email, ok := metadata["email"].(string); ok && strings.TrimSpace(email) != "" {
 		label = strings.TrimSpace(email)
 	}
+	// Mirror the watcher's file synthesizer (synthesizeFileAuths): both
+	// "prefix" and "disabled" are part of the physical auth-file contract, so
+	// rebuilding the in-memory auth from the file payload must carry them over.
+	// Without this, every host.auth.save from a plugin drops Prefix and the
+	// model registry loses the "<provider>/<model>" IDs until the watcher
+	// re-synthesizes the file (and re-flips Disabled back to active).
+	prefix := ""
+	prefixKeyPresent := false
+	if rawPrefix, ok := metadata["prefix"]; ok {
+		prefixKeyPresent = true
+		if rawString, okString := rawPrefix.(string); okString {
+			trimmed := strings.TrimSpace(rawString)
+			trimmed = strings.Trim(trimmed, "/")
+			if trimmed != "" && !strings.Contains(trimmed, "/") {
+				prefix = trimmed
+			}
+		}
+	}
+	disabled, _ := metadata["disabled"].(bool)
+	status := coreauth.StatusActive
+	if disabled {
+		status = coreauth.StatusDisabled
+	}
 	authID := h.authIDForPath(path)
 	if authID == "" {
 		authID = path
@@ -335,7 +358,9 @@ func (h *Host) buildAuthFromFileData(path string, data []byte) (*coreauth.Auth, 
 		Provider: provider,
 		FileName: filepath.Base(path),
 		Label:    label,
-		Status:   coreauth.StatusActive,
+		Prefix:   prefix,
+		Status:   status,
+		Disabled: disabled,
 		Attributes: map[string]string{
 			"path":   path,
 			"source": path,
@@ -350,6 +375,15 @@ func (h *Host) buildAuthFromFileData(path string, data []byte) (*coreauth.Auth, 
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRetryAfter = existing.NextRetryAfter
 			auth.Runtime = existing.Runtime
+			// Manager.Update replaces the whole record, so a payload written
+			// before the "prefix" field existed (key absent) must inherit the
+			// live Prefix — otherwise the model registry silently loses every
+			// "<prefix>/<model>" ID this auth had registered. An explicitly
+			// present key stays authoritative, even when it normalizes to
+			// empty (that is how a prefix gets removed).
+			if !prefixKeyPresent {
+				auth.Prefix = existing.Prefix
+			}
 		}
 	}
 	if errWeight := coreauth.ValidateAuthWeight(auth); errWeight != nil {

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -275,3 +275,89 @@ func TestHostAuthSaveCallbackWritesPhysicalFile(t *testing.T) {
 		t.Fatalf("auths = %#v, want one registered auth", auths)
 	}
 }
+
+// TestHostAuthSaveCallbackPreservesPrefixAndDisabled guards the host.auth.save
+// in-memory upsert path: rebuilding the auth from the saved file payload must
+// not drop Prefix (the source of "<prefix>/<model>" IDs in the model registry)
+// nor ignore the file's disabled flag. Regression test for plugins whose
+// scheduled check-in/lifecycle jobs rewrite their auth files daily.
+func TestHostAuthSaveCallbackPreservesPrefixAndDisabled(t *testing.T) {
+	authDir := t.TempDir()
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	manager := coreauth.NewManager(nil, nil, nil)
+	host.SetAuthManager(manager)
+
+	// Seed the runtime the way the watcher does at startup: the plugin's
+	// parse_auth response supplies the Prefix.
+	filePath := filepath.Join(authDir, "saved.json")
+	seed := &coreauth.Auth{
+		ID:       "saved.json",
+		Provider: "demo",
+		FileName: "saved.json",
+		Label:    "demo",
+		Prefix:   "workbuddy",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":   filePath,
+			"source": filePath,
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), seed); errRegister != nil {
+		t.Fatalf("seed register: %v", errRegister)
+	}
+
+	save := func(name, payload string) {
+		t.Helper()
+		req, errMarshal := json.Marshal(pluginapi.HostAuthSaveRequest{
+			Name: name,
+			JSON: json.RawMessage(payload),
+		})
+		if errMarshal != nil {
+			t.Fatalf("marshal request: %v", errMarshal)
+		}
+		if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSave, req); errCall != nil {
+			t.Fatalf("host.auth.save(%s): %v", name, errCall)
+		}
+	}
+
+	// Legacy payload without a "prefix" field: the rebuilt auth must inherit
+	// the live Prefix instead of clearing it.
+	save("saved.json", `{"type":"demo","email":"saved@example.com","api_key":"k1"}`)
+	if got, ok := manager.GetByID("saved.json"); !ok {
+		t.Fatal("auth disappeared after legacy save")
+	} else if got.Prefix != "workbuddy" {
+		t.Fatalf("Prefix after legacy save = %q, want inherited %q", got.Prefix, "workbuddy")
+	}
+
+	// Payload carrying prefix + disabled: the file is authoritative.
+	save("saved.json", `{"type":"demo","email":"saved@example.com","api_key":"k1","prefix":"qoderwork","disabled":true}`)
+	if got, ok := manager.GetByID("saved.json"); !ok {
+		t.Fatal("auth disappeared after prefixed save")
+	} else {
+		if got.Prefix != "qoderwork" {
+			t.Fatalf("Prefix after prefixed save = %q, want %q", got.Prefix, "qoderwork")
+		}
+		if !got.Disabled || got.Status != coreauth.StatusDisabled {
+			t.Fatalf("disabled state after save = (%v, %v), want (true, disabled)", got.Disabled, got.Status)
+		}
+	}
+
+	// Explicit empty "prefix" is how a prefix gets removed: the key is
+	// present, so it stays authoritative and must NOT fall back to the
+	// previous live value.
+	save("saved.json", `{"type":"demo","email":"saved@example.com","api_key":"k1","prefix":"","disabled":false}`)
+	if got, ok := manager.GetByID("saved.json"); !ok {
+		t.Fatal("auth disappeared after empty-prefix save")
+	} else if got.Prefix != "" {
+		t.Fatalf("Prefix after explicit empty save = %q, want cleared", got.Prefix)
+	}
+
+	// Fresh file (register path) with a prefix field: prefix comes from the file.
+	save("fresh.json", `{"type":"demo","email":"fresh@example.com","api_key":"k2","prefix":"demo"}`)
+	if got, ok := manager.GetByID("fresh.json"); !ok {
+		t.Fatal("fresh auth was not registered")
+	} else if got.Prefix != "demo" {
+		t.Fatalf("Prefix on fresh register = %q, want %q", got.Prefix, "demo")
+	}
+}


### PR DESCRIPTION
## Problem

When a plugin persists credential JSON through the `host.auth.save` RPC, the host rebuilds the in-memory `Auth` from that payload via `buildAuthFromFileData` and replaces the existing record via `upsertAuthRecord` → `Manager.Update` (whole-record replacement).

The rebuilt auth **ignored the file's `prefix` and `disabled` metadata**: `Prefix` stayed empty and `Status` was hardcoded to active. This produces two concrete failures for any plugin that rewrites its auth files on a schedule:

1. **Model prefix loss** — every scheduled rewrite (daily check-in at 09:00, token keepalive at 22:00, credit lifecycle reconcile) cleared `auth.Prefix`, so `applyModelPrefixes` stopped emitting `<prefix>/<model>` IDs and `/v1/models` silently fell back to bare model IDs until the next host restart (the watcher's re-synthesis goes through the plugin's `ParseAuth`, which restores `Prefix`).
2. **Disabled flag flip** — an auth file with `disabled: true` rewritten through `host.auth.save` came back as an active in-memory auth.

We hit (1) in production with a plugin whose daily check-in rewrites every auth file: all provider-prefixed model IDs disappeared every morning.

## Fix

- `buildAuthFromFileData`: parse `metadata["prefix"]` and `metadata["disabled"]` exactly the way the watcher's `synthesizer.SynthesizeAuthFile` already does (same trimming/validation rules), and carry both into the rebuilt `Auth` (`Prefix`, `Status`, `Disabled`).
- `upsertAuthRecord`: when updating an existing record and the payload carries no `prefix` (legacy auth files written before the field existed), inherit the live record's `Prefix` instead of clearing it.

## Testing

- New regression test `TestHostAuthSaveCallbackPreservesPrefixAndDisabled`:
  - legacy payload (no `prefix` field) → inherits the seeded live `Prefix`
  - payload with `prefix` + `disabled: true` → file is authoritative (`Prefix` updated, `Status` disabled)
  - fresh file with `prefix` → registered with the file's prefix
- Verified the test fails on unpatched code with `Prefix after legacy save = ""` (the exact production symptom).
- `go test ./internal/pluginhost/` passes; `go build ./...` clean.