### PR TITLE
fix(antigravity): omit tools when tool_choice is none

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -889,6 +889,8 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.mode", "AUTO")
 		case "none":
 			out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.mode", "NONE")
+			// Cloud Code ignores functionCallingConfig.mode=NONE and still invokes declared tools.
+			out, _ = sjson.DeleteBytes(out, "request.tools")
 		case "any":
 			out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.mode", "ANY")
 		case "tool":

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -1738,6 +1738,63 @@ func TestConvertClaudeRequestToAntigravity_ToolChoice_SpecificTool(t *testing.T)
 	}
 }
 
+func TestConvertClaudeRequestToAntigravity_ToolChoice_NoneOmitsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"get_weather",
+			"description":"Get weather",
+			"input_schema":{"type":"object","properties":{}}
+		}],
+		"tool_choice":{"type":"none"}
+	}`)
+	out := ConvertClaudeRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "NONE" {
+		t.Fatalf("functionCallingConfig.mode = %q, want NONE. Output: %s", got, out)
+	}
+	if tools := gjson.GetBytes(out, "request.tools"); tools.Exists() {
+		t.Fatalf("request.tools must be omitted when tool_choice is none. Output: %s", out)
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolChoice_NoneStringOmitsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"get_weather",
+			"description":"Get weather",
+			"input_schema":{"type":"object","properties":{}}
+		}],
+		"tool_choice":"none"
+	}`)
+	out := ConvertClaudeRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "NONE" {
+		t.Fatalf("functionCallingConfig.mode = %q, want NONE. Output: %s", got, out)
+	}
+	if tools := gjson.GetBytes(out, "request.tools"); tools.Exists() {
+		t.Fatalf("request.tools must be omitted when tool_choice is none. Output: %s", out)
+	}
+}
+
+func TestConvertClaudeRequestToAntigravity_ToolChoice_AutoKeepsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"name":"get_weather",
+			"description":"Get weather",
+			"input_schema":{"type":"object","properties":{}}
+		}],
+		"tool_choice":{"type":"auto"}
+	}`)
+	out := ConvertClaudeRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "AUTO" {
+		t.Fatalf("functionCallingConfig.mode = %q, want AUTO. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "request.tools.0.functionDeclarations.0.name").String(); got != "get_weather" {
+		t.Fatalf("functionDeclarations[0].name = %q, want get_weather. Output: %s", got, out)
+	}
+}
+
 func TestConvertClaudeRequestToAntigravity_ToolUse(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "claude-3-5-sonnet-20240620",

--- a/internal/translator/antigravity/interactions/interactions_antigravity_request.go
+++ b/internal/translator/antigravity/interactions/interactions_antigravity_request.go
@@ -25,6 +25,11 @@ func ConvertInteractionsRequestToAntigravity(modelName string, inputRawJSON []by
 	appendInteractionsInputToAntigravity(&contentItems, root.Get("input"))
 	out = translatorcommon.SetRawArrayItems(out, "request.contents", contentItems)
 	out = copyInteractionsToolsToAntigravity(out, root, functionNameMap)
+	if gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String() == "NONE" {
+		// Cloud Code ignores functionCallingConfig.mode=NONE and still invokes declared tools.
+		// Tool choice is applied before tools are copied; delete after copy so they cannot reappear.
+		out, _ = sjson.DeleteBytes(out, "request.tools")
+	}
 	out = rewriteInteractionsFunctionNames(out, functionNameMap)
 	out = attachDefaultAntigravitySafetySettings(out)
 	return out

--- a/internal/translator/antigravity/interactions/interactions_antigravity_test.go
+++ b/internal/translator/antigravity/interactions/interactions_antigravity_test.go
@@ -169,6 +169,26 @@ func TestConvertInteractionsRequestToAntigravityDeduplicatesAndDisambiguatesTool
 	}
 }
 
+func TestConvertInteractionsRequestToAntigravityToolChoiceNoneOmitsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"input":"hi",
+		"tools":[{
+			"type":"function",
+			"name":"get_weather",
+			"description":"Get weather",
+			"parameters":{"type":"object","properties":{}}
+		}],
+		"tool_choice":"none"
+	}`)
+	out := ConvertInteractionsRequestToAntigravity("antigravity-test", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "NONE" {
+		t.Fatalf("functionCallingConfig.mode = %q, want NONE. Output: %s", got, out)
+	}
+	if tools := gjson.GetBytes(out, "request.tools"); tools.Exists() {
+		t.Fatalf("request.tools must be omitted when tool_choice is none. Output: %s", out)
+	}
+}
+
 func TestConvertInteractionsRequestToAntigravityPreservesNameMappingWhitespace(t *testing.T) {
 	inputJSON := []byte(`{
 		"input":[{"type":"function_call","name":" read/file ","arguments":{}}],

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -500,15 +500,24 @@ func applyOpenAIToolChoiceToAntigravity(out, rawJSON []byte, functionNameMap map
 		case "required", "any":
 			mode = "ANY"
 		}
-	} else if toolChoice.IsObject() && strings.EqualFold(toolChoice.Get("type").String(), "function") {
-		mode = "ANY"
-		allowedName = toolChoice.Get("function.name").String()
+	} else if toolChoice.IsObject() {
+		switch strings.ToLower(strings.TrimSpace(toolChoice.Get("type").String())) {
+		case "none":
+			mode = "NONE"
+		case "function":
+			mode = "ANY"
+			allowedName = toolChoice.Get("function.name").String()
+		}
 	}
 	if mode == "" {
 		return out
 	}
 
 	out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.mode", mode)
+	if mode == "NONE" {
+		// Cloud Code ignores functionCallingConfig.mode=NONE and still invokes declared tools.
+		out, _ = sjson.DeleteBytes(out, "request.tools")
+	}
 	if strings.TrimSpace(allowedName) != "" {
 		mappedName := util.MapSanitizedFunctionName(functionNameMap, allowedName)
 		out, _ = sjson.SetBytes(out, "request.toolConfig.functionCallingConfig.allowedFunctionNames", []string{mappedName})

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -350,6 +350,72 @@ func TestConvertOpenAIRequestToAntigravityMapsToolChoiceModes(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToAntigravityToolChoiceNoneOmitsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"get_weather",
+				"description":"Get weather",
+				"parameters":{"type":"object","properties":{}}
+			}
+		}],
+		"tool_choice":"none"
+	}`)
+	out := ConvertOpenAIRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "NONE" {
+		t.Fatalf("functionCallingConfig.mode = %q, want NONE. Output: %s", got, out)
+	}
+	if tools := gjson.GetBytes(out, "request.tools"); tools.Exists() {
+		t.Fatalf("request.tools must be omitted when tool_choice is none. Output: %s", out)
+	}
+}
+
+func TestConvertOpenAIRequestToAntigravityToolChoiceNoneObjectOmitsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"get_weather",
+				"description":"Get weather",
+				"parameters":{"type":"object","properties":{}}
+			}
+		}],
+		"tool_choice":{"type":"none"}
+	}`)
+	out := ConvertOpenAIRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "NONE" {
+		t.Fatalf("functionCallingConfig.mode = %q, want NONE. Output: %s", got, out)
+	}
+	if tools := gjson.GetBytes(out, "request.tools"); tools.Exists() {
+		t.Fatalf("request.tools must be omitted when tool_choice type is none. Output: %s", out)
+	}
+}
+
+func TestConvertOpenAIRequestToAntigravityToolChoiceAutoKeepsTools(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"get_weather",
+				"description":"Get weather",
+				"parameters":{"type":"object","properties":{}}
+			}
+		}],
+		"tool_choice":"auto"
+	}`)
+	out := ConvertOpenAIRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String(); got != "AUTO" {
+		t.Fatalf("functionCallingConfig.mode = %q, want AUTO. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "request.tools.0.functionDeclarations.0.name").String(); got != "get_weather" {
+		t.Fatalf("functionDeclarations[0].name = %q, want get_weather. Output: %s", got, out)
+	}
+}
+
 func TestConvertOpenAIRequestToAntigravityMapsResponseFormatJSONObject(t *testing.T) {
 	inputJSON := []byte(`{
 		"model":"gemini-3.6-flash-high",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloud Code / Antigravity ignores `functionCallingConfig.mode=NONE` and still invokes any declared tools. When a client sends OpenAI or Claude `tool_choice: none` (string or `{type:none}`), the Antigravity request now sets mode `NONE` **and omits `request.tools`** so tools cannot be called.

Other `tool_choice` modes (`auto` / `any` / `required` / named function) are unchanged.

Inspired by [rome-xi/aster#288](https://github.com/rome-xi/aster/pull/288) and [AsterGateway/astergate#147](https://github.com/AsterGateway/astergate/pull/147). Minimal in-place rewrite — not a wholesale copy.

**Intended merge target:** [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) branch `dev`. This token cannot open a cross-fork PR on the upstream repo (403). Compare URL: https://github.com/router-for-me/CLIProxyAPI/compare/dev...rome-xi:cursor/omit-tools-tool-choice-none-ff19

## Changes
- **OpenAI chat-completions**: treat object `{type:none}` as mode `NONE`; delete `request.tools` after setting mode `NONE` (tools are already written before the helper).
- **Claude**: after setting mode `NONE` for string/`{type:none}`, delete `request.tools`.
- **Interactions**: `tool_choice` is applied before tools are copied, so tools are omitted as a post-condition after `copyInteractionsToolsToAntigravity` when mode is `NONE` (deleting only inside the tool_choice helper would let later writes reappear).
- Responses→Gemini→Antigravity left untouched (no verified same-class bug there).

## Tests
- OpenAI: string `"none"` and `{type:none}` → mode `NONE` + `request.tools` absent; `"auto"` still keeps tools.
- Claude: same coverage.
- Interactions: `tool_choice: none` with tools declared → no `request.tools` on output.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38770256-8351-4411-95c7-4aee0805ff19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38770256-8351-4411-95c7-4aee0805ff19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



Fork PR: https://github.com/rome-xi/CLIProxyAPI/pull/8