### PR TITLE
feat(claude): register Claude Fable 5.1 in the embedded model catalog

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -220,6 +220,36 @@
       ]
     },
     {
+      "id": "claude-fable-5-1",
+      "object": "model",
+      "created": 1788220800,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude Fable 5.1",
+      "description": "Anthropic's most capable widely released model, for the most demanding reasoning and long-horizon agentic work",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
       "id": "claude-fable-5",
       "object": "model",
       "created": 1781049600,


### PR DESCRIPTION
Registers `claude-fable-5-1` in the embedded model catalog (`internal/registry/models/models.json`).

Fixes #5402.

Anthropic released Claude Fable 5.1 on 2026-09-01 with API model ID `claude-fable-5-1` ([model page](https://platform.claude.com/docs/en/models/fable-5-1/overview)); Claude Code 2.1.257 made it the default Fable model. v7.2.147 only knows `claude-fable-5`, so requests for the new ID are rejected before they can reach an enabled Claude OAuth credential, and the model is absent from `/v1/models`.

Metadata mirrors the existing `claude-fable-5` entry and the published specs: 1M context, 128K max output, adaptive-only thinking with the low/medium/high/xhigh/max levels, text+image in / text out. `created` is 1788220800 (2026-09-01T00:00:00Z).

Note this only covers the embedded fallback and `--local-model` runs — the live catalog is fetched from `router-for-me/models`, so that repo needs the same entry for running instances to pick the model up without a release. PR sent there as well.

No other code paths needed changes: `claudeModelRejectsAssistantPrefill` matches the `fable` family by substring, and the Fable rate-limit handling in `internal/runtime/executor/helps/claude_ratelimit.go` keys off response headers rather than model IDs.

**Verification (local build, `--local-model`)**

- `gofmt -l .` clean; `go build ./cmd/server`; `go test ./internal/registry/... ./internal/client/claude/... ./sdk/api/handlers/claude/... ./internal/runtime/executor/...` all pass.
- `/v1/models` goes from 36 to 37 entries and now lists `claude-fable-5-1`.
- A `POST /v1/messages` with `"model":"claude-fable-5-1"` is no longer rejected locally — it is routed to an enabled Claude OAuth credential and reaches Anthropic.

**This entry is necessary but not sufficient — second blocker upstream**

That routed request comes back from Anthropic with:

```
invalid_request_error: Claude Code 2.1.220 does not support this model;
version 2.1.251 or newer is required.
```

Anthropic gates Fable 5.1 on the Claude Code version it observes, and the cloaking layer emulates 2.1.220 (`internal/runtime/executor/claude_executor_cloaking.go`, `claude-header-defaults` baseline `claude-cli/2.1.220`). So the model becomes visible and routable with this PR, but usable only once the emulated Claude Code baseline is re-measured at >= 2.1.251. I deliberately left that out of this PR: per `config.example.yaml`, the baseline should be updated "only after measuring a new Claude Code release", and the fingerprint spans system instructions, headers, beta ordering and cache-control — a maintainer call, not a guess. Happy to follow up if you want it in the same PR.
