### PR TITLE
fix(auth): preserve upstream overload errors

### DIFF
--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -61,6 +61,10 @@ const (
 // BuildErrorResponseBody builds an OpenAI-compatible JSON error response body.
 // If errText is already valid JSON, it is returned as-is to preserve upstream error payloads.
 func BuildErrorResponseBody(status int, errText string) []byte {
+	return buildErrorResponseBody(status, errText, "")
+}
+
+func buildErrorResponseBody(status int, errText, explicitCode string) []byte {
 	if status <= 0 {
 		status = http.StatusInternalServerError
 	}
@@ -93,6 +97,9 @@ func BuildErrorResponseBody(status int, errText string) []byte {
 			errType = "server_error"
 			code = "internal_server_error"
 		}
+	}
+	if explicitCode != "" {
+		code = explicitCode
 	}
 
 	payload, err := json.Marshal(ErrorResponse{

--- a/sdk/api/handlers/handlers_error_response_test.go
+++ b/sdk/api/handlers/handlers_error_response_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -288,7 +289,52 @@ func TestEnrichAuthSelectionError_IgnoresOtherErrors(t *testing.T) {
 	}
 }
 
-func TestEnrichAuthSelectionError_IncludesUpstreamErrorFromCause(t *testing.T) {
+func TestEnrichAuthSelectionError_PromotesUpstreamOverloadCause(t *testing.T) {
+	in := coreauth.WithCause(&coreauth.Error{
+		Code:    "auth_unavailable",
+		Message: "no auth available",
+	}, &coreauth.Error{
+		Code:       "server_is_overloaded",
+		Message:    `{"type":"error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","sequence_number":0}`,
+		HTTPStatus: http.StatusServiceUnavailable,
+	})
+	out := enrichAuthSelectionError(in, []string{"codex"}, "gpt-5.6-sol")
+
+	var got *coreauth.Error
+	if !errors.As(out, &got) || got == nil {
+		t.Fatalf("expected coreauth.Error, got %T", out)
+	}
+	if got.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", got.StatusCode(), http.StatusServiceUnavailable)
+	}
+	if got.Code != "server_is_overloaded" {
+		t.Fatalf("code = %q, want %q", got.Code, "server_is_overloaded")
+	}
+	if !got.Retryable {
+		t.Fatal("retryable = false, want true")
+	}
+	if got.Message != "Our servers are currently overloaded. Please try again later." {
+		t.Fatalf("message = %q", got.Message)
+	}
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	NewBaseAPIHandlers(nil, nil).WriteErrorResponse(c, executionErrorMessage(out))
+	var response ErrorResponse
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	if response.Error.Code != "server_is_overloaded" {
+		t.Fatalf("response code = %q, want %q", response.Error.Code, "server_is_overloaded")
+	}
+	if response.Error.Message != "Our servers are currently overloaded. Please try again later." {
+		t.Fatalf("response message = %q", response.Error.Message)
+	}
+}
+
+func TestEnrichAuthSelectionError_PromotesUntypedUpstreamOverloadCause(t *testing.T) {
 	in := coreauth.WithCause(&coreauth.Error{
 		Code:    "auth_unavailable",
 		Message: "no auth available",
@@ -299,17 +345,11 @@ func TestEnrichAuthSelectionError_IncludesUpstreamErrorFromCause(t *testing.T) {
 	if !errors.As(out, &got) || got == nil {
 		t.Fatalf("expected coreauth.Error, got %T", out)
 	}
-	if got.StatusCode() != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want %d", got.StatusCode(), http.StatusServiceUnavailable)
+	if got.Code != "server_is_overloaded" {
+		t.Fatalf("code = %q, want %q", got.Code, "server_is_overloaded")
 	}
-	if !strings.Contains(got.Message, "providers=codex") {
-		t.Fatalf("message missing provider context: %q", got.Message)
-	}
-	if !strings.Contains(got.Message, "model=gpt-5.6-sol") {
-		t.Fatalf("message missing model context: %q", got.Message)
-	}
-	if !strings.Contains(got.Message, "Our servers are currently overloaded. Please try again later.") && !strings.Contains(got.Message, "server_is_overloaded") {
-		t.Fatalf("message missing upstream error details: %q", got.Message)
+	if got.Message != "Our servers are currently overloaded. Please try again later." {
+		t.Fatalf("message = %q", got.Message)
 	}
 }
 

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -58,6 +58,11 @@ func enrichAuthSelectionError(err error, providers []string, model string) error
 		return err
 	}
 
+	cause := errors.Unwrap(err)
+	if overloaded := promotedOverloadError(cause); overloaded != nil {
+		return coreauth.WithCause(overloaded, cause)
+	}
+
 	providerText := strings.Join(providers, ",")
 	if providerText == "" {
 		providerText = "unknown"
@@ -72,7 +77,6 @@ func enrichAuthSelectionError(err error, providers []string, model string) error
 		baseMessage = "no auth available"
 	}
 
-	cause := errors.Unwrap(err)
 	var upstreamSummary string
 	if cause != nil {
 		upstreamSummary = coreauth.ExtractUpstreamErrorSummary(cause.Error())
@@ -104,6 +108,38 @@ func enrichAuthSelectionError(err error, providers []string, model string) error
 		return coreauth.WithCause(enriched, cause)
 	}
 	return enriched
+}
+
+func promotedOverloadError(cause error) *coreauth.Error {
+	const code = "server_is_overloaded"
+	for current := cause; current != nil; current = errors.Unwrap(current) {
+		var upstreamErr *coreauth.Error
+		if errors.As(current, &upstreamErr) && upstreamErr != nil && strings.TrimSpace(upstreamErr.Code) == code {
+			return newPromotedOverloadError(code, upstreamErr.Message, upstreamErr.HTTPStatus)
+		}
+		summary := coreauth.ExtractUpstreamErrorSummary(current.Error())
+		if strings.HasPrefix(strings.ToLower(summary), code+":") {
+			return newPromotedOverloadError(code, summary, http.StatusServiceUnavailable)
+		}
+	}
+	return nil
+}
+
+func newPromotedOverloadError(code, rawMessage string, status int) *coreauth.Error {
+	message := coreauth.ExtractUpstreamErrorSummary(rawMessage)
+	message = strings.TrimSpace(strings.TrimPrefix(message, code+":"))
+	if message == "" {
+		message = "Upstream servers are currently overloaded. Please try again later."
+	}
+	if status <= 0 {
+		status = http.StatusServiceUnavailable
+	}
+	return &coreauth.Error{
+		Code:       code,
+		Message:    message,
+		Retryable:  true,
+		HTTPStatus: status,
+	}
 }
 
 // WriteErrorResponse writes an error message to the response writer using the HTTP status embedded in the message.
@@ -141,6 +177,12 @@ func (h *BaseAPIHandler) WriteErrorResponse(c *gin.Context, msg *interfaces.Erro
 	}
 
 	body := BuildErrorResponseBody(status, errText)
+	if msg != nil && msg.Error != nil {
+		var authErr *coreauth.Error
+		if errors.As(msg.Error, &authErr) && authErr != nil && authErr.Code == "server_is_overloaded" {
+			body = buildErrorResponseBody(status, authErr.Message, authErr.Code)
+		}
+	}
 	// Append first to preserve upstream response logs, then drop duplicate payloads if already recorded.
 	var previous []byte
 	if existing, exists := c.Get("API_RESPONSE"); exists {

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -1025,6 +1025,13 @@ func TestExecuteStreamWithAuthManager_ForwardsOverloadErrorWhenAllAuthsOverloade
 	if gotErr == nil {
 		t.Fatalf("expected terminal error")
 	}
+	var firstAuthErr *coreauth.Error
+	if !errors.As(gotErr.Error, &firstAuthErr) || firstAuthErr == nil {
+		t.Fatalf("expected first coreauth.Error, got %T", gotErr.Error)
+	}
+	if firstAuthErr.Code != "server_is_overloaded" {
+		t.Fatalf("first error code = %q, want %q", firstAuthErr.Code, "server_is_overloaded")
+	}
 	if !strings.Contains(gotErr.Error.Error(), "Our servers are currently overloaded. Please try again later.") && !strings.Contains(gotErr.Error.Error(), "server_is_overloaded") {
 		t.Fatalf("expected error message to contain overload details, got: %q", gotErr.Error.Error())
 	}
@@ -1039,6 +1046,13 @@ func TestExecuteStreamWithAuthManager_ForwardsOverloadErrorWhenAllAuthsOverloade
 	}
 	if gotErr2 == nil {
 		t.Fatalf("expected terminal error on reconnect request")
+	}
+	var reconnectAuthErr *coreauth.Error
+	if !errors.As(gotErr2.Error, &reconnectAuthErr) || reconnectAuthErr == nil {
+		t.Fatalf("expected reconnect coreauth.Error, got %T", gotErr2.Error)
+	}
+	if reconnectAuthErr.Code != "server_is_overloaded" {
+		t.Fatalf("reconnect error code = %q, want %q", reconnectAuthErr.Code, "server_is_overloaded")
 	}
 	if !strings.Contains(gotErr2.Error.Error(), "Our servers are currently overloaded. Please try again later.") && !strings.Contains(gotErr2.Error.Error(), "server_is_overloaded") {
 		t.Fatalf("expected reconnect error message to contain overload details, got: %q", gotErr2.Error.Error())


### PR DESCRIPTION
## Summary

- promote a stored server_is_overloaded cause when auth selection later reports auth_unavailable
- return an OpenAI-compatible HTTP 503 body with code=server_is_overloaded
- keep credential selection, cooldown duration, and retry behavior unchanged

## Problem

After an upstream capacity error cools the only eligible credential, immediate reconnects currently report auth_unavailable as the primary error. The actual server_is_overloaded cause is only appended as last-upstream context, so clients can misdiagnose an upstream capacity incident as an authentication failure.

## Tests

- go test ./sdk/api/handlers -run ^(TestEnrichAuthSelectionError_PromotesUpstreamOverloadCause|TestEnrichAuthSelectionError_PromotesUntypedUpstreamOverloadCause|TestExecuteStreamWithAuthManager_ForwardsOverloadErrorWhenAllAuthsOverloaded)$ -count=1
- go build -buildvcs=false -o /tmp/cli-proxy-api-test ./cmd/server
- git diff --check

## Related work

This is complementary to #3229 and #4643: those PRs address retry/recovery before or during stream commitment, while this change preserves the correct upstream error identity after auth selection reaches cooldown.