### PR TITLE
fix(util): strip Gemini-rejected JSON Schema keywords

### DIFF
--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
@@ -766,12 +766,10 @@ func convertRefsToHints(jsonStr string, preserveSiblings bool) string {
 	return jsonStr
 }
 
-// projectExclusiveBounds rewrites numeric exclusiveMinimum / exclusiveMaximum into inclusive
-// minimum / maximum. Integer bounds shift by ±1 (floor(val)+1 / ceil(val)-1) because Gemini
-// has no exclusive-bound field; number bounds keep the same value (intentional widening).
-// An existing sibling inclusive bound is left unchanged. Draft-04 boolean exclusive flags
-// are dropped; the sibling inclusive bound is already the projected form. Property names
-// that collide with these keywords are preserved.
+// projectExclusiveBounds rewrites integer exclusiveMinimum / exclusiveMaximum into equivalent
+// inclusive bounds. Continuous number bounds use the closest supported inclusive bound and retain
+// their exact exclusivity as a description hint. Property names that collide with these keywords
+// are preserved.
 func projectExclusiveBounds(jsonStr string) string {
 	pathsByField := findPathsByFields(jsonStr, []string{"exclusiveMinimum", "exclusiveMaximum"})
 	for _, key := range []string{"exclusiveMinimum", "exclusiveMaximum"} {
@@ -789,15 +787,31 @@ func projectExclusiveBounds(jsonStr string) string {
 			if !val.Exists() {
 				continue
 			}
-			if val.Type == gjson.Number {
-				incPath := joinPath(parentPath, inclusive)
-				if !gjson.Get(jsonStr, incPath).Exists() {
-					projected := val.Raw
-					if gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "integer" {
-						projected = projectIntegerExclusiveBound(val.Raw, exclusiveMaximum)
+
+			incPath := joinPath(parentPath, inclusive)
+			integerSchema := gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "integer"
+			switch {
+			case val.Type == gjson.Number && integerSchema:
+				if projected, ok := projectIntegerExclusiveBound(val.Raw, exclusiveMaximum); ok {
+					jsonStr = setStricterNumericBound(jsonStr, incPath, projected, exclusiveMaximum)
+				} else {
+					jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
+				}
+			case val.Type == gjson.Number:
+				jsonStr = setStricterNumericBound(jsonStr, incPath, val.Raw, exclusiveMaximum)
+				jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
+			case (val.Type == gjson.True || val.Type == gjson.False) && val.Bool():
+				// Draft-04 represents exclusivity as a boolean flag on minimum / maximum.
+				bound := gjson.Get(jsonStr, incPath)
+				if integerSchema && bound.Type == gjson.Number {
+					if projected, ok := projectIntegerExclusiveBound(bound.Raw, exclusiveMaximum); ok {
+						updated, _ := sjson.SetRawBytes([]byte(jsonStr), incPath, []byte(projected))
+						jsonStr = string(updated)
+					} else {
+						jsonStr = appendHint(jsonStr, parentPath, key+": true")
 					}
-					updated, _ := sjson.SetRawBytes([]byte(jsonStr), incPath, []byte(projected))
-					jsonStr = string(updated)
+				} else if bound.Exists() {
+					jsonStr = appendHint(jsonStr, parentPath, key+": true")
 				}
 			}
 			jsonStr, _ = sjson.Delete(jsonStr, p)
@@ -806,24 +820,39 @@ func projectExclusiveBounds(jsonStr string) string {
 	return jsonStr
 }
 
-func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) string {
-	if i, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
-		if exclusiveMaximum {
-			return strconv.FormatInt(i-1, 10)
-		}
-		return strconv.FormatInt(i+1, 10)
+func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) (string, bool) {
+	value, ok := new(big.Rat).SetString(strings.TrimSpace(raw))
+	if !ok {
+		return "", false
 	}
-	f, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return raw
-	}
-	var projected float64
+
+	// Div rounds toward negative infinity because the denominator is positive.
+	projected := new(big.Int).Div(value.Num(), value.Denom())
 	if exclusiveMaximum {
-		projected = math.Ceil(f) - 1
+		if value.IsInt() {
+			projected.Sub(projected, big.NewInt(1))
+		}
 	} else {
-		projected = math.Floor(f) + 1
+		projected.Add(projected, big.NewInt(1))
 	}
-	return strconv.FormatInt(int64(projected), 10)
+	return projected.String(), true
+}
+
+func setStricterNumericBound(jsonStr, path, projected string, maximum bool) string {
+	existing := gjson.Get(jsonStr, path)
+	if existing.Exists() {
+		projectedValue, projectedOK := new(big.Rat).SetString(projected)
+		existingValue, existingOK := new(big.Rat).SetString(existing.Raw)
+		if !projectedOK || !existingOK {
+			return jsonStr
+		}
+		comparison := projectedValue.Cmp(existingValue)
+		if (maximum && comparison >= 0) || (!maximum && comparison <= 0) {
+			return jsonStr
+		}
+	}
+	updated, _ := sjson.SetRawBytes([]byte(jsonStr), path, []byte(projected))
+	return string(updated)
 }
 
 func convertConstToEnum(jsonStr string) string {
@@ -911,11 +940,19 @@ func addEnumHints(jsonStr string) string {
 func dropIgnoredEnumsToHints(jsonStr string, options jsonSchemaCleanOptions) string {
 	for _, path := range findPaths(jsonStr, "enum") {
 		parentPath := trimSuffix(path, ".enum")
-		shouldDrop := options.dropAllEnums || (options.dropBooleanEnums && isBooleanEnumSchema(jsonStr, parentPath, gjson.Get(jsonStr, path)))
+		enum := gjson.Get(jsonStr, path)
+		booleanEnum := isBooleanEnumSchema(jsonStr, parentPath, enum)
+		shouldDrop := options.dropAllEnums || (options.dropBooleanEnums && booleanEnum)
 		if !shouldDrop {
 			continue
 		}
-		enum := gjson.Get(jsonStr, path)
+		if booleanEnum {
+			typePath := joinPath(parentPath, "type")
+			if !gjson.Get(jsonStr, typePath).Exists() {
+				updated, _ := sjson.SetBytes([]byte(jsonStr), typePath, "boolean")
+				jsonStr = string(updated)
+			}
+		}
 		if enum.IsArray() && len(enum.Array()) == 1 {
 			jsonStr = appendHint(jsonStr, parentPath, "Allowed: "+enum.Array()[0].String())
 		}

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -1001,7 +1001,7 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 }
 
 func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
-	if !arr.IsArray() || len(arr.Array()) == 0 {
+	if !arr.IsArray() {
 		return false
 	}
 	hasBoolean := false
@@ -1018,10 +1018,22 @@ func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
 	schemaType := gjson.Get(jsonStr, joinPath(parentPath, "type"))
 	if schemaType.Exists() {
 		// An explicitly typed nullable boolean may be constrained to null alone. The member
-		// validation above still rejects string or numeric enums on boolean-first unions.
-		return effectiveSchemaType(schemaType) == "boolean"
+		// validation above still rejects string or numeric enums on boolean-containing unions.
+		return schemaTypeIncludes(schemaType, "boolean")
 	}
 	return hasBoolean
+}
+
+func schemaTypeIncludes(schemaType gjson.Result, target string) bool {
+	if !schemaType.IsArray() {
+		return schemaType.String() == target
+	}
+	for _, item := range schemaType.Array() {
+		if item.String() == target {
+			return true
+		}
+	}
+	return false
 }
 
 func enumContainsNull(arr gjson.Result) bool {
@@ -1074,14 +1086,13 @@ func dropIgnoredEnumsToHints(jsonStr string, options jsonSchemaCleanOptions) str
 		}
 		if booleanEnum {
 			typePath := joinPath(parentPath, "type")
-			if !gjson.Get(jsonStr, typePath).Exists() {
-				inferredType := any("boolean")
-				if enumContainsNull(enum) {
-					inferredType = []string{"boolean", "null"}
-				}
-				updated, _ := sjson.SetBytes([]byte(jsonStr), typePath, inferredType)
-				jsonStr = string(updated)
+			declaredType := gjson.Get(jsonStr, typePath)
+			normalizedType := any("boolean")
+			if enumContainsNull(enum) && (!declaredType.Exists() || schemaTypeIncludes(declaredType, "null")) {
+				normalizedType = []string{"boolean", "null"}
 			}
+			updated, _ := sjson.SetBytes([]byte(jsonStr), typePath, normalizedType)
+			jsonStr = string(updated)
 		}
 		if enum.IsArray() && len(enum.Array()) == 1 {
 			jsonStr = appendHint(jsonStr, parentPath, "Allowed: "+enumHintValue(enum.Array()[0]))

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -789,7 +789,7 @@ func projectExclusiveBounds(jsonStr string) string {
 			}
 
 			incPath := joinPath(parentPath, inclusive)
-			integerSchema := gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "integer"
+			integerSchema := effectiveSchemaType(gjson.Get(jsonStr, joinPath(parentPath, "type"))) == "integer"
 			switch {
 			case val.Type == gjson.Number && integerSchema:
 				if projected, ok := projectIntegerExclusiveBound(val.Raw, exclusiveMaximum); ok {
@@ -818,6 +818,20 @@ func projectExclusiveBounds(jsonStr string) string {
 		}
 	}
 	return jsonStr
+}
+
+// effectiveSchemaType mirrors flattenTypeArrays: for a type union, the first
+// non-null member is the scalar type that survives cleaning.
+func effectiveSchemaType(schemaType gjson.Result) string {
+	if !schemaType.IsArray() {
+		return schemaType.String()
+	}
+	for _, item := range schemaType.Array() {
+		if value := item.String(); value != "" && value != "null" {
+			return value
+		}
+	}
+	return ""
 }
 
 func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) (string, bool) {

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -766,14 +767,17 @@ func convertRefsToHints(jsonStr string, preserveSiblings bool) string {
 }
 
 // projectExclusiveBounds rewrites numeric exclusiveMinimum / exclusiveMaximum into inclusive
-// minimum / maximum with the same value. An existing sibling inclusive bound is left unchanged.
-// Draft-04 boolean exclusive flags are dropped; the sibling inclusive bound is already the
-// projected form. Property names that collide with these keywords are preserved.
+// minimum / maximum. Integer bounds shift by ±1 (floor(val)+1 / ceil(val)-1) because Gemini
+// has no exclusive-bound field; number bounds keep the same value (intentional widening).
+// An existing sibling inclusive bound is left unchanged. Draft-04 boolean exclusive flags
+// are dropped; the sibling inclusive bound is already the projected form. Property names
+// that collide with these keywords are preserved.
 func projectExclusiveBounds(jsonStr string) string {
 	pathsByField := findPathsByFields(jsonStr, []string{"exclusiveMinimum", "exclusiveMaximum"})
 	for _, key := range []string{"exclusiveMinimum", "exclusiveMaximum"} {
 		inclusive := "minimum"
-		if key == "exclusiveMaximum" {
+		exclusiveMaximum := key == "exclusiveMaximum"
+		if exclusiveMaximum {
 			inclusive = "maximum"
 		}
 		for _, p := range pathsByField[key] {
@@ -788,7 +792,11 @@ func projectExclusiveBounds(jsonStr string) string {
 			if val.Type == gjson.Number {
 				incPath := joinPath(parentPath, inclusive)
 				if !gjson.Get(jsonStr, incPath).Exists() {
-					updated, _ := sjson.SetRawBytes([]byte(jsonStr), incPath, []byte(val.Raw))
+					projected := val.Raw
+					if gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "integer" {
+						projected = projectIntegerExclusiveBound(val.Raw, exclusiveMaximum)
+					}
+					updated, _ := sjson.SetRawBytes([]byte(jsonStr), incPath, []byte(projected))
 					jsonStr = string(updated)
 				}
 			}
@@ -796,6 +804,26 @@ func projectExclusiveBounds(jsonStr string) string {
 		}
 	}
 	return jsonStr
+}
+
+func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) string {
+	if i, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
+		if exclusiveMaximum {
+			return strconv.FormatInt(i-1, 10)
+		}
+		return strconv.FormatInt(i+1, 10)
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return raw
+	}
+	var projected float64
+	if exclusiveMaximum {
+		projected = math.Ceil(f) - 1
+	} else {
+		projected = math.Floor(f) + 1
+	}
+	return strconv.FormatInt(int64(projected), 10)
 }
 
 func convertConstToEnum(jsonStr string) string {

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -799,12 +799,16 @@ func projectExclusiveBounds(jsonStr string) string {
 			switch {
 			case val.Type == gjson.Number && integerSchema:
 				if projected, ok := projectIntegerExclusiveBound(val.Raw, exclusiveMaximum); ok {
-					jsonStr = setStricterNumericBound(jsonStr, incPath, projected, exclusiveMaximum)
+					var represented bool
+					jsonStr, represented = setStricterNumericBound(jsonStr, incPath, projected, exclusiveMaximum)
+					if !represented {
+						jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
+					}
 				} else {
 					jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
 				}
 			case val.Type == gjson.Number:
-				jsonStr = setStricterNumericBound(jsonStr, incPath, val.Raw, exclusiveMaximum)
+				jsonStr, _ = setStricterNumericBound(jsonStr, incPath, val.Raw, exclusiveMaximum)
 				jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
 			case (val.Type == gjson.True || val.Type == gjson.False) && val.Bool():
 				// Draft-04 represents exclusivity as a boolean flag on minimum / maximum.
@@ -939,21 +943,31 @@ func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) (string, bo
 	return projected.String(), true
 }
 
-func setStricterNumericBound(jsonStr, path, projected string, maximum bool) string {
+// setStricterNumericBound returns whether the incoming bound is represented either by the
+// existing stricter bound or by a successful write. A capped numeric sibling cannot be compared
+// safely, so callers can preserve the incoming constraint as an exact description hint.
+func setStricterNumericBound(jsonStr, path, projected string, maximum bool) (string, bool) {
 	existing := gjson.Get(jsonStr, path)
 	if existing.Exists() {
 		projectedValue, projectedOK := parseSchemaNumericBound(projected)
+		if !projectedOK {
+			return jsonStr, false
+		}
+		if existing.Type != gjson.Number {
+			updated, _ := sjson.SetRawBytes([]byte(jsonStr), path, []byte(projected))
+			return string(updated), true
+		}
 		existingValue, existingOK := parseSchemaNumericBound(existing.Raw)
-		if !projectedOK || !existingOK {
-			return jsonStr
+		if !existingOK {
+			return jsonStr, false
 		}
 		comparison := projectedValue.Cmp(existingValue)
 		if (maximum && comparison >= 0) || (!maximum && comparison <= 0) {
-			return jsonStr
+			return jsonStr, true
 		}
 	}
 	updated, _ := sjson.SetRawBytes([]byte(jsonStr), path, []byte(projected))
-	return string(updated)
+	return string(updated), true
 }
 
 func convertConstToEnum(jsonStr string) string {
@@ -1138,14 +1152,17 @@ func moveConstraintsToDescription(jsonStr string, options jsonSchemaCleanOptions
 			if isPropertyDefinition(parentPath) {
 				continue
 			}
-			if val.IsObject() || val.IsArray() {
-				jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.Raw))
-				continue
-			}
-			jsonStr = appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", key, val.String()))
+			jsonStr = appendConstraintHint(jsonStr, parentPath, key, val)
 		}
 	}
 	return jsonStr
+}
+
+func appendConstraintHint(jsonStr, parentPath, field string, value gjson.Result) string {
+	if value.IsObject() || value.IsArray() {
+		return appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", field, value.Raw))
+	}
+	return appendHint(jsonStr, parentPath, fmt.Sprintf("%s: %s", field, value.String()))
 }
 
 func moveNotToDescription(jsonStr string) string {
@@ -1246,16 +1263,51 @@ func mergeAllOf(jsonStr string) string {
 	return jsonStr
 }
 
-// mergeAllOfSchemaAtPath preserves the parent-first behavior for schema shape while intersecting
-// numeric bounds. Bounds may be nested under properties, so this rule is intentionally recursive
-// and local to allOf rather than changing the merger also used for lossy anyOf projections.
+// mergeAllOfSchemaAtPath preserves parent-first schema shape while intersecting the constraints
+// that have safe projections. The rule is recursive and local to allOf rather than changing the
+// merger also used for lossy anyOf projections.
 func mergeAllOfSchemaAtPath(jsonStr, destination, field string, incoming gjson.Result) string {
+	parentPath := trimSuffix(destination, "."+escapeGJSONPathKey(field))
+	propertyDefinition := isPropertyDefinition(parentPath)
+	if field == "required" && incoming.IsArray() && !propertyDefinition {
+		current := getStrings(jsonStr, destination)
+		for _, required := range incoming.Array() {
+			if name := required.String(); !contains(current, name) {
+				current = append(current, name)
+			}
+		}
+		updated, _ := sjson.SetBytes([]byte(jsonStr), destination, current)
+		return string(updated)
+	}
+	if field == "enum" && incoming.IsArray() && !propertyDefinition {
+		if existing := gjson.Get(jsonStr, destination); existing.IsArray() {
+			updated, _ := sjson.SetRawBytes([]byte(jsonStr), destination, []byte(intersectEnumValues(existing, incoming)))
+			return string(updated)
+		}
+	}
+	if field == "additionalProperties" && !propertyDefinition {
+		existing := gjson.Get(jsonStr, destination)
+		switch {
+		case existing.Type == gjson.False:
+			return jsonStr
+		case incoming.Type == gjson.False:
+			updated, _ := sjson.SetBytes([]byte(jsonStr), destination, false)
+			return string(updated)
+		case existing.Type == gjson.True && incoming.IsObject():
+			updated, _ := sjson.SetRawBytes([]byte(jsonStr), destination, []byte(incoming.Raw))
+			return string(updated)
+		}
+	}
+	if shouldPreserveAllOfConstraintHints(field) && !propertyDefinition && gjson.Get(jsonStr, destination).Exists() {
+		return appendConstraintHint(jsonStr, parentPath, field, incoming)
+	}
 	if incoming.Type == gjson.Number {
-		switch field {
-		case "minimum":
-			return setStricterNumericBound(jsonStr, destination, incoming.Raw, false)
-		case "maximum":
-			return setStricterNumericBound(jsonStr, destination, incoming.Raw, true)
+		if maximum, ok := allOfBoundDirection(field); ok {
+			updated, represented := setStricterNumericBound(jsonStr, destination, incoming.Raw, maximum)
+			if !represented {
+				return appendConstraintHint(updated, parentPath, field, incoming)
+			}
+			return updated
 		}
 	}
 	if field == "description" && incoming.Type == gjson.String {
@@ -1281,6 +1333,81 @@ func mergeAllOfSchemaAtPath(jsonStr, destination, field string, incoming gjson.R
 		return true
 	})
 	return jsonStr
+}
+
+func intersectEnumValues(existing, incoming gjson.Result) string {
+	incomingValues := incoming.Array()
+	allowed := make(map[string]struct{}, len(incomingValues))
+	for _, value := range incomingValues {
+		allowed[enumValueKey(value)] = struct{}{}
+	}
+	emitted := make(map[string]struct{})
+	var result bytes.Buffer
+	result.WriteByte('[')
+	first := true
+	for _, candidate := range existing.Array() {
+		key := enumValueKey(candidate)
+		if _, ok := allowed[key]; !ok {
+			continue
+		}
+		if _, duplicate := emitted[key]; duplicate {
+			continue
+		}
+		emitted[key] = struct{}{}
+		if !first {
+			result.WriteByte(',')
+		}
+		result.WriteString(candidate.Raw)
+		first = false
+	}
+	result.WriteByte(']')
+	return result.String()
+}
+
+func enumValueKey(value gjson.Result) string {
+	switch value.Type {
+	case gjson.String:
+		return "string:" + value.String()
+	case gjson.Number:
+		if number, ok := parseSchemaNumericBound(value.Raw); ok {
+			return "number:" + number.RatString()
+		}
+		return "number-raw:" + value.Raw
+	case gjson.JSON:
+		var compact bytes.Buffer
+		if json.Compact(&compact, []byte(value.Raw)) == nil {
+			return "json:" + compact.String()
+		}
+		return "json-raw:" + value.Raw
+	case gjson.True:
+		return "boolean:true"
+	case gjson.False:
+		return "boolean:false"
+	case gjson.Null:
+		return "null"
+	default:
+		return fmt.Sprintf("unknown:%d:%s", value.Type, value.Raw)
+	}
+}
+
+func allOfBoundDirection(field string) (maximum bool, ok bool) {
+	switch field {
+	case "minimum", "minLength", "minItems", "minProperties":
+		return false, true
+	case "maximum", "maxLength", "maxItems", "maxProperties":
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+func shouldPreserveAllOfConstraintHints(field string) bool {
+	switch field {
+	case "pattern", "format", "contains", "uniqueItems", "multipleOf":
+		return true
+	default:
+		return false
+	}
 }
 
 // mergeMissingSchemaAtPath recursively fills absent fields without replacing any existing

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -113,7 +113,6 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 	if !options.preserveAdditionalPropertiesFalse {
 		jsonStr = addAdditionalPropertiesHints(jsonStr)
 	}
-	jsonStr = moveConstraintsToDescription(jsonStr, options)
 	if options.antigravitySemantics {
 		jsonStr = moveNotToDescription(jsonStr)
 	}
@@ -121,6 +120,9 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 	// Phase 2: Flatten complex structures
 	jsonStr = mergeConditionals(jsonStr)
 	jsonStr = mergeAllOf(jsonStr)
+	// Preserve only the effective constraint after intersecting allOf branches. Moving constraints
+	// before allOf flattening can leave a weaker branch's first-wins description hint behind.
+	jsonStr = moveConstraintsToDescription(jsonStr, options)
 	if options.flattenUnions {
 		jsonStr = flattenAnyOfOneOf(jsonStr)
 	}
@@ -772,6 +774,7 @@ func convertRefsToHints(jsonStr string, preserveSiblings bool) string {
 // are preserved.
 func projectExclusiveBounds(jsonStr string) string {
 	pathsByField := findPathsByFields(jsonStr, []string{"exclusiveMinimum", "exclusiveMaximum"})
+	integerSchemaPaths := findIntegerSchemaPaths(jsonStr)
 	for _, key := range []string{"exclusiveMinimum", "exclusiveMaximum"} {
 		inclusive := "minimum"
 		exclusiveMaximum := key == "exclusiveMaximum"
@@ -790,6 +793,9 @@ func projectExclusiveBounds(jsonStr string) string {
 
 			incPath := joinPath(parentPath, inclusive)
 			integerSchema := effectiveSchemaType(gjson.Get(jsonStr, joinPath(parentPath, "type"))) == "integer"
+			if !integerSchema {
+				_, integerSchema = integerSchemaPaths[logicalAllOfSchemaPath(parentPath)]
+			}
 			switch {
 			case val.Type == gjson.Number && integerSchema:
 				if projected, ok := projectIntegerExclusiveBound(val.Raw, exclusiveMaximum); ok {
@@ -820,6 +826,45 @@ func projectExclusiveBounds(jsonStr string) string {
 	return jsonStr
 }
 
+// findIntegerSchemaPaths records types by their logical location after allOf flattening. An allOf
+// branch inherits the intersection's integer domain even when its own bound-only branch omits type.
+func findIntegerSchemaPaths(jsonStr string) map[string]struct{} {
+	paths := make(map[string]struct{})
+	for _, typePath := range findPaths(jsonStr, "type") {
+		if effectiveSchemaType(gjson.Get(jsonStr, typePath)) != "integer" {
+			continue
+		}
+		parentPath := trimSuffix(typePath, ".type")
+		paths[logicalAllOfSchemaPath(parentPath)] = struct{}{}
+	}
+	return paths
+}
+
+func logicalAllOfSchemaPath(path string) string {
+	parts := splitGJSONPath(path)
+	logical := make([]string, 0, len(parts))
+	for index := 0; index < len(parts); index++ {
+		if parts[index] == "allOf" && index+1 < len(parts) && isDecimalPathIndex(parts[index+1]) {
+			index++
+			continue
+		}
+		logical = append(logical, parts[index])
+	}
+	return strings.Join(logical, ".")
+}
+
+func isDecimalPathIndex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := 0; index < len(value); index++ {
+		if value[index] < '0' || value[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // effectiveSchemaType mirrors flattenTypeArrays: for a type union, the first
 // non-null member is the scalar type that survives cleaning.
 func effectiveSchemaType(schemaType gjson.Result) string {
@@ -834,8 +879,50 @@ func effectiveSchemaType(schemaType gjson.Result) string {
 	return ""
 }
 
+const (
+	// Bounds larger than these limits cannot be represented usefully by the upstream schema APIs.
+	// Keeping both the literal and exponent bounded also prevents big.Rat from expanding a compact
+	// value such as 1e1000000000 into an enormous integer.
+	maxSchemaBoundLiteralLength = 4096
+	maxSchemaBoundExponent      = 4096
+)
+
+func parseSchemaNumericBound(raw string) (*big.Rat, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || len(raw) > maxSchemaBoundLiteralLength {
+		return nil, false
+	}
+
+	if exponentIndex := strings.IndexAny(raw, "eE"); exponentIndex >= 0 {
+		exponent := raw[exponentIndex+1:]
+		if exponent == "" {
+			return nil, false
+		}
+		if exponent[0] == '+' || exponent[0] == '-' {
+			exponent = exponent[1:]
+		}
+		if exponent == "" {
+			return nil, false
+		}
+		magnitude := 0
+		for i := 0; i < len(exponent); i++ {
+			if exponent[i] < '0' || exponent[i] > '9' {
+				return nil, false
+			}
+			digit := int(exponent[i] - '0')
+			if magnitude > (maxSchemaBoundExponent-digit)/10 {
+				return nil, false
+			}
+			magnitude = magnitude*10 + digit
+		}
+	}
+
+	value, ok := new(big.Rat).SetString(raw)
+	return value, ok
+}
+
 func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) (string, bool) {
-	value, ok := new(big.Rat).SetString(strings.TrimSpace(raw))
+	value, ok := parseSchemaNumericBound(raw)
 	if !ok {
 		return "", false
 	}
@@ -855,8 +942,8 @@ func projectIntegerExclusiveBound(raw string, exclusiveMaximum bool) (string, bo
 func setStricterNumericBound(jsonStr, path, projected string, maximum bool) string {
 	existing := gjson.Get(jsonStr, path)
 	if existing.Exists() {
-		projectedValue, projectedOK := new(big.Rat).SetString(projected)
-		existingValue, existingOK := new(big.Rat).SetString(existing.Raw)
+		projectedValue, projectedOK := parseSchemaNumericBound(projected)
+		existingValue, existingOK := parseSchemaNumericBound(existing.Raw)
 		if !projectedOK || !existingOK {
 			return jsonStr
 		}
@@ -914,18 +1001,41 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 }
 
 func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
-	if gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "boolean" {
-		return true
+	schemaType := gjson.Get(jsonStr, joinPath(parentPath, "type"))
+	if schemaType.Exists() {
+		return effectiveSchemaType(schemaType) == "boolean"
 	}
 	if !arr.IsArray() || len(arr.Array()) == 0 {
 		return false
 	}
+	hasBoolean := false
 	for _, item := range arr.Array() {
-		if item.Type != gjson.True && item.Type != gjson.False {
+		switch item.Type {
+		case gjson.True, gjson.False:
+			hasBoolean = true
+		case gjson.Null:
+			// An untyped boolean enum can express nullability through a null member.
+		default:
 			return false
 		}
 	}
-	return true
+	return hasBoolean
+}
+
+func enumContainsNull(arr gjson.Result) bool {
+	for _, item := range arr.Array() {
+		if item.Type == gjson.Null {
+			return true
+		}
+	}
+	return false
+}
+
+func enumHintValue(value gjson.Result) string {
+	if value.Type == gjson.Null {
+		return "null"
+	}
+	return value.String()
 }
 
 func addEnumHints(jsonStr string) string {
@@ -941,7 +1051,7 @@ func addEnumHints(jsonStr string) string {
 
 		var vals []string
 		for _, item := range items {
-			vals = append(vals, item.String())
+			vals = append(vals, enumHintValue(item))
 		}
 		jsonStr = appendHint(jsonStr, trimSuffix(p, ".enum"), "Allowed: "+strings.Join(vals, ", "))
 	}
@@ -963,12 +1073,16 @@ func dropIgnoredEnumsToHints(jsonStr string, options jsonSchemaCleanOptions) str
 		if booleanEnum {
 			typePath := joinPath(parentPath, "type")
 			if !gjson.Get(jsonStr, typePath).Exists() {
-				updated, _ := sjson.SetBytes([]byte(jsonStr), typePath, "boolean")
+				inferredType := any("boolean")
+				if enumContainsNull(enum) {
+					inferredType = []string{"boolean", "null"}
+				}
+				updated, _ := sjson.SetBytes([]byte(jsonStr), typePath, inferredType)
 				jsonStr = string(updated)
 			}
 		}
 		if enum.IsArray() && len(enum.Array()) == 1 {
-			jsonStr = appendHint(jsonStr, parentPath, "Allowed: "+enum.Array()[0].String())
+			jsonStr = appendHint(jsonStr, parentPath, "Allowed: "+enumHintValue(enum.Array()[0]))
 		}
 		jsonStr, _ = sjson.Delete(jsonStr, path)
 	}
@@ -1109,13 +1223,50 @@ func mergeAllOf(jsonStr string) string {
 					// Conditional applicability cannot be represented by the upstream schema.
 				default:
 					destination := joinPath(parentPath, escapeGJSONPathKey(field))
-					jsonStr = mergeMissingSchemaAtPath(jsonStr, destination, value)
+					jsonStr = mergeAllOfSchemaAtPath(jsonStr, destination, field, value)
 				}
 				return true
 			})
 		}
 		jsonStr, _ = sjson.Delete(jsonStr, p)
 	}
+	return jsonStr
+}
+
+// mergeAllOfSchemaAtPath preserves the parent-first behavior for schema shape while intersecting
+// numeric bounds. Bounds may be nested under properties, so this rule is intentionally recursive
+// and local to allOf rather than changing the merger also used for lossy anyOf projections.
+func mergeAllOfSchemaAtPath(jsonStr, destination, field string, incoming gjson.Result) string {
+	if incoming.Type == gjson.Number {
+		switch field {
+		case "minimum":
+			return setStricterNumericBound(jsonStr, destination, incoming.Raw, false)
+		case "maximum":
+			return setStricterNumericBound(jsonStr, destination, incoming.Raw, true)
+		}
+	}
+	if field == "description" && incoming.Type == gjson.String {
+		existing := gjson.Get(jsonStr, destination)
+		if existing.Type == gjson.String {
+			updated, _ := sjson.SetBytes([]byte(jsonStr), destination, mergeHint(existing.String(), incoming.String()))
+			return string(updated)
+		}
+	}
+
+	existing := gjson.Get(jsonStr, destination)
+	if !existing.Exists() {
+		updated, _ := sjson.SetRawBytes([]byte(jsonStr), destination, []byte(incoming.Raw))
+		return string(updated)
+	}
+	if !existing.IsObject() || !incoming.IsObject() {
+		return jsonStr
+	}
+	incoming.ForEach(func(key, value gjson.Result) bool {
+		field := key.String()
+		child := joinPath(destination, escapeGJSONPathKey(field))
+		jsonStr = mergeAllOfSchemaAtPath(jsonStr, child, field, value)
+		return true
+	})
 	return jsonStr
 }
 

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -173,7 +173,7 @@ func removeKeywords(jsonStr string, keywords []string) string {
 // removePlaceholderFields removes placeholder-only properties ("_" and "reason") and their required entries.
 func removePlaceholderFields(jsonStr string) string {
 	// Remove "_" placeholder properties.
-	paths := findPaths(jsonStr, "_")
+	paths := findPropertyNamePaths(jsonStr, "_")
 	sortByDepth(paths)
 	for _, p := range paths {
 		if !strings.HasSuffix(p, ".properties._") {
@@ -200,7 +200,7 @@ func removePlaceholderFields(jsonStr string) string {
 	}
 
 	// Remove placeholder-only "reason" objects.
-	reasonPaths := findPaths(jsonStr, "reason")
+	reasonPaths := findPropertyNamePaths(jsonStr, "reason")
 	sortByDepth(reasonPaths)
 	for _, p := range reasonPaths {
 		if !strings.HasSuffix(p, ".properties.reason") {
@@ -637,7 +637,7 @@ func inlineLocalRefs(jsonStr string) string {
 		return jsonStr
 	}
 
-	resolved := resolveLocalRefs(root, root, make(map[string]bool))
+	resolved := resolveLocalRefs(root, root, make(map[string]bool), "")
 	out, err := json.Marshal(resolved)
 	if err != nil {
 		return jsonStr
@@ -645,12 +645,12 @@ func inlineLocalRefs(jsonStr string) string {
 	return string(out)
 }
 
-func resolveLocalRefs(root, value any, active map[string]bool) any {
+func resolveLocalRefs(root, value any, active map[string]bool, path string) any {
 	switch node := value.(type) {
 	case []any:
 		out := make([]any, len(node))
 		for i, item := range node {
-			out[i] = resolveLocalRefs(root, item, active)
+			out[i] = resolveLocalRefs(root, item, active, joinPath(path, strconv.Itoa(i)))
 		}
 		return out
 	case map[string]any:
@@ -661,7 +661,7 @@ func resolveLocalRefs(root, value any, active map[string]bool) any {
 					return cyclicRefFallback(node, target, ref)
 				}
 				active[ref] = true
-				resolvedTarget := resolveLocalRefs(root, target, active)
+				resolvedTarget := resolveLocalRefs(root, target, active, path)
 				delete(active, ref)
 				if targetMap, okTarget := resolvedTarget.(map[string]any); okTarget {
 					out := make(map[string]any, len(targetMap)+len(node))
@@ -672,7 +672,11 @@ func resolveLocalRefs(root, value any, active map[string]bool) any {
 						if key == "$ref" {
 							continue
 						}
-						out[key] = resolveLocalRefs(root, item, active)
+						if isOpaqueSchemaValue(path, key) {
+							out[key] = item
+							continue
+						}
+						out[key] = resolveLocalRefs(root, item, active, joinPath(path, escapeGJSONPathKey(key)))
 					}
 					return out
 				}
@@ -681,7 +685,11 @@ func resolveLocalRefs(root, value any, active map[string]bool) any {
 
 		out := make(map[string]any, len(node))
 		for key, item := range node {
-			out[key] = resolveLocalRefs(root, item, active)
+			if isOpaqueSchemaValue(path, key) {
+				out[key] = item
+				continue
+			}
+			out[key] = resolveLocalRefs(root, item, active, joinPath(path, escapeGJSONPathKey(key)))
 		}
 		return out
 	default:
@@ -979,9 +987,9 @@ func convertConstToEnum(jsonStr string) string {
 		if !val.Exists() {
 			continue
 		}
-		enumPath := trimSuffix(p, ".const") + ".enum"
+		enumPath := joinPath(trimSuffix(p, ".const"), "enum")
 		if !gjson.Get(jsonStr, enumPath).Exists() {
-			updated, _ := sjson.SetBytes([]byte(jsonStr), enumPath, []interface{}{val.Value()})
+			updated, _ := sjson.SetRawBytes([]byte(jsonStr), enumPath, []byte("["+val.Raw+"]"))
 			jsonStr = string(updated)
 		}
 	}
@@ -1731,6 +1739,9 @@ func walkForExtensions(value gjson.Result, path string, paths *[]string) {
 				*paths = append(*paths, childPath)
 				return true
 			}
+			if isOpaqueSchemaValue(path, keyStr) {
+				return true
+			}
 
 			walkForExtensions(val, childPath, paths)
 			return true
@@ -1844,22 +1855,34 @@ func addEmptySchemaPlaceholder(jsonStr string) string {
 // --- Helpers ---
 
 func findPaths(jsonStr, field string) []string {
-	var paths []string
-	Walk(gjson.Parse(jsonStr), "", field, &paths)
-	return paths
+	pathsByField := findPathsByFields(jsonStr, []string{field})
+	return pathsByField[field]
+}
+
+// findPropertyNamePaths is used only when the caller intentionally searches author-selected
+// names in a schema name map (for example, cleanup of generated placeholder properties). It still
+// observes opaque literal boundaries, so a matching object key inside enum/const/default data is
+// never returned.
+func findPropertyNamePaths(jsonStr, field string) []string {
+	pathsByField := findPathsByFieldsWithPropertyNames(jsonStr, []string{field}, true)
+	return pathsByField[field]
 }
 
 func findPathsByFields(jsonStr string, fields []string) map[string][]string {
+	return findPathsByFieldsWithPropertyNames(jsonStr, fields, false)
+}
+
+func findPathsByFieldsWithPropertyNames(jsonStr string, fields []string, includePropertyNames bool) map[string][]string {
 	set := make(map[string]struct{}, len(fields))
 	for _, field := range fields {
 		set[field] = struct{}{}
 	}
 	paths := make(map[string][]string, len(set))
-	walkForFields(gjson.Parse(jsonStr), "", set, paths)
+	walkForFields(gjson.Parse(jsonStr), "", set, paths, includePropertyNames)
 	return paths
 }
 
-func walkForFields(value gjson.Result, path string, fields map[string]struct{}, paths map[string][]string) {
+func walkForFields(value gjson.Result, path string, fields map[string]struct{}, paths map[string][]string, includePropertyNames bool) {
 	switch value.Type {
 	case gjson.JSON:
 		value.ForEach(func(key, val gjson.Result) bool {
@@ -1873,15 +1896,35 @@ func walkForFields(value gjson.Result, path string, fields map[string]struct{}, 
 				childPath = path + "." + safeKey
 			}
 
-			if _, ok := fields[keyStr]; ok {
+			if _, ok := fields[keyStr]; ok && (includePropertyNames || !isPropertyDefinition(path)) {
 				paths[keyStr] = append(paths[keyStr], childPath)
 			}
+			if isOpaqueSchemaValue(path, keyStr) {
+				return true
+			}
 
-			walkForFields(val, childPath, fields, paths)
+			walkForFields(val, childPath, fields, paths, includePropertyNames)
 			return true
 		})
 	case gjson.String, gjson.Number, gjson.True, gjson.False, gjson.Null:
 		// Terminal types - no further traversal needed
+	}
+}
+
+// isOpaqueSchemaValue identifies schema keywords whose values are instance data or annotations,
+// not nested schemas. A matching name directly under properties/$defs is author-selected and its
+// value remains a schema, so property-name collision handling takes precedence.
+func isOpaqueSchemaValue(parentPath, field string) bool {
+	if isPropertyDefinition(parentPath) {
+		return false
+	}
+	switch field {
+	case "enum", "const", "default", "example", "examples",
+		"enumDescriptions", "enumTitles", "required", "dependentRequired",
+		"discriminator", "xml", "externalDocs":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -1001,10 +1001,6 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 }
 
 func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
-	schemaType := gjson.Get(jsonStr, joinPath(parentPath, "type"))
-	if schemaType.Exists() {
-		return effectiveSchemaType(schemaType) == "boolean"
-	}
 	if !arr.IsArray() || len(arr.Array()) == 0 {
 		return false
 	}
@@ -1018,6 +1014,12 @@ func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
 		default:
 			return false
 		}
+	}
+	schemaType := gjson.Get(jsonStr, joinPath(parentPath, "type"))
+	if schemaType.Exists() {
+		// An explicitly typed nullable boolean may be constrained to null alone. The member
+		// validation above still rejects string or numeric enums on boolean-first unions.
+		return effectiveSchemaType(schemaType) == "boolean"
 	}
 	return hasBoolean
 }

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -100,26 +100,29 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 	// Phase 0: Normalize malformed schemas (e.g. bare property maps and boolean required from MCP tools)
 	jsonStr = normalizeMalformedSchemaObjects(jsonStr, options.addMissingArrayItems)
 
-	// Phase 1: Convert and add hints
+	// Phase 1: Resolve references and normalize constraints that need their original JSON types.
 	if options.antigravitySemantics {
 		jsonStr = inlineLocalRefs(jsonStr)
 	}
 	jsonStr = convertRefsToHints(jsonStr, options.antigravitySemantics)
 	jsonStr = projectExclusiveBounds(jsonStr)
 	jsonStr = convertConstToEnum(jsonStr)
+	if options.antigravitySemantics {
+		jsonStr = moveNotToDescription(jsonStr)
+	}
+
+	// Intersect allOf before enum conversion or boolean inference erases the members' original
+	// types. Conditional properties are merged first so nested allOf schemas share this ordering.
+	jsonStr = mergeConditionals(jsonStr)
+	jsonStr = mergeAllOf(jsonStr)
+
+	// Phase 2: Convert constraints to their upstream-compatible representation and add hints.
 	jsonStr = convertEnumValuesToStrings(jsonStr, options.forceEnumStringType)
 	jsonStr = addEnumHints(jsonStr)
 	jsonStr = dropIgnoredEnumsToHints(jsonStr, options)
 	if !options.preserveAdditionalPropertiesFalse {
 		jsonStr = addAdditionalPropertiesHints(jsonStr)
 	}
-	if options.antigravitySemantics {
-		jsonStr = moveNotToDescription(jsonStr)
-	}
-
-	// Phase 2: Flatten complex structures
-	jsonStr = mergeConditionals(jsonStr)
-	jsonStr = mergeAllOf(jsonStr)
 	// Preserve only the effective constraint after intersecting allOf branches. Moving constraints
 	// before allOf flattening can leave a weaker branch's first-wins description hint behind.
 	jsonStr = moveConstraintsToDescription(jsonStr, options)
@@ -1365,28 +1368,73 @@ func intersectEnumValues(existing, incoming gjson.Result) string {
 }
 
 func enumValueKey(value gjson.Result) string {
+	var key strings.Builder
+	appendEnumValueKey(&key, value)
+	return key.String()
+}
+
+func appendEnumValueKey(key *strings.Builder, value gjson.Result) {
 	switch value.Type {
 	case gjson.String:
-		return "string:" + value.String()
+		key.WriteString("string:")
+		key.WriteString(strconv.Quote(value.String()))
 	case gjson.Number:
 		if number, ok := parseSchemaNumericBound(value.Raw); ok {
-			return "number:" + number.RatString()
+			key.WriteString("number:")
+			key.WriteString(number.RatString())
+			return
 		}
-		return "number-raw:" + value.Raw
+		key.WriteString("number-raw:")
+		key.WriteString(value.Raw)
 	case gjson.JSON:
-		var compact bytes.Buffer
-		if json.Compact(&compact, []byte(value.Raw)) == nil {
-			return "json:" + compact.String()
+		switch {
+		case value.IsArray():
+			key.WriteString("array:[")
+			for index, item := range value.Array() {
+				if index > 0 {
+					key.WriteByte(',')
+				}
+				appendEnumValueKey(key, item)
+			}
+			key.WriteByte(']')
+		case value.IsObject():
+			type objectMember struct {
+				name  string
+				value gjson.Result
+			}
+			members := make([]objectMember, 0)
+			value.ForEach(func(memberName, memberValue gjson.Result) bool {
+				members = append(members, objectMember{
+					name:  memberName.String(),
+					value: memberValue,
+				})
+				return true
+			})
+			sort.SliceStable(members, func(left, right int) bool {
+				return members[left].name < members[right].name
+			})
+			key.WriteString("object:{")
+			for index, member := range members {
+				if index > 0 {
+					key.WriteByte(',')
+				}
+				key.WriteString(strconv.Quote(member.name))
+				key.WriteByte(':')
+				appendEnumValueKey(key, member.value)
+			}
+			key.WriteByte('}')
+		default:
+			key.WriteString("json-raw:")
+			key.WriteString(value.Raw)
 		}
-		return "json-raw:" + value.Raw
 	case gjson.True:
-		return "boolean:true"
+		key.WriteString("boolean:true")
 	case gjson.False:
-		return "boolean:false"
+		key.WriteString("boolean:false")
 	case gjson.Null:
-		return "null"
+		key.WriteString("null")
 	default:
-		return fmt.Sprintf("unknown:%d:%s", value.Type, value.Raw)
+		fmt.Fprintf(key, "unknown:%d:%s", value.Type, value.Raw)
 	}
 }
 

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -499,7 +499,9 @@ func repairSchemaNode(node map[string]any, addMissingArrayItems bool) (map[strin
 		}
 	}
 
-	for _, key := range []string{"$defs", "definitions", "dependentSchemas"} {
+	// Legacy dependencies is a hybrid name map: object values are schemas, while array values are
+	// property-name lists. The type assertion below deliberately repairs only its schema values.
+	for _, key := range []string{"$defs", "definitions", "dependentSchemas", "dependencies"} {
 		if defsVal, ok := clone[key].(map[string]any); ok {
 			repairedDefs := make(map[string]any, len(defsVal))
 			defsModified := false
@@ -1957,11 +1959,13 @@ func setRawAt(jsonStr, path, value string) string {
 }
 
 // schemaNameMapKeywords are the schema keywords whose value maps author-chosen names to
-// subschemas. A key directly under one of them is a name, never a schema keyword.
+// subschemas. Legacy dependencies may also map a name to a string array. A key directly under any
+// of these maps is a name, never a schema keyword.
 var schemaNameMapKeywords = map[string]struct{}{
 	"properties":        {},
 	"patternProperties": {},
 	"dependentSchemas":  {},
+	"dependencies":      {},
 	"$defs":             {},
 	"definitions":       {},
 }

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -90,6 +90,7 @@ func CleanJSONSchemaForGemini(jsonStr string) string {
 		removeGeminiMetadata: true,
 		flattenUnions:        true,
 		forceEnumStringType:  true,
+		dropBooleanEnums:     true,
 	})
 }
 
@@ -103,6 +104,7 @@ func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 		jsonStr = inlineLocalRefs(jsonStr)
 	}
 	jsonStr = convertRefsToHints(jsonStr, options.antigravitySemantics)
+	jsonStr = projectExclusiveBounds(jsonStr)
 	jsonStr = convertConstToEnum(jsonStr)
 	jsonStr = convertEnumValuesToStrings(jsonStr, options.forceEnumStringType)
 	jsonStr = addEnumHints(jsonStr)
@@ -763,6 +765,39 @@ func convertRefsToHints(jsonStr string, preserveSiblings bool) string {
 	return jsonStr
 }
 
+// projectExclusiveBounds rewrites numeric exclusiveMinimum / exclusiveMaximum into inclusive
+// minimum / maximum with the same value. An existing sibling inclusive bound is left unchanged.
+// Draft-04 boolean exclusive flags are dropped; the sibling inclusive bound is already the
+// projected form. Property names that collide with these keywords are preserved.
+func projectExclusiveBounds(jsonStr string) string {
+	pathsByField := findPathsByFields(jsonStr, []string{"exclusiveMinimum", "exclusiveMaximum"})
+	for _, key := range []string{"exclusiveMinimum", "exclusiveMaximum"} {
+		inclusive := "minimum"
+		if key == "exclusiveMaximum" {
+			inclusive = "maximum"
+		}
+		for _, p := range pathsByField[key] {
+			parentPath := trimSuffix(p, "."+key)
+			if isPropertyDefinition(parentPath) {
+				continue
+			}
+			val := gjson.Get(jsonStr, p)
+			if !val.Exists() {
+				continue
+			}
+			if val.Type == gjson.Number {
+				incPath := joinPath(parentPath, inclusive)
+				if !gjson.Get(jsonStr, incPath).Exists() {
+					updated, _ := sjson.SetRawBytes([]byte(jsonStr), incPath, []byte(val.Raw))
+					jsonStr = string(updated)
+				}
+			}
+			jsonStr, _ = sjson.Delete(jsonStr, p)
+		}
+	}
+	return jsonStr
+}
+
 func convertConstToEnum(jsonStr string) string {
 	for _, p := range findPaths(jsonStr, "const") {
 		val := gjson.Get(jsonStr, p)
@@ -787,6 +822,10 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 		if !arr.IsArray() {
 			continue
 		}
+		parentPath := trimSuffix(p, ".enum")
+		if isBooleanEnumSchema(jsonStr, parentPath, arr) {
+			continue
+		}
 
 		var stringVals []string
 		for _, item := range arr.Array() {
@@ -796,12 +835,26 @@ func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 		updated, _ := sjson.SetBytes([]byte(jsonStr), p, stringVals)
 		jsonStr = string(updated)
 		if forceStringType {
-			parentPath := trimSuffix(p, ".enum")
 			updated, _ = sjson.SetBytes([]byte(jsonStr), joinPath(parentPath, "type"), "string")
 			jsonStr = string(updated)
 		}
 	}
 	return jsonStr
+}
+
+func isBooleanEnumSchema(jsonStr, parentPath string, arr gjson.Result) bool {
+	if gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "boolean" {
+		return true
+	}
+	if !arr.IsArray() || len(arr.Array()) == 0 {
+		return false
+	}
+	for _, item := range arr.Array() {
+		if item.Type != gjson.True && item.Type != gjson.False {
+			return false
+		}
+	}
+	return true
 }
 
 func addEnumHints(jsonStr string) string {
@@ -830,7 +883,7 @@ func addEnumHints(jsonStr string) string {
 func dropIgnoredEnumsToHints(jsonStr string, options jsonSchemaCleanOptions) string {
 	for _, path := range findPaths(jsonStr, "enum") {
 		parentPath := trimSuffix(path, ".enum")
-		shouldDrop := options.dropAllEnums || (options.dropBooleanEnums && gjson.Get(jsonStr, joinPath(parentPath, "type")).String() == "boolean")
+		shouldDrop := options.dropAllEnums || (options.dropBooleanEnums && isBooleanEnumSchema(jsonStr, parentPath, gjson.Get(jsonStr, path)))
 		if !shouldDrop {
 			continue
 		}
@@ -853,8 +906,8 @@ func addAdditionalPropertiesHints(jsonStr string) string {
 }
 
 var unsupportedConstraints = []string{
-	"minLength", "maxLength", "exclusiveMinimum", "exclusiveMaximum",
-	"pattern", "minItems", "maxItems", "uniqueItems", "contains", "format",
+	"minLength", "maxLength",
+	"pattern", "minItems", "maxItems", "minProperties", "maxProperties", "uniqueItems", "contains", "format",
 	"default", "examples", // Claude rejects these in VALIDATED mode
 }
 

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -2459,24 +2459,24 @@ func TestCleanJSONSchemaForGemini_BooleanEnumKeepsBooleanType(t *testing.T) {
 	}
 }
 
-func TestCleanJSONSchemaForGemini_UntypedBooleanEnumNotForcedToString(t *testing.T) {
+func TestCleanJSONSchema_UntypedBooleanConstraintsInferBooleanType(t *testing.T) {
 	input := `{
 		"type": "object",
 		"properties": {
-			"toggle": {"enum": [true, false]}
+			"toggle": {"enum": [true, false]},
+			"enabled": {"const": true}
 		}
 	}`
 
-	result := CleanJSONSchemaForGemini(input)
-	toggle := gjson.Get(result, "properties.toggle")
-	if toggle.Get("type").String() == "string" {
-		t.Errorf("untyped boolean-only enum was forced to string: %s", result)
-	}
-	if toggle.Get("enum").Exists() {
-		for _, item := range toggle.Get("enum").Array() {
-			if item.Type == gjson.String {
-				t.Errorf("untyped boolean-only enum was rewritten to strings: %s", result)
-				break
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		for _, property := range []string{"toggle", "enabled"} {
+			schema := gjson.Get(result, "properties."+property)
+			if schema.Get("type").String() != "boolean" {
+				t.Errorf("%s: untyped boolean %s did not infer boolean type: %s", name, property, result)
+			}
+			if schema.Get("enum").Exists() || schema.Get("const").Exists() {
+				t.Errorf("%s: unsupported boolean constraint survived on %s: %s", name, property, result)
 			}
 		}
 	}
@@ -2534,10 +2534,9 @@ func TestCleanJSONSchemaForAntigravityResponse_BooleanEnumNotRewrittenToString(t
 	}
 }
 
-// TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive rewrites exclusiveMinimum /
-// exclusiveMaximum into inclusive minimum / maximum. Integer bounds shift by ±1; number
-// bounds keep the same value (intentional widening). Gemini keeps those inclusive keywords;
-// Antigravity then lifts them into description hints.
+// TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive rewrites integer exclusiveMinimum /
+// exclusiveMaximum into equivalent inclusive bounds. Continuous bounds retain exact hints because
+// their closest supported inclusive projections cannot express an open interval by themselves.
 func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 	input := `{
 		"type": "object",
@@ -2558,6 +2557,13 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 				"maximum": 10,
 				"exclusiveMinimum": 0,
 				"exclusiveMaximum": 20
+			},
+			"tightened": {
+				"type": "integer",
+				"minimum": -100,
+				"maximum": 100,
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 10
 			}
 		}
 	}`
@@ -2568,7 +2574,10 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 		t.Errorf("Gemini exclusive bounds survived: %s", gemini.Raw)
 	}
 	if score.Get("minimum").String() != "0" || score.Get("maximum").String() != "10" {
-		t.Errorf("Gemini number exclusive bounds were not projected in place: %s", gemini.Raw)
+		t.Errorf("Gemini number exclusive bounds lack closest inclusive projections: %s", gemini.Raw)
+	}
+	if description := score.Get("description").String(); !strings.Contains(description, "exclusiveMinimum: 0") || !strings.Contains(description, "exclusiveMaximum: 10") {
+		t.Errorf("Gemini number exclusive bound hints missing: %s", gemini.Raw)
 	}
 
 	count := gemini.Get("properties.count")
@@ -2587,6 +2596,11 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 		t.Errorf("Gemini overwrote existing inclusive bounds: %s", gemini.Raw)
 	}
 
+	tightened := gemini.Get("properties.tightened")
+	if tightened.Get("minimum").String() != "1" || tightened.Get("maximum").String() != "9" {
+		t.Errorf("Gemini failed to select stricter projected bounds: %s", gemini.Raw)
+	}
+
 	for name, clean := range map[string]func(string) string{
 		"antigravity":         CleanJSONSchemaForAntigravity,
 		"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
@@ -2600,11 +2614,8 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 		if parsed.Get("properties.score.minimum").Exists() || parsed.Get("properties.score.maximum").Exists() {
 			t.Errorf("%s: inclusive bounds should be hinted, not kept: %s", name, got)
 		}
-		if strings.Contains(scoreDesc, "exclusiveMinimum") || strings.Contains(scoreDesc, "exclusiveMaximum") {
-			t.Errorf("%s: exclusive keywords appeared as hints: %s", name, got)
-		}
-		if !strings.Contains(scoreDesc, "minimum: 0") || !strings.Contains(scoreDesc, "maximum: 10") {
-			t.Errorf("%s: projected number inclusive hints missing: %s", name, got)
+		if !strings.Contains(scoreDesc, "exclusiveMinimum: 0") || !strings.Contains(scoreDesc, "exclusiveMaximum: 10") {
+			t.Errorf("%s: exact number exclusive hints missing: %s", name, got)
 		}
 
 		countDesc := parsed.Get("properties.count.description").String()
@@ -2628,6 +2639,41 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 		if strings.Contains(clampedDesc, "exclusiveMinimum") || strings.Contains(clampedDesc, "exclusiveMaximum") {
 			t.Errorf("%s: exclusive keywords appeared as hints on clamped: %s", name, got)
 		}
+
+		tightenedDesc := parsed.Get("properties.tightened.description").String()
+		if !strings.Contains(tightenedDesc, "minimum: 1") || !strings.Contains(tightenedDesc, "maximum: 9") {
+			t.Errorf("%s: stricter projected bounds missing: %s", name, got)
+		}
+	}
+}
+
+func TestCleanJSONSchema_IntegerExclusiveBoundsUseExactArithmetic(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"aboveInt64": {"type": "integer", "exclusiveMinimum": 9223372036854775807},
+			"belowInt64": {"type": "integer", "exclusiveMaximum": -9223372036854775808},
+			"fractional": {"type": "integer", "exclusiveMinimum": -1.2, "exclusiveMaximum": 3.8},
+			"large": {"type": "integer", "exclusiveMinimum": 92233720368547758081234567890}
+		}
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	parsed := gjson.Parse(result)
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"properties.aboveInt64.minimum", "9223372036854775808"},
+		{"properties.belowInt64.maximum", "-9223372036854775809"},
+		{"properties.fractional.minimum", "-1"},
+		{"properties.fractional.maximum", "3"},
+		{"properties.large.minimum", "92233720368547758081234567891"},
+	}
+	for _, test := range tests {
+		if got := parsed.Get(test.path).Raw; got != test.want {
+			t.Errorf("%s = %s, want %s: %s", test.path, got, test.want, result)
+		}
 	}
 }
 
@@ -2640,7 +2686,12 @@ func TestCleanJSONSchema_Draft04BooleanExclusiveFlagsDropped(t *testing.T) {
 				"minimum": 0,
 				"exclusiveMinimum": true,
 				"maximum": 120,
-				"exclusiveMaximum": false
+				"exclusiveMaximum": true
+			},
+			"ratio": {
+				"type": "number",
+				"minimum": 0,
+				"exclusiveMinimum": true
 			}
 		}
 	}`
@@ -2652,9 +2703,16 @@ func TestCleanJSONSchema_Draft04BooleanExclusiveFlagsDropped(t *testing.T) {
 		if age.Get("exclusiveMinimum").Exists() || age.Get("exclusiveMaximum").Exists() {
 			t.Errorf("%s: Draft-04 exclusive flags survived: %s", name, got)
 		}
+		ratio := parsed.Get("properties.ratio")
+		if ratio.Get("exclusiveMinimum").Exists() {
+			t.Errorf("%s: Draft-04 number exclusive flag survived: %s", name, got)
+		}
 		if name == "gemini" {
-			if age.Get("minimum").String() != "0" || age.Get("maximum").String() != "120" {
-				t.Errorf("%s: sibling inclusive bounds were lost: %s", name, got)
+			if age.Get("minimum").String() != "1" || age.Get("maximum").String() != "119" {
+				t.Errorf("%s: Draft-04 integer bounds were not shifted: %s", name, got)
+			}
+			if ratio.Get("minimum").String() != "0" || !strings.Contains(ratio.Get("description").String(), "exclusiveMinimum: true") {
+				t.Errorf("%s: Draft-04 number exclusivity was not retained as a hint: %s", name, got)
 			}
 			continue
 		}
@@ -2662,11 +2720,15 @@ func TestCleanJSONSchema_Draft04BooleanExclusiveFlagsDropped(t *testing.T) {
 		if age.Get("minimum").Exists() || age.Get("maximum").Exists() {
 			t.Errorf("%s: inclusive bounds should be hinted: %s", name, got)
 		}
-		if !strings.Contains(desc, "minimum: 0") || !strings.Contains(desc, "maximum: 120") {
-			t.Errorf("%s: sibling inclusive hints missing: %s", name, got)
+		if !strings.Contains(desc, "minimum: 1") || !strings.Contains(desc, "maximum: 119") {
+			t.Errorf("%s: projected inclusive hints missing: %s", name, got)
 		}
 		if strings.Contains(desc, "exclusiveMinimum") || strings.Contains(desc, "exclusiveMaximum") {
 			t.Errorf("%s: exclusive flags appeared as hints: %s", name, got)
+		}
+		ratioDesc := ratio.Get("description").String()
+		if ratio.Get("minimum").Exists() || !strings.Contains(ratioDesc, "minimum: 0") || !strings.Contains(ratioDesc, "exclusiveMinimum: true") {
+			t.Errorf("%s: Draft-04 number hints missing: %s", name, got)
 		}
 	}
 }

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1524,6 +1524,54 @@ func TestCleanJSONSchemaForGemini_MixedBooleanStringUnionUsesEnumType(t *testing
 	}
 }
 
+func TestCleanJSONSchema_ExplicitBooleanEmptyEnumIsDropped(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"flag": {"type": "boolean", "enum": []},
+			"nullableFlag": {"type": ["boolean", "null"], "enum": []},
+			"untyped": {"enum": []}
+		}
+	}`
+
+	for name, clean := range map[string]func(string) string{
+		"gemini":              CleanJSONSchemaForGemini,
+		"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
+	} {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		for _, field := range []string{"flag", "nullableFlag"} {
+			schema := parsed.Get("properties." + field)
+			if schema.Get("type").String() != "boolean" || schema.Get("enum").Exists() {
+				t.Errorf("%s: explicit boolean empty enum was not dropped on %s: %s", name, field, result)
+			}
+		}
+		if schema := parsed.Get("properties.untyped"); schema.Get("type").String() == "boolean" {
+			t.Errorf("%s: untyped empty enum incorrectly inferred boolean: %s", name, result)
+		}
+	}
+}
+
+func TestCleanJSONSchema_BooleanEnumSelectsBooleanFromTypeUnion(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"flag": {"type": ["string", "boolean"], "enum": [true, false]}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		flag := gjson.Get(result, "properties.flag")
+		if flag.Get("type").String() != "boolean" || flag.Get("enum").Exists() {
+			t.Errorf("%s: boolean enum did not select boolean from type union: %s", name, result)
+		}
+		if !strings.Contains(flag.Get("description").String(), "Allowed: true, false") {
+			t.Errorf("%s: boolean enum hint missing after union narrowing: %s", name, result)
+		}
+	}
+}
+
 func TestCleanJSONSchemaForAntigravityResponseHintsIgnoredConstraints(t *testing.T) {
 	input := `{"type":"object","properties":{"value":{"type":"number","minimum":1,"maximum":2,"not":{"enum":[1.5]}}}}`
 	result := gjson.Parse(CleanJSONSchemaForAntigravityResponse(input))

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1503,11 +1503,24 @@ func TestCleanJSONSchemaForAntigravityToolKeepsNumericEnumType(t *testing.T) {
 }
 
 func TestCleanJSONSchemaForAntigravityResponseDropsIgnoredBooleanEnum(t *testing.T) {
-	input := `{"type":"object","properties":{"value":{"type":"boolean","enum":["true"]}},"required":["value"]}`
+	input := `{"type":"object","properties":{"value":{"type":"boolean","enum":[true]}},"required":["value"]}`
 	result := gjson.Parse(CleanJSONSchemaForAntigravityResponse(input))
 	value := result.Get("properties.value")
 	if value.Get("enum").Exists() || value.Get("type").String() != "boolean" || !strings.Contains(value.Get("description").String(), "Allowed: true") {
 		t.Fatalf("ignored boolean response enum was not projected to a hint: %s", result.Raw)
+	}
+}
+
+func TestCleanJSONSchemaForGemini_MixedBooleanStringUnionUsesEnumType(t *testing.T) {
+	input := `{"type":"object","properties":{"answer":{"type":["boolean","string"],"enum":["yes","no"]}}}`
+	result := gjson.Parse(CleanJSONSchemaForGemini(input))
+	answer := result.Get("properties.answer")
+
+	if got := answer.Get("type").String(); got != "string" {
+		t.Fatalf("mixed union with string enum flattened to %q, want string: %s", got, result.Raw)
+	}
+	if got := getStrings(result.Raw, "properties.answer.enum"); !reflect.DeepEqual(got, []string{"yes", "no"}) {
+		t.Fatalf("mixed union string enum = %v, want [yes no]: %s", got, result.Raw)
 	}
 }
 

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -3300,4 +3300,108 @@ func TestIntersectEnumValuesScalesAndPreservesTypedOrder(t *testing.T) {
 	if typed != `[1,"1",true,null,{"a":1}]` {
 		t.Fatalf("typed enum intersection = %s", typed)
 	}
+
+	composite := intersectEnumValues(
+		gjson.Parse(`[{"a":1,"nested":{"values":[2,3.0]}}]`),
+		gjson.Parse(`[{"nested":{"values":[2.0,3]},"a":1.0}]`),
+	)
+	if composite != `[{"a":1,"nested":{"values":[2,3.0]}}]` {
+		t.Fatalf("canonical composite enum intersection = %s", composite)
+	}
+	if reorderedArray := intersectEnumValues(gjson.Parse(`[[1,2]]`), gjson.Parse(`[[2,1]]`)); reorderedArray != `[]` {
+		t.Fatalf("array order was ignored during enum intersection: %s", reorderedArray)
+	}
+}
+
+func TestCleanJSONSchema_AllOfIntersectsNumericEnumsBeforeStringConversion(t *testing.T) {
+	typed := `{"type":"number","enum":[1,0.5,1e3]}`
+	equivalent := `{"enum":[1.0,5e-1,1000.0]}`
+
+	for order, branches := range []string{typed + `,` + equivalent, equivalent + `,` + typed} {
+		input := `{"type":"object","properties":{"amount":{"allOf":[` + branches + `]}}}`
+		for name, clean := range schemaCleaners() {
+			result := clean(input)
+			amount := gjson.Get(result, "properties.amount")
+			if name == "antigravity" {
+				description := amount.Get("description").String()
+				if amount.Get("enum").Exists() || !strings.Contains(description, "Allowed:") || strings.Count(description, ",") < 2 {
+					t.Errorf("order %d %s: numeric enum was not retained as a tool hint: %s", order, name, result)
+				}
+			} else {
+				values := amount.Get("enum").Array()
+				if len(values) != 3 {
+					t.Errorf("order %d %s: numeric enum intersection has %d values, want 3: %s", order, name, len(values), result)
+				} else {
+					want := []string{"1", "1/2", "1000"}
+					for index, value := range values {
+						number, ok := parseSchemaNumericBound(value.String())
+						if !ok || number.RatString() != want[index] {
+							t.Errorf("order %d %s: enum[%d] = %q, want numeric %s: %s", order, name, index, value.String(), want[index], result)
+						}
+					}
+				}
+			}
+			wantType := "number"
+			if name == "gemini" {
+				wantType = "string"
+			}
+			if gotType := amount.Get("type").String(); gotType != wantType {
+				t.Errorf("order %d %s: amount type = %q, want %q: %s", order, name, gotType, wantType, result)
+			}
+
+			secondPass := clean(result)
+			if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+				t.Errorf("order %d %s: numeric enum cleaning is not idempotent:\nfirst: %s\nsecond: %s", order, name, result, secondPass)
+			}
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfPropagatesNullableBooleanTypeBeforeEnumConversion(t *testing.T) {
+	typeBranch := `{"type":["boolean","null"]}`
+	constBranch := `{"const":null}`
+	enumBranch := `{"enum":[true,null]}`
+
+	for order, branches := range []struct {
+		fixed  string
+		choice string
+	}{
+		{fixed: typeBranch + `,` + constBranch, choice: typeBranch + `,` + enumBranch},
+		{fixed: constBranch + `,` + typeBranch, choice: enumBranch + `,` + typeBranch},
+	} {
+		input := `{"type":"object","properties":{` +
+			`"fixed":{"allOf":[` + branches.fixed + `]},` +
+			`"choice":{"allOf":[` + branches.choice + `]}` +
+			`}}`
+		for name, clean := range schemaCleaners() {
+			result := clean(input)
+			parsed := gjson.Parse(result)
+			for _, field := range []string{"fixed", "choice"} {
+				schema := parsed.Get("properties." + field)
+				if schema.Get("type").String() != "boolean" {
+					t.Errorf("order %d %s: %s nullable boolean became %q: %s", order, name, field, schema.Get("type").String(), result)
+				}
+				if schema.Get("enum").Exists() || schema.Get("const").Exists() {
+					t.Errorf("order %d %s: %s retained unsupported enum/const: %s", order, name, field, result)
+				}
+				if !strings.Contains(schema.Get("description").String(), "nullable") {
+					t.Errorf("order %d %s: %s nullable hint missing: %s", order, name, field, result)
+				}
+				if name != "gemini" && !schema.Get("nullable").Bool() {
+					t.Errorf("order %d %s: %s native nullable marker missing: %s", order, name, field, result)
+				}
+			}
+			if !strings.Contains(parsed.Get("properties.fixed.description").String(), "Allowed: null") {
+				t.Errorf("order %d %s: null const hint missing: %s", order, name, result)
+			}
+			if !strings.Contains(parsed.Get("properties.choice.description").String(), "Allowed: true, null") {
+				t.Errorf("order %d %s: nullable boolean enum hint missing: %s", order, name, result)
+			}
+
+			secondPass := clean(result)
+			if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+				t.Errorf("order %d %s: cleaner is not idempotent:\nfirst: %s\nsecond: %s", order, name, result, secondPass)
+			}
+		}
+	}
 }

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -2341,3 +2341,327 @@ func TestCleanJSONSchemaForAntigravityResponse_ContainsKeywordStripped(t *testin
 		}
 	}
 }
+
+func schemaCleaners() map[string]func(string) string {
+	return map[string]func(string) string{
+		"gemini":              CleanJSONSchemaForGemini,
+		"antigravity":         CleanJSONSchemaForAntigravity,
+		"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
+	}
+}
+
+// TestCleanJSONSchema_MinMaxPropertiesHintAndDrop covers private Gemini/Antigravity 400s on
+// minProperties / maxProperties. Those keywords follow the same hint-and-drop path as minItems.
+func TestCleanJSONSchema_MinMaxPropertiesHintAndDrop(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"meta": {
+				"type": "object",
+				"description": "Metadata",
+				"minProperties": 1,
+				"maxProperties": 3,
+				"properties": {
+					"name": {"type": "string"}
+				}
+			}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		got := clean(input)
+		parsed := gjson.Parse(got)
+		meta := parsed.Get("properties.meta")
+		if meta.Get("minProperties").Exists() || meta.Get("maxProperties").Exists() {
+			t.Errorf("%s: minProperties/maxProperties survived: %s", name, got)
+		}
+		desc := meta.Get("description").String()
+		if !strings.Contains(desc, "minProperties: 1") {
+			t.Errorf("%s: minProperties hint missing: %s", name, got)
+		}
+		if !strings.Contains(desc, "maxProperties: 3") {
+			t.Errorf("%s: maxProperties hint missing: %s", name, got)
+		}
+		if !strings.Contains(desc, "Metadata") {
+			t.Errorf("%s: original description lost: %s", name, got)
+		}
+	}
+}
+
+func TestCleanJSONSchema_KeepsPropertiesNamedMinMaxProperties(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"minProperties": {"type": "integer"},
+			"maxProperties": {"type": "integer"}
+		},
+		"required": ["minProperties"]
+	}`
+
+	for name, clean := range schemaCleaners() {
+		got := gjson.Parse(clean(input))
+		if got.Get("properties.minProperties.type").String() != "integer" {
+			t.Errorf("%s: property named minProperties was removed: %s", name, got.Raw)
+		}
+		if got.Get("properties.maxProperties.type").String() != "integer" {
+			t.Errorf("%s: property named maxProperties was removed: %s", name, got.Raw)
+		}
+	}
+}
+
+// TestCleanJSONSchemaForGemini_BooleanEnumKeepsBooleanType covers the Gemini 400 class where
+// boolean enum/const was rewritten to type:string plus a string enum.
+func TestCleanJSONSchemaForGemini_BooleanEnumKeepsBooleanType(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"enabled": {"type": "boolean", "enum": [true, false]},
+			"flag": {"type": "boolean", "const": true},
+			"status": {"type": "string", "enum": ["active", "inactive"]}
+		}
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	parsed := gjson.Parse(result)
+
+	enabled := parsed.Get("properties.enabled")
+	if enabled.Get("type").String() != "boolean" {
+		t.Errorf("boolean enum type rewritten: %s", result)
+	}
+	if enabled.Get("enum").Exists() {
+		t.Errorf("boolean enum survived on Gemini: %s", result)
+	}
+	if !strings.Contains(enabled.Get("description").String(), "Allowed: true, false") {
+		t.Errorf("boolean enum hint missing: %s", result)
+	}
+
+	flag := parsed.Get("properties.flag")
+	if flag.Get("type").String() != "boolean" {
+		t.Errorf("boolean const type rewritten: %s", result)
+	}
+	if flag.Get("enum").Exists() || flag.Get("const").Exists() {
+		t.Errorf("boolean const constraint survived: %s", result)
+	}
+	if !strings.Contains(flag.Get("description").String(), "Allowed: true") {
+		t.Errorf("boolean const hint missing: %s", result)
+	}
+
+	status := parsed.Get("properties.status")
+	if status.Get("type").String() != "string" {
+		t.Errorf("string enum type changed: %s", result)
+	}
+	var enumVals []string
+	for _, item := range status.Get("enum").Array() {
+		enumVals = append(enumVals, item.String())
+	}
+	if !reflect.DeepEqual(enumVals, []string{"active", "inactive"}) {
+		t.Errorf("string enum values = %v, want [active inactive]: %s", enumVals, result)
+	}
+}
+
+func TestCleanJSONSchemaForGemini_UntypedBooleanEnumNotForcedToString(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"toggle": {"enum": [true, false]}
+		}
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	toggle := gjson.Get(result, "properties.toggle")
+	if toggle.Get("type").String() == "string" {
+		t.Errorf("untyped boolean-only enum was forced to string: %s", result)
+	}
+	if toggle.Get("enum").Exists() {
+		for _, item := range toggle.Get("enum").Array() {
+			if item.Type == gjson.String {
+				t.Errorf("untyped boolean-only enum was rewritten to strings: %s", result)
+				break
+			}
+		}
+	}
+}
+
+func TestCleanJSONSchemaForAntigravity_BooleanEnumNotRewrittenToString(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"enabled": {"type": "boolean", "enum": [true, false]},
+			"status": {"type": "string", "enum": ["on", "off"]}
+		}
+	}`
+
+	result := CleanJSONSchemaForAntigravity(input)
+	parsed := gjson.Parse(result)
+
+	enabled := parsed.Get("properties.enabled")
+	if enabled.Get("type").String() != "boolean" || enabled.Get("enum").Exists() {
+		t.Errorf("boolean tool enum should stay typed boolean without enum: %s", result)
+	}
+	if !strings.Contains(enabled.Get("description").String(), "Allowed: true, false") {
+		t.Errorf("boolean tool enum hint missing: %s", result)
+	}
+
+	status := parsed.Get("properties.status")
+	if status.Get("type").String() != "string" || status.Get("enum").Exists() {
+		t.Errorf("string tool enum should stay string and be dropped: %s", result)
+	}
+}
+
+func TestCleanJSONSchemaForAntigravityResponse_BooleanEnumNotRewrittenToString(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"enabled": {"type": "boolean", "enum": [true, false]},
+			"flag": {"type": "boolean", "const": false}
+		}
+	}`
+
+	result := CleanJSONSchemaForAntigravityResponse(input)
+	parsed := gjson.Parse(result)
+
+	enabled := parsed.Get("properties.enabled")
+	if enabled.Get("type").String() != "boolean" || enabled.Get("enum").Exists() {
+		t.Errorf("boolean response enum should stay typed boolean without enum: %s", result)
+	}
+	if !strings.Contains(enabled.Get("description").String(), "Allowed: true, false") {
+		t.Errorf("boolean response enum hint missing: %s", result)
+	}
+
+	flag := parsed.Get("properties.flag")
+	if flag.Get("type").String() != "boolean" || flag.Get("enum").Exists() || flag.Get("const").Exists() {
+		t.Errorf("boolean response const should stay typed boolean without constraint: %s", result)
+	}
+}
+
+// TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive rewrites numeric exclusiveMinimum /
+// exclusiveMaximum into inclusive minimum / maximum with the same value. Gemini keeps those
+// inclusive keywords; Antigravity then lifts them into description hints.
+func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"score": {
+				"type": "number",
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 100
+			},
+			"clamped": {
+				"type": "integer",
+				"minimum": 1,
+				"maximum": 10,
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 20
+			}
+		}
+	}`
+
+	gemini := gjson.Parse(CleanJSONSchemaForGemini(input))
+	score := gemini.Get("properties.score")
+	if score.Get("exclusiveMinimum").Exists() || score.Get("exclusiveMaximum").Exists() {
+		t.Errorf("Gemini exclusive bounds survived: %s", gemini.Raw)
+	}
+	if score.Get("minimum").String() != "0" || score.Get("maximum").String() != "100" {
+		t.Errorf("Gemini exclusive bounds were not projected: %s", gemini.Raw)
+	}
+
+	clamped := gemini.Get("properties.clamped")
+	if clamped.Get("exclusiveMinimum").Exists() || clamped.Get("exclusiveMaximum").Exists() {
+		t.Errorf("Gemini exclusive siblings survived: %s", gemini.Raw)
+	}
+	if clamped.Get("minimum").String() != "1" || clamped.Get("maximum").String() != "10" {
+		t.Errorf("Gemini overwrote existing inclusive bounds: %s", gemini.Raw)
+	}
+
+	for name, clean := range map[string]func(string) string{
+		"antigravity":         CleanJSONSchemaForAntigravity,
+		"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
+	} {
+		got := clean(input)
+		parsed := gjson.Parse(got)
+		scoreDesc := parsed.Get("properties.score.description").String()
+		if parsed.Get("properties.score.exclusiveMinimum").Exists() || parsed.Get("properties.score.exclusiveMaximum").Exists() {
+			t.Errorf("%s: exclusive keywords survived: %s", name, got)
+		}
+		if parsed.Get("properties.score.minimum").Exists() || parsed.Get("properties.score.maximum").Exists() {
+			t.Errorf("%s: inclusive bounds should be hinted, not kept: %s", name, got)
+		}
+		if strings.Contains(scoreDesc, "exclusiveMinimum") || strings.Contains(scoreDesc, "exclusiveMaximum") {
+			t.Errorf("%s: exclusive keywords appeared as hints: %s", name, got)
+		}
+		if !strings.Contains(scoreDesc, "minimum: 0") || !strings.Contains(scoreDesc, "maximum: 100") {
+			t.Errorf("%s: projected inclusive hints missing: %s", name, got)
+		}
+
+		clampedDesc := parsed.Get("properties.clamped.description").String()
+		if parsed.Get("properties.clamped.minimum").Exists() || parsed.Get("properties.clamped.maximum").Exists() {
+			t.Errorf("%s: existing inclusive bounds should be hinted: %s", name, got)
+		}
+		if !strings.Contains(clampedDesc, "minimum: 1") || !strings.Contains(clampedDesc, "maximum: 10") {
+			t.Errorf("%s: existing inclusive hints missing: %s", name, got)
+		}
+		if strings.Contains(clampedDesc, "exclusiveMinimum") || strings.Contains(clampedDesc, "exclusiveMaximum") {
+			t.Errorf("%s: exclusive keywords appeared as hints on clamped: %s", name, got)
+		}
+	}
+}
+
+func TestCleanJSONSchema_Draft04BooleanExclusiveFlagsDropped(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"age": {
+				"type": "integer",
+				"minimum": 0,
+				"exclusiveMinimum": true,
+				"maximum": 120,
+				"exclusiveMaximum": false
+			}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		got := clean(input)
+		parsed := gjson.Parse(got)
+		age := parsed.Get("properties.age")
+		if age.Get("exclusiveMinimum").Exists() || age.Get("exclusiveMaximum").Exists() {
+			t.Errorf("%s: Draft-04 exclusive flags survived: %s", name, got)
+		}
+		if name == "gemini" {
+			if age.Get("minimum").String() != "0" || age.Get("maximum").String() != "120" {
+				t.Errorf("%s: sibling inclusive bounds were lost: %s", name, got)
+			}
+			continue
+		}
+		desc := age.Get("description").String()
+		if age.Get("minimum").Exists() || age.Get("maximum").Exists() {
+			t.Errorf("%s: inclusive bounds should be hinted: %s", name, got)
+		}
+		if !strings.Contains(desc, "minimum: 0") || !strings.Contains(desc, "maximum: 120") {
+			t.Errorf("%s: sibling inclusive hints missing: %s", name, got)
+		}
+		if strings.Contains(desc, "exclusiveMinimum") || strings.Contains(desc, "exclusiveMaximum") {
+			t.Errorf("%s: exclusive flags appeared as hints: %s", name, got)
+		}
+	}
+}
+
+func TestCleanJSONSchema_KeepsPropertyNamedExclusiveMinimum(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"exclusiveMinimum": {"type": "number"},
+			"exclusiveMaximum": {"type": "number"}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		got := gjson.Parse(clean(input))
+		if got.Get("properties.exclusiveMinimum.type").String() != "number" {
+			t.Errorf("%s: property named exclusiveMinimum was removed: %s", name, got.Raw)
+		}
+		if got.Get("properties.exclusiveMaximum.type").String() != "number" {
+			t.Errorf("%s: property named exclusiveMaximum was removed: %s", name, got.Raw)
+		}
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -3581,3 +3581,78 @@ func TestCleanJSONSchema_RootCompositeConstPreservesExactValue(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanJSONSchema_LegacyDependenciesRespectSchemaAndArrayValues(t *testing.T) {
+	arrayDependency := `["const","default","examples","minProperties","$ref"]`
+	input := `{
+		"type": "object",
+		"dependencies": {
+			"enum": {"type": "object", "minProperties": 1},
+			"const": {"type": "object", "maxProperties": 2},
+			"default": {
+				"type": "object",
+				"minProperties": 3,
+				"properties": {"child": {"type": "string", "required": true}},
+				"dependencies": {"enum": ` + arrayDependency + `}
+			},
+			"examples": {"$ref": "#/$defs/Referenced"}
+		},
+		"$defs": {
+			"Referenced": {
+				"type": "object",
+				"properties": {"resolved": {"type": "string", "format": "uuid"}},
+				"required": ["resolved"]
+			}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+
+		for _, testCase := range []struct {
+			entry string
+			hint  string
+		}{
+			{entry: "enum", hint: "minProperties: 1"},
+			{entry: "const", hint: "maxProperties: 2"},
+			{entry: "default", hint: "minProperties: 3"},
+		} {
+			schema := parsed.Get("dependencies." + testCase.entry)
+			if !schema.IsObject() {
+				t.Errorf("%s: schema-valued dependency %s was changed: %s", name, testCase.entry, result)
+				continue
+			}
+			if !strings.Contains(schema.Get("description").String(), testCase.hint) {
+				t.Errorf("%s: dependency %s was not recursively cleaned: %s", name, testCase.entry, result)
+			}
+		}
+
+		defaultDependency := parsed.Get("dependencies.default")
+		if defaultDependency.Get("properties.child.required").Exists() ||
+			defaultDependency.Get("required.0").String() != "child" {
+			t.Errorf("%s: schema-valued dependency was not normalized: %s", name, result)
+		}
+		gotArrayDependency := defaultDependency.Get("dependencies.enum")
+		if !reflect.DeepEqual(gotArrayDependency.Value(), gjson.Parse(arrayDependency).Value()) {
+			t.Errorf("%s: array-valued dependency changed: got %s, want %s", name, gotArrayDependency.Raw, arrayDependency)
+		}
+
+		refDependency := parsed.Get("dependencies.examples")
+		if name == "gemini" {
+			if !strings.Contains(refDependency.Get("description").String(), "See: Referenced") {
+				t.Errorf("%s: dependency ref hint missing: %s", name, result)
+			}
+		} else {
+			resolved := refDependency.Get("properties.resolved")
+			if !resolved.Exists() || !strings.Contains(resolved.Get("description").String(), "format: uuid") {
+				t.Errorf("%s: dependency ref was not inlined and cleaned: %s", name, result)
+			}
+		}
+
+		secondPass := clean(result)
+		if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+			t.Errorf("%s: legacy dependency cleaning is not idempotent:\nfirst: %s\nsecond: %s", name, result, secondPass)
+		}
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -3405,3 +3405,179 @@ func TestCleanJSONSchema_AllOfPropagatesNullableBooleanTypeBeforeEnumConversion(
 		}
 	}
 }
+
+func TestCleanJSONSchema_PreservesCompositeLiteralValues(t *testing.T) {
+	enumLiteral := `{
+		"minProperties": 1,
+		"maxProperties": 3,
+		"exclusiveMinimum": 2,
+		"format": "literal-format",
+		"$ref": "#/$defs/Referenced",
+		"x-literal": {"maxItems": 4},
+		"type": ["literal", "null"],
+		"nested": [
+			{"enum": [{"minLength": 5}]},
+			{"const": {"maxLength": 6}}
+		]
+	}`
+	constLiteral := `{
+		"large": 9007199254740993,
+		"minProperties": 7,
+		"nested": [{"exclusiveMaximum": 8, "x-value": true}]
+	}`
+	input := `{
+		"type": "object",
+		"properties": {
+			"choice": {"type": "object", "enum": [` + enumLiteral + `]},
+			"fixed": {"type": "object", "const": ` + constLiteral + `},
+			"defaulted": {"type": "object", "default": ` + enumLiteral + `},
+			"sampled": {"type": "object", "examples": [` + constLiteral + `]}
+		},
+		"$defs": {
+			"Referenced": {"type": "object", "properties": {"resolved": {"type": "boolean"}}}
+		}
+	}`
+
+	extractAllowed := func(t *testing.T, result, cleaner, property string) string {
+		t.Helper()
+		schema := gjson.Get(result, "properties."+property)
+		if cleaner != "antigravity" {
+			return schema.Get("enum.0").String()
+		}
+		const prefix = "Allowed: "
+		description := schema.Get("description").String()
+		if !strings.HasPrefix(description, prefix) {
+			t.Fatalf("%s: %s literal hint missing: %s", cleaner, property, result)
+		}
+		return strings.TrimPrefix(description, prefix)
+	}
+	assertLiteral := func(t *testing.T, cleaner, property, got, want string) {
+		t.Helper()
+		if !gjson.Valid(got) {
+			t.Fatalf("%s: %s literal is invalid JSON: %q", cleaner, property, got)
+		}
+		if enumValueKey(gjson.Parse(got)) != enumValueKey(gjson.Parse(want)) {
+			t.Fatalf("%s: %s literal changed:\ngot:  %s\nwant: %s", cleaner, property, got, want)
+		}
+	}
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		choice := extractAllowed(t, result, name, "choice")
+		fixed := extractAllowed(t, result, name, "fixed")
+		assertLiteral(t, name, "choice", choice, enumLiteral)
+		assertLiteral(t, name, "fixed", fixed, constLiteral)
+		if got := gjson.Get(fixed, "large").Raw; got != "9007199254740993" {
+			t.Errorf("%s: composite const large integer = %s: %s", name, got, result)
+		}
+
+		defaultHint := gjson.Get(result, "properties.defaulted.description").String()
+		const defaultPrefix = "default: "
+		if !strings.HasPrefix(defaultHint, defaultPrefix) {
+			t.Errorf("%s: default literal hint missing: %s", name, result)
+		} else {
+			assertLiteral(t, name, "defaulted", strings.TrimPrefix(defaultHint, defaultPrefix), enumLiteral)
+		}
+		examplesHint := gjson.Get(result, "properties.sampled.description").String()
+		const examplesPrefix = "examples: "
+		if !strings.HasPrefix(examplesHint, examplesPrefix) {
+			t.Errorf("%s: examples literal hint missing: %s", name, result)
+		} else {
+			examples := gjson.Parse(strings.TrimPrefix(examplesHint, examplesPrefix)).Array()
+			if len(examples) != 1 {
+				t.Errorf("%s: examples literal count = %d: %s", name, len(examples), result)
+			} else {
+				assertLiteral(t, name, "sampled", examples[0].Raw, constLiteral)
+			}
+		}
+
+		secondPass := clean(result)
+		if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+			t.Errorf("%s: literal cleaning is not idempotent:\nfirst: %s\nsecond: %s", name, result, secondPass)
+		}
+	}
+}
+
+func TestCleanJSONSchema_LiteralKeywordPropertyNamesRemainSchemas(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"enum": {"type": "object", "minProperties": 1},
+			"const": {"type": "object", "maxProperties": 2},
+			"default": {"type": "string", "format": "date"},
+			"examples": {"type": "array", "items": {"type": "string"}, "minItems": 1}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		for _, testCase := range []struct {
+			property string
+			keyword  string
+			hint     string
+		}{
+			{property: "enum", keyword: "minProperties", hint: "minProperties: 1"},
+			{property: "const", keyword: "maxProperties", hint: "maxProperties: 2"},
+			{property: "default", keyword: "format", hint: "format: date"},
+			{property: "examples", keyword: "minItems", hint: "minItems: 1"},
+		} {
+			schema := parsed.Get("properties." + testCase.property)
+			if !schema.Exists() || schema.Get(testCase.keyword).Exists() {
+				t.Errorf("%s: property named %s was skipped or retained %s: %s", name, testCase.property, testCase.keyword, result)
+			}
+			if !strings.Contains(schema.Get("description").String(), testCase.hint) {
+				t.Errorf("%s: property named %s lost hint %q: %s", name, testCase.property, testCase.hint, result)
+			}
+		}
+
+		secondPass := clean(result)
+		if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+			t.Errorf("%s: keyword-named property cleaning is not idempotent:\nfirst: %s\nsecond: %s", name, result, secondPass)
+		}
+	}
+}
+
+func TestCleanJSONSchema_RootCompositeConstPreservesExactValue(t *testing.T) {
+	constLiteral := `{
+		"large": 9007199254740993,
+		"minProperties": 1,
+		"nested": [{"const": {"exclusiveMinimum": 2}}]
+	}`
+	input := `{"type":"object","const":` + constLiteral + `}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		if _, exists := parsed.Map()[""]; exists {
+			t.Fatalf("%s: root const conversion created an empty-key object: %s", name, result)
+		}
+
+		var literal string
+		if name == "antigravity" {
+			const prefix = "Allowed: "
+			description := parsed.Get("description").String()
+			if !strings.HasPrefix(description, prefix) {
+				t.Fatalf("%s: root const hint missing: %s", name, result)
+			}
+			literal = strings.TrimPrefix(description, prefix)
+		} else {
+			literal = parsed.Get("enum.0").String()
+		}
+
+		if !gjson.Valid(literal) {
+			t.Fatalf("%s: root const literal is invalid JSON: %q", name, literal)
+		}
+		if enumValueKey(gjson.Parse(literal)) != enumValueKey(gjson.Parse(constLiteral)) {
+			t.Fatalf("%s: root const changed:\ngot:  %s\nwant: %s", name, literal, constLiteral)
+		}
+		if got := gjson.Get(literal, "large").Raw; got != "9007199254740993" {
+			t.Errorf("%s: root const large integer = %s: %s", name, got, result)
+		}
+
+		secondPass := clean(result)
+		if !reflect.DeepEqual(gjson.Parse(result).Value(), gjson.Parse(secondPass).Value()) {
+			t.Errorf("%s: root const cleaning is not idempotent:\nfirst: %s\nsecond: %s", name, result, secondPass)
+		}
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -2777,3 +2777,201 @@ func TestCleanJSONSchema_KeepsPropertyNamedExclusiveMinimum(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanJSONSchema_OversizedNumericBoundsDoNotExpand(t *testing.T) {
+	const oversizedExponent = "1e1000000000"
+	input := `{
+		"type": "object",
+		"properties": {
+			"integerBound": {
+				"type": "integer",
+				"exclusiveMinimum": ` + oversizedExponent + `
+			},
+			"numberBound": {
+				"type": "number",
+				"minimum": 0,
+				"exclusiveMinimum": ` + oversizedExponent + `
+			}
+		}
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	parsed := gjson.Parse(result)
+	integerBound := parsed.Get("properties.integerBound")
+	if integerBound.Get("exclusiveMinimum").Exists() || integerBound.Get("minimum").Exists() {
+		t.Fatalf("oversized integer bound should be retained only as a hint: %s", result)
+	}
+	if !strings.Contains(integerBound.Get("description").String(), "exclusiveMinimum: "+oversizedExponent) {
+		t.Fatalf("oversized integer bound hint missing: %s", result)
+	}
+
+	numberBound := parsed.Get("properties.numberBound")
+	if got := numberBound.Get("minimum").Raw; got != "0" {
+		t.Fatalf("oversized number bound replaced existing minimum with %s: %s", got, result)
+	}
+	if !strings.Contains(numberBound.Get("description").String(), "exclusiveMinimum: "+oversizedExponent) {
+		t.Fatalf("oversized number bound hint missing: %s", result)
+	}
+}
+
+func TestParseSchemaNumericBoundCapsWork(t *testing.T) {
+	tests := []string{
+		"1e1000000000",
+		"1e-1000000000",
+		strings.Repeat("9", maxSchemaBoundLiteralLength+1),
+	}
+	for _, raw := range tests {
+		if _, ok := parseSchemaNumericBound(raw); ok {
+			t.Errorf("parseSchemaNumericBound(%q) unexpectedly succeeded", raw)
+		}
+	}
+
+	reasonableLargeInteger := strings.Repeat("9", 512)
+	if projected, ok := projectIntegerExclusiveBound(reasonableLargeInteger, false); !ok || len(projected) != 513 || projected[0] != '1' {
+		t.Fatalf("reasonable large integer was not projected exactly: ok=%v result=%q", ok, projected)
+	}
+}
+
+func TestCleanJSONSchema_NullableBooleanConstraintsPreserveType(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"choice": {
+				"type": ["boolean", "null"],
+				"enum": [true, false, null]
+			},
+			"fixed": {
+				"type": ["null", "boolean"],
+				"const": null
+			},
+			"inferred": {
+				"enum": [true, null]
+			}
+		},
+		"required": ["choice", "fixed", "inferred"]
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		for _, field := range []string{"choice", "fixed", "inferred"} {
+			schema := parsed.Get("properties." + field)
+			if got := schema.Get("type").String(); got != "boolean" {
+				t.Errorf("%s: %s type = %q, want boolean: %s", name, field, got, result)
+			}
+			if schema.Get("enum").Exists() || schema.Get("const").Exists() {
+				t.Errorf("%s: unsupported constraint survived on %s: %s", name, field, result)
+			}
+			if !strings.Contains(schema.Get("description").String(), "nullable") {
+				t.Errorf("%s: nullable hint missing on %s: %s", name, field, result)
+			}
+			if name != "gemini" && !schema.Get("nullable").Bool() {
+				t.Errorf("%s: native nullable marker missing on %s: %s", name, field, result)
+			}
+		}
+
+		choiceDescription := parsed.Get("properties.choice.description").String()
+		if !strings.Contains(choiceDescription, "Allowed: true, false, null") {
+			t.Errorf("%s: nullable boolean enum hint malformed: %s", name, result)
+		}
+		fixedDescription := parsed.Get("properties.fixed.description").String()
+		if !strings.Contains(fixedDescription, "Allowed: null") {
+			t.Errorf("%s: nullable boolean const hint malformed: %s", name, result)
+		}
+
+		required := getStrings(result, "required")
+		if name == "gemini" {
+			if len(required) != 0 {
+				t.Errorf("%s: nullable fields remained required: %s", name, result)
+			}
+		} else if !reflect.DeepEqual(required, []string{"choice", "fixed", "inferred"}) {
+			t.Errorf("%s: natively nullable required fields changed: %s", name, result)
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfUsesStrictestBounds(t *testing.T) {
+	input := `{
+		"type": "integer",
+		"minimum": -100,
+		"maximum": 100,
+		"allOf": [
+			{"type": "integer", "exclusiveMinimum": 0, "exclusiveMaximum": 20},
+			{"minimum": 10, "maximum": 15},
+			{"minimum": 5, "maximum": 18}
+		]
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		if parsed.Get("allOf").Exists() || parsed.Get("exclusiveMinimum").Exists() || parsed.Get("exclusiveMaximum").Exists() {
+			t.Errorf("%s: allOf or exclusive bounds survived: %s", name, result)
+		}
+		if name == "gemini" {
+			if got := parsed.Get("minimum").Raw; got != "10" {
+				t.Errorf("%s: minimum = %s, want 10: %s", name, got, result)
+			}
+			if got := parsed.Get("maximum").Raw; got != "15" {
+				t.Errorf("%s: maximum = %s, want 15: %s", name, got, result)
+			}
+			continue
+		}
+		if parsed.Get("minimum").Exists() || parsed.Get("maximum").Exists() {
+			t.Errorf("%s: native bounds should be replaced by hints: %s", name, result)
+		}
+		description := parsed.Get("description").String()
+		if !strings.Contains(description, "minimum: 10") || !strings.Contains(description, "maximum: 15") {
+			t.Errorf("%s: strictest bound hints missing: %s", name, result)
+		}
+		if description != "minimum: 10 (maximum: 15)" {
+			t.Errorf("%s: weaker branch bound leaked into hints: %s", name, result)
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfUsesStrictestNestedBounds(t *testing.T) {
+	input := `{
+		"type": "object",
+		"allOf": [
+			{"properties": {"count": {"type": "integer", "exclusiveMinimum": 0, "maximum": 100}}},
+			{"properties": {"count": {"minimum": 10, "exclusiveMaximum": 20}}}
+		]
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	count := gjson.Get(result, "properties.count")
+	if got := count.Get("minimum").Raw; got != "10" {
+		t.Fatalf("nested minimum = %s, want 10: %s", got, result)
+	}
+	if got := count.Get("maximum").Raw; got != "19" {
+		t.Fatalf("nested maximum = %s, want 19: %s", got, result)
+	}
+}
+
+func TestCleanJSONSchema_AllOfPreservesContinuousExclusiveHints(t *testing.T) {
+	input := `{
+		"allOf": [
+			{"type": "number", "exclusiveMinimum": 0},
+			{"type": "number", "exclusiveMaximum": 10}
+		]
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		description := parsed.Get("description").String()
+		if !strings.Contains(description, "exclusiveMinimum: 0") || !strings.Contains(description, "exclusiveMaximum: 10") {
+			t.Errorf("%s: exact continuous exclusivity hint lost: %s", name, result)
+		}
+		if name == "gemini" {
+			if parsed.Get("minimum").Raw != "0" || parsed.Get("maximum").Raw != "10" {
+				t.Errorf("%s: closest continuous bounds missing: %s", name, result)
+			}
+			continue
+		}
+		if parsed.Get("minimum").Exists() || parsed.Get("maximum").Exists() {
+			t.Errorf("%s: continuous bounds should be retained only as hints: %s", name, result)
+		}
+	}
+}

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -2677,6 +2677,31 @@ func TestCleanJSONSchema_IntegerExclusiveBoundsUseExactArithmetic(t *testing.T) 
 	}
 }
 
+func TestCleanJSONSchema_NullableIntegerExclusiveBoundsUseIntegerProjection(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"lower": {"type": ["integer", "null"], "exclusiveMinimum": 0},
+			"upper": {"type": ["null", "integer"], "exclusiveMaximum": 10}
+		}
+	}`
+
+	result := CleanJSONSchemaForGemini(input)
+	parsed := gjson.Parse(result)
+	if got := parsed.Get("properties.lower.type").String(); got != "integer" {
+		t.Fatalf("lower type = %q, want integer: %s", got, result)
+	}
+	if got := parsed.Get("properties.lower.minimum").Raw; got != "1" {
+		t.Fatalf("lower minimum = %s, want 1: %s", got, result)
+	}
+	if got := parsed.Get("properties.upper.type").String(); got != "integer" {
+		t.Fatalf("upper type = %q, want integer: %s", got, result)
+	}
+	if got := parsed.Get("properties.upper.maximum").Raw; got != "9" {
+		t.Fatalf("upper maximum = %s, want 9: %s", got, result)
+	}
+}
+
 func TestCleanJSONSchema_Draft04BooleanExclusiveFlagsDropped(t *testing.T) {
 	input := `{
 		"type": "object",

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -2534,9 +2534,10 @@ func TestCleanJSONSchemaForAntigravityResponse_BooleanEnumNotRewrittenToString(t
 	}
 }
 
-// TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive rewrites numeric exclusiveMinimum /
-// exclusiveMaximum into inclusive minimum / maximum with the same value. Gemini keeps those
-// inclusive keywords; Antigravity then lifts them into description hints.
+// TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive rewrites exclusiveMinimum /
+// exclusiveMaximum into inclusive minimum / maximum. Integer bounds shift by ±1; number
+// bounds keep the same value (intentional widening). Gemini keeps those inclusive keywords;
+// Antigravity then lifts them into description hints.
 func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 	input := `{
 		"type": "object",
@@ -2544,7 +2545,12 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 			"score": {
 				"type": "number",
 				"exclusiveMinimum": 0,
-				"exclusiveMaximum": 100
+				"exclusiveMaximum": 10
+			},
+			"count": {
+				"type": "integer",
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 10
 			},
 			"clamped": {
 				"type": "integer",
@@ -2561,8 +2567,16 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 	if score.Get("exclusiveMinimum").Exists() || score.Get("exclusiveMaximum").Exists() {
 		t.Errorf("Gemini exclusive bounds survived: %s", gemini.Raw)
 	}
-	if score.Get("minimum").String() != "0" || score.Get("maximum").String() != "100" {
-		t.Errorf("Gemini exclusive bounds were not projected: %s", gemini.Raw)
+	if score.Get("minimum").String() != "0" || score.Get("maximum").String() != "10" {
+		t.Errorf("Gemini number exclusive bounds were not projected in place: %s", gemini.Raw)
+	}
+
+	count := gemini.Get("properties.count")
+	if count.Get("exclusiveMinimum").Exists() || count.Get("exclusiveMaximum").Exists() {
+		t.Errorf("Gemini integer exclusive bounds survived: %s", gemini.Raw)
+	}
+	if count.Get("minimum").String() != "1" || count.Get("maximum").String() != "9" {
+		t.Errorf("Gemini integer exclusive bounds were not shifted: %s", gemini.Raw)
 	}
 
 	clamped := gemini.Get("properties.clamped")
@@ -2589,8 +2603,19 @@ func TestCleanJSONSchema_ExclusiveBoundsProjectedToInclusive(t *testing.T) {
 		if strings.Contains(scoreDesc, "exclusiveMinimum") || strings.Contains(scoreDesc, "exclusiveMaximum") {
 			t.Errorf("%s: exclusive keywords appeared as hints: %s", name, got)
 		}
-		if !strings.Contains(scoreDesc, "minimum: 0") || !strings.Contains(scoreDesc, "maximum: 100") {
-			t.Errorf("%s: projected inclusive hints missing: %s", name, got)
+		if !strings.Contains(scoreDesc, "minimum: 0") || !strings.Contains(scoreDesc, "maximum: 10") {
+			t.Errorf("%s: projected number inclusive hints missing: %s", name, got)
+		}
+
+		countDesc := parsed.Get("properties.count.description").String()
+		if parsed.Get("properties.count.minimum").Exists() || parsed.Get("properties.count.maximum").Exists() {
+			t.Errorf("%s: integer inclusive bounds should be hinted, not kept: %s", name, got)
+		}
+		if !strings.Contains(countDesc, "minimum: 1") || !strings.Contains(countDesc, "maximum: 9") {
+			t.Errorf("%s: projected integer inclusive hints missing: %s", name, got)
+		}
+		if strings.Contains(countDesc, "exclusiveMinimum") || strings.Contains(countDesc, "exclusiveMaximum") {
+			t.Errorf("%s: exclusive keywords appeared as hints on count: %s", name, got)
 		}
 
 		clampedDesc := parsed.Get("properties.clamped.description").String()

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -3034,5 +3035,269 @@ func TestCleanJSONSchema_AllOfPreservesContinuousExclusiveHints(t *testing.T) {
 		if parsed.Get("minimum").Exists() || parsed.Get("maximum").Exists() {
 			t.Errorf("%s: continuous bounds should be retained only as hints: %s", name, result)
 		}
+	}
+}
+
+func TestCleanJSONSchema_UncomparableInclusiveSiblingKeepsExclusiveSemantics(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"lower": {"type": "integer", "minimum": -1e1000000000, "exclusiveMinimum": 0},
+			"upper": {"type": "integer", "maximum": 1e1000000000, "exclusiveMaximum": 10},
+			"strictLower": {"type": "integer", "minimum": 1e1000000000, "exclusiveMinimum": 0},
+			"strictUpper": {"type": "integer", "maximum": -1e1000000000, "exclusiveMaximum": 10},
+			"invalidLower": {"type": "integer", "minimum": "invalid", "exclusiveMinimum": 0},
+			"invalidUpper": {"type": "integer", "maximum": false, "exclusiveMaximum": 10},
+			"continuous": {"type": "number", "minimum": -1e1000000000, "exclusiveMinimum": 0}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		for _, field := range []string{"lower", "upper", "strictLower", "strictUpper", "invalidLower", "invalidUpper", "continuous"} {
+			schema := parsed.Get("properties." + field)
+			if schema.Get("exclusiveMinimum").Exists() || schema.Get("exclusiveMaximum").Exists() {
+				t.Errorf("%s: exclusive keyword survived on %s: %s", name, field, result)
+			}
+		}
+
+		if !strings.Contains(parsed.Get("properties.lower.description").String(), "exclusiveMinimum: 0") {
+			t.Errorf("%s: capped lower sibling lost exact exclusive hint: %s", name, result)
+		}
+		if !strings.Contains(parsed.Get("properties.upper.description").String(), "exclusiveMaximum: 10") {
+			t.Errorf("%s: capped upper sibling lost exact exclusive hint: %s", name, result)
+		}
+		if !strings.Contains(parsed.Get("properties.strictLower.description").String(), "exclusiveMinimum: 0") {
+			t.Errorf("%s: potentially stricter capped lower sibling lost exact exclusive hint: %s", name, result)
+		}
+		if !strings.Contains(parsed.Get("properties.strictUpper.description").String(), "exclusiveMaximum: 10") {
+			t.Errorf("%s: potentially stricter capped upper sibling lost exact exclusive hint: %s", name, result)
+		}
+		if !strings.Contains(parsed.Get("properties.continuous.description").String(), "exclusiveMinimum: 0") {
+			t.Errorf("%s: continuous capped sibling lost exact exclusive hint: %s", name, result)
+		}
+
+		invalidLower := parsed.Get("properties.invalidLower")
+		invalidUpper := parsed.Get("properties.invalidUpper")
+		if name == "gemini" {
+			if invalidLower.Get("minimum").Raw != "1" || invalidUpper.Get("maximum").Raw != "9" {
+				t.Errorf("%s: invalid siblings were not replaced by projected bounds: %s", name, result)
+			}
+			continue
+		}
+		if !strings.Contains(invalidLower.Get("description").String(), "minimum: 1") ||
+			!strings.Contains(invalidUpper.Get("description").String(), "maximum: 9") {
+			t.Errorf("%s: projected bounds from invalid siblings were not retained as hints: %s", name, result)
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfIntersectsMonotonicSizeConstraints(t *testing.T) {
+	weak := `{
+		"minProperties": 1,
+		"maxProperties": 9,
+		"properties": {
+			"text": {"type": "string", "minLength": 1, "maxLength": 9},
+			"items": {"type": "array", "minItems": 1, "maxItems": 9}
+		}
+	}`
+	strict := `{
+		"minProperties": 5,
+		"maxProperties": 7,
+		"properties": {
+			"text": {"minLength": 5, "maxLength": 7},
+			"items": {"minItems": 5, "maxItems": 7}
+		}
+	}`
+
+	for order, input := range []string{
+		`{"type":"object","allOf":[` + weak + `,` + strict + `]}`,
+		`{"type":"object","allOf":[` + strict + `,` + weak + `]}`,
+	} {
+		for name, clean := range schemaCleaners() {
+			result := clean(input)
+			parsed := gjson.Parse(result)
+			descriptions := map[string]string{
+				"root":  parsed.Get("description").String(),
+				"text":  parsed.Get("properties.text.description").String(),
+				"items": parsed.Get("properties.items.description").String(),
+			}
+			want := map[string]string{
+				"root":  "minProperties: 5 (maxProperties: 7)",
+				"text":  "minLength: 5 (maxLength: 7)",
+				"items": "minItems: 5 (maxItems: 7)",
+			}
+			for path, wantDescription := range want {
+				if descriptions[path] != wantDescription {
+					t.Errorf("order %d %s: %s description = %q, want %q: %s", order, name, path, descriptions[path], wantDescription, result)
+				}
+			}
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfPreservesNonOrderableConstraintHints(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"code": {
+				"type": "string",
+				"allOf": [
+					{"pattern": "^a", "format": "first"},
+					{"pattern": "z$", "format": "second"}
+				]
+			},
+			"amount": {
+				"type": "number",
+				"allOf": [{"multipleOf": 2}, {"multipleOf": 3}]
+			},
+			"tags": {
+				"type": "array",
+				"allOf": [
+					{"contains": {"type": "string", "enum": ["a"]}, "uniqueItems": false},
+					{"contains": {"type": "string", "enum": ["b"]}, "uniqueItems": true}
+				]
+			}
+		}
+	}`
+
+	for name, clean := range schemaCleaners() {
+		result := clean(input)
+		parsed := gjson.Parse(result)
+		codeDescription := parsed.Get("properties.code.description").String()
+		for _, hint := range []string{"pattern: ^a", "pattern: z$", "format: first", "format: second"} {
+			if !strings.Contains(codeDescription, hint) {
+				t.Errorf("%s: code constraint hint %q missing: %s", name, hint, result)
+			}
+		}
+		amountDescription := parsed.Get("properties.amount.description").String()
+		if name == "gemini" {
+			if parsed.Get("properties.amount.multipleOf").Raw != "2" || !strings.Contains(amountDescription, "multipleOf: 3") {
+				t.Errorf("%s: native and advisory multipleOf intersection lost: %s", name, result)
+			}
+		} else if !strings.Contains(amountDescription, "multipleOf: 2") || !strings.Contains(amountDescription, "multipleOf: 3") {
+			t.Errorf("%s: multipleOf intersection hints lost: %s", name, result)
+		}
+		tagsDescription := parsed.Get("properties.tags.description").String()
+		for _, hint := range []string{"contains:", "uniqueItems: false", "uniqueItems: true"} {
+			if !strings.Contains(tagsDescription, hint) {
+				t.Errorf("%s: tags constraint hint %q missing: %s", name, hint, result)
+			}
+		}
+		for _, value := range []string{"a", "b"} {
+			if !strings.Contains(tagsDescription, `"`+value+`"`) && !strings.Contains(tagsDescription, "Allowed: "+value) {
+				t.Errorf("%s: contains value %q missing from hints: %s", name, value, result)
+			}
+		}
+	}
+}
+
+func TestCleanJSONSchema_AllOfMergesNestedRequiredEnumAndClosedObjects(t *testing.T) {
+	first := `{
+		"properties": {
+			"config": {
+				"type": "object",
+				"properties": {"a": {"type": "string"}},
+				"required": ["a"],
+				"additionalProperties": true
+			},
+			"choice": {"type": "string", "enum": ["a", "b"]}
+		}
+	}`
+	second := `{
+		"properties": {
+			"config": {
+				"properties": {"b": {"type": "string"}},
+				"required": ["b"],
+				"additionalProperties": false
+			},
+			"choice": {"enum": ["b", "c"]}
+		}
+	}`
+
+	for order, input := range []string{
+		`{"type":"object","allOf":[` + first + `,` + second + `]}`,
+		`{"type":"object","allOf":[` + second + `,` + first + `]}`,
+	} {
+		for name, clean := range schemaCleaners() {
+			result := clean(input)
+			config := gjson.Get(result, "properties.config")
+			required := getStrings(result, "properties.config.required")
+			if !contains(required, "a") || !contains(required, "b") {
+				t.Errorf("order %d %s: nested required union = %v: %s", order, name, required, result)
+			}
+			if name == "antigravityResponse" && config.Get("additionalProperties").Type != gjson.False {
+				t.Errorf("order %d %s: additionalProperties:false was not retained: %s", order, name, result)
+			}
+			if name == "gemini" || name == "antigravityResponse" {
+				choiceEnum := getStrings(result, "properties.choice.enum")
+				if !reflect.DeepEqual(choiceEnum, []string{"b"}) {
+					t.Errorf("order %d %s: enum intersection = %v, want [b]: %s", order, name, choiceEnum, result)
+				}
+			}
+		}
+	}
+}
+
+func TestMergeAllOf_AdditionalPropertiesUsesStrictestSchema(t *testing.T) {
+	open := `{"additionalProperties":true}`
+	typed := `{"additionalProperties":{"type":"string","minLength":2}}`
+	closed := `{"additionalProperties":false}`
+
+	for name, testCase := range map[string]struct {
+		branches string
+		closed   bool
+	}{
+		"openThenTyped":   {branches: open + `,` + typed},
+		"typedThenOpen":   {branches: typed + `,` + open},
+		"typedThenClosed": {branches: typed + `,` + closed, closed: true},
+		"closedThenTyped": {branches: closed + `,` + typed, closed: true},
+	} {
+		result := gjson.Parse(mergeAllOf(`{"allOf":[` + testCase.branches + `]}`))
+		additional := result.Get("additionalProperties")
+		if testCase.closed {
+			if additional.Type != gjson.False {
+				t.Errorf("%s: false did not dominate additionalProperties: %s", name, result.Raw)
+			}
+			continue
+		}
+		if !additional.IsObject() || additional.Get("type").String() != "string" || additional.Get("minLength").Raw != "2" {
+			t.Errorf("%s: schema did not dominate true additionalProperties: %s", name, result.Raw)
+		}
+	}
+}
+
+func TestIntersectEnumValuesScalesAndPreservesTypedOrder(t *testing.T) {
+	existing := make([]string, 2000)
+	incoming := make([]string, 2000)
+	for index := range existing {
+		existing[index] = "value-" + strconv.Itoa(index)
+		incoming[index] = "value-" + strconv.Itoa(index+1000)
+	}
+	existingJSON, errExisting := json.Marshal(existing)
+	if errExisting != nil {
+		t.Fatal(errExisting)
+	}
+	incomingJSON, errIncoming := json.Marshal(incoming)
+	if errIncoming != nil {
+		t.Fatal(errIncoming)
+	}
+
+	intersection := intersectEnumValues(gjson.ParseBytes(existingJSON), gjson.ParseBytes(incomingJSON))
+	var got []string
+	if err := json.Unmarshal([]byte(intersection), &got); err != nil {
+		t.Fatalf("intersection is invalid JSON: %v: %s", err, intersection)
+	}
+	if len(got) != 1000 || got[0] != "value-1000" || got[len(got)-1] != "value-1999" {
+		t.Fatalf("large enum intersection has wrong ordered range: len=%d first=%q last=%q", len(got), got[0], got[len(got)-1])
+	}
+
+	typed := intersectEnumValues(
+		gjson.Parse(`[1,1.0,"1",true,null,{"a":1}]`),
+		gjson.Parse(`[1e0,"1",true,null,{"a":1}]`),
+	)
+	if typed != `[1,"1",true,null,{"a":1}]` {
+		t.Fatalf("typed enum intersection = %s", typed)
 	}
 }


### PR DESCRIPTION
## Summary

Private Gemini/Antigravity backends reject several JSON Schema keywords. Extend the existing cleaner so unsupported constraints do not reach those backends while retaining their meaning where possible:

- move `minProperties` / `maxProperties` and other unsupported constraints to description hints before removal
- preserve or infer boolean type for boolean `enum` / `const`, including nullable unions, while retaining allowed values as hints
- project integer `exclusiveMinimum` / `exclusiveMaximum` exactly with bounded arbitrary-precision arithmetic; retain exact hints for continuous or unrepresentable cases
- reject impractically large numeric literals/exponents before arbitrary-precision parsing
- recursively intersect `allOf` bounds, sizes, required fields, typed enums, and `additionalProperties` before lossy conversion; preserve non-orderable constraint hints
- keep composite `enum`, `const`, `default`, and `examples` values opaque to schema walkers so literal objects are never rewritten; preserve root const paths and large-integer spellings exactly
- distinguish author-selected names in `properties`, definition maps, pattern/dependent schema maps, and legacy hybrid `dependencies`, including schema-valued and array-valued dependencies

Property names that collide with schema keywords remain schemas and are still cleaned recursively.

## Validation

- `go test ./internal/util -count=1`
- targeted regressions repeated 10 times
- `go test -race ./internal/util -count=1`
- `go vet ./internal/util`
- server build and full diff check

Fork PR: https://github.com/rome-xi/CLIProxyAPI/pull/7
