### PR TITLE
feat(management): fall back APICall to direct when the proxy is down

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -133,6 +133,9 @@ redis-usage-queue-retention-seconds: 60
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""
+# When true, management APICall (quota refresh) falls back to a direct connection
+# if the configured proxy is down or CONNECT hangs. Outage is remembered for 30s.
+# proxy-fallback-direct: false
 
 # When true, unprefixed model requests only use credentials without a prefix (except when prefix == model name).
 force-model-prefix: false

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -172,6 +172,13 @@ func (h *Handler) APICall(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to build request"})
 		return
 	}
+	if body.Data != "" {
+		payload := body.Data
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(payload)), nil
+		}
+		req.ContentLength = int64(len(payload))
+	}
 
 	for key, value := range reqHeaders {
 		if strings.EqualFold(key, "host") {
@@ -192,7 +199,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
 		log.WithError(errDo).Debug("management APICall request failed")
-		c.JSON(http.StatusBadGateway, gin.H{"error": "request failed"})
+		c.JSON(http.StatusBadGateway, gin.H{"error": apiCallRequestFailedMessage(errDo)})
 		return
 	}
 	defer func() {
@@ -481,10 +488,20 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
+func (h *Handler) maybeWrapProxyFallback(proxyStr string, transport http.RoundTripper) http.RoundTripper {
+	if transport == nil {
+		return nil
+	}
+	if h != nil && h.cfg != nil && h.cfg.ProxyFallbackDirect {
+		return wrapProxyDirectFallback(proxyStr, transport)
+	}
+	return transport
+}
+
 func (h *Handler) apiCallTransport(auth *coreauth.Auth, requestProxyURL string) http.RoundTripper {
 	if proxyStr := strings.TrimSpace(requestProxyURL); proxyStr != "" {
 		if transport := buildProxyTransport(proxyStr); transport != nil {
-			return transport
+			return h.maybeWrapProxyFallback(proxyStr, transport)
 		}
 		return directAPICallTransport()
 	}
@@ -508,7 +525,7 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth, requestProxyURL string) 
 
 	for _, proxyStr := range proxyCandidates {
 		if transport := buildProxyTransport(proxyStr); transport != nil {
-			return transport
+			return h.maybeWrapProxyFallback(proxyStr, transport)
 		}
 	}
 

--- a/internal/api/handlers/management/api_tools_proxy.go
+++ b/internal/api/handlers/management/api_tools_proxy.go
@@ -1,0 +1,250 @@
+package management
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/proxy"
+)
+
+const (
+	proxyFallbackDialTimeout = 5 * time.Second
+	proxyFallbackRememberFor = 30 * time.Second
+)
+
+var proxyFallbackStates sync.Map // map[string]*proxyFallbackState
+
+type proxyFallbackState struct {
+	mu        sync.Mutex
+	downUntil time.Time
+}
+
+type proxyDirectFallbackTransport struct {
+	proxyKey string
+	proxy    http.RoundTripper
+	direct   http.RoundTripper
+}
+
+func wrapProxyDirectFallback(proxyStr string, fallback http.RoundTripper) http.RoundTripper {
+	proxyTransport := buildTimeoutAwareProxyTransport(proxyStr)
+	if proxyTransport == nil {
+		if fallback != nil {
+			return fallback
+		}
+		return directAPICallTransport()
+	}
+	return &proxyDirectFallbackTransport{
+		proxyKey: strings.TrimSpace(proxyStr),
+		proxy:    proxyTransport,
+		direct:   directAPICallTransport(),
+	}
+}
+
+func buildTimeoutAwareProxyTransport(proxyStr string) *http.Transport {
+	dialer, mode, errBuild := proxyutil.BuildDialer(proxyStr)
+	if errBuild != nil || mode != proxyutil.ModeProxy || dialer == nil {
+		return buildProxyTransport(proxyStr)
+	}
+
+	transport := proxyutil.NewDirectTransport()
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		dialCtx, cancel := context.WithTimeout(ctx, proxyFallbackDialTimeout)
+		defer cancel()
+		if contextAware, ok := dialer.(proxy.ContextDialer); ok {
+			return contextAware.DialContext(dialCtx, network, addr)
+		}
+		return dialer.Dial(network, addr)
+	}
+	return transport
+}
+
+func (t *proxyDirectFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t == nil {
+		return nil, errors.New("proxy fallback transport is nil")
+	}
+	// A remembered proxy outage may bypass the proxy only for replay-safe
+	// methods. Non-idempotent requests must continue through the proxy so a
+	// transport error cannot turn into an unapproved direct retry.
+	if isProxyFallbackRetrySafe(req) && proxyFallbackUnavailable(t.proxyKey) {
+		return t.direct.RoundTrip(req)
+	}
+
+	retryAllowed := isProxyFallbackRetrySafe(req)
+	var retryReq *http.Request
+	var errClone error
+	if retryAllowed {
+		retryReq, errClone = cloneAPICallRequest(req)
+	}
+	resp, errDo := t.proxy.RoundTrip(req)
+	if errDo == nil {
+		if retryReq != nil && retryReq.Body != nil && retryReq.Body != http.NoBody {
+			_ = retryReq.Body.Close()
+		}
+		return resp, nil
+	}
+	if !isProxyFallbackError(errDo) {
+		return nil, errDo
+	}
+	markProxyFallbackDown(t.proxyKey)
+	if !retryAllowed {
+		log.WithError(errDo).
+			WithField("proxy", proxyutil.Redact(t.proxyKey)).
+			Warn("management APICall proxy failed; direct fallback suppressed for non-replay-safe method")
+		return nil, errDo
+	}
+	log.WithError(errDo).WithField("proxy", proxyutil.Redact(t.proxyKey)).Warn("management APICall proxy failed; falling back to direct")
+	if retryReq == nil {
+		if errClone != nil {
+			return nil, errDo
+		}
+		return t.direct.RoundTrip(req)
+	}
+	return t.direct.RoundTrip(retryReq)
+}
+
+// Proxy fallback retries only methods whose HTTP semantics are safe to repeat.
+// Retrying a POST or PATCH after a transport error can duplicate a side effect
+// when the proxy already forwarded the request before the connection failed.
+func isProxyFallbackRetrySafe(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(req.Method)) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneAPICallRequest(req *http.Request) (*http.Request, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	clone := req.Clone(req.Context())
+	if req.Body == nil || req.Body == http.NoBody {
+		return clone, nil
+	}
+	if req.GetBody == nil {
+		return nil, errors.New("request body cannot be replayed")
+	}
+	body, errBody := req.GetBody()
+	if errBody != nil {
+		return nil, errBody
+	}
+	clone.Body = body
+	return clone, nil
+}
+
+func proxyFallbackUnavailable(proxyKey string) bool {
+	state := proxyFallbackStateFor(proxyKey)
+	if state == nil {
+		return false
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return time.Now().Before(state.downUntil)
+}
+
+func markProxyFallbackDown(proxyKey string) {
+	state := proxyFallbackStateFor(proxyKey)
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	state.downUntil = time.Now().Add(proxyFallbackRememberFor)
+	state.mu.Unlock()
+}
+
+func resetProxyFallbackState(proxyKey string) {
+	proxyKey = strings.TrimSpace(proxyKey)
+	if proxyKey == "" {
+		return
+	}
+	proxyFallbackStates.Delete(proxyKey)
+}
+
+func proxyFallbackStateFor(proxyKey string) *proxyFallbackState {
+	proxyKey = strings.TrimSpace(proxyKey)
+	if proxyKey == "" {
+		return nil
+	}
+	if existing, ok := proxyFallbackStates.Load(proxyKey); ok {
+		if state, okState := existing.(*proxyFallbackState); okState {
+			return state
+		}
+	}
+	state := &proxyFallbackState{}
+	actual, _ := proxyFallbackStates.LoadOrStore(proxyKey, state)
+	if stored, ok := actual.(*proxyFallbackState); ok {
+		return stored
+	}
+	return state
+}
+
+func isProxyFallbackError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"connection refused",
+		"network is unreachable",
+		"no such host",
+		"i/o timeout",
+		"dial http proxy failed",
+		"proxy connect",
+		"connection reset",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func apiCallRequestFailedMessage(err error) string {
+	if err == nil {
+		return "request failed"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "request canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
+		return "request timed out"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "connection refused"):
+		return "proxy connection refused"
+	case strings.Contains(msg, "proxy connect"), strings.Contains(msg, "dial http proxy failed"):
+		return "proxy connect failed"
+	default:
+		return "request failed"
+	}
+}
+
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout")
+}

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +14,180 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestAPICallFallsBackToDirectWhenProxyRefused(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("direct-ok"))
+	}))
+	defer upstream.Close()
+
+	const deadProxy = "http://127.0.0.1:1"
+	resetProxyFallbackState(deadProxy)
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{
+				ProxyURL:            deadProxy,
+				ProxyFallbackDirect: true,
+			},
+		},
+	}
+	router := gin.New()
+	router.POST("/", h.APICall)
+
+	body := `{"method":"GET","url":"` + upstream.URL + `/quota"}`
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response apiCallResponse
+	if errDecode := json.NewDecoder(recorder.Body).Decode(&response); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("upstream status code = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if response.Body != "direct-ok" {
+		t.Fatalf("upstream body = %q, want %q", response.Body, "direct-ok")
+	}
+}
+
+func TestAPICallReportsProxyRefusedWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("should-not-reach"))
+	}))
+	defer upstream.Close()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://127.0.0.1:1"},
+		},
+	}
+	router := gin.New()
+	router.POST("/", h.APICall)
+
+	body := `{"method":"GET","url":"` + upstream.URL + `/quota"}`
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d; body = %s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "proxy connection refused") && !strings.Contains(recorder.Body.String(), "request failed") {
+		t.Fatalf("body = %s, want a proxy/request failure message", recorder.Body.String())
+	}
+}
+
+func TestAPICallRequestFailedMessage(t *testing.T) {
+	t.Parallel()
+
+	if got := apiCallRequestFailedMessage(context.DeadlineExceeded); got != "request timed out" {
+		t.Fatalf("deadline message = %q", got)
+	}
+	if got := apiCallRequestFailedMessage(errors.New("dial tcp 127.0.0.1:1082: connect: connection refused")); got != "proxy connection refused" {
+		t.Fatalf("refused message = %q", got)
+	}
+	if got := apiCallRequestFailedMessage(errors.New("proxy CONNECT returned status 503")); got != "proxy connect failed" {
+		t.Fatalf("connect message = %q", got)
+	}
+}
+
+func TestAPICallTransportFallbackWrapsGlobalProxy(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{
+				ProxyURL:            "http://127.0.0.1:1082",
+				ProxyFallbackDirect: true,
+			},
+		},
+	}
+
+	transport := h.apiCallTransport(nil, "")
+	if _, ok := transport.(*proxyDirectFallbackTransport); !ok {
+		t.Fatalf("transport type = %T, want *proxyDirectFallbackTransport", transport)
+	}
+}
+
+func TestProxyDirectFallbackDoesNotRetryPost(t *testing.T) {
+	t.Parallel()
+
+	const proxyKey = "test-post-proxy"
+	resetProxyFallbackState(proxyKey)
+	defer resetProxyFallbackState(proxyKey)
+
+	proxyErr := errors.New("connection refused")
+	directCalls := 0
+	transport := &proxyDirectFallbackTransport{
+		proxyKey: proxyKey,
+		proxy: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, proxyErr
+		}),
+		direct: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			directCalls++
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("payload"))
+	_, errRoundTrip := transport.RoundTrip(req)
+	if !errors.Is(errRoundTrip, proxyErr) {
+		t.Fatalf("RoundTrip error = %v, want proxy error %v", errRoundTrip, proxyErr)
+	}
+	if directCalls != 0 {
+		t.Fatalf("direct fallback calls = %d, want 0 for POST", directCalls)
+	}
+}
+
+func TestProxyDirectFallbackRetriesGetAfterProxyFailure(t *testing.T) {
+	t.Parallel()
+
+	const proxyKey = "test-get-proxy"
+	resetProxyFallbackState(proxyKey)
+	defer resetProxyFallbackState(proxyKey)
+
+	directCalls := 0
+	transport := &proxyDirectFallbackTransport{
+		proxyKey: proxyKey,
+		proxy: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		}),
+		direct: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			directCalls++
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, errRoundTrip := transport.RoundTrip(req)
+	if errRoundTrip != nil {
+		t.Fatalf("RoundTrip error = %v, want nil", errRoundTrip)
+	}
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("response = %#v, want HTTP 200", resp)
+	}
+	if directCalls != 1 {
+		t.Fatalf("direct fallback calls = %d, want 1 for GET", directCalls)
+	}
+}
 
 func TestAPICallUsesRequestProxyURL(t *testing.T) {
 	t.Parallel()

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -9,6 +9,11 @@ type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
+	// ProxyFallbackDirect falls back to a direct connection when the configured
+	// proxy is unreachable. Management APICall uses this so quota refresh does
+	// not sit in "running" while a local proxy accepts TCP but never completes CONNECT.
+	ProxyFallbackDirect bool `yaml:"proxy-fallback-direct" json:"proxy-fallback-direct"`
+
 	// DisableImageGeneration controls whether the built-in image_generation tool is injected/allowed.
 	//
 	// Supported values:


### PR DESCRIPTION
## Summary
- Add opt-in `proxy-fallback-direct` so management APICall (quota refresh) can fall back to a direct connection after a proxy connect failure.
- Retry only GET/HEAD/OPTIONS, remember the outage for 30s, and classify 502 text.

## Test plan
- [ ] `go test ./internal/api/handlers/management ./internal/config`
- [ ] With the flag false, existing proxy override behavior is unchanged
- [ ] With the flag true and a dead proxy, GET APICall succeeds directly


Made with [Cursor](https://cursor.com)