### PR TITLE
feat(pluginhost): preserve stream-close HTTP status for cooldown

### DIFF
--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -262,7 +262,7 @@ func (h *Host) callHostStreamClose(request []byte) ([]byte, error) {
 	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
 		return nil, fmt.Errorf("decode stream close request: %w", errUnmarshal)
 	}
-	h.streams.close(req.StreamID, req.Error)
+	h.streams.close(req.StreamID, req.Error, req.StatusCode)
 	return marshalRPCResult(rpcEmptyResponse{})
 }
 

--- a/internal/pluginhost/stream_bridge.go
+++ b/internal/pluginhost/stream_bridge.go
@@ -40,8 +40,22 @@ type streamBridgeEmit struct {
 
 type streamBridgeClose struct {
 	errorMessage string
+	statusCode   int
 	accepted     chan struct{}
 }
+
+// streamBridgeError preserves the downstream HTTP status attached to an
+// asynchronous plugin stream close. The status is consumed by the core auth
+// manager for refresh/cooldown decisions; keeping it on the error avoids
+// reducing a Cursor 401/429 trailer to an opaque string across the plugin ABI.
+type streamBridgeError struct {
+	message    string
+	statusCode int
+}
+
+func (e streamBridgeError) Error() string { return e.message }
+
+func (e streamBridgeError) StatusCode() int { return e.statusCode }
 
 type rpcStreamEmitRequest struct {
 	StreamID string `json:"stream_id"`
@@ -50,8 +64,9 @@ type rpcStreamEmitRequest struct {
 }
 
 type rpcStreamCloseRequest struct {
-	StreamID string `json:"stream_id"`
-	Error    string `json:"error,omitempty"`
+	StreamID   string `json:"stream_id"`
+	Error      string `json:"error,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
 }
 
 func newStreamBridge() *streamBridge {
@@ -98,7 +113,7 @@ func (s *streamBridgeStream) run() {
 			s.markClosed()
 			close(request.accepted)
 			if request.errorMessage != "" {
-				queue = append(queue, pluginapi.ExecutorStreamChunk{Err: fmt.Errorf("%s", request.errorMessage)})
+				queue = append(queue, pluginapi.ExecutorStreamChunk{Err: streamBridgeError{message: request.errorMessage, statusCode: request.statusCode}})
 			}
 			for len(queue) > 0 {
 				select {
@@ -161,12 +176,13 @@ func (s *streamBridgeStream) emit(ctx context.Context, chunk pluginapi.ExecutorS
 	return <-request.done
 }
 
-func (s *streamBridgeStream) close(errorMessage string) {
+func (s *streamBridgeStream) close(errorMessage string, statusCode int) {
 	if s == nil {
 		return
 	}
 	request := streamBridgeClose{
 		errorMessage: errorMessage,
+		statusCode:   statusCode,
 		accepted:     make(chan struct{}),
 	}
 	select {
@@ -228,7 +244,7 @@ func (b *streamBridge) emit(ctx context.Context, id string, chunk pluginapi.Exec
 	return nil
 }
 
-func (b *streamBridge) close(id string, errorMessage string) {
+func (b *streamBridge) close(id string, errorMessage string, statusCodes ...int) {
 	if b == nil || id == "" {
 		return
 	}
@@ -239,5 +255,9 @@ func (b *streamBridge) close(id string, errorMessage string) {
 	if stream == nil {
 		return
 	}
-	stream.close(errorMessage)
+	statusCode := 0
+	if len(statusCodes) > 0 {
+		statusCode = statusCodes[0]
+	}
+	stream.close(errorMessage, statusCode)
 }

--- a/internal/pluginhost/stream_bridge_test.go
+++ b/internal/pluginhost/stream_bridge_test.go
@@ -2,6 +2,7 @@ package pluginhost
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -156,6 +157,43 @@ func TestStreamBridgeCloseDeliversTerminalError(t *testing.T) {
 	}
 	if _, ok = <-chunks; ok {
 		t.Fatal("stream remains open after terminal error")
+	}
+}
+
+func TestStreamBridgeClosePreservesHTTPStatus(t *testing.T) {
+	bridge := newStreamBridge()
+	streamID, chunks, _ := bridge.open(context.Background())
+
+	bridge.close(streamID, "Cursor quota exhausted", http.StatusTooManyRequests)
+
+	chunk, ok := <-chunks
+	if !ok || chunk.Err == nil {
+		t.Fatal("stream closed before terminal status error")
+	}
+	if got := chunk.Err.Error(); got != "Cursor quota exhausted" {
+		t.Fatalf("terminal error = %q, want Cursor quota exhausted", got)
+	}
+	statusErr, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("terminal error %T does not preserve StatusCode", chunk.Err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("terminal status = %d, want %d", got, http.StatusTooManyRequests)
+	}
+}
+
+func TestStreamBridgeCloseDefaultsStatusForLegacyError(t *testing.T) {
+	bridge := newStreamBridge()
+	streamID, chunks, _ := bridge.open(context.Background())
+	bridge.close(streamID, "legacy stream failure")
+
+	chunk := <-chunks
+	statusErr, ok := chunk.Err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("legacy terminal error %T does not implement StatusCode", chunk.Err)
+	}
+	if got := statusErr.StatusCode(); got != 0 {
+		t.Fatalf("legacy terminal status = %d, want omitted status 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Carry optional `status_code` on plugin stream close so auth cooldown can see 401/429 instead of an opaque string.
- Keep legacy `close(id, msg)` callers at status 0 (ABI additive).

## Test plan
- [ ] `go test ./internal/pluginhost`
- [ ] Confirm a plugin stream close with 429 is treated as a rate-limit/cooldown signal


Made with [Cursor](https://cursor.com)