### PR TITLE
feat(responses): add remote compaction v2 for Codex and opt-in compat

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -614,6 +614,7 @@ nonstream-keepalive-interval: 0
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
+#     remote-compaction-v2: false # optional: keep compaction_trigger on POST /responses (default false)
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
 #     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -49,6 +49,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Headers               map[string]string                        `json:"headers,omitempty"`
 	SupportPromptCacheKey bool                                     `json:"support-prompt-cache-key,omitempty"`
 	DisableCooling        *bool                                    `json:"disable-cooling,omitempty"`
+	RemoteCompactionV2    bool                                     `json:"remote-compaction-v2,omitempty"`
 	RequestRetry          *int                                     `json:"request-retry,omitempty"`
 	RequestScopedErrors   []config.RequestScopedErrorRule          `json:"request-scoped-errors,omitempty"`
 	AuthIndex             string                                   `json:"auth-index,omitempty"`
@@ -310,6 +311,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Headers:               entry.Headers,
 			SupportPromptCacheKey: entry.SupportPromptCacheKey,
 			DisableCooling:        entry.DisableCooling,
+			RemoteCompactionV2:    entry.RemoteCompactionV2,
 			RequestRetry:          entry.RequestRetry,
 			RequestScopedErrors:   entry.RequestScopedErrors,
 			AuthIndex:             "",

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -801,6 +801,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Models                *[]config.OpenAICompatibilityModel  `json:"models"`
 		Headers               *map[string]string                  `json:"headers"`
 		SupportPromptCacheKey *bool                               `json:"support-prompt-cache-key"`
+		RemoteCompactionV2    *bool                               `json:"remote-compaction-v2"`
 		RequestRetry          *int                                `json:"request-retry"`
 		RequestScopedErrors   *[]config.RequestScopedErrorRule    `json:"request-scoped-errors"`
 	}
@@ -846,6 +847,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if !applyDisableCoolingPatch(c, body.Value.DisableCooling, &entry.DisableCooling) {
 		return
+	}
+	if body.Value.RemoteCompactionV2 != nil {
+		entry.RemoteCompactionV2 = *body.Value.RemoteCompactionV2
 	}
 	if body.Value.RequestRetry != nil {
 		entry.RequestRetry = body.Value.RequestRetry

--- a/internal/api/handlers/management/config_openai_compat_test.go
+++ b/internal/api/handlers/management/config_openai_compat_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -63,5 +64,51 @@ func TestGetOpenAICompatIncludesDisableCooling(t *testing.T) {
 	}
 	if body.OpenAICompatibility[0].RequestRetry == nil || *body.OpenAICompatibility[0].RequestRetry != 0 {
 		t.Fatalf("expected request-retry to be present and 0, got %#v", body.OpenAICompatibility[0].RequestRetry)
+	}
+}
+
+func TestOpenAICompatRemoteCompactionV2GetAndPatch(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	h := NewHandlerWithoutConfigFilePath(&config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name:               "compact-provider",
+				BaseURL:            "https://compact.example.com/v1",
+				APIKeyEntries:      []config.OpenAICompatibilityAPIKey{{APIKey: "test-key"}},
+				RemoteCompactionV2: true,
+			},
+		},
+	}, nil)
+	h.configFilePath = writeTestConfigFile(t)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/openai-compatibility", nil)
+	h.GetOpenAICompat(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var getBody struct {
+		OpenAICompatibility []struct {
+			RemoteCompactionV2 bool `json:"remote-compaction-v2"`
+		} `json:"openai-compatibility"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &getBody); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	if len(getBody.OpenAICompatibility) != 1 || !getBody.OpenAICompatibility[0].RemoteCompactionV2 {
+		t.Fatalf("GET remote-compaction-v2 = %#v", getBody.OpenAICompatibility)
+	}
+
+	patchRec := httptest.NewRecorder()
+	patchCtx, _ := gin.CreateTestContext(patchRec)
+	patchCtx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/openai-compatibility", strings.NewReader(`{"index":0,"value":{"remote-compaction-v2":false}}`))
+	patchCtx.Request.Header.Set("Content-Type", "application/json")
+	h.PatchOpenAICompat(patchCtx)
+	if patchRec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, body=%s", patchRec.Code, patchRec.Body.String())
+	}
+	if h.cfg.OpenAICompatibility[0].RemoteCompactionV2 {
+		t.Fatal("PATCH did not clear remote-compaction-v2")
 	}
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -679,6 +679,11 @@ type OpenAICompatibility struct {
 	// True disables auth/model cooldowns; false explicitly enables them.
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
+	// RemoteCompactionV2 enables the Responses remote compaction v2 protocol for
+	// this OpenAI-compatible provider. It is opt-in because compatibility
+	// endpoints do not necessarily implement the protocol correctly.
+	RemoteCompactionV2 bool `yaml:"remote-compaction-v2,omitempty" json:"remote-compaction-v2,omitempty"`
+
 	// RequestRetry optionally overrides the global request-retry for this provider.
 	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`

--- a/internal/config/remote_compaction_test.go
+++ b/internal/config/remote_compaction_test.go
@@ -1,0 +1,25 @@
+package config
+
+import "testing"
+
+func TestParseConfigBytesOpenAICompatibilityRemoteCompactionV2(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte(`openai-compatibility:
+  - name: compact-provider
+    base-url: https://compact.example.com/v1
+    remote-compaction-v2: true
+  - name: plain-provider
+    base-url: https://plain.example.com/v1
+`))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", err)
+	}
+	if len(cfg.OpenAICompatibility) != 2 {
+		t.Fatalf("OpenAICompatibility length = %d, want 2", len(cfg.OpenAICompatibility))
+	}
+	if !cfg.OpenAICompatibility[0].RemoteCompactionV2 {
+		t.Fatal("remote-compaction-v2=true was not parsed")
+	}
+	if cfg.OpenAICompatibility[1].RemoteCompactionV2 {
+		t.Fatal("remote-compaction-v2 unexpectedly enabled by default")
+	}
+}

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -124,8 +124,8 @@ func (e *AIStudioExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.A
 
 // Execute performs a non-streaming request to the AI Studio API.
 func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	if opts.Alt == "responses/compact" {
-		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return resp, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
@@ -196,8 +196,8 @@ func (e *AIStudioExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth,
 
 // ExecuteStream performs a streaming request to the AI Studio API.
 func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return nil, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -24,8 +24,8 @@ import (
 
 // Execute performs a non-streaming request to the Antigravity API.
 func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	if opts.Alt == "responses/compact" {
-		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return resp, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	if inCooldown, remaining, errCooldown := antigravityIsInShortCooldownRequired(ctx, auth, baseModel, time.Now()); errCooldown != nil {

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -21,8 +21,8 @@ import (
 
 // ExecuteStream performs a streaming request to the Antigravity API.
 func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return nil, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -17,8 +17,8 @@ import (
 )
 
 func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	if opts.Alt == "responses/compact" {
-		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return resp, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -19,8 +19,8 @@ import (
 )
 
 func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return nil, err
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)

--- a/internal/runtime/executor/codex_executor_compact_test.go
+++ b/internal/runtime/executor/codex_executor_compact_test.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -77,4 +79,129 @@ func TestCodexExecutorCompactAddsDefaultInstructionsWithoutInjectingImageTool(t 
 			}
 		})
 	}
+}
+
+func TestCodexExecutorRemoteCompactionV2PreservesOutputItem(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"cmp_1","type":"compaction","encrypted_content":"opaque-state"}}` + "\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","output":[{"id":"cmp_1","type":"compaction","encrypted_content":"opaque-state"}]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	payload := []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`)
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Fatalf("path = %q, want /responses", gotPath)
+	}
+	if gjson.GetBytes(gotBody, "tools").Exists() {
+		t.Fatalf("v2 compact request injected tools: %s", gotBody)
+	}
+	input := gjson.GetBytes(gotBody, "input").Array()
+	if len(input) != 2 || input[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("compaction_trigger was dropped: %s", gotBody)
+	}
+	if gjson.GetBytes(resp.Payload, "output.0.type").String() != "compaction" {
+		t.Fatalf("payload = %s", resp.Payload)
+	}
+	if gjson.GetBytes(resp.Payload, "output.0.encrypted_content").String() != "opaque-state" {
+		t.Fatalf("encrypted_content changed: %s", resp.Payload)
+	}
+}
+
+func TestCodexExecutorRemoteCompactionV2RejectsOrdinaryOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary"}]}}` + "\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary"}]}]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.Execute(context.Background(), authForCodexTest(server.URL), cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err == nil {
+		t.Fatal("expected missing compaction item to fail")
+	}
+	if !strings.Contains(err.Error(), "got 0 from 1 output items") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCodexExecutorRemoteCompactionV2ResponseFailedIsRequestScoped(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "execute", true: "stream"}[stream], func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"type":"server_error","code":"upstream_failed","message":"compaction failed"}}}` + "\n\n"))
+			}))
+			defer server.Close()
+
+			executor := NewCodexExecutor(&config.Config{})
+			auth := authForCodexTest(server.URL)
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.4",
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`),
+			}
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: stream}
+			if !stream {
+				_, err := executor.Execute(context.Background(), auth, req, opts)
+				if err == nil {
+					t.Fatal("Execute succeeded, want response.failed error")
+				}
+				if got := statusCodeFromTestError(t, err); got != http.StatusBadGateway {
+					t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadGateway, err)
+				}
+				assertRequestScopedTestError(t, err)
+				return
+			}
+
+			result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+			if err != nil {
+				t.Fatalf("ExecuteStream setup error: %v", err)
+			}
+			var streamErr error
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if streamErr == nil {
+				t.Fatal("stream completed, want response.failed error")
+			}
+			if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadGateway {
+				t.Fatalf("stream status code = %d, want %d; err=%v", got, http.StatusBadGateway, streamErr)
+			}
+			assertRequestScopedTestError(t, streamErr)
+		})
+	}
+}
+
+func authForCodexTest(baseURL string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": baseURL,
+		"api_key":  "test",
+	}}
 }

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -61,7 +61,8 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
+	compactionTrigger := helps.ResponsesHasCompactionTrigger(req.Payload, originalPayload)
+	if !compactionTrigger && (e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff) {
 		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
@@ -140,6 +141,10 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventType := gjson.GetBytes(eventData, "type").String()
 
 		if streamErr, terminalBody, ok := codexTerminalFailureErr(eventData); ok {
+			if compactionTrigger {
+				err = remoteCompactionV2TerminalError(eventType)
+				return resp, err
+			}
 			if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
 				return resp, errClearReplay
 			}
@@ -162,6 +167,10 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 
 		if eventType != "response.completed" && eventType != "response.incomplete" {
+			if compactionTrigger && isRemoteCompactionV2TerminalEvent(eventType) {
+				err = remoteCompactionV2TerminalError(eventType)
+				return resp, err
+			}
 			continue
 		}
 
@@ -171,6 +180,12 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		publishCodexImageToolUsage(ctx, reporter, body, eventData)
 
 		completedData := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
+		if compactionTrigger {
+			if errCompaction := validateRemoteCompactionV2Response(completedData, eventType); errCompaction != nil {
+				err = errCompaction
+				return resp, err
+			}
+		}
 		if eventType == "response.completed" {
 			cacheCodexReasoningReplayFromCompleted(replayScope, completedData)
 		}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -22,7 +22,7 @@ import (
 
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+		return nil, newRemoteCompactionV2ProtocolError(http.StatusBadRequest, "streaming not supported for /responses/compact")
 	}
 	if isCodexOpenAIImageRequest(opts) {
 		return e.executeOpenAIImageStream(ctx, auth, req, opts)
@@ -67,7 +67,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
-	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
+	compactionTrigger := helps.ResponsesHasCompactionTrigger(req.Payload, originalPayload)
+	if !compactionTrigger && (e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff) {
 		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
@@ -174,6 +175,13 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				translatedLine = append([]byte("data: "), data...)
 				eventType := gjson.GetBytes(data, "type").String()
 				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
+					if compactionTrigger {
+						compactionErr := remoteCompactionV2TerminalError(eventType)
+						closeBootstrapBody()
+						helps.RecordAPIResponseError(ctx, e.cfg, compactionErr)
+						reporter.PublishFailure(ctx, compactionErr)
+						return nil, compactionErr
+					}
 					closeBootstrapBody()
 					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
 						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
@@ -200,16 +208,32 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				case "response.output_item.done":
 					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 				case "response.completed", "response.incomplete":
+					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
+					if compactionTrigger {
+						if errCompaction := validateRemoteCompactionV2Response(data, eventType); errCompaction != nil {
+							closeBootstrapBody()
+							helps.RecordAPIResponseError(ctx, e.cfg, errCompaction)
+							reporter.PublishFailure(ctx, errCompaction)
+							return nil, errCompaction
+						}
+					}
 					terminalSuccess = true
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
 					publishCodexImageToolUsage(ctx, reporter, body, data)
-					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					if eventType == "response.completed" {
 						cacheCodexReasoningReplayFromCompleted(replayScope, data)
 					}
 					translatedLine = append([]byte("data: "), data...)
+				default:
+					if compactionTrigger && isRemoteCompactionV2TerminalEvent(eventType) {
+						compactionErr := remoteCompactionV2TerminalError(eventType)
+						closeBootstrapBody()
+						helps.RecordAPIResponseError(ctx, e.cfg, compactionErr)
+						reporter.PublishFailure(ctx, compactionErr)
+						return nil, compactionErr
+					}
 				}
 			} else {
 				isHandshake = true
@@ -300,6 +324,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				translatedLine = append([]byte("data: "), data...)
 				eventType := gjson.GetBytes(data, "type").String()
 				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
+					if compactionTrigger {
+						compactionErr := remoteCompactionV2TerminalError(eventType)
+						helps.RecordAPIResponseError(ctx, e.cfg, compactionErr)
+						reporter.PublishFailure(ctx, compactionErr)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: compactionErr}:
+						case <-ctx.Done():
+						}
+						return
+					}
 					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
 						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
 						reporter.PublishFailure(ctx, errClearReplay)
@@ -321,16 +355,38 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				case "response.output_item.done":
 					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 				case "response.completed", "response.incomplete":
+					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
+					if compactionTrigger {
+						if errCompaction := validateRemoteCompactionV2Response(data, eventType); errCompaction != nil {
+							helps.RecordAPIResponseError(ctx, e.cfg, errCompaction)
+							reporter.PublishFailure(ctx, errCompaction)
+							select {
+							case out <- cliproxyexecutor.StreamChunk{Err: errCompaction}:
+							case <-ctx.Done():
+							}
+							return
+						}
+					}
 					terminalSuccess = true
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
 					publishCodexImageToolUsage(ctx, reporter, body, data)
-					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
 					if eventType == "response.completed" {
 						cacheCodexReasoningReplayFromCompleted(replayScope, data)
 					}
 					translatedLine = append([]byte("data: "), data...)
+				default:
+					if compactionTrigger && isRemoteCompactionV2TerminalEvent(eventType) {
+						compactionErr := remoteCompactionV2TerminalError(eventType)
+						helps.RecordAPIResponseError(ctx, e.cfg, compactionErr)
+						reporter.PublishFailure(ctx, compactionErr)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: compactionErr}:
+						case <-ctx.Done():
+						}
+						return
+					}
 				}
 			}
 

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -26,6 +26,9 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if opts.Alt == "responses/compact" {
 		return e.CodexExecutor.executeCompact(ctx, auth, req, opts)
 	}
+	if helps.ResponsesHasCompactionTrigger(req.Payload, opts.OriginalRequest) {
+		return e.CodexExecutor.Execute(ctx, auth, req, opts)
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	apiKey, baseURL := codexCreds(auth)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -24,7 +24,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		ctx = context.Background()
 	}
 	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+		return nil, newRemoteCompactionV2ProtocolError(http.StatusBadRequest, "streaming not supported for /responses/compact")
+	}
+	if helps.ResponsesHasCompactionTrigger(req.Payload, opts.OriginalRequest) {
+		return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName

--- a/internal/runtime/executor/compaction_support.go
+++ b/internal/runtime/executor/compaction_support.go
@@ -1,0 +1,136 @@
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// remoteCompactionV2ProtocolError identifies a failure in the compaction
+// response contract. It deliberately remains status-bearing for downstream
+// clients while preventing credential rotation and cooldown side effects.
+type remoteCompactionV2ProtocolError struct {
+	statusErr
+}
+
+func (remoteCompactionV2ProtocolError) IsRequestScoped() bool { return true }
+
+func (e remoteCompactionV2ProtocolError) Unwrap() error { return e.statusErr }
+
+func newRemoteCompactionV2ProtocolError(code int, message string) error {
+	return remoteCompactionV2ProtocolError{statusErr: statusErr{code: code, msg: message, requestScoped: true}}
+}
+
+func rejectUnsupportedCompaction(opts cliproxyexecutor.Options, payloads ...[]byte) error {
+	if opts.Alt == "responses/compact" {
+		return statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	}
+	if helps.ResponsesHasCompactionTrigger(payloads...) {
+		return newRemoteCompactionV2ProtocolError(http.StatusNotImplemented, "remote compaction v2 is not supported for this provider")
+	}
+	return nil
+}
+
+func remoteCompactionV2MissingItemErr(payload []byte) error {
+	typed, total := helps.ResponsesOutputItemCounts(payload, "compaction")
+	if typed == 1 {
+		return nil
+	}
+	return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, fmt.Sprintf("remote compaction v2 expected exactly one compaction output item, got %d from %d output items", typed, total))
+}
+
+// validateRemoteCompactionV2Response enforces the terminal response contract
+// for a compaction_trigger request. An incomplete (or any other non-completed)
+// terminal event is an upstream failure even when it happens to contain a
+// compaction item; that item must never be replayed as a successful state.
+//
+// eventType is the SSE event type when the response came from a stream. For a
+// non-stream response it may be empty; in that case the response status fields
+// are used when present.
+func validateRemoteCompactionV2Response(payload []byte, eventType string) error {
+	eventType = strings.TrimSpace(eventType)
+	if eventType != "" && eventType != "response.completed" {
+		if eventType == "response.incomplete" {
+			return remoteCompactionV2IncompleteErr()
+		}
+		return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, fmt.Sprintf("remote compaction v2 expected response.completed, got %s", eventType))
+	}
+
+	status := ""
+	if eventType != "" {
+		// SSE terminal events carry the actual response object under response;
+		// do not let an envelope status hide a missing response.status field.
+		status = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.status").String()))
+	} else {
+		status = strings.ToLower(strings.TrimSpace(remoteCompactionV2ResponseStatus(payload)))
+	}
+	if status == "incomplete" {
+		return remoteCompactionV2IncompleteErr()
+	}
+	if status == "" {
+		return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, "remote compaction v2 response is missing completed status")
+	}
+	if status != "completed" {
+		return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, fmt.Sprintf("remote compaction v2 expected completed response status, got %s", status))
+	}
+	return remoteCompactionV2MissingItemErr(payload)
+}
+
+func remoteCompactionV2IncompleteErr() error {
+	return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, "remote compaction v2 received response.incomplete")
+}
+
+func remoteCompactionV2TerminalError(eventType string) error {
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "response.incomplete" {
+		return remoteCompactionV2IncompleteErr()
+	}
+	if eventType == "" {
+		return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, "remote compaction v2 upstream terminated without response.completed")
+	}
+	return newRemoteCompactionV2ProtocolError(http.StatusBadGateway, fmt.Sprintf("remote compaction v2 expected response.completed, got %s", eventType))
+}
+
+func isRemoteCompactionV2TerminalEvent(eventType string) bool {
+	switch strings.TrimSpace(eventType) {
+	case "response.completed", "response.incomplete", "response.failed", "response.done", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func remoteCompactionV2ResponseStatus(payload []byte) string {
+	for _, path := range []string{"response.status", "status"} {
+		if result := gjson.GetBytes(payload, path); result.Exists() && result.Type == gjson.String {
+			return result.String()
+		}
+	}
+	return ""
+}
+
+// remoteCompactionV2EventType extracts a terminal event type from either a
+// single Responses event or an SSE body. It is used before SSE aggregation so
+// the completed/incomplete distinction cannot be lost.
+func remoteCompactionV2EventType(payload []byte) string {
+	trimmed := bytes.TrimSpace(payload)
+	if eventType := strings.TrimSpace(gjson.GetBytes(trimmed, "type").String()); eventType != "" && eventType != "response" {
+		return eventType
+	}
+	for _, line := range bytes.Split(trimmed, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, dataTag) {
+			continue
+		}
+		eventType := gjson.GetBytes(bytes.TrimSpace(line[len(dataTag):]), "type").String()
+		if isRemoteCompactionV2TerminalEvent(eventType) {
+			return eventType
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/compaction_support_test.go
+++ b/internal/runtime/executor/compaction_support_test.go
@@ -1,0 +1,139 @@
+package executor
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestValidateRemoteCompactionV2Response(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		eventType string
+		wantErr   string
+	}{
+		{
+			name:      "completed event with one compaction item",
+			payload:   `{"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+		},
+		{
+			name:      "completed event missing response status fails closed",
+			payload:   `{"type":"response.completed","response":{"output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "missing completed status",
+		},
+		{
+			name:      "completed event does not infer status from top level",
+			payload:   `{"type":"response.completed","status":"completed","response":{"output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "missing completed status",
+		},
+		{
+			name:      "nested incomplete status takes precedence",
+			payload:   `{"type":"response.completed","status":"completed","response":{"status":"incomplete","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "response.incomplete",
+		},
+		{
+			name:      "wrong response status fails closed",
+			payload:   `{"type":"response.completed","response":{"status":"failed","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "got failed",
+		},
+		{
+			name:      "two compaction output items fail closed",
+			payload:   `{"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"one"},{"type":"compaction","encrypted_content":"two"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "got 2 from 2 output items",
+		},
+		{
+			name:      "zero output items fail closed",
+			payload:   `{"type":"response.completed","response":{"status":"completed","output":[]}}`,
+			eventType: "response.completed",
+			wantErr:   "got 0 from 0 output items",
+		},
+		{
+			name:      "function call output is not compaction",
+			payload:   `{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","name":"foo","arguments":"{}"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "got 0 from 1 output items",
+		},
+		{
+			name:      "incomplete event is never successful",
+			payload:   `{"type":"response.incomplete","response":{"status":"incomplete","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.incomplete",
+			wantErr:   "response.incomplete",
+		},
+		{
+			name:    "incomplete response status is never successful",
+			payload: `{"id":"resp_1","object":"response","status":"incomplete","output":[{"type":"compaction","encrypted_content":"opaque"}]}`,
+			wantErr: "response.incomplete",
+		},
+		{
+			name:      "nested incomplete response status is never successful",
+			payload:   `{"type":"response.incomplete","response":{"status":"incomplete","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "response.incomplete",
+		},
+		{
+			name:      "completed event with ordinary output fails",
+			payload:   `{"type":"response.completed","response":{"status":"completed","output":[{"type":"message"}]}}`,
+			eventType: "response.completed",
+			wantErr:   "got 0 from 1 output items",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateRemoteCompactionV2Response([]byte(test.payload), test.eventType)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateRemoteCompactionV2Response() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("validateRemoteCompactionV2Response() succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, test.wantErr)
+			}
+			var status interface{ StatusCode() int }
+			if !errors.As(err, &status) || status.StatusCode() != http.StatusBadGateway {
+				t.Fatalf("error status = %T/%v, want HTTP %d", err, status, http.StatusBadGateway)
+			}
+			var requestErr cliproxyexecutor.RequestScopedError
+			if !errors.As(err, &requestErr) || requestErr == nil || !requestErr.IsRequestScoped() {
+				t.Fatalf("error = %T/%v, want request-scoped error", err, err)
+			}
+		})
+	}
+}
+
+func TestRemoteCompactionV2EventType(t *testing.T) {
+	if got := remoteCompactionV2EventType([]byte(`data: {"type":"response.incomplete","response":{"status":"incomplete"}}\n\n`)); got != "response.incomplete" {
+		t.Fatalf("event type = %q, want response.incomplete", got)
+	}
+	if got := remoteCompactionV2EventType([]byte(`{"type":"response.completed","response":{"status":"completed"}}`)); got != "response.completed" {
+		t.Fatalf("event type = %q, want response.completed", got)
+	}
+	for _, eventType := range []string{"response.failed", "response.done", "error"} {
+		t.Run(eventType, func(t *testing.T) {
+			payload := []byte(`{"type":"` + eventType + `","status":"completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`)
+			got := remoteCompactionV2EventType(payload)
+			if got != eventType {
+				t.Fatalf("event type = %q, want %q", got, eventType)
+			}
+			if err := validateRemoteCompactionV2Response(payload, got); err == nil {
+				t.Fatalf("validateRemoteCompactionV2Response() succeeded for %s", eventType)
+			} else if !strings.Contains(err.Error(), "expected response.completed") {
+				t.Fatalf("error = %v, want terminal event rejection", err)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -127,8 +127,8 @@ func (e *GeminiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Aut
 //   - cliproxyexecutor.Response: The response from the API
 //   - error: An error if the request fails
 func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	if opts.Alt == "responses/compact" {
-		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return resp, err
 	}
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractions(ctx, auth, req, opts)
@@ -246,8 +246,8 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 // ExecuteStream performs a streaming request to the Gemini API.
 func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return nil, err
 	}
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractionsStream(ctx, auth, req, opts)

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -236,8 +236,8 @@ func (e *GeminiVertexExecutor) HttpRequest(ctx context.Context, auth *cliproxyau
 
 // Execute performs a non-streaming request to the Vertex AI API.
 func (e *GeminiVertexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
-	if opts.Alt == "responses/compact" {
-		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return resp, err
 	}
 	// Try API key authentication first
 	apiKey, baseURL := vertexAPICreds(auth)
@@ -257,8 +257,8 @@ func (e *GeminiVertexExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 // ExecuteStream performs a streaming request to the Vertex AI API.
 func (e *GeminiVertexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
-	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	if err := rejectUnsupportedCompaction(opts, req.Payload, opts.OriginalRequest); err != nil {
+		return nil, err
 	}
 	// Try API key authentication first
 	apiKey, baseURL := vertexAPICreds(auth)

--- a/internal/runtime/executor/helps/responses_compaction.go
+++ b/internal/runtime/executor/helps/responses_compaction.go
@@ -1,0 +1,60 @@
+package helps
+
+import "github.com/tidwall/gjson"
+
+// ResponsesInputHasItemType reports whether any Responses input item has the given type.
+func ResponsesInputHasItemType(body []byte, itemType string) bool {
+	if len(body) == 0 || itemType == "" {
+		return false
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		if item.Get("type").String() == itemType {
+			return true
+		}
+	}
+	return false
+}
+
+// ResponsesHasCompactionTrigger reports whether any payload contains a remote
+// compaction v2 trigger item.
+func ResponsesHasCompactionTrigger(payloads ...[]byte) bool {
+	for _, payload := range payloads {
+		if ResponsesInputHasItemType(payload, "compaction_trigger") {
+			return true
+		}
+	}
+	return false
+}
+
+// ResponsesOutputItemCounts returns how many output items match itemType and
+// the total number of output items. It accepts a Responses JSON object, a
+// response.completed event, or an SSE data line wrapping either.
+func ResponsesOutputItemCounts(payload []byte, itemType string) (typed, total int) {
+	output := responsesOutputArray(payload)
+	if !output.IsArray() {
+		return 0, 0
+	}
+	items := output.Array()
+	total = len(items)
+	for _, item := range items {
+		if item.Get("type").String() == itemType {
+			typed++
+		}
+	}
+	return typed, total
+}
+
+func responsesOutputArray(payload []byte) gjson.Result {
+	trimmed := payload
+	if len(trimmed) >= 5 && string(trimmed[:5]) == "data:" {
+		trimmed = trimmed[5:]
+	}
+	if output := gjson.GetBytes(trimmed, "output"); output.Exists() {
+		return output
+	}
+	return gjson.GetBytes(trimmed, "response.output")
+}

--- a/internal/runtime/executor/helps/responses_compaction_test.go
+++ b/internal/runtime/executor/helps/responses_compaction_test.go
@@ -1,0 +1,26 @@
+package helps
+
+import "testing"
+
+func TestResponsesHasCompactionTrigger(t *testing.T) {
+	if ResponsesHasCompactionTrigger([]byte(`{"input":[{"type":"message"},{"type":"compaction_trigger"}]}`)) != true {
+		t.Fatal("expected compaction_trigger to be detected")
+	}
+	if ResponsesHasCompactionTrigger([]byte(`{"input":[{"type":"message"}]}`)) {
+		t.Fatal("ordinary input must not look like a compaction trigger")
+	}
+	if ResponsesHasCompactionTrigger(nil, []byte(`{"input":[{"type":"compaction_trigger"}]}`)) != true {
+		t.Fatal("expected trigger on a later payload")
+	}
+}
+
+func TestResponsesOutputItemCounts(t *testing.T) {
+	typed, total := ResponsesOutputItemCounts([]byte(`{"output":[{"type":"message"}]}`), "compaction")
+	if typed != 0 || total != 1 {
+		t.Fatalf("typed=%d total=%d, want 0 and 1", typed, total)
+	}
+	typed, total = ResponsesOutputItemCounts([]byte(`{"type":"response.completed","response":{"output":[{"type":"compaction","encrypted_content":"x"}]}}`), "compaction")
+	if typed != 1 || total != 1 {
+		t.Fatalf("typed=%d total=%d, want 1 and 1", typed, total)
+	}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -89,6 +89,9 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if endpointPath := openAICompatImageEndpointPath(opts); endpointPath != "" {
 		return e.executeImages(ctx, auth, req, opts, endpointPath)
 	}
+	if opts.Alt != "responses/compact" && helps.ResponsesHasCompactionTrigger(req.Payload, opts.OriginalRequest) {
+		return e.executeResponsesCompactionTrigger(ctx, auth, req, opts)
+	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
@@ -307,6 +310,12 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if endpointPath := openAICompatImageEndpointPath(opts); endpointPath != "" {
 		return e.executeImagesStream(ctx, auth, req, opts, endpointPath)
+	}
+	if opts.Alt == "responses/compact" {
+		return nil, newRemoteCompactionV2ProtocolError(http.StatusBadRequest, "streaming not supported for /responses/compact")
+	}
+	if helps.ResponsesHasCompactionTrigger(req.Payload, opts.OriginalRequest) {
+		return e.executeResponsesCompactionTriggerStream(ctx, auth, req, opts)
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
@@ -1011,9 +1020,10 @@ func openAICompatStreamDataError(payload []byte, eventName string) (statusErr, b
 }
 
 type statusErr struct {
-	code       int
-	msg        string
-	retryAfter *time.Duration
+	code          int
+	msg           string
+	retryAfter    *time.Duration
+	requestScoped bool
 }
 
 func (e statusErr) Error() string {
@@ -1024,3 +1034,4 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+func (e statusErr) IsRequestScoped() bool      { return e.requestScoped }

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -76,6 +76,182 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	}
 }
 
+func TestOpenAICompatExecutorRemoteCompactionV2UsesResponses(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","status":"completed","output":[{"type":"compaction","encrypted_content":"opaque-out"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("v2 compact was translated to chat completions: %s", gotBody)
+	}
+	input := gjson.GetBytes(gotBody, "input").Array()
+	if len(input) != 2 || input[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("compaction_trigger was dropped: %s", gotBody)
+	}
+	if gjson.GetBytes(resp.Payload, "output.0.type").String() != "compaction" {
+		t.Fatalf("payload = %s", resp.Payload)
+	}
+}
+
+func TestOpenAICompatExecutorRemoteCompactionV2RejectsChatStyleOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"summary"}]}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"compaction_trigger"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err == nil {
+		t.Fatal("expected missing compaction item to fail")
+	}
+	if !strings.Contains(err.Error(), "got 0 from 1 output items") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestOpenAICompatExecutorRemoteCompactionV2ResponseFailedIsRequestScoped(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "execute", true: "stream"}[stream], func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if stream {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte(`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"type":"server_error","message":"compaction failed"}}}` + "\n\n"))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"type":"server_error","message":"compaction failed"}}}`))
+			}))
+			defer server.Close()
+
+			executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"base_url": server.URL + "/v1",
+				"api_key":  "test",
+			}}
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.4",
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"history"},{"type":"compaction_trigger"}]}`),
+			}
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: stream}
+			if !stream {
+				_, err := executor.Execute(context.Background(), auth, req, opts)
+				if err == nil {
+					t.Fatal("Execute succeeded, want response.failed error")
+				}
+				if got := statusCodeFromTestError(t, err); got != http.StatusBadGateway {
+					t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadGateway, err)
+				}
+				assertRequestScopedTestError(t, err)
+				return
+			}
+
+			result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+			if err != nil {
+				t.Fatalf("ExecuteStream setup error: %v", err)
+			}
+			var streamErr error
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if streamErr == nil {
+				t.Fatal("stream completed, want response.failed error")
+			}
+			if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadGateway {
+				t.Fatalf("stream status code = %d, want %d; err=%v", got, http.StatusBadGateway, streamErr)
+			}
+			assertRequestScopedTestError(t, streamErr)
+		})
+	}
+}
+
+func TestOpenAICompatExecutorRemoteCompactionV2RejectsTerminalEventWithCompletedStatus(t *testing.T) {
+	for _, eventType := range []string{"response.failed", "response.done", "error", "response.unknown"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", eventType, stream), func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					payload := fmt.Sprintf(`{"type":%q,"status":"completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"opaque"}]}}`, eventType)
+					if stream {
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = fmt.Fprintf(w, "data: %s\n\n", payload)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, payload)
+				}))
+				defer server.Close()
+
+				executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{
+					"base_url": server.URL + "/v1",
+					"api_key":  "test",
+				}}
+				req := cliproxyexecutor.Request{
+					Model:   "gpt-5.4",
+					Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"compaction_trigger"}]}`),
+				}
+				opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), Stream: stream}
+				if !stream {
+					_, err := executor.Execute(context.Background(), auth, req, opts)
+					if err == nil {
+						t.Fatalf("Execute succeeded for %s", eventType)
+					}
+					assertRequestScopedTestError(t, err)
+					return
+				}
+				result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+				if err != nil {
+					t.Fatalf("ExecuteStream setup error: %v", err)
+				}
+				var streamErr error
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						streamErr = chunk.Err
+					}
+				}
+				if streamErr == nil {
+					t.Fatalf("stream succeeded for %s", eventType)
+				}
+				assertRequestScopedTestError(t, streamErr)
+			})
+		}
+	}
+}
+
 func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -508,9 +684,9 @@ func TestOpenAICompatExecutorPromptCacheKeyExecuteStream(t *testing.T) {
 }
 
 func TestOpenAICompatExecutorPromptCacheKeyStreamCompactSkipped(t *testing.T) {
-	var gotBody []byte
+	var upstreamRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
+		upstreamRequests++
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[]}` + "\n\n"))
 		_, _ = w.Write([]byte("data: [DONE]\n\n"))
@@ -532,7 +708,7 @@ func TestOpenAICompatExecutorPromptCacheKeyStreamCompactSkipped(t *testing.T) {
 			"provider_key": "compat",
 		},
 	}
-	result, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+	_, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "gpt-5.6",
 		Payload: []byte(`{"model":"gpt-5.6","messages":[{"role":"user","content":"hello"}],"stream":true}`),
 	}, cliproxyexecutor.Options{
@@ -541,16 +717,14 @@ func TestOpenAICompatExecutorPromptCacheKeyStreamCompactSkipped(t *testing.T) {
 		Stream:       true,
 		Metadata:     map[string]any{cliproxyexecutor.DerivedSessionIDMetadataKey: "ctx:v1:compact-stream"},
 	})
-	if errExecute != nil {
-		t.Fatalf("ExecuteStream error: %v", errExecute)
+	if errExecute == nil {
+		t.Fatal("ExecuteStream succeeded, want legacy /responses/compact streaming rejection")
 	}
-	for chunk := range result.Chunks {
-		if chunk.Err != nil {
-			t.Fatalf("stream chunk error: %v", chunk.Err)
-		}
+	if got := statusCodeFromTestError(t, errExecute); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadRequest, errExecute)
 	}
-	if gjson.GetBytes(gotBody, "prompt_cache_key").Exists() {
-		t.Fatalf("unexpected prompt_cache_key in streaming compact body: %s", string(gotBody))
+	if upstreamRequests != 0 {
+		t.Fatalf("upstream request count = %d, want 0", upstreamRequests)
 	}
 }
 

--- a/internal/runtime/executor/openai_compat_executor_compaction.go
+++ b/internal/runtime/executor/openai_compat_executor_compaction.go
@@ -1,0 +1,326 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func (e *OpenAICompatExecutor) executeResponsesCompactionTrigger(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	prepared, errPrepare := e.prepareResponsesCompactionTrigger(ctx, auth, req, opts, false)
+	if errPrepare != nil {
+		return resp, errPrepare
+	}
+	defer prepared.reporter.TrackFailure(ctx, &err)
+
+	httpResp, errDo := e.doOpenAICompatRequest(ctx, auth, prepared, opts, false)
+	if errDo != nil {
+		return resp, errDo
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("openai compat executor: close response body error: %v", errClose)
+		}
+	}()
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		return resp, statusErr{code: httpResp.StatusCode, msg: string(b)}
+	}
+
+	body, errRead := io.ReadAll(httpResp.Body)
+	if errRead != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+		return resp, errRead
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	eventType := remoteCompactionV2EventType(body)
+	body = aggregateResponsesCompactionPayload(body)
+	if errCompaction := validateRemoteCompactionV2Response(body, eventType); errCompaction != nil {
+		return resp, errCompaction
+	}
+	prepared.reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
+	prepared.reporter.EnsurePublished(ctx)
+
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, prepared.to, prepared.responseFormat, req.Model, opts.OriginalRequest, prepared.body, body, &param)
+	if prepared.responseFormat == sdktranslator.FormatOpenAIResponse {
+		out = helps.EnsureResponsesUsageDetails(out)
+	}
+	return cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}, nil
+}
+
+func (e *OpenAICompatExecutor) executeResponsesCompactionTriggerStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	prepared, errPrepare := e.prepareResponsesCompactionTrigger(ctx, auth, req, opts, true)
+	if errPrepare != nil {
+		return nil, errPrepare
+	}
+	defer prepared.reporter.TrackFailure(ctx, &err)
+
+	httpResp, errDo := e.doOpenAICompatRequest(ctx, auth, prepared, opts, true)
+	if errDo != nil {
+		return nil, errDo
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("openai compat executor: close response body error: %v", errClose)
+		}
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("openai compat executor: close response body error: %v", errClose)
+			}
+		}()
+
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		claudeInputTokens := helps.NewClaudeInputTokenState(prepared.from, prepared.to, prepared.responseFormat, prepared.originalPayload)
+		var param any
+		outputItemsByIndex := make(map[int64][]byte)
+		var outputItemsFallback [][]byte
+		sawCompleted := false
+
+		for scanner.Scan() {
+			line := bytes.Clone(scanner.Bytes())
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			translatedLine := line
+			if bytes.HasPrefix(line, dataTag) {
+				data := bytes.TrimSpace(line[5:])
+				eventType := gjson.GetBytes(data, "type").String()
+				switch eventType {
+				case "response.output_item.done":
+					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
+				case "response.completed", "response.incomplete":
+					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
+					if errCompaction := validateRemoteCompactionV2Response(data, eventType); errCompaction != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errCompaction)
+						prepared.reporter.PublishFailure(ctx, errCompaction)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: errCompaction}:
+						case <-ctx.Done():
+						}
+						return
+					}
+					if eventType == "response.completed" {
+						if detail, ok := helps.ParseCodexUsage(data); ok {
+							prepared.reporter.Publish(ctx, detail)
+						} else {
+							prepared.reporter.Publish(ctx, helps.ParseOpenAIUsage(data))
+						}
+						sawCompleted = true
+					}
+					translatedLine = append([]byte("data: "), data...)
+				default:
+					if isRemoteCompactionV2TerminalEvent(eventType) {
+						streamErr := remoteCompactionV2TerminalError(eventType)
+						helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+						prepared.reporter.PublishFailure(ctx, streamErr)
+						select {
+						case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+						case <-ctx.Done():
+						}
+						return
+					}
+				}
+			}
+
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, prepared.to, prepared.responseFormat, req.Model, opts.OriginalRequest, prepared.body, translatedLine, &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if sawCompleted {
+				return
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			streamErr := newRemoteCompactionV2ProtocolError(http.StatusBadGateway, "remote compaction v2 stream read failed: "+errScan.Error())
+			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+			prepared.reporter.PublishFailure(ctx, streamErr)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case <-ctx.Done():
+			}
+			return
+		}
+		streamErr := newRemoteCompactionV2ProtocolError(http.StatusBadGateway, "upstream stream closed before response.completed")
+		helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+		prepared.reporter.PublishFailure(ctx, streamErr)
+		select {
+		case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+		case <-ctx.Done():
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+type openAICompatResponsesRequest struct {
+	from            sdktranslator.Format
+	to              sdktranslator.Format
+	responseFormat  sdktranslator.Format
+	baseModel       string
+	originalPayload []byte
+	body            []byte
+	url             string
+	apiKey          string
+	reporter        *helps.UsageReporter
+}
+
+func (e *OpenAICompatExecutor) prepareResponsesCompactionTrigger(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*openAICompatResponsesRequest, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+
+	baseURL, apiKey := e.resolveCredentials(auth)
+	if baseURL == "" {
+		var err error = statusErr{code: http.StatusUnauthorized, msg: "missing provider baseURL"}
+		reporter.TrackFailure(ctx, &err)
+		return nil, err
+	}
+
+	from := opts.SourceFormat
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	to := sdktranslator.FromString("openai-response")
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	isCompat := helps.APIKeyModelIsCompat(req)
+	originalTranslated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayloadSource, stream, isCompat)
+	translated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream, isCompat)
+	translated, err := helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, err
+	}
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	if !stream {
+		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
+			translated = updated
+		}
+	} else {
+		translated = helps.SetBoolIfDifferent(translated, "stream", true)
+	}
+	translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
+	reporter.SetTranslatedReasoningEffort(translated, to.String())
+
+	return &openAICompatResponsesRequest{
+		from:            from,
+		to:              to,
+		responseFormat:  responseFormat,
+		baseModel:       baseModel,
+		originalPayload: originalPayloadSource,
+		body:            translated,
+		url:             strings.TrimSuffix(baseURL, "/") + "/responses",
+		apiKey:          apiKey,
+		reporter:        reporter,
+	}, nil
+}
+
+func (e *OpenAICompatExecutor) doOpenAICompatRequest(ctx context.Context, auth *cliproxyauth.Auth, prepared *openAICompatResponsesRequest, opts cliproxyexecutor.Options, stream bool) (*http.Response, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, prepared.url, bytes.NewReader(prepared.body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if prepared.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+prepared.apiKey)
+	}
+	httpReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+	if stream {
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("Cache-Control", "no-cache")
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs, opts.Headers)
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       prepared.url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      prepared.body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = prepared.reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	return httpResp, nil
+}
+
+func aggregateResponsesCompactionPayload(body []byte) []byte {
+	if !bytes.Contains(body, dataTag) {
+		return body
+	}
+
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+	lines := bytes.Split(body, []byte("\n"))
+	for _, line := range lines {
+		if !bytes.HasPrefix(line, dataTag) {
+			continue
+		}
+		eventData := bytes.TrimSpace(line[5:])
+		eventType := gjson.GetBytes(eventData, "type").String()
+		if eventType == "response.output_item.done" {
+			collectCodexOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
+			continue
+		}
+		if eventType != "response.completed" && eventType != "response.incomplete" {
+			continue
+		}
+		completed := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
+		response := gjson.GetBytes(completed, "response")
+		if response.Exists() && response.Type == gjson.JSON {
+			return []byte(response.Raw)
+		}
+		return completed
+	}
+	return body
+}

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -17,7 +17,7 @@ import (
 
 func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+		return nil, newRemoteCompactionV2ProtocolError(http.StatusBadRequest, "streaming not supported for /responses/compact")
 	}
 	if xaiInputHasItemType(req.Payload, "compaction_trigger") {
 		return e.executeCompactionTriggerStream(ctx, auth, req, opts)

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -428,7 +428,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 		ctx = context.Background()
 	}
 	if opts.Alt == "responses/compact" {
-		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+		return nil, newRemoteCompactionV2ProtocolError(http.StatusBadRequest, "streaming not supported for /responses/compact")
 	}
 	executionSessionID := executionSessionIDFromOptions(opts)
 	stateSessionID := xaiExecutionSessionID(req, opts)

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -312,6 +312,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"provider_key": internalProviderKey,
 				"config_index": strconv.Itoa(i),
 			}
+			if compat.RemoteCompactionV2 {
+				attrs[coreauth.AttributeRemoteCompactionV2] = "true"
+			}
 			metadata := map[string]any{}
 			if disableCooling != nil {
 				metadata["disable_cooling"] = *disableCooling
@@ -357,6 +360,9 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"compat_name":  compat.Name,
 				"provider_key": internalProviderKey,
 				"config_index": strconv.Itoa(i),
+			}
+			if compat.RemoteCompactionV2 {
+				attrs[coreauth.AttributeRemoteCompactionV2] = "true"
 			}
 			metadata := map[string]any{}
 			if disableCooling != nil {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -733,6 +733,40 @@ func TestConfigSynthesizer_OpenAICompat_UsesNamespacedProviderKey(t *testing.T) 
 	}
 }
 
+func TestConfigSynthesizer_OpenAICompat_RemoteCompactionV2Attribute(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name:               "compact-provider",
+				BaseURL:            "https://compact.example.com/v1",
+				RemoteCompactionV2: true,
+				APIKeyEntries:      []config.OpenAICompatibilityAPIKey{{APIKey: "compact-key"}},
+			},
+			{
+				Name:    "plain-provider",
+				BaseURL: "https://plain.example.com/v1",
+			},
+		}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths, got %d", len(auths))
+	}
+	if got := auths[0].Attributes[coreauth.AttributeRemoteCompactionV2]; got != "true" {
+		t.Fatalf("enabled provider attribute = %q, want true", got)
+	}
+	if _, ok := auths[1].Attributes[coreauth.AttributeRemoteCompactionV2]; ok {
+		t.Fatal("disabled provider unexpectedly received remote compaction attribute")
+	}
+}
+
 func TestConfigSynthesizer_VertexCompat(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -40,9 +40,13 @@ func claudeOAuthRequestCancellation(ctx context.Context, auth *Auth, err error) 
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	req, opts = cliproxysession.Enrich(req, opts)
+	opts = markRemoteCompactionRequirement(opts, req.Payload)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+	if err := m.ensureRemoteCompactionCapability(normalized, opts); err != nil {
+		return cliproxyexecutor.Response{}, err
 	}
 	if m.HomeEnabled() {
 		resp, errHome := m.executeHome(ctx, normalized, req, opts, false)
@@ -87,9 +91,13 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	req, opts = cliproxysession.Enrich(req, opts)
+	opts = markRemoteCompactionRequirement(opts, req.Payload)
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+	if err := m.ensureRemoteCompactionCapability(normalized, opts); err != nil {
+		return cliproxyexecutor.Response{}, err
 	}
 	if m.HomeEnabled() {
 		resp, errHome := m.executeHome(ctx, normalized, req, opts, true)
@@ -127,6 +135,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	req, opts = cliproxysession.Enrich(req, opts)
+	opts = markRemoteCompactionRequirement(opts, req.Payload)
 	if m.HomeEnabled() {
 		if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 			defer unlockSession()
@@ -135,6 +144,9 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
+	}
+	if err := m.ensureRemoteCompactionCapability(normalized, opts); err != nil {
+		return nil, err
 	}
 
 	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
@@ -226,6 +238,9 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 		req.Payload = bytes.Clone(resp.Body)
 		opts.OriginalRequest = bytes.Clone(resp.Body)
 	}
+	if errTrigger := ensureRemoteCompactionTriggerPreserved(req, opts); errTrigger != nil {
+		return req, opts, errTrigger
+	}
 	if resp.Terminate {
 		return req, opts, &cliproxyexecutor.RequestTerminatedError{
 			HTTPStatus: resp.StatusCode,
@@ -234,6 +249,16 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 		}
 	}
 	return req, opts, nil
+}
+
+func ensureRemoteCompactionTriggerPreserved(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+	if !remoteCompactionRequired(opts) {
+		return nil
+	}
+	if requestHasRemoteCompactionTrigger(req.Payload) || requestHasRemoteCompactionTrigger(opts.OriginalRequest) {
+		return nil
+	}
+	return NewRequestScopedError("remote compaction v2 trigger was removed during request processing", http.StatusBadRequest)
 }
 
 func requestToFormat(provider string, executor ProviderExecutor, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
@@ -363,6 +388,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare), Options: pickOpts}
 			m.MarkResult(execCtx, result)
+			if isRequestInvalidError(errPrepare) {
+				return cliproxyexecutor.Response{}, errPrepare
+			}
 			lastErr = errPrepare
 			continue
 		}
@@ -537,6 +565,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare), Options: pickOpts}
 			m.MarkResult(execCtx, result)
+			if isRequestInvalidError(errPrepare) {
+				return cliproxyexecutor.Response{}, errPrepare
+			}
 			lastErr = errPrepare
 			continue
 		}
@@ -864,6 +895,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "prepare_failed"); errEnd != nil {
 					return nil, errEnd
 				}
+			}
+			if isRequestInvalidError(errPrepare) {
+				return nil, errPrepare
 			}
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -930,6 +930,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		return nil, errRetained
 	}
 	if retainedOK {
+		if remoteCompactionRequired(opts) && !authHandlesRemoteCompactionTrigger(retained.CloneAuth()) {
+			retained.End("remote_compaction_unsupported")
+			return nil, remoteCompactionUnsupportedError()
+		}
 		return retained, nil
 	}
 	if sessionID := homeExecutionSessionIDFromMetadata(opts.Metadata); sessionID != "" {
@@ -1120,6 +1124,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if !okExecutor {
 		endScope()
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered", HTTPStatus: http.StatusBadGateway}
+	}
+	if remoteCompactionRequired(opts) && !authHandlesRemoteCompactionTrigger(&auth) {
+		endScope()
+		return nil, remoteCompactionUnsupportedError()
 	}
 	if scope == nil {
 		var errInstall error

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -58,6 +58,7 @@ type authSelectionEligibility struct {
 	requiredKind     string
 	credentialPolicy string
 	disallowFreeAuth bool
+	remoteCompaction bool
 }
 
 func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
@@ -77,7 +78,10 @@ func credentialPolicyFromContext(ctx context.Context) string {
 }
 
 func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecutor.Options) authSelectionEligibility {
-	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata)}
+	eligibility := authSelectionEligibility{
+		disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata),
+		remoteCompaction: remoteCompactionRequired(opts),
+	}
 	if ctx != nil {
 		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
 		eligibility.credentialPolicy, _ = ctx.Value(credentialPolicyContextKey{}).(string)
@@ -93,6 +97,9 @@ func (e authSelectionEligibility) allows(auth *Auth) bool {
 		return false
 	}
 	if e.credentialPolicy != "" && !credentialPolicyAllows(e.credentialPolicy, auth) {
+		return false
+	}
+	if e.remoteCompaction && !authHandlesRemoteCompactionTrigger(auth) {
 		return false
 	}
 	return !e.disallowFreeAuth || !isFreeCodexAuth(auth)

--- a/sdk/cliproxy/auth/home_selection.go
+++ b/sdk/cliproxy/auth/home_selection.go
@@ -271,7 +271,7 @@ func preserveHomeRoutingAttributes(updated, previous *Auth) {
 	if updated.Attributes == nil {
 		updated.Attributes = make(map[string]string)
 	}
-	for _, key := range []string{homeUpstreamModelAttributeKey, homeForceMappingAttributeKey, homeOriginalAliasAttributeKey} {
+	for _, key := range []string{homeUpstreamModelAttributeKey, homeForceMappingAttributeKey, homeOriginalAliasAttributeKey, AttributeRemoteCompactionV2} {
 		if value := strings.TrimSpace(previous.Attributes[key]); value != "" {
 			updated.Attributes[key] = value
 		}

--- a/sdk/cliproxy/auth/remote_compaction_capability.go
+++ b/sdk/cliproxy/auth/remote_compaction_capability.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// AttributeRemoteCompactionV2 marks an explicitly configured provider as
+// supporting the Responses remote compaction v2 protocol.
+const AttributeRemoteCompactionV2 = "remote_compaction_v2"
+
+const remoteCompactionRequiredMetadataKey = "cliproxy.remote_compaction_v2.required"
+
+// requestHasRemoteCompactionTrigger reports whether a Responses request asks
+// the upstream to compact a conversation. It intentionally only inspects the
+// input item type and does not depend on executor internals.
+func requestHasRemoteCompactionTrigger(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() || !input.IsArray() {
+		return false
+	}
+	found := false
+	input.ForEach(func(_, item gjson.Result) bool {
+		if strings.TrimSpace(item.Get("type").String()) == "compaction_trigger" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func markRemoteCompactionRequirement(opts cliproxyexecutor.Options, payload []byte) cliproxyexecutor.Options {
+	if !requestHasRemoteCompactionTrigger(payload) && !requestHasRemoteCompactionTrigger(opts.OriginalRequest) {
+		return opts
+	}
+	opts.EnsureMetadata()[remoteCompactionRequiredMetadataKey] = true
+	return opts
+}
+
+// ensureRemoteCompactionCapability fails before selection when no configured
+// credential can handle the request. This keeps the failure request-scoped so
+// it cannot cool down credentials or trigger credential retries.
+func (m *Manager) ensureRemoteCompactionCapability(providers []string, opts cliproxyexecutor.Options) error {
+	if m == nil || !remoteCompactionRequired(opts) || m.HomeEnabled() {
+		return nil
+	}
+	providerSet := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider != "" {
+			providerSet[provider] = struct{}{}
+		}
+	}
+	if len(providerSet) == 0 {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled || !authHandlesRemoteCompactionTrigger(auth) {
+			continue
+		}
+		provider := executorKeyFromAuth(auth)
+		if _, ok := providerSet[provider]; !ok {
+			continue
+		}
+		if _, ok := m.executors[provider]; !ok {
+			continue
+		}
+		return nil
+	}
+	return remoteCompactionUnsupportedError()
+}
+
+func remoteCompactionRequired(opts cliproxyexecutor.Options) bool {
+	if len(opts.Metadata) > 0 {
+		switch value := opts.Metadata[remoteCompactionRequiredMetadataKey].(type) {
+		case bool:
+			if value {
+				return true
+			}
+		case string:
+			if strings.EqualFold(strings.TrimSpace(value), "true") {
+				return true
+			}
+		}
+	}
+	return requestHasRemoteCompactionTrigger(opts.OriginalRequest)
+}
+
+func authSupportsRemoteCompactionV2(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes[AttributeRemoteCompactionV2]), "true") {
+		return true
+	}
+	// Native Codex OAuth/API credentials speak the Responses compaction
+	// protocol by default. Compatibility credentials must opt in explicitly.
+	return strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") && !isOpenAICompatAuth(auth)
+}
+
+// authHandlesRemoteCompactionTrigger reports whether a credential can consume a
+// compaction_trigger item. Native Codex and explicit opt-in providers speak
+// remote compaction v2. xAI keeps origin's v1 adapter (strip trigger, POST
+// /responses/compact) so xAI-only pools remain selectable.
+func authHandlesRemoteCompactionTrigger(auth *Auth) bool {
+	if authSupportsRemoteCompactionV2(auth) {
+		return true
+	}
+	return auth != nil && strings.EqualFold(strings.TrimSpace(auth.Provider), "xai")
+}
+
+func isOpenAICompatAuth(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes != nil && strings.TrimSpace(auth.Attributes["compat_name"]) != "" {
+		return true
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	return provider == "openai-compatibility" || strings.HasPrefix(provider, "openai-compatibility:")
+}
+
+func remoteCompactionUnsupportedError() *Error {
+	return NewRequestScopedError("remote compaction v2 is not supported by any eligible provider", http.StatusNotImplemented)
+}

--- a/sdk/cliproxy/auth/remote_compaction_capability_test.go
+++ b/sdk/cliproxy/auth/remote_compaction_capability_test.go
@@ -1,0 +1,203 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type remoteCompactionCountingExecutor struct {
+	executeCalls atomic.Int32
+	countCalls   atomic.Int32
+	streamCalls  atomic.Int32
+}
+
+func (e *remoteCompactionCountingExecutor) Identifier() string { return "codex" }
+
+func (e *remoteCompactionCountingExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.executeCalls.Add(1)
+	return cliproxyexecutor.Response{Payload: []byte("unexpected execute")}, nil
+}
+
+func (e *remoteCompactionCountingExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.streamCalls.Add(1)
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("unexpected stream")}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *remoteCompactionCountingExecutor) Refresh(context.Context, *Auth) (*Auth, error) {
+	return nil, nil
+}
+
+func (e *remoteCompactionCountingExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.countCalls.Add(1)
+	return cliproxyexecutor.Response{Payload: []byte("unexpected count")}, nil
+}
+
+func (e *remoteCompactionCountingExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func newRemoteCompactionInterceptorManager(t *testing.T, executor *remoteCompactionCountingExecutor) *Manager {
+	t.Helper()
+	const (
+		authID = "remote-compaction-interceptor-auth"
+		model  = "remote-compaction-interceptor-model"
+	)
+	manager := NewManager(nil, nil, nil)
+	manager.SetRetryConfig(0, 0, 1)
+	manager.RegisterExecutor(executor)
+	registry.GetGlobalRegistry().RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	return manager
+}
+
+func assertRemoteCompactionInterceptorError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("execution error = nil, want request-scoped trigger removal error")
+	}
+	var requestErr *Error
+	if !errors.As(err, &requestErr) {
+		t.Fatalf("execution error = %T (%v), want *Error", err, err)
+	}
+	if !requestErr.IsRequestScoped() {
+		t.Fatalf("error code = %q, want request-scoped", requestErr.Code)
+	}
+	if requestErr.HTTPStatus != http.StatusBadRequest {
+		t.Fatalf("error status = %d, want %d", requestErr.HTTPStatus, http.StatusBadRequest)
+	}
+}
+
+func TestAuthSupportsRemoteCompactionV2(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *Auth
+		want bool
+	}{
+		{name: "explicit compatibility opt in", auth: &Auth{Provider: "openai-compatible-provider", Attributes: map[string]string{AttributeRemoteCompactionV2: "true", "compat_name": "provider"}}, want: true},
+		{name: "compatibility default off", auth: &Auth{Provider: "openai-compatible-provider", Attributes: map[string]string{"compat_name": "provider"}}, want: false},
+		{name: "native codex default on", auth: &Auth{Provider: "codex"}, want: true},
+		{name: "native codex remains enabled", auth: &Auth{Provider: "codex", Attributes: map[string]string{AttributeRemoteCompactionV2: "false"}}, want: true},
+		{name: "xai is not v2", auth: &Auth{Provider: "xai"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authSupportsRemoteCompactionV2(tt.auth); got != tt.want {
+				t.Fatalf("authSupportsRemoteCompactionV2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthHandlesRemoteCompactionTriggerIncludesXAI(t *testing.T) {
+	if !authHandlesRemoteCompactionTrigger(&Auth{Provider: "xai"}) {
+		t.Fatal("xAI must remain selectable for compaction_trigger via the origin v1 adapter")
+	}
+	if authHandlesRemoteCompactionTrigger(&Auth{Provider: "gemini"}) {
+		t.Fatal("gemini must not handle compaction_trigger")
+	}
+}
+
+func TestMarkRemoteCompactionRequirementChecksPayloadAndOriginalRequest(t *testing.T) {
+	trigger := []byte(`{"input":[{"type":"compaction_trigger"}]}`)
+	ordinary := []byte(`{"input":[{"type":"message"}]}`)
+
+	for _, test := range []struct {
+		name            string
+		payload         []byte
+		originalRequest []byte
+		want            bool
+	}{
+		{name: "request payload", payload: trigger, originalRequest: ordinary, want: true},
+		{name: "original request", payload: ordinary, originalRequest: trigger, want: true},
+		{name: "no trigger", payload: ordinary, originalRequest: ordinary, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			opts := markRemoteCompactionRequirement(cliproxyexecutor.Options{OriginalRequest: test.originalRequest}, test.payload)
+			if got := remoteCompactionRequired(opts); got != test.want {
+				t.Fatalf("remoteCompactionRequired() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRequestHasRemoteCompactionTriggerRequiresCanonicalCase(t *testing.T) {
+	for _, triggerType := range []string{"Compaction_Trigger", "COMPACTION_TRIGGER", "compaction_Trigger"} {
+		t.Run(triggerType, func(t *testing.T) {
+			payload := []byte(`{"input":[{"type":"` + triggerType + `"}]}`)
+			if requestHasRemoteCompactionTrigger(payload) {
+				t.Fatalf("requestHasRemoteCompactionTrigger(%q) = true, want false", triggerType)
+			}
+		})
+	}
+}
+
+func TestPreserveHomeRoutingAttributesKeepsRemoteCompactionCapability(t *testing.T) {
+	previous := &Auth{Attributes: map[string]string{AttributeRemoteCompactionV2: "true"}}
+	updated := &Auth{}
+
+	preserveHomeRoutingAttributes(updated, previous)
+
+	if got := updated.Attributes[AttributeRemoteCompactionV2]; got != "true" {
+		t.Fatalf("remote compaction attribute = %q, want true", got)
+	}
+}
+
+func TestRequestAfterAuthInterceptorTriggerRemovalIsRequestScoped(t *testing.T) {
+	const model = "remote-compaction-interceptor-model"
+	for _, test := range []struct {
+		name string
+		run  func(*Manager, cliproxyexecutor.Request, cliproxyexecutor.Options) error
+		get  func(*remoteCompactionCountingExecutor) int32
+	}{
+		{
+			name: "execute",
+			run: func(manager *Manager, request cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"codex"}, request, opts)
+				return errExecute
+			},
+			get: func(executor *remoteCompactionCountingExecutor) int32 { return executor.executeCalls.Load() },
+		},
+		{
+			name: "execute_count",
+			run: func(manager *Manager, request cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, errCount := manager.ExecuteCount(context.Background(), []string{"codex"}, request, opts)
+				return errCount
+			},
+			get: func(executor *remoteCompactionCountingExecutor) int32 { return executor.countCalls.Load() },
+		},
+		{
+			name: "execute_stream",
+			run: func(manager *Manager, request cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, errStream := manager.ExecuteStream(context.Background(), []string{"codex"}, request, opts)
+				return errStream
+			},
+			get: func(executor *remoteCompactionCountingExecutor) int32 { return executor.streamCalls.Load() },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			executor := &remoteCompactionCountingExecutor{}
+			manager := newRemoteCompactionInterceptorManager(t, executor)
+			request := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":[{"type":"message","content":"history"},{"type":"compaction_trigger"}]}`)}
+			opts := cliproxyexecutor.Options{Stream: test.name == "execute_stream", RequestAfterAuthInterceptor: func(context.Context, cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+				return cliproxyexecutor.RequestAfterAuthInterceptResponse{Body: []byte(`{"input":[{"type":"message","content":"history"}]}`)}
+			}}
+
+			assertRemoteCompactionInterceptorError(t, test.run(manager, request, opts))
+			if got := test.get(executor); got != 0 {
+				t.Fatalf("executor calls = %d, want 0", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Keep `compaction_trigger` on POST `/responses` and require exactly one `compaction` + `encrypted_content` output item (v2). Failures are request-scoped.
- Native Codex always speaks v2; OpenAI-compat is opt-in via `remote-compaction-v2`. Origin xAI still strips the trigger and uses v1 `/responses/compact`.

## Test plan
- [ ] `go test ./internal/runtime/executor ./internal/runtime/executor/helps ./sdk/cliproxy/auth ./internal/config ./internal/watcher/synthesizer ./internal/api/handlers/management`
- [ ] Codex trigger request stays on `/responses` and rejects chat-style output
- [ ] xAI-only pools still compact via origin's v1 adapter
- [ ] Compat providers stay off unless `remote-compaction-v2: true`


Made with [Cursor](https://cursor.com)