### PR TITLE
feat(codex): dedicated /backend-api/codex/models catalog

### DIFF
--- a/internal/api/server_codex_models_test.go
+++ b/internal/api/server_codex_models_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCodexDirectModelsRouteIgnoresUserAgent(t *testing.T) {
+	server := newTestServer(t)
+
+	responses := make([][]byte, 0, 2)
+	for _, userAgent := range []string{"claude-cli/1.0", "Mozilla/5.0"} {
+		req := httptest.NewRequest(http.MethodGet, "/backend-api/codex/models", nil)
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("User-Agent %q: status = %d, want %d; body=%s", userAgent, rr.Code, http.StatusOK, rr.Body.String())
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("User-Agent %q: invalid JSON: %v", userAgent, err)
+		}
+		if _, ok := payload["models"]; !ok {
+			t.Fatalf("User-Agent %q: response missing models catalog: %s", userAgent, rr.Body.String())
+		}
+		responses = append(responses, append([]byte(nil), rr.Body.Bytes()...))
+	}
+
+	if string(responses[0]) != string(responses[1]) {
+		t.Fatalf("Codex catalog varies by User-Agent:\nclaude=%s\nother=%s", responses[0], responses[1])
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -111,6 +111,9 @@ func (s *Server) setupRoutes() {
 	codexDirect := s.engine.Group("/backend-api/codex")
 	codexDirect.Use(AuthMiddleware(s.accessManager))
 	{
+		// Codex CLI expects its enriched catalog regardless of User-Agent. Keep this
+		// route isolated from the generic /v1/models content negotiation logic.
+		codexDirect.GET("/models", s.codexDirectModelsHandler(openaiHandlers))
 		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
 		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
@@ -185,6 +188,26 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Management routes are registered lazily by registerManagementRoutes when a secret is configured.
+}
+
+// codexDirectModelsHandler serves the enriched Codex client catalog without
+// content-negotiation based on User-Agent headers.
+func (s *Server) codexDirectModelsHandler(openaiHandler *openai.OpenAIAPIHandler) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if s != nil && s.cfg != nil && s.cfg.Home.Enabled {
+			s.handleHomeCodexClientModels(c)
+			return
+		}
+		if openaiHandler == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "openai model handler unavailable"})
+			return
+		}
+		optimizeMultiAgentV2 := false
+		if s != nil && s.cfg != nil {
+			optimizeMultiAgentV2 = s.cfg.Codex.OptimizeMultiAgentV2
+		}
+		c.JSON(http.StatusOK, codexmodels.BuildResponse(openaiHandler.Models(), registry.GetGlobalRegistry().GetModelProviders, optimizeMultiAgentV2))
+	}
 }
 
 func (s *Server) codexAlphaSearchModelRouterHost() handlers.PluginModelRouterHost {

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -65,9 +65,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
-			if optimizeMultiAgentV2 {
-				entry["multi_agent_version"] = "v2"
-			}
+			applyCodexClientMultiAgentVersion(entry, optimizeMultiAgentV2)
 			result = append(result, entry)
 			continue
 		}
@@ -271,9 +269,7 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 	entry["display_name"] = displayName
 	entry["description"] = description
 	entry["prefer_websockets"] = false
-	if optimizeMultiAgentV2 {
-		entry["multi_agent_version"] = "v2"
-	}
+	applyCodexClientMultiAgentVersion(entry, optimizeMultiAgentV2)
 	entry["service_tiers"] = []any{}
 	delete(entry, "apply_patch_tool_type")
 	delete(entry, "upgrade")
@@ -289,6 +285,19 @@ func applyCodexClientModelMetadata(entry map[string]any, id string, model map[st
 	}
 	if plans, ok := model["available_in_plans"]; ok {
 		entry["available_in_plans"] = cloneCodexClientModelValue(plans)
+	}
+}
+
+func applyCodexClientMultiAgentVersion(entry map[string]any, optimizeMultiAgentV2 bool) {
+	if entry == nil {
+		return
+	}
+	if optimizeMultiAgentV2 {
+		entry["multi_agent_version"] = "v2"
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(stringModelValue(entry, "multi_agent_version")), "v2") {
+		delete(entry, "multi_agent_version")
 	}
 }
 

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -143,6 +143,41 @@ func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.
 	}
 }
 
+func TestCodexClientModelsResponse_ClearsTemplateMultiAgentV2WhenDisabled(t *testing.T) {
+	resp := BuildResponse([]map[string]any{
+		{"id": "gpt-5.6-sol"},
+		{"id": "gpt-5.6-terra"},
+		{"id": "gpt-5.6-luna"},
+	}, nil, false)
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	bySlug := make(map[string]map[string]any, len(models))
+	for _, model := range models {
+		bySlug[stringModelValue(model, "slug")] = model
+	}
+
+	for _, slug := range []string{"gpt-5.6-sol", "gpt-5.6-terra"} {
+		entry := bySlug[slug]
+		if entry == nil {
+			t.Fatalf("missing model %q", slug)
+		}
+		if got, exists := entry["multi_agent_version"]; exists {
+			t.Errorf("%s multi_agent_version = %#v (exists=%t), want omitted when optimize-multi-agent-v2 is false", slug, got, exists)
+		}
+	}
+
+	luna := bySlug["gpt-5.6-luna"]
+	if luna == nil {
+		t.Fatal("missing model gpt-5.6-luna")
+	}
+	if got := luna["multi_agent_version"]; got != "v1" {
+		t.Fatalf("gpt-5.6-luna multi_agent_version = %#v, want preserved v1", got)
+	}
+}
+
 func TestCodexClientModelsResponse_RewritesTemplateMultiAgentVersionWhenEnabled(t *testing.T) {
 	modelIDs := []string{"gpt-5.6-luna", "gpt-5.5"}
 	resp := BuildResponse([]map[string]any{{"id": modelIDs[0]}, {"id": modelIDs[1]}}, nil, true)
@@ -321,6 +356,16 @@ func TestApplyCodexClientModelMetadataPreservesMultiAgentVersionWhenDisabled(t *
 	applyCodexClientModelMetadata(entry, "custom-model", model, true)
 	if got := entry["multi_agent_version"]; got != "v2" {
 		t.Fatalf("enabled multi_agent_version = %#v, want v2", got)
+	}
+}
+
+func TestApplyCodexClientModelMetadataClearsTemplateMultiAgentV2WhenDisabled(t *testing.T) {
+	entry := map[string]any{"multi_agent_version": "v2"}
+	model := map[string]any{"id": "custom-model"}
+
+	applyCodexClientModelMetadata(entry, "custom-model", model, false)
+	if got, exists := entry["multi_agent_version"]; exists {
+		t.Fatalf("disabled template v2 multi_agent_version = %#v (exists=%t), want omitted", got, exists)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `GET /backend-api/codex/models` so Codex CLI with `chatgpt_base_url` gets a catalog that does not negotiate by User-Agent.
- When `optimize-multi-agent-v2` is off, strip template `multi_agent_version=v2` and leave `v1`/missing alone.

## Test plan
- [ ] `go test ./internal/api ./internal/client/codex/models`
- [ ] Confirm `/backend-api/codex/models` returns the same body for `claude-cli` and browser User-Agents
- [ ] Confirm sol/terra omit `v2` when the optimize flag is false


Made with [Cursor](https://cursor.com)