### PR TITLE
feat(grok): add tts and stt support

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -67,6 +67,8 @@ func (s *Server) setupRoutes() {
 		v1.POST("/completions", openaiHandlers.Completions)
 		v1.POST("/images/generations", openaiHandlers.ImagesGenerations)
 		v1.POST("/images/edits", openaiHandlers.ImagesEdits)
+		v1.POST("/tts", openaiHandlers.GrokTTS)
+		v1.POST("/stt", openaiHandlers.GrokSTT)
 		v1.POST("/videos", openaiHandlers.XAIVideosGenerations)
 		v1.POST("/videos/generations", openaiHandlers.XAIVideosGenerations)
 		v1.POST("/videos/edits", openaiHandlers.XAIVideosEdits)

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -15,6 +15,9 @@ const (
 	xaiBuiltinVideoModelID        = "grok-imagine-video"
 	xaiBuiltinVideo15ModelID      = "grok-imagine-video-1.5"
 	xaiBuiltinVideo15PreviewID    = "grok-imagine-video-1.5-preview"
+	// Voice entries are routing-only models for the native Grok Voice endpoints.
+	xaiBuiltinTTSModelID = "grok-tts"
+	xaiBuiltinSTTModelID = "grok-stt"
 )
 
 // staticModelsJSON mirrors the top-level structure of models.json.
@@ -119,10 +122,16 @@ func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
 	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo())
 }
 
-// WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
+// WithXAIBuiltins injects hard-coded xAI image/video/voice model definitions that should
 // not depend on remote models.json updates.
 func WithXAIBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, xaiBuiltinImageModelInfo(), xaiBuiltinImageQualityModelInfo(), xaiBuiltinImage20ModelInfo(), xaiBuiltinVideoModelInfo(), xaiBuiltinVideo15ModelInfo(), xaiBuiltinVideo15PreviewModelInfo())
+	return upsertModelInfos(models, xaiBuiltinImageModelInfo(), xaiBuiltinImageQualityModelInfo(), xaiBuiltinImage20ModelInfo(), xaiBuiltinVideoModelInfo(), xaiBuiltinVideo15ModelInfo(), xaiBuiltinVideo15PreviewModelInfo(), xaiBuiltinTTSModelInfo(), xaiBuiltinSTTModelInfo())
+}
+
+// WithXAIVoiceBuiltins adds the routing-only model definitions required by the
+// native Grok Voice endpoints without changing an operator's custom model list.
+func WithXAIVoiceBuiltins(models []*ModelInfo) []*ModelInfo {
+	return upsertModelInfos(models, xaiBuiltinTTSModelInfo(), xaiBuiltinSTTModelInfo())
 }
 
 func normalizeAntigravityCapabilityModelID(modelID string) string {
@@ -232,6 +241,34 @@ func xaiBuiltinVideo15PreviewModelInfo() *ModelInfo {
 		DisplayName: "Grok Imagine Video 1.5 Preview",
 		Name:        xaiBuiltinVideo15PreviewID,
 		Description: "Compatibility alias for the xAI Grok video generation model.",
+	}
+}
+
+func xaiBuiltinTTSModelInfo() *ModelInfo {
+	// This model identifies the xAI account pool; the upstream TTS payload may omit model.
+	return &ModelInfo{
+		ID:          xaiBuiltinTTSModelID,
+		Object:      "model",
+		Created:     1735689600,
+		OwnedBy:     "xai",
+		Type:        "xai",
+		DisplayName: "Grok Text to Speech",
+		Name:        xaiBuiltinTTSModelID,
+		Description: "xAI Grok text-to-speech voice endpoint routing model.",
+	}
+}
+
+func xaiBuiltinSTTModelInfo() *ModelInfo {
+	// This model identifies the xAI account pool; the upstream STT payload may omit model.
+	return &ModelInfo{
+		ID:          xaiBuiltinSTTModelID,
+		Object:      "model",
+		Created:     1735689600,
+		OwnedBy:     "xai",
+		Type:        "xai",
+		DisplayName: "Grok Speech to Text",
+		Name:        xaiBuiltinSTTModelID,
+		Description: "xAI Grok speech-to-text voice endpoint routing model.",
 	}
 }
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -80,6 +80,39 @@ func TestWithXAIBuiltinsIncludesVideo15GAAndPreviewAlias(t *testing.T) {
 	}
 }
 
+func TestWithXAIBuiltinsIncludesVoiceRoutingModels(t *testing.T) {
+	models := WithXAIBuiltins(nil)
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		if model != nil {
+			seen[model.ID] = true
+		}
+	}
+	for _, id := range []string{xaiBuiltinTTSModelID, xaiBuiltinSTTModelID} {
+		if !seen[id] {
+			t.Fatalf("expected xAI builtin voice model %s", id)
+		}
+	}
+}
+
+func TestWithXAIVoiceBuiltinsPreservesCustomModels(t *testing.T) {
+	models := WithXAIVoiceBuiltins([]*ModelInfo{{ID: "custom-grok-model"}})
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		if model != nil {
+			seen[model.ID] = true
+		}
+	}
+	for _, id := range []string{"custom-grok-model", xaiBuiltinTTSModelID, xaiBuiltinSTTModelID} {
+		if !seen[id] {
+			t.Fatalf("missing xAI model %s", id)
+		}
+	}
+	if seen[xaiBuiltinImageModelID] {
+		t.Fatalf("voice builtins unexpectedly added image model %s", xaiBuiltinImageModelID)
+	}
+}
+
 func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing.T) {
 	registryRef := GetGlobalRegistry()
 	registryRef.RegisterClient("test-antigravity-websearch-route", "antigravity", []*ModelInfo{

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -19,6 +19,9 @@ import (
 )
 
 func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "voice/tts" || opts.Alt == "voice/stt" {
+		return e.executeVoice(ctx, auth, req, opts)
+	}
 	if opts.Alt == "responses/compact" {
 		return e.executeCompact(ctx, auth, req, opts)
 	}

--- a/internal/runtime/executor/xai_executor_media.go
+++ b/internal/runtime/executor/xai_executor_media.go
@@ -70,6 +70,65 @@ func (e *XAIExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth
 	return cliproxyexecutor.Response{Payload: data, Headers: httpResp.Header.Clone()}, nil
 }
 
+// executeVoice forwards Grok Voice HTTP requests without translating their
+// payload. TTS returns audio bytes, while STT commonly uses multipart input.
+func (e *XAIExecutor) executeVoice(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	// Voice model IDs are routing-only; do not parse the potentially large
+	// multipart/audio payload just to derive usage metadata.
+	model := strings.TrimSpace(req.Model)
+	reporter := helps.NewExecutorUsageReporter(ctx, e, model, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	token, _ := xaiCreds(auth)
+	baseURL := xaiVoiceBaseURL(auth)
+	logXAIResolvedBaseURL(ctx, baseURL)
+	endpoint := "/tts"
+	if opts.Alt == "voice/stt" {
+		endpoint = "/stt"
+	}
+	requestURL := strings.TrimSuffix(baseURL, "/") + endpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(req.Payload))
+	if err != nil {
+		return resp, err
+	}
+	contentType := "application/json"
+	if opts.Headers != nil && opts.Headers.Get("Content-Type") != "" {
+		contentType = opts.Headers.Get("Content-Type")
+	}
+	httpReq.Header.Set("Content-Type", contentType)
+	applyXAIHeaders(httpReq, auth, token, false, "", opts.Headers)
+	httpReq.Header.Set("Content-Type", contentType)
+	// Voice endpoints may return either JSON (STT) or binary audio (TTS).
+	// Set this after applyXAIHeaders so the generic JSON default does not win.
+	httpReq.Header.Set("Accept", "application/json, audio/*")
+	e.recordXAIRequest(ctx, auth, requestURL, httpReq.Header.Clone(), req.Payload)
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("xai voice executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
+		return resp, xaiStatusErr(httpResp.StatusCode, data)
+	}
+	reporter.EnsurePublished(ctx)
+	return cliproxyexecutor.Response{Payload: data, Headers: httpResp.Header.Clone()}, nil
+}
+
 func (e *XAIExecutor) executeVideos(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	model := strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
 	if model == "" {

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -257,6 +257,18 @@ func xaiCompactBaseURL(auth *cliproxyauth.Auth) string {
 	return baseURL
 }
 
+// xaiVoiceBaseURL returns a base URL that exposes the official xAI Voice APIs.
+// The CLI chat proxy does not implement /tts or /stt, so OAuth traffic using
+// that default must be redirected to api.x.ai while explicit custom relays are
+// still honored.
+func xaiVoiceBaseURL(auth *cliproxyauth.Auth) string {
+	_, baseURL := xaiCreds(auth)
+	if baseURL == "" || xaiIsCLIChatProxyBaseURL(baseURL) {
+		return xaiauth.DefaultAPIBaseURL
+	}
+	return baseURL
+}
+
 func xaiNormalizeBaseURL(baseURL string) string {
 	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
 }

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -5931,6 +5931,25 @@ func TestXAICompactBaseURL(t *testing.T) {
 	}
 }
 
+func TestXAIVoiceBaseURL(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *cliproxyauth.Auth
+		want string
+	}{
+		{name: "empty defaults to official api", auth: &cliproxyauth.Auth{}, want: xaiauth.DefaultAPIBaseURL},
+		{name: "cli chat proxy defaults to official api", auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": xaiauth.CLIChatProxyBaseURL}}, want: xaiauth.DefaultAPIBaseURL},
+		{name: "custom relay is honored", auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://gateway.example.com/v1"}}, want: "https://gateway.example.com/v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := xaiVoiceBaseURL(tt.auth); got != tt.want {
+				t.Fatalf("xaiVoiceBaseURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyXAIChatHeaders(t *testing.T) {
 	t.Run("non OAuth defaults to official API headers", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "https://example.invalid/responses", nil)

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
@@ -103,6 +104,7 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
 	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), responseProtocol, normalizedModel, originalRequestedModel, executedOpts, rawResponseHeaders, responseHeaders, executedOpts.OriginalRequest, executedReq.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
+	responseHeaders = restoreVoiceContentType(alt, rawResponseHeaders, responseHeaders)
 	lifecycle.complete(pluginapi.RequestCompletionSucceeded, http.StatusOK, nil)
 	return body, responseHeaders, nil
 }
@@ -216,8 +218,25 @@ func (h *BaseAPIHandler) executeWithPluginExecutor(ctx context.Context, entryPro
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
 	body, responseHeaders := h.applyResponseInterceptors(execCtx, lifecycle.requestID(), responseProtocol, modelName, originalRequestedModel, opts, rawResponseHeaders, responseHeaders, opts.OriginalRequest, req.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
+	responseHeaders = restoreVoiceContentType(alt, rawResponseHeaders, responseHeaders)
 	lifecycle.complete(pluginapi.RequestCompletionSucceeded, http.StatusOK, nil)
 	return body, responseHeaders, nil
+}
+
+// restoreVoiceContentType keeps the upstream MIME type for Voice responses
+// even when general response-header passthrough is disabled. This applies to
+// both normal auth-manager and plugin-executor routes.
+func restoreVoiceContentType(alt string, rawResponseHeaders, responseHeaders http.Header) http.Header {
+	if !strings.HasPrefix(alt, "voice/") || responseHeaders.Get("Content-Type") != "" {
+		return responseHeaders
+	}
+	if contentType := rawResponseHeaders.Get("Content-Type"); contentType != "" {
+		if responseHeaders == nil {
+			responseHeaders = make(http.Header)
+		}
+		responseHeaders.Set("Content-Type", contentType)
+	}
+	return responseHeaders
 }
 
 func (h *BaseAPIHandler) countWithPluginExecutor(ctx context.Context, handlerType, modelName, originalRequestedModel string, rawJSON []byte, alt, executorPluginID string, execOptions modelExecutionOptions) ([]byte, http.Header, *interfaces.ErrorMessage) {

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -31,6 +31,20 @@ type handlerInterceptorTestHost struct {
 	includeStreamChunkRequestBodies bool
 }
 
+func TestRestoreVoiceContentTypePreservesUpstreamMIME(t *testing.T) {
+	raw := http.Header{"Content-Type": {"audio/mpeg"}}
+	if got := restoreVoiceContentType("voice/tts", raw, nil).Get("Content-Type"); got != "audio/mpeg" {
+		t.Fatalf("restored Content-Type = %q, want audio/mpeg", got)
+	}
+	pluginHeaders := http.Header{"Content-Type": {"audio/wav"}}
+	if got := restoreVoiceContentType("voice/tts", raw, pluginHeaders).Get("Content-Type"); got != "audio/wav" {
+		t.Fatalf("plugin Content-Type = %q, want audio/wav", got)
+	}
+	if got := restoreVoiceContentType("chat", raw, nil); got != nil {
+		t.Fatalf("non-voice headers = %#v, want nil", got)
+	}
+}
+
 type handlerInterceptorNoStreamTestHost struct {
 	*handlerInterceptorTestHost
 }

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 
@@ -132,6 +133,43 @@ func (h *OpenAIAPIHandler) ChatCompletions(c *gin.Context) {
 		h.handleNonStreamingResponse(c, rawJSON)
 	}
 
+}
+
+// GrokTTS forwards a Grok Voice text-to-speech request and preserves the
+// upstream audio response instead of wrapping it as JSON.
+// The routing model is only used to select the xAI account pool; Voice
+// requests do not require a text model in their upstream payload.
+func (h *OpenAIAPIHandler) GrokTTS(c *gin.Context) {
+	h.handleGrokVoice(c, "voice/tts", "grok-tts")
+}
+
+// GrokSTT forwards a Grok Voice speech-to-text multipart request.
+func (h *OpenAIAPIHandler) GrokSTT(c *gin.Context) {
+	h.handleGrokVoice(c, "voice/stt", "grok-stt")
+}
+
+func (h *OpenAIAPIHandler) handleGrokVoice(c *gin.Context, alt, model string) {
+	raw, errRead := io.ReadAll(c.Request.Body)
+	if errRead != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: errRead.Error(), Type: "invalid_request_error"}})
+		return
+	}
+	ctx, cancel := h.GetContextWithCancel(h, c, context.Background())
+	defer cancel()
+	body, headers, errMsg := h.ExecuteWithAuthManager(ctx, h.HandlerType(), model, raw, alt)
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), headers)
+	if c.Writer.Header().Get("Content-Type") == "" {
+		contentType := "application/octet-stream"
+		if alt == "voice/stt" {
+			contentType = "application/json"
+		}
+		c.Header("Content-Type", contentType)
+	}
+	_, _ = c.Writer.Write(body)
 }
 
 // shouldTreatAsResponsesFormat detects OpenAI Responses-style payloads that are

--- a/sdk/cliproxy/service_codex_models_test.go
+++ b/sdk/cliproxy/service_codex_models_test.go
@@ -96,6 +96,35 @@ func TestRegisterModelsForAuthCodexAPIKeyModels(t *testing.T) {
 	}
 }
 
+func TestRegisterModelsForAuthXAIConfiguredModelsRetainsVoiceRoutes(t *testing.T) {
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	authID := "xai-configured-voice-models"
+	modelRegistry.UnregisterClient(authID)
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+
+	service := &Service{cfg: &config.Config{XAIKey: []config.XAIKey{{
+		APIKey: "configured-xai-key",
+		Models: []internalconfig.XAIModel{{Name: "grok-4.5", Alias: "configured-grok"}},
+	}}}}
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			coreauth.AttributeAPIKey:      "configured-xai-key",
+			coreauth.AttributeConfigIndex: "0",
+		},
+	}
+
+	service.registerModelsForAuth(context.Background(), auth)
+	gotIDs := codexModelIDSet(modelRegistry.GetModelsForClient(authID))
+	for _, modelID := range []string{"configured-grok", "grok-tts", "grok-stt"} {
+		if _, ok := gotIDs[modelID]; !ok {
+			t.Errorf("missing registered xAI model %q: got %#v", modelID, gotIDs)
+		}
+	}
+}
+
 func TestRegisterModelsForAuthCodexAPIKeyDefaultRequiresConfigMatch(t *testing.T) {
 	defaultIDs := codexModelIDSet(internalregistry.GetCodexProModels())
 	tests := []struct {

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -148,7 +148,7 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		models = registry.GetXAIModels()
 		if entry := s.resolveConfigXAIKey(a); entry != nil {
 			if len(entry.Models) > 0 {
-				models = buildXAIConfigModels(entry)
+				models = registry.WithXAIVoiceBuiltins(buildXAIConfigModels(entry))
 			}
 			if authKind == "apikey" {
 				excluded = entry.ExcludedModels


### PR DESCRIPTION
Adds native Grok Voice support for CLIProxyAPI.
- Adds POST /v1/tts for Grok text-to-speech requests.
- Adds POST /v1/stt for Grok speech-to-text requests.
- Forwards TTS JSON and STT multipart/form-data bodies directly to the xAI Voice endpoints.
- Preserves upstream TTS audio responses instead of wrapping binary data in a JSON management response.
- Registers grok-tts and grok-stt as xAI routing-only models.
- Documents that the Voice routing models are used only to select the xAI account pool; upstream Voice payloads do not require a model field.