### PR TITLE
fix(claude): gate block binding beta on final body

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -114,11 +114,14 @@ func TestApplyClaudeHeaders_CustomHeadersCannotOverrideAnthropicIdentity(t *test
 	for _, stream := range []bool{false, true} {
 		req := newClaudeHeaderTestRequest(t, nil)
 		if err := applyClaudeHeaders(req, auth, "key-custom-headers", stream, nil,
-			[]byte(`{"model":"claude-opus-5"}`), nil, nil, false); err != nil {
+			[]byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`), nil, nil, false); err != nil {
 			t.Fatalf("applyClaudeHeaders(stream=%v) error = %v", stream, err)
 		}
 		if got := req.Header.Get("Anthropic-Beta"); got == "attacker-controlled-2099-01-01" {
 			t.Fatalf("stream=%v: custom header overrode Anthropic-Beta", stream)
+		}
+		if tokens := countBetaTokens(req.Header.Get("Anthropic-Beta")); tokens[strings.ToLower(claudeThinkingBindingControlsBeta)] != 1 {
+			t.Fatalf("stream=%v: Anthropic-Beta = %q, want %s preserved after custom header check", stream, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
 		}
 		if got := req.Header.Get("Accept-Encoding"); got != "gzip, deflate, br, zstd" {
 			t.Fatalf("stream=%v: Accept-Encoding = %q, want the negotiated transport", stream, got)
@@ -521,5 +524,790 @@ func TestApplyClaudeHeaders_StructuredHelperBetaOrderPreservedWithAdvisor(t *tes
 	got := req.Header.Get("Anthropic-Beta")
 	if got != helperBeta {
 		t.Fatalf("helper Anthropic-Beta =\n got:  %q\n want: %q", got, helperBeta)
+	}
+}
+
+func TestParseAnthropicBetasFromHeader_DeterministicOrder(t *testing.T) {
+	incoming := http.Header{
+		"x-other":        []string{"foo"},
+		"anthropic-beta": []string{"beta-lower-1, beta-lower-2", "beta-lower-3"},
+		"Anthropic-Beta": []string{"beta-canonical-1", "beta-canonical-2, beta-canonical-3"},
+		"ANTHROPIC-BETA": []string{"beta-upper-1", "beta-upper-2"},
+	}
+	want := []string{
+		"beta-upper-1", "beta-upper-2",
+		"beta-canonical-1", "beta-canonical-2", "beta-canonical-3",
+		"beta-lower-1", "beta-lower-2", "beta-lower-3",
+	}
+	got := parseAnthropicBetasFromHeader(incoming)
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if parseAnthropicBetasFromHeader(nil) != nil {
+		t.Fatal("nil headers must yield no betas")
+	}
+	if parseAnthropicBetasFromHeader(http.Header{"Anthropic-Beta": []string{" , "}}) != nil {
+		t.Fatal("blank CSV items must be dropped")
+	}
+}
+
+func countBetaTokens(headerValue string) map[string]int {
+	counts := make(map[string]int)
+	for _, part := range strings.Split(headerValue, ",") {
+		if token := strings.TrimSpace(part); token != "" {
+			counts[strings.ToLower(token)]++
+		}
+	}
+	return counts
+}
+
+// claudeBetaOccurrences counts the tokens of headerValue that match beta
+// case-insensitively, and how many of those use beta's canonical spelling.
+func claudeBetaOccurrences(headerValue, beta string) (matches int, canonical int) {
+	for _, part := range strings.Split(headerValue, ",") {
+		token := strings.TrimSpace(part)
+		if token == "" || !strings.EqualFold(token, beta) {
+			continue
+		}
+		matches++
+		if token == beta {
+			canonical++
+		}
+	}
+	return matches, canonical
+}
+
+func assertCanonicalBetaOnce(t *testing.T, headerValue, beta string) {
+	t.Helper()
+	matches, canonical := claudeBetaOccurrences(headerValue, beta)
+	if matches != 1 || canonical != 1 {
+		t.Fatalf("Anthropic-Beta = %q, want %s exactly once in canonical spelling (matches=%d canonical=%d)",
+			headerValue, beta, matches, canonical)
+	}
+}
+
+func assertBetaAbsent(t *testing.T, headerValue, beta string) {
+	t.Helper()
+	if matches, _ := claudeBetaOccurrences(headerValue, beta); matches != 0 {
+		t.Fatalf("Anthropic-Beta = %q, want no %s", headerValue, beta)
+	}
+}
+
+func TestClaudeBodyHasBlockBinding(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"enabled with empty binding object", `{"thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`, true},
+		{"adaptive with populated binding", `{"thinking":{"type":"adaptive","block_binding":{"strategy":"auto"}}}`, true},
+		{"binding without an explicit type", `{"thinking":{"block_binding":{"strategy":"auto"}}}`, true},
+		{"disabled outranks the binding", `{"thinking":{"type":"disabled","block_binding":{"strategy":"auto"}}}`, false},
+		{"disabled is matched case-insensitively", `{"thinking":{"type":"DISABLED","block_binding":{}}}`, false},
+		{"disabled with surrounding spaces", `{"thinking":{"type":" disabled ","block_binding":{}}}`, false},
+		{"binding null", `{"thinking":{"type":"enabled","block_binding":null}}`, false},
+		{"binding boolean", `{"thinking":{"type":"enabled","block_binding":true}}`, false},
+		{"binding string", `{"thinking":{"type":"enabled","block_binding":"auto"}}`, false},
+		{"binding array", `{"thinking":{"type":"enabled","block_binding":[]}}`, false},
+		{"no binding", `{"thinking":{"type":"enabled","budget_tokens":2048}}`, false},
+		{"no thinking block", `{"model":"claude-opus-5"}`, false},
+		{"thinking is not an object", `{"thinking":"enabled"}`, false},
+		{"empty body", ``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeBodyHasBlockBinding([]byte(tc.body)); got != tc.want {
+				t.Fatalf("claudeBodyHasBlockBinding(%s) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeClaudeBetaToken(t *testing.T) {
+	cases := []struct {
+		name      string
+		betas     string
+		canonical string
+		want      string
+	}{
+		{"rewrites in place", "a,THINKING-BINDING-CONTROLS-2026-08-01,b", claudeThinkingBindingControlsBeta, "a," + claudeThinkingBindingControlsBeta + ",b"},
+		{"leaves an exact match alone", "a," + claudeThinkingBindingControlsBeta, claudeThinkingBindingControlsBeta, "a," + claudeThinkingBindingControlsBeta},
+		{"leaves unrelated tokens alone", "a,b", claudeThinkingBindingControlsBeta, "a,b"},
+		{"empty list", "", claudeThinkingBindingControlsBeta, ""},
+		// Exactly one occurrence survives, at the first matching position.
+		{
+			"collapses exact duplicates",
+			claudeThinkingBindingControlsBeta + ",a," + claudeThinkingBindingControlsBeta,
+			claudeThinkingBindingControlsBeta,
+			claudeThinkingBindingControlsBeta + ",a",
+		},
+		{
+			"collapses mixed variants onto the first position",
+			"a,THINKING-BINDING-CONTROLS-2026-08-01,b," + claudeThinkingBindingControlsBeta,
+			claudeThinkingBindingControlsBeta,
+			"a," + claudeThinkingBindingControlsBeta + ",b",
+		},
+		{
+			"keeps the first canonical occurrence and drops later variants",
+			"a," + claudeThinkingBindingControlsBeta + ",b,Thinking-Binding-Controls-2026-08-01",
+			claudeThinkingBindingControlsBeta,
+			"a," + claudeThinkingBindingControlsBeta + ",b",
+		},
+		{
+			"three occurrences collapse to one",
+			"THINKING-BINDING-CONTROLS-2026-08-01,a," + claudeThinkingBindingControlsBeta + ",b,Thinking-Binding-Controls-2026-08-01",
+			claudeThinkingBindingControlsBeta,
+			claudeThinkingBindingControlsBeta + ",a,b",
+		},
+		{
+			"surrounding whitespace does not hide a duplicate",
+			"a, THINKING-BINDING-CONTROLS-2026-08-01 ,b, " + claudeThinkingBindingControlsBeta,
+			claudeThinkingBindingControlsBeta,
+			"a," + claudeThinkingBindingControlsBeta + ",b",
+		},
+		{
+			"duplicates of another owned token",
+			claudeFastModeBeta + ",a,FAST-MODE-2026-02-01",
+			claudeFastModeBeta,
+			claudeFastModeBeta + ",a",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalizeClaudeBetaToken(tc.betas, tc.canonical); got != tc.want {
+				t.Fatalf("canonicalizeClaudeBetaToken(%q, %q) = %q, want %q", tc.betas, tc.canonical, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyClaudeHeaders_ThinkingBlockBindingInjectsBeta_EnabledAndAdaptive(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"enabled", []byte(`{"model":"claude-sonnet-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`)},
+		{"adaptive", []byte(`{"model":"claude-opus-5","thinking":{"type":"adaptive","block_binding":{"strategy":"auto"}}}`)},
+	}
+	for _, tc := range cases {
+		for _, stream := range []bool{false, true} {
+			req := newClaudeHeaderTestRequest(t, nil)
+			if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, stream, nil, tc.body, nil, nil, false); err != nil {
+				t.Fatalf("%s stream=%v: %v", tc.name, stream, err)
+			}
+			assertCanonicalBetaOnce(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+		}
+	}
+}
+
+func TestApplyClaudeHeaders_ThinkingBlockBindingAbsentWithoutBlockBinding(t *testing.T) {
+	cases := [][]byte{
+		[]byte(`{"model":"claude-sonnet-5","thinking":{"type":"enabled","budget_tokens":2048}}`),
+		[]byte(`{"model":"claude-sonnet-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":null}}`),
+		[]byte(`{"model":"claude-sonnet-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":"auto"}}`),
+		[]byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hello"}]}`),
+	}
+	for _, body := range cases {
+		req := newClaudeHeaderTestRequest(t, nil)
+		if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil, body, nil, nil, false); err != nil {
+			t.Fatalf("applyClaudeHeaders error = %v", err)
+		}
+		assertBetaAbsent(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+	}
+}
+
+// thinking.type=disabled turns extended thinking off upstream, so a block_binding
+// left beside it configures nothing and must not pull the beta in.
+func TestApplyClaudeHeaders_ThinkingBlockBindingAbsentWhenThinkingDisabled(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"model":"claude-opus-5","thinking":{"type":"disabled","block_binding":{"strategy":"auto"}}}`),
+		[]byte(`{"model":"claude-opus-5","thinking":{"type":"DISABLED","block_binding":{}}}`),
+	}
+	for _, body := range bodies {
+		for _, stream := range []bool{false, true} {
+			req := newClaudeHeaderTestRequest(t, nil)
+			if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, stream, nil, body, nil, nil, false); err != nil {
+				t.Fatalf("applyClaudeHeaders(stream=%v) error = %v", stream, err)
+			}
+			assertBetaAbsent(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+		}
+	}
+}
+
+// Beta dedup is case-insensitive, so a caller casing variant would otherwise
+// swallow the append and ship a spelling api.anthropic.com does not recognise.
+// The canonical token has to replace the variant in place: same position, same
+// count, canonical spelling.
+func TestApplyClaudeHeaders_ThinkingBlockBindingCanonicalizesCallerCasing(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`)
+	upperVariant := strings.ToUpper(claudeThinkingBindingControlsBeta)
+
+	cases := []struct {
+		name                string
+		incoming            string
+		confirmedClaudeCode bool
+		want                string
+	}{
+		{
+			name:     "caller owned passthrough, sole token",
+			incoming: upperVariant,
+			want:     claudeThinkingBindingControlsBeta,
+		},
+		{
+			name:     "caller owned passthrough keeps the caller position",
+			incoming: claudeCodeBeta + ",Thinking-Binding-Controls-2026-08-01," + claudeEffortBeta,
+			want:     claudeCodeBeta + "," + claudeThinkingBindingControlsBeta + "," + claudeEffortBeta,
+		},
+		{
+			name:                "confirmed native client",
+			incoming:            claudeCodeBeta + "," + upperVariant,
+			confirmedClaudeCode: true,
+			want:                claudeCodeBeta + "," + claudeThinkingBindingControlsBeta,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			incoming := http.Header{}
+			incoming.Set("Anthropic-Beta", tc.incoming)
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-binding-casing"}}
+			req := newClaudeHeaderTestRequest(t, incoming)
+			if err := applyClaudeHeaders(req, auth, "key-binding-casing", false, nil, body, nil, incoming, tc.confirmedClaudeCode); err != nil {
+				t.Fatalf("applyClaudeHeaders() error = %v", err)
+			}
+			got := req.Header.Get("Anthropic-Beta")
+			if got != tc.want {
+				t.Fatalf("Anthropic-Beta = %q, want %q", got, tc.want)
+			}
+			assertCanonicalBetaOnce(t, got, claudeThinkingBindingControlsBeta)
+		})
+	}
+}
+
+// A caller sending the token more than once - identically or in mixed spellings,
+// in one CSV value or across repeated header values - must not put it on the wire
+// twice. The first position wins, canonically spelled, and every later occurrence
+// disappears.
+func TestApplyClaudeHeaders_ThinkingBindingBetaCollapsesCallerDuplicates(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`)
+	upperVariant := strings.ToUpper(claudeThinkingBindingControlsBeta)
+	mixedVariant := "Thinking-Binding-Controls-2026-08-01"
+
+	cases := []struct {
+		name                string
+		incoming            []string
+		confirmedClaudeCode bool
+		want                string
+	}{
+		{
+			name:     "exact duplicates in one caller value",
+			incoming: []string{claudeThinkingBindingControlsBeta + "," + claudeCodeBeta + "," + claudeThinkingBindingControlsBeta},
+			want:     claudeThinkingBindingControlsBeta + "," + claudeCodeBeta,
+		},
+		{
+			name:     "mixed variants in one caller value",
+			incoming: []string{upperVariant + "," + claudeEffortBeta + "," + mixedVariant + "," + claudeThinkingBindingControlsBeta},
+			want:     claudeThinkingBindingControlsBeta + "," + claudeEffortBeta,
+		},
+		{
+			name:     "duplicates across repeated header values",
+			incoming: []string{claudeCodeBeta + "," + upperVariant, mixedVariant, claudeThinkingBindingControlsBeta},
+			want:     claudeCodeBeta + "," + claudeThinkingBindingControlsBeta,
+		},
+		{
+			name:                "mixed variants for a confirmed native client",
+			incoming:            []string{claudeCodeBeta + "," + upperVariant + "," + claudeEffortBeta + "," + mixedVariant},
+			confirmedClaudeCode: true,
+			want:                claudeCodeBeta + "," + claudeThinkingBindingControlsBeta + "," + claudeEffortBeta,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			incoming := http.Header{}
+			for _, value := range tc.incoming {
+				incoming.Add("Anthropic-Beta", value)
+			}
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-binding-duplicates"}}
+			req := newClaudeHeaderTestRequest(t, incoming)
+			if err := applyClaudeHeaders(req, auth, "key-binding-duplicates", false, nil, body, nil, incoming, tc.confirmedClaudeCode); err != nil {
+				t.Fatalf("applyClaudeHeaders() error = %v", err)
+			}
+			got := req.Header.Get("Anthropic-Beta")
+			if got != tc.want {
+				t.Fatalf("Anthropic-Beta = %q, want %q", got, tc.want)
+			}
+			assertCanonicalBetaOnce(t, got, claudeThinkingBindingControlsBeta)
+		})
+	}
+}
+
+// Same contract for the other beta whose spelling CPA owns.
+func TestApplyClaudeHeaders_FastModeBetaCollapsesCallerDuplicates(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","speed":"fast"}`)
+	for _, incomingValue := range []string{
+		claudeFastModeBeta + "," + claudeFastModeBeta,
+		strings.ToUpper(claudeFastModeBeta) + "," + claudeEffortBeta + "," + claudeFastModeBeta,
+	} {
+		t.Run(incomingValue, func(t *testing.T) {
+			incoming := http.Header{}
+			incoming.Set("Anthropic-Beta", incomingValue)
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-fast-duplicates"}}
+
+			req := newClaudeHeaderTestRequest(t, incoming)
+			if err := applyClaudeHeaders(req, auth, "key-fast-duplicates", false, nil, body, nil, incoming, false); err != nil {
+				t.Fatalf("applyClaudeHeaders() error = %v", err)
+			}
+			assertCanonicalBetaOnce(t, req.Header.Get("Anthropic-Beta"), claudeFastModeBeta)
+		})
+	}
+}
+
+// No wire capture pins where a native client would place the binding beta, so its
+// position is CPA's own decision. The policy is the minimal one: append at the end
+// of the assembled baseline and never move a beta that is already there. Comparing
+// the same request with and without thinking.block_binding pins exactly that: one
+// token added at the end, every historical position byte-identical.
+func TestApplyClaudeHeaders_ThinkingBindingBetaAppendedAfterExistingBetas(t *testing.T) {
+	withBinding := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`)
+	withoutBinding := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048}}`)
+
+	betasFor := func(t *testing.T, body []byte, auth *cliproxyauth.Auth, apiKey string, incoming http.Header, confirmed bool) string {
+		t.Helper()
+		req := newClaudeHeaderTestRequest(t, incoming)
+		if err := applyClaudeHeaders(req, auth, apiKey, false, nil, body, nil, incoming, confirmed); err != nil {
+			t.Fatalf("applyClaudeHeaders() error = %v", err)
+		}
+		return req.Header.Get("Anthropic-Beta")
+	}
+	assertAppended := func(t *testing.T, baseline, got string) {
+		t.Helper()
+		if baseline == "" {
+			t.Fatal("baseline is empty: the ordering assertion would be vacuous")
+		}
+		assertBetaAbsent(t, baseline, claudeThinkingBindingControlsBeta)
+		if want := baseline + "," + claudeThinkingBindingControlsBeta; got != want {
+			t.Fatalf("Anthropic-Beta =\n got:  %q\n want: %q", got, want)
+		}
+		assertCanonicalBetaOnce(t, got, claudeThinkingBindingControlsBeta)
+	}
+
+	t.Run("cloaked cli baseline", func(t *testing.T) {
+		auth, key := claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey
+		baseline := betasFor(t, withoutBinding, auth, key, nil, false)
+		// The full measured baseline stays intact, credential trailer included.
+		if !strings.HasPrefix(baseline, claudeCodeBeta+","+claudeOAuthBeta+",") ||
+			!strings.HasSuffix(baseline, ","+claudeExtendedCacheTTLBeta) {
+			t.Fatalf("baseline = %q, want the measured CLI list", baseline)
+		}
+		assertAppended(t, baseline, betasFor(t, withBinding, auth, key, nil, false))
+	})
+
+	t.Run("caller owned passthrough keeps the caller list untouched", func(t *testing.T) {
+		callerBetas := claudeCodeBeta + "," + claudeOAuthBeta + "," + claudeEffortBeta
+		incoming := http.Header{}
+		incoming.Set("Anthropic-Beta", callerBetas)
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-binding-order"}}
+
+		baseline := betasFor(t, withoutBinding, auth, "key-binding-order", incoming, false)
+		if baseline != callerBetas {
+			t.Fatalf("baseline = %q, want the caller list forwarded as sent %q", baseline, callerBetas)
+		}
+		assertAppended(t, baseline, betasFor(t, withBinding, auth, "key-binding-order", incoming, false))
+	})
+
+	t.Run("confirmed native client lands after the credential trailer", func(t *testing.T) {
+		incoming := http.Header{}
+		incoming.Set("Anthropic-Beta", claudeCodeBeta+","+claudeEffortBeta)
+		auth, key := claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey
+
+		baseline := betasFor(t, withoutBinding, auth, key, incoming, true)
+		if want := claudeCodeBeta + "," + claudeOAuthBeta + "," + claudeEffortBeta + "," + claudeExtendedCacheTTLBeta; baseline != want {
+			t.Fatalf("baseline = %q, want %q", baseline, want)
+		}
+		assertAppended(t, baseline, betasFor(t, withBinding, auth, key, incoming, true))
+	})
+}
+
+// The same rewrite must keep working for the other beta whose spelling CPA owns.
+func TestApplyClaudeHeaders_FastModeBetaCanonicalizesCallerCasing(t *testing.T) {
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", strings.ToUpper(claudeFastModeBeta))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-fast-casing"}}
+
+	req := newClaudeHeaderTestRequest(t, incoming)
+	if err := applyClaudeHeaders(req, auth, "key-fast-casing", false, nil,
+		[]byte(`{"model":"claude-opus-5","speed":"fast"}`), nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", err)
+	}
+	if got := req.Header.Get("Anthropic-Beta"); got != claudeFastModeBeta {
+		t.Fatalf("Anthropic-Beta = %q, want canonical %q", got, claudeFastModeBeta)
+	}
+}
+
+// The lowercased requested map is what lets a caller casing variant still select
+// the measured baseline's conditional betas, which are always emitted canonically.
+func TestApplyClaudeHeaders_KnownCallerBetaSelectsCanonicalBaselineToken(t *testing.T) {
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", strings.ToUpper(claudeContext1MBeta))
+
+	req := newClaudeHeaderTestRequest(t, incoming)
+	if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil,
+		[]byte(`{"model":"claude-opus-5"}`), nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", err)
+	}
+	assertCanonicalBetaOnce(t, req.Header.Get("Anthropic-Beta"), claudeContext1MBeta)
+}
+
+// The beta is derived from the finished upstream body and from nothing else. A
+// caller asking for it through the header or through body "betas" must not get it
+// onto a first-party request whose body carries no thinking.block_binding.
+func TestApplyClaudeHeaders_ThinkingBindingBetaNeverInjectedFromCallerRequestAlone(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048}}`)
+
+	t.Run("header only", func(t *testing.T) {
+		incoming := http.Header{}
+		incoming.Set("Anthropic-Beta", claudeThinkingBindingControlsBeta)
+		req := newClaudeHeaderTestRequest(t, incoming)
+		if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil, body, nil, incoming, false); err != nil {
+			t.Fatalf("applyClaudeHeaders() error = %v", err)
+		}
+		assertBetaAbsent(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+	})
+
+	t.Run("header casing variant only", func(t *testing.T) {
+		incoming := http.Header{}
+		incoming.Set("Anthropic-Beta", strings.ToUpper(claudeThinkingBindingControlsBeta))
+		req := newClaudeHeaderTestRequest(t, incoming)
+		if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil, body, nil, incoming, false); err != nil {
+			t.Fatalf("applyClaudeHeaders() error = %v", err)
+		}
+		assertBetaAbsent(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+	})
+
+	t.Run("body betas only", func(t *testing.T) {
+		req := newClaudeHeaderTestRequest(t, nil)
+		if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false,
+			[]string{claudeThinkingBindingControlsBeta}, body, nil, nil, false); err != nil {
+			t.Fatalf("applyClaudeHeaders() error = %v", err)
+		}
+		assertBetaAbsent(t, req.Header.Get("Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+	})
+
+	// Caller-owned passthrough forwards every caller beta verbatim, and this one is
+	// not special-cased (see TestApplyClaudeHeaders_UnknownBodyBetaPreservedOnAnthropic).
+	// What must never happen is CPA adding a beta the body never asked for.
+	t.Run("caller owned passthrough adds nothing", func(t *testing.T) {
+		auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-binding-passthrough"}}
+		req := newClaudeHeaderTestRequest(t, nil)
+		if err := applyClaudeHeaders(req, auth, "key-binding-passthrough", false, nil, body, nil, nil, false); err != nil {
+			t.Fatalf("applyClaudeHeaders() error = %v", err)
+		}
+		if got := req.Header.Get("Anthropic-Beta"); got != "" {
+			t.Fatalf("Anthropic-Beta = %q, want empty: nothing in this request asks for a beta", got)
+		}
+	})
+}
+
+func TestApplyClaudeHeaders_NonPropagationOfUnrecognizedBetasOnFirstParty(t *testing.T) {
+	incoming := http.Header{"Anthropic-Beta": []string{"custom-header-beta"}}
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{}}}`)
+	extra := []string{"custom-extra-beta"}
+
+	req := newClaudeHeaderTestRequest(t, nil)
+	if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, extra, body, nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders error = %v", err)
+	}
+	got := req.Header.Get("Anthropic-Beta")
+	assertCanonicalBetaOnce(t, got, claudeThinkingBindingControlsBeta)
+	tokens := countBetaTokens(got)
+	for _, bad := range []string{"custom-header-beta", "custom-extra-beta"} {
+		if tokens[bad] > 0 {
+			t.Fatalf("unexpected leaked beta %q on first-party", bad)
+		}
+	}
+}
+
+// Non-Anthropic upstreams have their own beta vocabulary: the token CPA derives
+// for api.anthropic.com must not reach them, and their caller betas must survive
+// with CSV, multi-value and case-insensitive dedup intact.
+func TestApplyClaudeHeaders_CustomNonAnthropicRoutePreservesCallerBetas(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://api.kimi.com/v1/messages", nil)
+	body := []byte(`{"model":"kimi-k2.5","thinking":{"type":"enabled","block_binding":{}}}`)
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "k", "base_url": "https://api.kimi.com"}}
+	incoming := http.Header{"Anthropic-Beta": []string{"caller-custom-1, duplicate-beta"}}
+
+	if err := applyClaudeHeaders(req, auth, "k", false, []string{"DUPLICATE-BETA, caller-extra-2"}, body, nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders error = %v", err)
+	}
+	got := req.Header.Get("Anthropic-Beta")
+	assertBetaAbsent(t, got, claudeThinkingBindingControlsBeta)
+	tokens := countBetaTokens(got)
+	if tokens["caller-custom-1"] != 1 || tokens["caller-extra-2"] != 1 || tokens["duplicate-beta"] != 1 {
+		t.Fatalf("caller betas not preserved or deduplicated: %v", tokens)
+	}
+	// An unknown caller token keeps the caller's own casing: canonicalisation is
+	// reserved for the betas CPA owns the spelling of.
+	if !strings.Contains(got, "duplicate-beta") {
+		t.Fatalf("Anthropic-Beta = %q, want the caller's first spelling preserved", got)
+	}
+}
+
+func claudeBlockBindingTestAuth() *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID: "official-oauth",
+		Attributes: map[string]string{
+			"api_key":             "sk-ant-oat-test",
+			"fingerprint_profile": "claude-code-cli",
+		},
+		Metadata: claudeOAuthTestMetadata(),
+	}
+}
+
+func TestClaudeExecutor_StreamingFirstPartyCapturesBlockBinding(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+
+	transport := claudeFingerprintRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		seenBody, _ = io.ReadAll(req.Body)
+		seenHeaders = req.Header.Clone()
+		sse := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-opus-5\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(sse)),
+		}, nil
+	})
+
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	executor := NewClaudeExecutor(&config.Config{})
+
+	payload := []byte(`{"model":"claude-opus-5","max_tokens":4096,"stream":true,"thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{"strict":true}},"messages":[{"role":"user","content":"stream test"}]}`)
+	opts := cliproxyexecutor.Options{
+		Stream:       true,
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers: http.Header{
+			"Anthropic-Beta": []string{"unrecognized-caller-beta-2099"},
+		},
+	}
+
+	res, err := executor.ExecuteStream(ctx, claudeBlockBindingTestAuth(), cliproxyexecutor.Request{
+		Model:   "claude-opus-5",
+		Payload: payload,
+	}, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v", err)
+	}
+	for chunk := range res.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("chunk error = %v", chunk.Err)
+		}
+	}
+
+	if got := gjson.GetBytes(seenBody, "thinking.block_binding"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("upstream body thinking.block_binding missing: %s", string(seenBody))
+	}
+	if !gjson.GetBytes(seenBody, "thinking.block_binding.strict").Bool() {
+		t.Fatalf("upstream body thinking.block_binding.strict != true: %s", string(seenBody))
+	}
+
+	betas := claudeFingerprintHeaderValue(seenHeaders, "Anthropic-Beta")
+	assertCanonicalBetaOnce(t, betas, claudeThinkingBindingControlsBeta)
+	if countBetaTokens(betas)["unrecognized-caller-beta-2099"] != 0 {
+		t.Fatalf("Anthropic-Beta = %q, leaked unrecognized beta on first-party", betas)
+	}
+}
+
+// Non-streaming symmetry of the streaming capture above: both request paths build
+// their header from the same finished body, so neither may drift.
+func TestClaudeExecutor_NonStreamingFirstPartyCapturesBlockBinding(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+
+	transport := claudeFingerprintRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		seenBody, _ = io.ReadAll(req.Body)
+		seenHeaders = req.Header.Clone()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"msg_1","type":"message","model":"claude-opus-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`,
+			)),
+		}, nil
+	})
+
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	payload := []byte(`{"model":"claude-opus-5","max_tokens":4096,"thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{"strict":true}},"messages":[{"role":"user","content":"non stream test"}]}`)
+
+	if _, err := NewClaudeExecutor(&config.Config{}).Execute(ctx, claudeBlockBindingTestAuth(), cliproxyexecutor.Request{
+		Model:   "claude-opus-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers: http.Header{
+			"Anthropic-Beta": []string{"unrecognized-caller-beta-2099"},
+		},
+	}); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	if got := gjson.GetBytes(seenBody, "thinking.block_binding"); !got.Exists() || !got.IsObject() {
+		t.Fatalf("upstream body thinking.block_binding missing: %s", string(seenBody))
+	}
+	if !gjson.GetBytes(seenBody, "thinking.block_binding.strict").Bool() {
+		t.Fatalf("upstream body thinking.block_binding.strict != true: %s", string(seenBody))
+	}
+
+	betas := claudeFingerprintHeaderValue(seenHeaders, "Anthropic-Beta")
+	assertCanonicalBetaOnce(t, betas, claudeThinkingBindingControlsBeta)
+	if countBetaTokens(betas)["unrecognized-caller-beta-2099"] != 0 {
+		t.Fatalf("Anthropic-Beta = %q, leaked unrecognized beta on first-party", betas)
+	}
+}
+
+// tool_choice forcing tool use makes disableThinkingIfToolChoiceForced delete the
+// whole thinking block from the body that is actually sent. Because the beta is
+// keyed on that finished body, the header follows and stops declaring a feature
+// the request no longer uses.
+func TestClaudeExecutor_ToolChoiceForcedDropsThinkingAndBindingBeta(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-5","max_tokens":4096,"thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{"strict":true}},"tool_choice":{"type":"any"},"tools":[{"name":"read_file","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"forced tool"}]}`)
+
+	assertDropped := func(t *testing.T, seenBody []byte, seenHeaders http.Header) {
+		t.Helper()
+		if len(seenBody) == 0 {
+			t.Fatal("expected an upstream request")
+		}
+		if got := gjson.GetBytes(seenBody, "thinking"); got.Exists() {
+			t.Fatalf("thinking = %s, want deleted when tool_choice forces tool use", got.Raw)
+		}
+		assertBetaAbsent(t, claudeFingerprintHeaderValue(seenHeaders, "Anthropic-Beta"), claudeThinkingBindingControlsBeta)
+	}
+
+	t.Run("execute", func(t *testing.T) {
+		var seenBody []byte
+		var seenHeaders http.Header
+		transport := claudeFingerprintRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			seenBody, _ = io.ReadAll(req.Body)
+			seenHeaders = req.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"msg_1","type":"message","model":"claude-opus-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`,
+				)),
+			}, nil
+		})
+		ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+		if _, err := NewClaudeExecutor(&config.Config{}).Execute(ctx, claudeBlockBindingTestAuth(), cliproxyexecutor.Request{
+			Model:   "claude-opus-5",
+			Payload: payload,
+		}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}); err != nil {
+			t.Fatalf("Execute error = %v", err)
+		}
+		assertDropped(t, seenBody, seenHeaders)
+	})
+
+	t.Run("execute stream", func(t *testing.T) {
+		var seenBody []byte
+		var seenHeaders http.Header
+		transport := claudeFingerprintRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			seenBody, _ = io.ReadAll(req.Body)
+			seenHeaders = req.Header.Clone()
+			sse := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-opus-5\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(sse)),
+			}, nil
+		})
+		ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+		res, err := NewClaudeExecutor(&config.Config{}).ExecuteStream(ctx, claudeBlockBindingTestAuth(), cliproxyexecutor.Request{
+			Model:   "claude-opus-5",
+			Payload: payload,
+		}, cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatClaude})
+		if err != nil {
+			t.Fatalf("ExecuteStream error = %v", err)
+		}
+		for chunk := range res.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("chunk error = %v", chunk.Err)
+			}
+		}
+		assertDropped(t, seenBody, seenHeaders)
+	})
+}
+
+// count_tokens follows the same rule as /v1/messages because the rule is a
+// property of the JSON that goes on the wire, not of the endpoint: if the
+// count_tokens body still carries thinking.block_binding, Anthropic rejects it
+// without the beta, so the beta has to be declared there too. This pins the
+// derived header against the observed body only; no wire capture is claimed for
+// the count_tokens beta profile itself.
+func TestClaudeExecutor_CountTokensFollowsFinalBodyForBlockBinding(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{
+			name:    "binding present",
+			payload: `{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048,"block_binding":{"strict":true}},"messages":[{"role":"user","content":"hello"}]}`,
+			want:    true,
+		},
+		{
+			name:    "thinking disabled",
+			payload: `{"model":"claude-opus-5","thinking":{"type":"disabled","block_binding":{"strict":true}},"messages":[{"role":"user","content":"hello"}]}`,
+			want:    false,
+		},
+		{
+			name:    "no binding",
+			payload: `{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":2048},"messages":[{"role":"user","content":"hello"}]}`,
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seenBody []byte
+			var seenHeaders http.Header
+			var seenPath string
+			transport := claudeFingerprintRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				seenBody, _ = io.ReadAll(req.Body)
+				seenHeaders = req.Header.Clone()
+				seenPath = req.URL.Path
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(`{"input_tokens":7}`)),
+					Request:    req,
+				}, nil
+			})
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			payload := []byte(tc.payload)
+			if _, err := NewClaudeExecutor(&config.Config{}).CountTokens(ctx, claudeBlockBindingTestAuth(),
+				cliproxyexecutor.Request{Model: "claude-opus-5", Payload: payload},
+				cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, OriginalRequest: payload}); err != nil {
+				t.Fatalf("CountTokens error = %v", err)
+			}
+			if !strings.HasSuffix(seenPath, "/count_tokens") {
+				t.Fatalf("upstream path = %q, want the count_tokens endpoint", seenPath)
+			}
+			betas := claudeFingerprintHeaderValue(seenHeaders, "Anthropic-Beta")
+			// Positive pin first, so the beta assertion cannot pass vacuously.
+			if got := gjson.GetBytes(seenBody, "messages.#").Int(); got != 1 {
+				t.Fatalf("upstream messages length = %d, want 1: %s", got, seenBody)
+			}
+			hasBinding := claudeBodyHasBlockBinding(seenBody)
+			if hasBinding != tc.want {
+				t.Fatalf("count_tokens body block binding = %v, want %v: %s", hasBinding, tc.want, seenBody)
+			}
+			if tc.want {
+				assertCanonicalBetaOnce(t, betas, claudeThinkingBindingControlsBeta)
+			} else {
+				assertBetaAbsent(t, betas, claudeThinkingBindingControlsBeta)
+			}
+		})
 	}
 }

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -34,21 +34,22 @@ import (
 )
 
 const (
-	claudeTokenCountingBeta      = "token-counting-2024-11-01"
-	claudeFastModeBeta           = "fast-mode-2026-02-01"
-	claudeOAuthBeta              = "oauth-2025-04-20"
-	claudeCodeBeta               = "claude-code-20250219"
-	claudeContext1MBeta          = "context-1m-2025-08-07"
-	claudeMidConvSystemBeta      = "mid-conversation-system-2026-04-07"
-	claudeAdvisorToolBeta        = "advisor-tool-2026-03-01"
-	claudeAdvancedToolUseBeta    = "advanced-tool-use-2025-11-20"
-	claudeEffortBeta             = "effort-2025-11-24"
-	claudeServerSideFallbackBeta = "server-side-fallback-2026-06-01"
-	claudeFallbackCreditBeta     = "fallback-credit-2026-06-01"
-	claudeStructuredOutputsBeta  = "structured-outputs-2025-12-15"
-	claudeExtendedCacheTTLBeta   = "extended-cache-ttl-2025-04-11"
-	claudeCacheDiagnosisBeta     = "cache-diagnosis-2026-04-07"
-	claudeRedactThinkingBeta     = "redact-thinking-2026-02-12"
+	claudeTokenCountingBeta           = "token-counting-2024-11-01"
+	claudeFastModeBeta                = "fast-mode-2026-02-01"
+	claudeOAuthBeta                   = "oauth-2025-04-20"
+	claudeCodeBeta                    = "claude-code-20250219"
+	claudeContext1MBeta               = "context-1m-2025-08-07"
+	claudeMidConvSystemBeta           = "mid-conversation-system-2026-04-07"
+	claudeAdvisorToolBeta             = "advisor-tool-2026-03-01"
+	claudeAdvancedToolUseBeta         = "advanced-tool-use-2025-11-20"
+	claudeEffortBeta                  = "effort-2025-11-24"
+	claudeServerSideFallbackBeta      = "server-side-fallback-2026-06-01"
+	claudeFallbackCreditBeta          = "fallback-credit-2026-06-01"
+	claudeStructuredOutputsBeta       = "structured-outputs-2025-12-15"
+	claudeExtendedCacheTTLBeta        = "extended-cache-ttl-2025-04-11"
+	claudeCacheDiagnosisBeta          = "cache-diagnosis-2026-04-07"
+	claudeRedactThinkingBeta          = "redact-thinking-2026-02-12"
+	claudeThinkingBindingControlsBeta = "thinking-binding-controls-2026-08-01"
 )
 
 // claudeCodeCLIConstantBetas are the betas Claude Code 2.1.220 sends on every
@@ -379,18 +380,86 @@ func claudeBodyIndicatesFastModeCredits(body []byte) bool {
 			(strings.Contains(message, "usage credits") || strings.Contains(message, "credits are required")))
 }
 
-// claudeRequestedBetas collects every beta the caller asked for, from the
+// parseAnthropicBetasFromHeader flattens every Anthropic-Beta token the caller
+// sent into one ordered slice.
+//
+// It delegates to helps.ClaudeBetaTokens so this path and the native-client
+// detector read one identical view of the header. A detector reading only the
+// canonical key could confirm a measured native profile on a partial view while
+// this path forwarded a different, larger one.
+func parseAnthropicBetasFromHeader(headers http.Header) []string {
+	return helps.ClaudeBetaTokens(headers)
+}
+
+// claudeBodyHasBlockBinding reports whether the finished upstream body carries a
+// thinking.block_binding object on an active thinking configuration.
+//
+// thinking.type == "disabled" switches extended thinking off entirely, so a
+// block_binding left next to it configures nothing and must not pull the
+// protocol beta onto the request. Only an object counts: a missing key, an
+// explicit null, or a scalar placeholder are all "no binding requested".
+func claudeBodyHasBlockBinding(body []byte) bool {
+	thinking := gjson.GetBytes(body, "thinking")
+	if !thinking.IsObject() {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(thinking.Get("type").String()), "disabled") {
+		return false
+	}
+	return thinking.Get("block_binding").IsObject()
+}
+
+// canonicalizeClaudeBetaToken guarantees exactly one occurrence of canonical in
+// betas: the first token matching case-insensitively keeps its position and is
+// rewritten to canonical's exact spelling, every later match is removed. All
+// other tokens and separators are left untouched.
+//
+// Beta dedup is case-insensitive, so without the rewrite a caller casing variant
+// already present in the list would suppress the canonical token CPA owns and
+// ship a spelling upstream does not recognise. Without the removal, a caller
+// sending the same token twice - identically or in mixed spellings - would put
+// it on the wire twice, which no real client does.
+func canonicalizeClaudeBetaToken(betas, canonical string) string {
+	parts := strings.Split(betas, ",")
+	kept := make([]string, 0, len(parts))
+	changed := false
+	seen := false
+	for _, part := range parts {
+		if !strings.EqualFold(strings.TrimSpace(part), canonical) {
+			kept = append(kept, part)
+			continue
+		}
+		if seen {
+			changed = true
+			continue
+		}
+		seen = true
+		if part != canonical {
+			part = canonical
+			changed = true
+		}
+		kept = append(kept, part)
+	}
+	if !changed {
+		return betas
+	}
+	return strings.Join(kept, ",")
+}
+
+// claudeRequestedBetas collects every beta the caller asked for, lowercased, from the
 // Anthropic-Beta header and from betas lifted out of the request body.
 func claudeRequestedBetas(incomingBetas string, extraBetas []string) map[string]bool {
 	requested := make(map[string]bool)
 	for _, beta := range strings.Split(incomingBetas, ",") {
-		if beta = strings.TrimSpace(beta); beta != "" {
+		if beta = strings.ToLower(strings.TrimSpace(beta)); beta != "" {
 			requested[beta] = true
 		}
 	}
 	for _, beta := range extraBetas {
-		if beta = strings.TrimSpace(beta); beta != "" {
-			requested[beta] = true
+		for _, part := range strings.Split(beta, ",") {
+			if part = strings.ToLower(strings.TrimSpace(part)); part != "" {
+				requested[part] = true
+			}
 		}
 	}
 	return requested
@@ -784,7 +853,8 @@ func applyClaudeHeadersWithNativeProfile(
 		}
 	}
 
-	incomingBetas := strings.TrimSpace(strings.Join(incomingHeaders.Values("Anthropic-Beta"), ","))
+	incomingBetasSlice := parseAnthropicBetasFromHeader(incomingHeaders)
+	incomingBetas := strings.Join(incomingBetasSlice, ",")
 	countTokens := r.URL != nil && strings.HasSuffix(r.URL.Path, "/count_tokens")
 	requestedMap := claudeRequestedBetas(incomingBetas, extraBetas)
 	advisorNeeded := requestedMap[claudeAdvisorToolBeta] || claudeBodyHasAdvisorTool(body)
@@ -820,12 +890,12 @@ func applyClaudeHeadersWithNativeProfile(
 	existingSet := make(map[string]bool)
 	for _, beta := range strings.Split(baseBetas, ",") {
 		if beta = strings.TrimSpace(beta); beta != "" {
-			existingSet[beta] = true
+			existingSet[strings.ToLower(beta)] = true
 		}
 	}
 	appendBeta := func(beta string) {
 		beta = strings.TrimSpace(beta)
-		if beta == "" || existingSet[beta] {
+		if beta == "" || existingSet[strings.ToLower(beta)] {
 			return
 		}
 		if strings.TrimSpace(baseBetas) == "" {
@@ -833,31 +903,75 @@ func applyClaudeHeadersWithNativeProfile(
 		} else {
 			baseBetas += "," + beta
 		}
-		existingSet[beta] = true
+		existingSet[strings.ToLower(beta)] = true
+	}
+	// appendCanonicalBeta places a beta whose spelling CPA owns, as opposed to a
+	// token forwarded from the caller. Dedup is case-insensitive, so a caller
+	// casing variant sitting in baseBetas would otherwise silently swallow the
+	// append and leave an unrecognised spelling on the wire. Rewriting that
+	// occurrence in place keeps the caller's ordering and emits the canonical
+	// token exactly once. Caller-owned tokens still go through appendBeta and
+	// keep their casing.
+	appendCanonicalBeta := func(beta string) {
+		if existingSet[strings.ToLower(beta)] {
+			baseBetas = canonicalizeClaudeBetaToken(baseBetas, beta)
+			return
+		}
+		appendBeta(beta)
 	}
 	if preserveCallerFingerprint {
-		// Caller-owned mode preserves both header and body-lifted betas verbatim.
-		// The explicit speed=fast request still needs its protocol beta.
+		// Caller-owned mode forwards the caller's header and body-lifted betas as
+		// they were sent. The only exceptions are the tokens whose spelling CPA
+		// owns - the speed=fast protocol beta here and the body-driven binding beta
+		// appended below - which are normalised in place to a single canonical
+		// occurrence instead of being duplicated.
 		if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, "speed").String()), "fast") {
-			appendBeta(claudeFastModeBeta)
+			appendCanonicalBeta(claudeFastModeBeta)
 		}
 		for _, beta := range extraBetas {
-			appendBeta(beta)
+			for _, part := range strings.Split(beta, ",") {
+				appendBeta(part)
+			}
 		}
 	} else {
 		// On direct Anthropic an unconfirmed CLI-profile caller's own betas are
 		// dropped: appending them to the measured baseline produces a shape real
 		// Claude Code never sends. Custom gateways keep caller extensions.
 		if !confirmedClaudeCode && incomingBetas != "" && !isAnthropicBase {
-			for _, beta := range strings.Split(incomingBetas, ",") {
+			for _, beta := range incomingBetasSlice {
 				appendBeta(beta)
 			}
 		}
 		if !isAnthropicBase {
 			for _, beta := range extraBetas {
-				appendBeta(beta)
+				for _, part := range strings.Split(beta, ",") {
+					appendBeta(part)
+				}
 			}
 		}
+	}
+	// thinking.block_binding is a body-driven protocol opt-in: Anthropic rejects
+	// the field unless thinking-binding-controls-2026-08-01 is declared. The
+	// trigger is the finished upstream body and nothing else, deliberately.
+	//
+	// Deriving it from the caller's Anthropic-Beta header or body "betas" instead
+	// would let any caller pin a beta onto a first-party request whose body never
+	// uses it, and would keep declaring it after a later rewrite dropped the
+	// thinking block (disableThinkingIfToolChoiceForced deletes it whenever
+	// tool_choice forces tool use). Reading the same bytes that go on the wire
+	// keeps header and body in agreement on every path, count_tokens included.
+	//
+	// Restricted to first-party Anthropic: other Anthropic-compatible upstreams
+	// have their own beta vocabulary and must not receive a token CPA invented
+	// for api.anthropic.com.
+	//
+	// Position policy: no wire capture of a native client sending this beta
+	// exists, so its place in the list is CPA's own decision, not a measurement.
+	// The minimal one is taken here: append at the end of the assembled baseline
+	// and never move a beta that is already present, which leaves every historical
+	// position byte-identical to what the caller or the baseline produced.
+	if isAnthropicBase && claudeBodyHasBlockBinding(body) {
+		appendCanonicalBeta(claudeThinkingBindingControlsBeta)
 	}
 	applyBetaHeader := func() {
 		if strings.TrimSpace(baseBetas) == "" {

--- a/internal/runtime/executor/helps/claude_client_detection.go
+++ b/internal/runtime/executor/helps/claude_client_detection.go
@@ -191,36 +191,48 @@ func matchesMeasuredClaudeCodeHelperProfile(
 	return measuredClaudeCodeHelperSessionMatches(headers, payload)
 }
 
-// normalizedClaudeBetaHeader joins every Anthropic-Beta value in wire order.
-// Values() is tried first so canonical headers keep a deterministic order; the
-// case-insensitive fallback only exists for hand-built header maps that store a
-// non-canonical key, where ranging the map alone would be order-dependent.
+// ClaudeBetaTokens returns every Anthropic-Beta token the caller sent, in a
+// deterministic order: matching header keys sorted bytewise, then each value in
+// slice order, then the comma-separated items inside each value. Items are
+// trimmed and empty ones are dropped.
+//
+// This is the single reader of that header: the native-client detector and the
+// outgoing request path must see the exact same tokens. The scan always covers
+// every case spelling of the key instead of stopping at the canonical one,
+// because SDK callers hand-build header maps whose literal "anthropic-beta" is
+// invisible to Header.Values. Reading only the canonical key would let a request
+// carrying two spellings confirm a measured native profile on a partial view
+// while the request path forwards a different, larger one. Sorting the keys
+// replaces Go's randomised map iteration with one stable order.
+func ClaudeBetaTokens(headers http.Header) []string {
+	if len(headers) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, 1)
+	for key := range headers {
+		if strings.EqualFold(key, "Anthropic-Beta") {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	var betas []string
+	for _, key := range keys {
+		for _, value := range headers[key] {
+			for _, beta := range strings.Split(value, ",") {
+				if beta = strings.TrimSpace(beta); beta != "" {
+					betas = append(betas, beta)
+				}
+			}
+		}
+	}
+	return betas
+}
+
+// normalizedClaudeBetaHeader joins the tokens ClaudeBetaTokens extracted, which
+// is the view the measured-profile allowlist is keyed on.
 func normalizedClaudeBetaHeader(headers http.Header) string {
-	if headers == nil {
-		return ""
-	}
-	values := headers.Values("Anthropic-Beta")
-	if len(values) == 0 {
-		keys := make([]string, 0, 2)
-		for key := range headers {
-			if strings.EqualFold(key, "Anthropic-Beta") {
-				keys = append(keys, key)
-			}
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			values = append(values, headers[key]...)
-		}
-	}
-	betas := make([]string, 0, 12)
-	for _, value := range values {
-		for _, beta := range strings.Split(value, ",") {
-			if beta = strings.TrimSpace(beta); beta != "" {
-				betas = append(betas, beta)
-			}
-		}
-	}
-	return strings.Join(betas, ",")
+	return strings.Join(ClaudeBetaTokens(headers), ",")
 }
 
 // measuredClaudeCodeHelperHeadersMatch validates the helper transport envelope.
@@ -498,19 +510,9 @@ func headerValue(headers http.Header, name string) string {
 }
 
 func headerContainsClaudeCodeBeta(headers http.Header) bool {
-	if headers == nil {
-		return false
-	}
-	for key, values := range headers {
-		if !strings.EqualFold(key, "Anthropic-Beta") {
-			continue
-		}
-		for _, value := range values {
-			for _, beta := range strings.Split(value, ",") {
-				if strings.TrimSpace(beta) == "claude-code-20250219" {
-					return true
-				}
-			}
+	for _, beta := range ClaudeBetaTokens(headers) {
+		if beta == "claude-code-20250219" {
+			return true
 		}
 	}
 	return false

--- a/internal/runtime/executor/helps/claude_client_detection_test.go
+++ b/internal/runtime/executor/helps/claude_client_detection_test.go
@@ -528,3 +528,80 @@ func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
 		}
 	})
 }
+
+// ClaudeBetaTokens is the single reader of Anthropic-Beta, so it has to expose
+// every spelling of the key at once, flatten repeated values and CSV items, and
+// return one order that does not depend on Go's map iteration.
+func TestClaudeBetaTokens(t *testing.T) {
+	headers := http.Header{
+		"X-Other":        {"ignored"},
+		"anthropic-beta": {"beta-lower-1, beta-lower-2", "beta-lower-3"},
+		"Anthropic-Beta": {"beta-canonical-1", " beta-canonical-2 ,beta-canonical-3"},
+		"ANTHROPIC-BETA": {"beta-upper-1", "beta-upper-2"},
+	}
+	// Keys sorted bytewise, then values in slice order, then CSV items.
+	want := []string{
+		"beta-upper-1", "beta-upper-2",
+		"beta-canonical-1", "beta-canonical-2", "beta-canonical-3",
+		"beta-lower-1", "beta-lower-2", "beta-lower-3",
+	}
+	for run := 0; run < 50; run++ {
+		got := ClaudeBetaTokens(headers)
+		if len(got) != len(want) {
+			t.Fatalf("len(got) = %d, want %d (%v)", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d token[%d] = %q, want %q (%v)", run, i, got[i], want[i], got)
+			}
+		}
+	}
+
+	for name, header := range map[string]http.Header{
+		"nil":               nil,
+		"empty":             {},
+		"no beta key":       {"X-Other": {"ignored"}},
+		"blank csv":         {"Anthropic-Beta": {" , "}},
+		"blank values":      {"Anthropic-Beta": {"", "   "}},
+		"blank across keys": {"Anthropic-Beta": {""}, "anthropic-beta": {" ,, "}},
+	} {
+		if got := ClaudeBetaTokens(header); got != nil {
+			t.Fatalf("%s header tokens = %v, want none", name, got)
+		}
+	}
+
+	sparse := ClaudeBetaTokens(http.Header{"Anthropic-Beta": {"a,, ,b", " ", "c"}})
+	if len(sparse) != 3 || sparse[0] != "a" || sparse[1] != "b" || sparse[2] != "c" {
+		t.Fatalf("sparse tokens = %v, want [a b c]", sparse)
+	}
+
+	// The joined form the measured-profile allowlist is keyed on stays in step.
+	if got, want := normalizedClaudeBetaHeader(headers), strings.Join(want, ","); got != want {
+		t.Fatalf("normalizedClaudeBetaHeader = %q, want %q", got, want)
+	}
+}
+
+// The detector and claude_executor_request.go read the same header through
+// ClaudeBetaTokens. A second, non-canonical key changes the profile actually
+// forwarded upstream, so it has to break confirmation here instead of staying
+// invisible to a reader that stops at the canonical key.
+func TestDetectClaudeCodeRequestRejectsHelperWithExtraBetaHeaderKey(t *testing.T) {
+	payload := measuredClaudeCodeMinimalHelperPayload()
+
+	control := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+	if detection := DetectClaudeCodeRequest(control, payload, false); !detection.Confirmed || !detection.HelperProfile {
+		t.Fatalf("control detection = %#v, want the measured profile confirmed", detection)
+	}
+
+	for _, key := range []string{"anthropic-beta", "ANTHROPIC-BETA"} {
+		t.Run(key, func(t *testing.T) {
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers[key] = []string{"extra-beta-2099-01-01"}
+
+			detection := DetectClaudeCodeRequest(headers, payload, false)
+			if detection.HelperProfile || detection.Confirmed {
+				t.Fatalf("detection = %#v, want an extra %q key to disqualify the measured profile", detection, key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `thinking-binding-controls-2026-08-01` only for first-party Anthropic requests whose final serialized body contains an object-valued `thinking.block_binding`
- skip the beta when `thinking.type` is `disabled`, and do not enable it from caller headers or `body.betas` alone
- use one deterministic parser for case-insensitive, multi-value/CSV `Anthropic-Beta` handling in both Claude client detection and request forwarding
- canonicalize CPA-owned beta tokens and collapse mixed-case duplicates without reordering existing tokens
- cover non-streaming, streaming, `count_tokens`, forced tool choice, custom gateways, and duplicate/header edge cases

## Why

Anthropic rejects `thinking.block_binding` unless the matching beta is present. The request pipeline can add or remove thinking fields before serialization, so the header must be derived from the exact final body sent upstream rather than from the original caller request.

The shared header parser also prevents client detection and forwarding from observing different beta lists when a hand-built `http.Header` contains multiple case spellings.

## Validation

- `go test ./... -count=1`
- `go test -race` on the changed executor and helper paths
- `go vet ./internal/runtime/executor/...`
- `go build ./cmd/server`
- `gofmt` and `git diff --check`

All checks pass locally with Go 1.26.5.
