### PR TITLE
fix(codex): treat usage_limit_reached as credential-scoped quota

### DIFF
--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"testing"
@@ -72,6 +73,9 @@ func TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	if err.RetryAfter() != nil {
 		t.Fatalf("expected nil explicit retryAfter for capacity fallback, got %v", *err.RetryAfter())
 	}
+	if err.IsCredentialScoped() {
+		t.Fatal("expected model capacity errors to stay model-scoped")
+	}
 }
 
 func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
@@ -88,6 +92,27 @@ func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
 	}
 	if *retryAfter != 120*time.Second {
 		t.Fatalf("retryAfter = %v, want %v", *retryAfter, 120*time.Second)
+	}
+	if !err.IsCredentialScoped() {
+		t.Fatal("expected usage_limit_reached to be credential-scoped")
+	}
+}
+
+func TestNewCodexStatusErrDefaultsUsageLimitCooldownWhenResetMissing(t *testing.T) {
+	err := newCodexStatusErr(http.StatusBadRequest, []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}`))
+
+	if got := err.StatusCode(); got != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", got, http.StatusTooManyRequests)
+	}
+	if !err.IsCredentialScoped() {
+		t.Fatal("expected usage_limit_reached without reset timing to be credential-scoped")
+	}
+	retryAfter := err.RetryAfter()
+	if retryAfter == nil {
+		t.Fatal("expected default retryAfter for usage_limit_reached without reset timing")
+	}
+	if *retryAfter != defaultCodexUsageLimitCooldown {
+		t.Fatalf("retryAfter = %v, want default %v", *retryAfter, defaultCodexUsageLimitCooldown)
 	}
 }
 
@@ -218,4 +243,12 @@ func assertCodexErrorCode(t *testing.T, raw string, wantType string, wantCode st
 
 func itoa(v int64) string {
 	return strconv.FormatInt(v, 10)
+}
+
+func isTestCredentialScoped(err error) bool {
+	type credentialScopeProvider interface {
+		IsCredentialScoped() bool
+	}
+	var csp credentialScopeProvider
+	return errors.As(err, &csp) && csp != nil && csp.IsCredentialScoped()
 }

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -613,6 +613,9 @@ func TestCodexTerminalStreamErrHandlesUsageLimitErrorEvent(t *testing.T) {
 	if *retryAfter != 300*time.Second {
 		t.Fatalf("retryAfter = %v, want %v", *retryAfter, 300*time.Second)
 	}
+	if !streamErr.IsCredentialScoped() {
+		t.Fatal("expected usage_limit_reached terminal error to be credential-scoped")
+	}
 }
 
 func TestCodexTerminalStreamErrHandlesUsageLimitResponseFailed(t *testing.T) {
@@ -625,6 +628,9 @@ func TestCodexTerminalStreamErrHandlesUsageLimitResponseFailed(t *testing.T) {
 	}
 	if streamErr.RetryAfter() == nil {
 		t.Fatal("expected retryAfter from usage_limit_reached response.failed terminal error")
+	}
+	if !streamErr.IsCredentialScoped() {
+		t.Fatal("expected usage_limit_reached response.failed error to be credential-scoped")
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -289,9 +289,7 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	}
 	body = classifyCodexStatusError(errCode, body)
 	err := statusErr{code: errCode, msg: string(body)}
-	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
-		err.retryAfter = retryAfter
-	}
+	applyCodexUsageLimitMetadata(&err, body)
 	return err
 }
 
@@ -361,6 +359,34 @@ func isCodexModelCapacityError(errorBody []byte) bool {
 		}
 	}
 	return false
+}
+
+// defaultCodexUsageLimitCooldown is used when Codex reports usage_limit_reached
+// without resets_at/resets_in_seconds. Plus accounts share a rolling 5-hour
+// window across models, so a missing reset hint still pauses the credential.
+const defaultCodexUsageLimitCooldown = 5 * time.Hour
+
+// applyCodexUsageLimitMetadata marks plan-quota exhaustion as credential-scoped
+// so the auth manager pauses the whole account and fails over to another auth
+// instead of retrying sibling models that share the same Plus window.
+func applyCodexUsageLimitMetadata(err *statusErr, body []byte) {
+	if err == nil {
+		return
+	}
+	if !isCodexUsageLimitError(body) {
+		if retryAfter := parseCodexRetryAfter(err.code, body, time.Now()); retryAfter != nil {
+			err.retryAfter = retryAfter
+		}
+		return
+	}
+	err.code = http.StatusTooManyRequests
+	err.credentialScoped = true
+	if retryAfter := parseCodexRetryAfter(http.StatusTooManyRequests, body, time.Now()); retryAfter != nil {
+		err.retryAfter = retryAfter
+		return
+	}
+	wait := defaultCodexUsageLimitCooldown
+	err.retryAfter = &wait
 }
 
 // isCodexUsageLimitError reports whether the error body represents a Codex

--- a/internal/runtime/executor/codex_executor_usage_limit_test.go
+++ b/internal/runtime/executor/codex_executor_usage_limit_test.go
@@ -1,0 +1,172 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexExecutor_AuthManager_UsageLimitBlocksAllModelsOnCredential(t *testing.T) {
+	var upstreamAttempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAttempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_in_seconds":18000}}`))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.RegisterExecutor(NewCodexExecutor(&config.Config{DisableCooling: false}))
+
+	auth := &cliproxyauth.Auth{
+		ID:       uuid.NewString() + "-codex-plus",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "plus-exhausted",
+			"base_url": server.URL,
+		},
+	}
+	registerCodexAuthModels(t, auth.ID, "gpt-5.4", "gpt-5.4-mini")
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("failed to register auth: %v", errRegister)
+	}
+
+	payload := []byte(`{"model":"gpt-5.4","input":"hello"}`)
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if err == nil {
+		t.Fatal("expected usage limit error, got nil")
+	}
+	if attempts := upstreamAttempts.Load(); attempts != 1 {
+		t.Fatalf("upstream attempts = %d, want 1", attempts)
+	}
+
+	_, errMini := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.4-mini",
+		Payload: []byte(`{"model":"gpt-5.4-mini","input":"hello"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if errMini == nil {
+		t.Fatal("expected sibling model to be blocked locally, got nil")
+	}
+	if attempts := upstreamAttempts.Load(); attempts != 1 {
+		t.Fatalf("upstream attempts after sibling model = %d, want 1 (must be blocked locally)", attempts)
+	}
+
+	registeredAuth, ok := manager.GetByID(auth.ID)
+	if !ok || registeredAuth == nil {
+		t.Fatal("auth not found")
+	}
+	if !registeredAuth.Unavailable || !registeredAuth.Quota.Exceeded || registeredAuth.Quota.Reason != "credential_quota" {
+		t.Fatalf("auth cooldown = unavailable=%v quota=%+v, want credential_quota", registeredAuth.Unavailable, registeredAuth.Quota)
+	}
+}
+
+func TestCodexExecutor_AuthManager_UsageLimitFailsOverToAnotherAccount(t *testing.T) {
+	var exhaustedAttempts atomic.Int32
+	var healthyAttempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+		switch authHeader {
+		case "Bearer plus-exhausted":
+			exhaustedAttempts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_in_seconds":18000}}`))
+		case "Bearer plus-healthy":
+			healthyAttempts.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_ok\",\"object\":\"response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.RegisterExecutor(NewCodexExecutor(&config.Config{DisableCooling: false}))
+
+	exhausted := &cliproxyauth.Auth{
+		ID:       uuid.NewString() + "-codex-exhausted",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "plus-exhausted",
+			"base_url": server.URL,
+			"priority": "10",
+		},
+	}
+	healthy := &cliproxyauth.Auth{
+		ID:       uuid.NewString() + "-codex-healthy",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "plus-healthy",
+			"base_url": server.URL,
+		},
+	}
+	registerCodexAuthModels(t, exhausted.ID, "gpt-5.4")
+	registerCodexAuthModels(t, healthy.ID, "gpt-5.4")
+	if _, errRegister := manager.Register(context.Background(), exhausted); errRegister != nil {
+		t.Fatalf("failed to register exhausted auth: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), healthy); errRegister != nil {
+		t.Fatalf("failed to register healthy auth: %v", errRegister)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want failover success", err)
+	}
+	if len(resp.Payload) == 0 {
+		t.Fatal("expected failover response payload")
+	}
+	if got := exhaustedAttempts.Load(); got != 1 {
+		t.Fatalf("exhausted account attempts = %d, want 1", got)
+	}
+	if got := healthyAttempts.Load(); got != 1 {
+		t.Fatalf("healthy account attempts = %d, want 1", got)
+	}
+
+	updatedExhausted, ok := manager.GetByID(exhausted.ID)
+	if !ok || updatedExhausted == nil {
+		t.Fatal("exhausted auth not found")
+	}
+	if !updatedExhausted.Quota.Exceeded || updatedExhausted.Quota.Reason != "credential_quota" {
+		t.Fatalf("exhausted auth quota = %+v, want credential_quota", updatedExhausted.Quota)
+	}
+	if updatedExhausted.Quota.NextRecoverAt.Before(time.Now().Add(4 * time.Hour)) {
+		t.Fatalf("exhausted auth recover at %v, want about 5 hours", updatedExhausted.Quota.NextRecoverAt)
+	}
+}
+
+func registerCodexAuthModels(t *testing.T, authID string, models ...string) {
+	t.Helper()
+	infos := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		infos = append(infos, &registry.ModelInfo{ID: model})
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", infos)
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+}

--- a/internal/runtime/executor/codex_websockets_errors.go
+++ b/internal/runtime/executor/codex_websockets_errors.go
@@ -44,9 +44,8 @@ func parseCodexWebsocketError(payload []byte) (error, bool) {
 	out := buildCodexWebsocketErrorPayload(payload, status)
 	headers := parseCodexWebsocketErrorHeaders(payload)
 	statusError := statusErr{code: status, msg: string(out)}
-	if retryAfter := parseCodexRetryAfter(status, out, time.Now()); retryAfter != nil {
-		statusError.retryAfter = retryAfter
-	} else if isCodexWebsocketConnectionLimitError(payload) {
+	applyCodexUsageLimitMetadata(&statusError, out)
+	if statusError.retryAfter == nil && isCodexWebsocketConnectionLimitError(payload) {
 		retryAfter := time.Duration(0)
 		statusError.retryAfter = &retryAfter
 	}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -150,7 +150,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			return e.CodexExecutor.Execute(ctx, auth, req, opts)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
-			return resp, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
+			return resp, newCodexStatusErr(respHS.StatusCode, bodyErr)
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
 		return resp, errDial

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1548,6 +1548,31 @@ func TestParseCodexWebsocketErrorUsesUsageLimitRetryMetadata(t *testing.T) {
 	if got := *retryable.RetryAfter(); got != 7*time.Second {
 		t.Fatalf("retryAfter = %v, want 7s", got)
 	}
+	if !isTestCredentialScoped(err) {
+		t.Fatal("expected usage_limit_reached websocket errors to be credential-scoped")
+	}
+}
+
+func TestParseCodexWebsocketErrorDefaultsUsageLimitCooldownWhenResetMissing(t *testing.T) {
+	err, ok := parseCodexWebsocketError([]byte(`{"type":"error","status":400,"body":{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}}`))
+	if !ok {
+		t.Fatalf("expected websocket error")
+	}
+
+	status, ok := err.(interface{ StatusCode() int })
+	if !ok || status.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("status = %#v, want 429", err)
+	}
+	retryable, ok := err.(interface{ RetryAfter() *time.Duration })
+	if !ok || retryable.RetryAfter() == nil {
+		t.Fatalf("expected default retryAfter for usage limit websocket error")
+	}
+	if got := *retryable.RetryAfter(); got != defaultCodexUsageLimitCooldown {
+		t.Fatalf("retryAfter = %v, want default %v", got, defaultCodexUsageLimitCooldown)
+	}
+	if !isTestCredentialScoped(err) {
+		t.Fatal("expected usage_limit_reached websocket errors to be credential-scoped")
+	}
 }
 
 func TestParseCodexWebsocketErrorPreservesWrappedBodyAndHeaders(t *testing.T) {

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -158,7 +158,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			if sess != nil {
 				sess.reqMu.Unlock()
 			}
-			return nil, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
+			return nil, newCodexStatusErr(respHS.StatusCode, bodyErr)
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
 		if sess != nil {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -1011,9 +1011,10 @@ func openAICompatStreamDataError(payload []byte, eventName string) (statusErr, b
 }
 
 type statusErr struct {
-	code       int
-	msg        string
-	retryAfter *time.Duration
+	code             int
+	msg              string
+	retryAfter       *time.Duration
+	credentialScoped bool
 }
 
 func (e statusErr) Error() string {
@@ -1024,3 +1025,4 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+func (e statusErr) IsCredentialScoped() bool   { return e.credentialScoped }


### PR DESCRIPTION
## Summary
- Keep origin's `usage_limit_reached` → 429 + retryAfter mapping.
- Mark plan-quota exhaustion as credential-scoped so sibling models on the same account do not keep retrying; default 5h cooldown when reset timing is missing.

## Test plan
- [ ] `go test ./internal/runtime/executor ./sdk/cliproxy/auth`
- [ ] Confirm capacity errors stay model-scoped
- [ ] Confirm a second credential can fail over after the first hits usage_limit_reached


Made with [Cursor](https://cursor.com)