### PR TITLE
fix(usage): honor SGLang-style flat top-level reasoning_tokens

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -726,7 +726,10 @@ func hasOpenAIStyleUsageBucketFields(usageNode gjson.Result) bool {
 		usageNode.Get("input_tokens_details.cache_write_tokens").Exists() ||
 		usageNode.Get("input_tokens_details.cache_creation_tokens").Exists() ||
 		usageNode.Get("completion_tokens_details.reasoning_tokens").Exists() ||
-		usageNode.Get("output_tokens_details.reasoning_tokens").Exists()
+		usageNode.Get("output_tokens_details.reasoning_tokens").Exists() ||
+		// Some OpenAI-compatible gateways (e.g. SGLang) report reasoning tokens
+		// as a flat top-level usage field instead of a details sub-object.
+		usageNode.Get("reasoning_tokens").Exists()
 }
 
 func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
@@ -764,6 +767,10 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
 	if !reasoning.Exists() {
 		reasoning = usageNode.Get("output_tokens_details.reasoning_tokens")
+	}
+	if !reasoning.Exists() {
+		// SGLang-style gateways emit a flat top-level reasoning_tokens field.
+		reasoning = usageNode.Get("reasoning_tokens")
 	}
 	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -199,6 +199,42 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	}
 }
 
+func TestParseOpenAIUsageSGLangFlatReasoningTokens(t *testing.T) {
+	// SGLang-style gateways report reasoning tokens as a flat top-level usage field.
+	data := []byte(`{"usage":{"prompt_tokens":18,"total_tokens":243,"completion_tokens":225,"prompt_tokens_details":null,"reasoning_tokens":162}}`)
+	detail := ParseOpenAIUsage(data)
+	if detail.InputTokens != 18 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 18)
+	}
+	if detail.OutputTokens != 225 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 225)
+	}
+	if detail.TotalTokens != 243 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 243)
+	}
+	if detail.ReasoningTokens != 162 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 162)
+	}
+	if !detail.TokenBreakdown.Valid() || detail.TokenBreakdown.Output.ReasoningTokens != 162 {
+		t.Fatalf("token breakdown = %+v", detail.TokenBreakdown)
+	}
+}
+
+func TestStreamUsageBufferObservesSGLangFlatReasoningTokens(t *testing.T) {
+	var buffer StreamUsageBuffer
+	buffer.ObserveOpenAIStream([]byte(`data: {"id":"e2f091d1086a4f5bb62594d402a894c9","object":"chat.completion.chunk","created":1788265038,"model":"glm-5.3-flash","choices":[],"usage":{"prompt_tokens":18,"total_tokens":243,"completion_tokens":225,"prompt_tokens_details":null,"reasoning_tokens":162}}`))
+	detail, ok := buffer.Detail()
+	if !ok {
+		t.Fatal("StreamUsageBuffer.Detail() ok = false, want true")
+	}
+	if detail.InputTokens != 18 || detail.OutputTokens != 225 || detail.TotalTokens != 243 {
+		t.Fatalf("detail = %+v", detail)
+	}
+	if detail.ReasoningTokens != 162 {
+		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 162)
+	}
+}
+
 func TestStreamUsageBufferKeepsLastUsage(t *testing.T) {
 	var buffer StreamUsageBuffer
 	buffer.Observe(usage.Detail{}, true)

--- a/internal/translator/openai/gemini/openai_gemini_response.go
+++ b/internal/translator/openai/gemini/openai_gemini_response.go
@@ -642,6 +642,10 @@ func reasoningTokensFromUsage(usage gjson.Result) int64 {
 		if v := usage.Get("output_tokens_details.reasoning_tokens"); v.Exists() {
 			return v.Int()
 		}
+		// SGLang-style gateways emit a flat top-level reasoning_tokens field.
+		if v := usage.Get("reasoning_tokens"); v.Exists() {
+			return v.Int()
+		}
 	}
 	return 0
 }

--- a/internal/translator/openai/interactions/chat-completions/interactions_openai_response.go
+++ b/internal/translator/openai/interactions/chat-completions/interactions_openai_response.go
@@ -362,9 +362,10 @@ func setInteractionsUsageFromOpenAIChat(out []byte, path string, usage gjson.Res
 		out, _ = sjson.SetBytes(out, path+".cached_tokens", value.Int())
 		out, _ = sjson.SetBytes(out, path+".total_cached_tokens", value.Int())
 	}
-	if value := usage.Get("completion_tokens_details.reasoning_tokens"); value.Exists() {
-		out, _ = sjson.SetBytes(out, path+".reasoning_tokens", value.Int())
-		out, _ = sjson.SetBytes(out, path+".total_thought_tokens", value.Int())
+	reasoningTokens, hasReasoningTokens := interactionsUsageInt(usage, "completion_tokens_details.reasoning_tokens", "output_tokens_details.reasoning_tokens", "reasoning_tokens")
+	if hasReasoningTokens {
+		out, _ = sjson.SetBytes(out, path+".reasoning_tokens", reasoningTokens)
+		out, _ = sjson.SetBytes(out, path+".total_thought_tokens", reasoningTokens)
 	}
 	return out
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -321,6 +321,10 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		} else if v := usage.Get("completion_tokens_details.reasoning_tokens"); v.Exists() {
 			st.ReasoningTokens = v.Int()
 			st.UsageSeen = true
+		} else if v := usage.Get("reasoning_tokens"); v.Exists() {
+			// SGLang-style gateways emit a flat top-level reasoning_tokens field.
+			st.ReasoningTokens = v.Int()
+			st.UsageSeen = true
 		}
 		if v := usage.Get("total_tokens"); v.Exists() {
 			st.TotalTokens = v.Int()
@@ -981,8 +985,14 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 				resp, _ = sjson.SetBytes(resp, "usage.input_tokens_details.cached_tokens", d.Int())
 			}
 			resp, _ = sjson.SetBytes(resp, "usage.output_tokens", usage.Get("completion_tokens").Int())
-			// Reasoning tokens not available in Chat Completions; set only if present under output_tokens_details
+			// Reasoning tokens may appear under output_tokens_details (Responses style),
+			// completion_tokens_details (chat completions style), or as a flat top-level
+			// field on SGLang-style gateways; map whichever is present.
 			if d := usage.Get("output_tokens_details.reasoning_tokens"); d.Exists() {
+				resp, _ = sjson.SetBytes(resp, "usage.output_tokens_details.reasoning_tokens", d.Int())
+			} else if d := usage.Get("completion_tokens_details.reasoning_tokens"); d.Exists() {
+				resp, _ = sjson.SetBytes(resp, "usage.output_tokens_details.reasoning_tokens", d.Int())
+			} else if d := usage.Get("reasoning_tokens"); d.Exists() {
 				resp, _ = sjson.SetBytes(resp, "usage.output_tokens_details.reasoning_tokens", d.Int())
 			}
 			resp, _ = sjson.SetBytes(resp, "usage.total_tokens", usage.Get("total_tokens").Int())


### PR DESCRIPTION
## Problem

Some OpenAI-compatible gateways such as SGLang report reasoning tokens as a **flat top-level field** in the usage object:

```json
{"usage":{"prompt_tokens":18,"total_tokens":243,"completion_tokens":225,"prompt_tokens_details":null,"reasoning_tokens":162}}
```

CLIProxyAPI only read `usage.completion_tokens_details.reasoning_tokens` and `usage.output_tokens_details.reasoning_tokens`, so for these upstreams reasoning tokens were silently recorded as `0` in usage accounting, and clients of translated formats (Responses / Interactions / Gemini) also lost the value.

## Changes

Fall back to the flat `usage.reasoning_tokens` field when the nested fields are absent. Nested fields keep precedence, so providers already emitting nested details are unaffected.

- `internal/runtime/executor/helps/usage_helpers.go`: shared OpenAI-style usage parser (`parseOpenAIStyleUsageNode`, `hasOpenAIStyleUsageBucketFields`) — covers the streaming (`StreamUsageBuffer.ObserveOpenAIStream`) and non-streaming accounting paths of the OpenAI-compat executor (and other OpenAI-style executors)
- `internal/translator/openai/openai/responses/openai_openai-responses_response.go`: chat-completions → Responses, streaming usage state + non-stream usage mapping
- `internal/translator/openai/interactions/chat-completions/interactions_openai_response.go`: chat-completions → Interactions
- `internal/translator/openai/gemini/openai_gemini_response.go`: chat-completions → Gemini (`usageMetadata.thoughtsTokenCount`)

## Testing

- Added unit tests in `usage_helpers_test.go` using the exact SGLang chunk shape (flat `reasoning_tokens: 162`): non-stream `ParseOpenAIUsage` and streaming `StreamUsageBuffer.ObserveOpenAIStream` both report the value.
- `go test ./internal/runtime/executor/... ./internal/translator/... -count=1` — all pass.
- Verified on a production deployment (OpenAICompatExecutor → SGLang, `glm-5.3-flash`): usage stats now show non-zero reasoning tokens (e.g. output 73 tokens, of which 69 reasoning).