### PR TITLE
fix(management): bound log tails when limit is omitted

### DIFF
--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -28,6 +28,10 @@ const (
 	logScannerMaxBuffer     = 8 * 1024 * 1024
 	logCursorVersion        = 1
 	logCursorFingerprintMax = 4 * 1024
+	// Keep accidental legacy /logs requests bounded. Callers that need more
+	// data can page with the returned cursor.
+	defaultLogLimit = 1000
+	maxLogLimit     = 5000
 )
 
 // GetLogs returns log lines with optional incremental loading.
@@ -603,14 +607,19 @@ func readTailLogLines(path string, limit int) (completeLogRead, error) {
 	if errBoundary != nil {
 		return completeLogRead{}, errBoundary
 	}
-	if boundary == 0 {
-		return completeLogRead{lines: []string{}}, nil
+	result := completeLogRead{lines: []string{}, endOffset: boundary}
+	if boundary > 0 {
+		start, errStart := tailStartOffset(path, boundary, limit)
+		if errStart != nil {
+			return completeLogRead{}, errStart
+		}
+		read, errRead := readCompleteLogLines(path, start, boundary, limit)
+		if errRead != nil {
+			return completeLogRead{}, errRead
+		}
+		result = read
 	}
-	start, errStart := tailStartOffset(path, boundary, limit)
-	if errStart != nil {
-		return completeLogRead{}, errStart
-	}
-	return readCompleteLogLines(path, start, boundary, limit)
+	return result, nil
 }
 
 func tailStartOffset(path string, boundary int64, limit int) (int64, error) {
@@ -1217,7 +1226,7 @@ func parseCutoff(raw string) int64 {
 func parseLimit(raw string) (int, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return 0, nil
+		return defaultLogLimit, nil
 	}
 	limit, err := strconv.Atoi(value)
 	if err != nil {
@@ -1225,6 +1234,9 @@ func parseLimit(raw string) (int, error) {
 	}
 	if limit <= 0 {
 		return 0, fmt.Errorf("must be greater than zero")
+	}
+	if limit > maxLogLimit {
+		return maxLogLimit, nil
 	}
 	return limit, nil
 }

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -179,17 +179,17 @@ func TestGetLogsTailLimitDoesNotScanOlderFilesForLineCount(t *testing.T) {
 	}
 }
 
-func TestGetLogsNoLimitKeepsFullScanBehavior(t *testing.T) {
+func TestGetLogsDefaultTailSkipsTrailingPartial(t *testing.T) {
 	dir := t.TempDir()
 	writeMainLog(t, dir, "complete\npartial")
 
 	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs")
-	wantLines := []string{"complete", "partial"}
+	wantLines := []string{"complete"}
 	if !reflect.DeepEqual(resp.Lines, wantLines) {
 		t.Fatalf("lines = %#v, want %#v", resp.Lines, wantLines)
 	}
-	if resp.LineCount != 2 {
-		t.Fatalf("line-count = %d, want full scan count 2", resp.LineCount)
+	if resp.LineCount != 1 {
+		t.Fatalf("line-count = %d, want complete line count 1", resp.LineCount)
 	}
 	if resp.NextCursor == "" {
 		t.Fatal("next-cursor is empty")
@@ -200,6 +200,54 @@ func TestGetLogsNoLimitKeepsFullScanBehavior(t *testing.T) {
 	}
 	if cursor.Offset != int64(len("complete\n")) {
 		t.Fatalf("cursor offset = %d, want complete-line boundary", cursor.Offset)
+	}
+
+	appendMainLog(t, dir, "\n")
+	completed := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?cursor="+url.QueryEscape(resp.NextCursor))
+	if !reflect.DeepEqual(completed.Lines, []string{"partial"}) {
+		t.Fatalf("completed lines = %#v, want partial exactly once after newline", completed.Lines)
+	}
+	next := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?cursor="+url.QueryEscape(completed.NextCursor))
+	if len(next.Lines) != 0 {
+		t.Fatalf("next lines = %#v, want no duplicate partial line", next.Lines)
+	}
+}
+
+func TestGetLogsNoLimitUsesBoundedTail(t *testing.T) {
+	dir := t.TempDir()
+	rotatedPath := filepath.Join(dir, defaultLogFileName+".1")
+	if err := os.WriteFile(rotatedPath, []byte(strings.Repeat("x", logScannerMaxBuffer+1)+"\n"), 0o644); err != nil {
+		t.Fatalf("write rotated log: %v", err)
+	}
+	mainLines := make([]string, defaultLogLimit)
+	for i := range mainLines {
+		mainLines[i] = "current-" + strconv.Itoa(i)
+	}
+	writeMainLog(t, dir, strings.Join(mainLines, "\n")+"\n")
+
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs")
+	if len(resp.Lines) != defaultLogLimit {
+		t.Fatalf("line count = %d, want default limit %d", len(resp.Lines), defaultLogLimit)
+	}
+	if resp.Lines[0] != mainLines[0] || resp.Lines[len(resp.Lines)-1] != mainLines[len(mainLines)-1] {
+		t.Fatalf("unexpected bounded tail: first=%q last=%q", resp.Lines[0], resp.Lines[len(resp.Lines)-1])
+	}
+}
+
+func TestGetLogsClampsOversizedLimit(t *testing.T) {
+	dir := t.TempDir()
+	mainLines := make([]string, maxLogLimit+1)
+	for i := range mainLines {
+		mainLines[i] = "line-" + strconv.Itoa(i)
+	}
+	writeMainLog(t, dir, strings.Join(mainLines, "\n")+"\n")
+
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?limit=999999")
+	if len(resp.Lines) != maxLogLimit {
+		t.Fatalf("line count = %d, want hard maximum %d", len(resp.Lines), maxLogLimit)
+	}
+	if resp.Lines[0] != mainLines[1] || resp.Lines[len(resp.Lines)-1] != mainLines[len(mainLines)-1] {
+		t.Fatalf("unexpected clamped tail: first=%q last=%q", resp.Lines[0], resp.Lines[len(resp.Lines)-1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Default omitted `limit` to 1000 and clamp to 5000 so the management panel does not scan the full log file.
- Skip trailing partial lines on the default tail path; always return `endOffset` when the boundary is 0.

## Test plan
- [ ] `go test ./internal/api/handlers/management`
- [ ] Confirm `GET /v0/management/logs` without `limit` returns the last 1000 lines plus a cursor


Made with [Cursor](https://cursor.com)