### PR TITLE
fix(gemini): use non-empty leading-user placeholder

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -345,9 +345,9 @@ func sanitizeAntigravityGeminiRequestSignatures(modelName string, rawJSON []byte
 	return normalizeAntigravityGeminiFunctionResponseRoles(rawJSON)
 }
 
-// ensureAntigravityGeminiLeadingUserContent prepends a synthetic empty user turn
+// ensureAntigravityGeminiLeadingUserContent prepends a placeholder user turn
 // after every contents rewrite, including reasoning replay. Claude targets are
-// left unchanged because the adapter rejects empty text parts.
+// left unchanged because the adapter rejects synthetic placeholder text parts.
 func ensureAntigravityGeminiLeadingUserContent(modelName string, payload []byte) []byte {
 	if strings.Contains(strings.ToLower(modelName), "claude") {
 		return payload

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -73,7 +73,7 @@ func assertIssue4959LeadingUserContents(t *testing.T, contents []gjson.Result) {
 		t.Fatalf("contents too short: %d", len(contents))
 	}
 	leadingText := contents[0].Get("parts.0.text")
-	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != " " {
 		t.Fatalf("synthetic leading user missing: %s", contents[0].Raw)
 	}
 	if contents[1].Get("role").String() != "model" || !contentHasNamedPart(contents[1], "functionCall", "Bash") {
@@ -321,7 +321,7 @@ func TestAntigravityStreamPrependsLeadingUserForGemini(t *testing.T) {
 			t.Fatalf("upstream roles malformed: %s", body)
 		}
 		leadingText := contents[0].Get("parts.0.text")
-		if !leadingText.Exists() || leadingText.String() != "" {
+		if !leadingText.Exists() || leadingText.String() != " " {
 			t.Fatalf("synthetic leading user missing: %s", body)
 		}
 		if !contents[1].Get("parts.0.functionCall").Exists() || !contents[2].Get("parts.0.functionResponse").Exists() {
@@ -502,7 +502,7 @@ func TestAntigravityStreamPrependsLeadingUserAfterReplayInsertsFunctionCall(t *t
 		t.Fatalf("contents len = %d, want 3; body=%s", len(contents), body)
 	}
 	leadingText := contents[0].Get("parts.0.text")
-	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != " " {
 		t.Fatalf("synthetic leading user missing after replay insert: %s", contents[0].Raw)
 	}
 	if contents[1].Get("role").String() != "model" || contents[1].Get("parts.0.functionCall.id").String() != "call-1" {
@@ -730,7 +730,7 @@ func TestAntigravityCountTokensMatchesTargetLeadingUserPolicy(t *testing.T) {
 			}
 			if strings.HasPrefix(tt.wantRoles, "user,") {
 				text := contents[0].Get("parts.0.text")
-				if !text.Exists() || text.String() != "" {
+				if !text.Exists() || text.String() != " " {
 					t.Fatalf("synthetic countTokens user missing: %s", upstreamBody)
 				}
 			}
@@ -839,7 +839,7 @@ func TestAntigravityExecutorCountTokensReconstructsCompactedClaudeToolCall(t *te
 		t.Fatal("countTokens upstream body was not captured")
 	}
 	leadingText := gjson.GetBytes(upstreamBody, "request.contents.0.parts.0.text")
-	if gjson.GetBytes(upstreamBody, "request.contents.0.role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+	if gjson.GetBytes(upstreamBody, "request.contents.0.role").String() != "user" || !leadingText.Exists() || leadingText.String() != " " {
 		t.Fatalf("synthetic leading user missing after replay insert: %s", upstreamBody)
 	}
 	call := gjson.GetBytes(upstreamBody, "request.contents.1.parts.0")

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -124,8 +124,8 @@ func TestGeminiExecutorExecutePrependsLeadingUser(t *testing.T) {
 	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" || contents[2].Get("role").String() != "user" {
 		t.Fatalf("upstream roles malformed: %s", upstreamBody)
 	}
-	if got := contents[0].Get("parts.0.text").String(); got != "" {
-		t.Fatalf("leading user prompt = %q, want empty string; body=%s", got, upstreamBody)
+	if got := contents[0].Get("parts.0.text").String(); got != " " {
+		t.Fatalf("leading user prompt = %q, want single-space placeholder; body=%s", got, upstreamBody)
 	}
 }
 
@@ -190,7 +190,7 @@ func TestGeminiExecutorCountTokensPrependsLeadingUser(t *testing.T) {
 	if len(contents) != 2 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
 		t.Fatalf("countTokens roles malformed: %s", upstreamBody)
 	}
-	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != " " {
 		t.Fatalf("countTokens synthetic user missing: %s", upstreamBody)
 	}
 	if got := contents[1].Get("parts.0.text").String(); got != "prior output" {
@@ -243,7 +243,7 @@ func TestGeminiExecutorAppliesPayloadRulesBeforeLeadingUserNormalization(t *test
 	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
 		t.Fatalf("upstream roles malformed: %s", upstreamBody)
 	}
-	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != " " {
 		t.Fatalf("synthetic leading user changed: %s", upstreamBody)
 	}
 	if got := contents[1].Get("parts.0.text").String(); got != "payload override" {

--- a/internal/runtime/executor/helps/gemini_content_turns.go
+++ b/internal/runtime/executor/helps/gemini_content_turns.go
@@ -7,10 +7,12 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-var emptyGeminiUserTurnJSON = []byte(`{"role":"user","parts":[{"text":""}]}`)
+// A single space: some Gemini endpoints reject an empty text part, while
+// Claude-on-Antigravity still rejects even this and is skipped upstream.
+var placeholderGeminiUserTurnJSON = []byte(`{"role":"user","parts":[{"text":" "}]}`)
 
-// EnsureGeminiLeadingUserContent ensures that the contents array at the given path
-// starts with a user turn when sending to Gemini/Antigravity upstreams.
+// EnsureGeminiLeadingUserContent prepends a placeholder user turn when the
+// contents array at the given path starts with role=model.
 func EnsureGeminiLeadingUserContent(payload []byte, path string) []byte {
 	firstRole := gjson.GetBytes(payload, path+".0.role")
 	if firstRole.String() != "model" {
@@ -26,7 +28,7 @@ func EnsureGeminiLeadingUserContent(payload []byte, path string) []byte {
 	}
 
 	contentItems := make([][]byte, 0, len(contentArray)+1)
-	contentItems = append(contentItems, emptyGeminiUserTurnJSON)
+	contentItems = append(contentItems, placeholderGeminiUserTurnJSON)
 	for _, content := range contentArray {
 		contentItems = append(contentItems, []byte(content.Raw))
 	}

--- a/internal/runtime/executor/helps/gemini_content_turns_test.go
+++ b/internal/runtime/executor/helps/gemini_content_turns_test.go
@@ -29,11 +29,11 @@ func TestEnsureGeminiLeadingUserContentReusesLargeValidPayload(t *testing.T) {
 
 func TestEnsureGeminiLeadingUserContent(t *testing.T) {
 	tests := []struct {
-		name             string
-		inputJSON        string
-		path             string
-		wantRoles        string
-		wantLeadingEmpty bool
+		name            string
+		inputJSON       string
+		path            string
+		wantRoles       string
+		wantPlaceholder bool
 	}{
 		{
 			name:      "user first is unchanged",
@@ -42,25 +42,25 @@ func TestEnsureGeminiLeadingUserContent(t *testing.T) {
 			wantRoles: "user",
 		},
 		{
-			name:             "leading model functionCall gets empty user",
-			inputJSON:        `{"contents":[{"role":"model","parts":[{"functionCall":{"name":"run"}}]},{"role":"user","parts":[{"functionResponse":{"name":"run"}}]}]}`,
-			path:             "contents",
-			wantRoles:        "user,model,user",
-			wantLeadingEmpty: true,
+			name:            "leading model functionCall gets placeholder user",
+			inputJSON:       `{"contents":[{"role":"model","parts":[{"functionCall":{"name":"run"}}]},{"role":"user","parts":[{"functionResponse":{"name":"run"}}]}]}`,
+			path:            "contents",
+			wantRoles:       "user,model,user",
+			wantPlaceholder: true,
 		},
 		{
-			name:             "leading model text gets empty user and preserves following turns",
-			inputJSON:        `{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}`,
-			path:             "contents",
-			wantRoles:        "user,model,user",
-			wantLeadingEmpty: true,
+			name:            "leading model text gets placeholder user and preserves following turns",
+			inputJSON:       `{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}`,
+			path:            "contents",
+			wantRoles:       "user,model,user",
+			wantPlaceholder: true,
 		},
 		{
-			name:             "nested contents are normalized",
-			inputJSON:        `{"request":{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}}`,
-			path:             "request.contents",
-			wantRoles:        "request.user,model,user",
-			wantLeadingEmpty: true,
+			name:            "nested contents are normalized",
+			inputJSON:       `{"request":{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}}`,
+			path:            "request.contents",
+			wantRoles:       "request.user,model,user",
+			wantPlaceholder: true,
 		},
 		{
 			name:      "empty contents are unchanged",
@@ -88,10 +88,10 @@ func TestEnsureGeminiLeadingUserContent(t *testing.T) {
 			if got := strings.Join(roles, ","); got != expectedRoles {
 				t.Fatalf("roles = %q, want %q; output=%s", got, expectedRoles, out)
 			}
-			if tt.wantLeadingEmpty {
+			if tt.wantPlaceholder {
 				text := gjson.GetBytes(out, tt.path+".0.parts.0.text")
-				if !text.Exists() || text.String() != "" {
-					t.Fatalf("leading empty user part missing; output=%s", out)
+				if !text.Exists() || text.String() != " " {
+					t.Fatalf("leading placeholder user part missing; output=%s", out)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

Some Gemini endpoints reject an empty text part. Change the synthetic leading user turn from an empty string to a single-space placeholder whenever a request begins with `role: model`.

The shared executor helper covers Gemini execute/countTokens and Gemini-on-Antigravity paths; the corresponding executor and integration expectations are updated.

The translator changes previously bundled in this PR were removed to comply with the repository translator contribution policy and are tracked separately:

- #5483 — tighten Claude no-prefill model-family matching
- #5484 — preserve non-result slots while aligning Claude tool results

## Validation

- `go test ./internal/runtime/executor/... -count=1`
- full Go suite passes apart from the unchanged environment-dependent WebRTC DataChannel test
- server build
- `git diff --check`