### PR TITLE
feat(claude): add claude-fable-5-1 and bump Claude Code fingerprint to 2.1.251

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -250,6 +250,36 @@
       ]
     },
     {
+      "id": "claude-fable-5-1",
+      "object": "model",
+      "created": 1788393600,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude Fable 5.1",
+      "description": "Anthropic's most capable widely released model, for the most demanding reasoning and long-horizon agentic work",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
       "id": "claude-opus-4-5-20251101",
       "object": "model",
       "created": 1761955200,
@@ -3611,7 +3641,6 @@
         "text"
       ]
     }
-
   ],
   "xai": [
     {

--- a/internal/runtime/executor/helps/claude_device_profile.go
+++ b/internal/runtime/executor/helps/claude_device_profile.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultClaudeFingerprintUserAgent      = "claude-cli/2.1.220 (external, cli)"
+	defaultClaudeFingerprintUserAgent      = "claude-cli/2.1.251 (external, cli)"
 	defaultClaudeFingerprintPackageVersion = "0.94.0"
 	defaultClaudeFingerprintRuntimeVersion = "v26.3.0"
 	defaultClaudeFingerprintOS             = "MacOS"


### PR DESCRIPTION
Anthropic's `/v1/models` now returns `claude-fable-5-1` for subscription (OAuth) accounts, but the proxy rejects it with `unknown provider for model claude-fable-5-1` because it is missing from the embedded registry in `internal/registry/models/models.json`.

Adding the model alone is **not sufficient**. Anthropic gates it on the advertised client version and returns:

```
Claude Code 2.1.220 does not support this model; version 2.1.251 or newer is
required. Run 'claude update', or update the Claude desktop app, then try again.
```

so this also bumps `defaultClaudeFingerprintUserAgent` in
`internal/runtime/executor/helps/claude_device_profile.go` from `2.1.220` to `2.1.251`.

### Verification

Built from this branch and run against a live Claude subscription account:

- before: `POST /v1/chat/completions` with `claude-fable-5-1` -> `400 unknown provider for model`
- after adding the registry entry only -> `400 Claude Code 2.1.220 does not support this model`
- after both changes -> `200`, model echoes back as `claude-fable-5-1`

`/v1/models` goes from 38 to 39 entries. Regression-checked `claude-fable-5`,
`claude-opus-5` and `claude-sonnet-5` — all still `200`.

### Notes

The registry entry mirrors `claude-fable-5`: 1M context, 128k max completion,
thinking levels `low..max`, `text`+`image` in / `text` out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)