### PR TITLE
fix(claude): align beta assembly and helper transport with the measured 2.1.258

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -588,7 +588,8 @@ nonstream-keepalive-interval: 0
 # Anthropic-Beta is assembled per request rather than sent as a fixed list, matching
 # Claude Code: context-1m sits right after claude-code, mid-conversation-system
 # is added only for models that accept a role=system turn, advanced-tool-use only when
-# the request declares tools, and server-side-fallback / fallback-credit /
+# the request uses tool search (deferred tools) or another advanced tool-use feature,
+# afk-mode sits between fast-mode and extended-cache-ttl, and server-side-fallback / fallback-credit /
 # structured-outputs trail effort. On direct api.anthropic.com a caller may only ask for
 # betas real Claude Code also sends, and they are placed at their observed positions;
 # anything else is dropped so the outgoing set stays one a real client could produce.

--- a/internal/runtime/executor/claude_executor_native_helper_test.go
+++ b/internal/runtime/executor/claude_executor_native_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -284,6 +285,66 @@ func TestClaudeBodyNeedsBillingFallbackTracksSystemPresence(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := claudeBodyNeedsBillingFallback([]byte(test.body)); got != test.want {
 				t.Fatalf("claudeBodyNeedsBillingFallback() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// A 2.1.258 helper that reaches CPA through ANTHROPIC_BASE_URL carries no
+// x-client-request-id, because the client attaches it only for a first-party base
+// URL. The header must stay absent on a custom upstream instead of being
+// synthesized, while a helper that did carry one keeps its own value.
+func TestApplyClaudeHeadersHelperRequestIDFollowsUpstreamBase(t *testing.T) {
+	const nativeRequestID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+	for _, test := range []struct {
+		name          string
+		url           string
+		incomingID    string
+		wantGenerated bool
+		wantID        string
+	}{
+		{name: "first party base without caller id", url: "https://api.anthropic.com/v1/messages?beta=true", wantGenerated: true},
+		{name: "custom base without caller id", url: "https://gateway.example.com/v1/messages"},
+		{name: "custom base keeps caller id", url: "https://gateway.example.com/v1/messages", incomingID: nativeRequestID, wantID: nativeRequestID},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, errRequest := http.NewRequest(http.MethodPost, test.url, nil)
+			if errRequest != nil {
+				t.Fatal(errRequest)
+			}
+			incoming := http.Header{}
+			if test.incomingID != "" {
+				incoming.Set("X-Client-Request-Id", test.incomingID)
+			}
+			if errHeaders := applyClaudeHeadersWithNativeProfile(
+				request,
+				&cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-api-key"}},
+				"test-api-key",
+				false,
+				nil,
+				[]byte(`{"model":"claude-haiku-4-5-20251001"}`),
+				&config.Config{},
+				incoming,
+				true,
+				true,
+				claudeNativeHelperSessionID,
+			); errHeaders != nil {
+				t.Fatalf("applyClaudeHeadersWithNativeProfile() error = %v", errHeaders)
+			}
+			got := request.Header.Get("X-Client-Request-Id")
+			switch {
+			case test.wantID != "":
+				if got != test.wantID {
+					t.Fatalf("X-Client-Request-Id = %q, want caller value %q", got, test.wantID)
+				}
+			case test.wantGenerated:
+				if _, errParse := uuid.Parse(got); errParse != nil {
+					t.Fatalf("X-Client-Request-Id = %q, want a generated UUID", got)
+				}
+			default:
+				if got != "" {
+					t.Fatalf("X-Client-Request-Id = %q, want the header to stay absent", got)
+				}
 			}
 		})
 	}

--- a/internal/runtime/executor/claude_executor_native_helper_test.go
+++ b/internal/runtime/executor/claude_executor_native_helper_test.go
@@ -23,7 +23,7 @@ const (
 	claudeNativeHelperCoreBetas = "oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05"
 )
 
-func claudeNativeHelperHeaders(betas, compression string, structured bool) http.Header {
+func claudeNativeHelperHeaders(betas, compression string) http.Header {
 	headers := http.Header{
 		"Accept":            {"application/json"},
 		"Accept-Encoding":   {compression},
@@ -43,9 +43,6 @@ func claudeNativeHelperHeaders(betas, compression string, structured bool) http.
 		"X-Stainless-Arch":                          {"arm64"},
 		"X-Stainless-Retry-Count":                   {"0"},
 		"X-Stainless-Timeout":                       {"600"},
-	}
-	if structured {
-		headers.Set("X-Stainless-Async", "async")
 	}
 	canonical := make(http.Header, len(headers))
 	for name, values := range headers {
@@ -121,7 +118,7 @@ func TestClaudeExecutorMinimalNativeHelperPreservesMarkerlessWire(t *testing.T) 
 	defer server.Close()
 
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"}}`)
-	headers := claudeNativeHelperHeaders(claudeNativeHelperCoreBetas, "gzip", false)
+	headers := claudeNativeHelperHeaders(claudeNativeHelperCoreBetas, "gzip, deflate, br, zstd")
 	executor := NewClaudeExecutor(&config.Config{})
 	_, errExecute := executor.Execute(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",
@@ -165,7 +162,7 @@ func TestClaudeExecutorStructuredNativeHelperPreservesStreamProfile(t *testing.T
 
 	betas := claudeNativeHelperCoreBetas + ",structured-outputs-2025-12-15"
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":[{"type":"text","text":"helper probe"}]}],"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.258; cc_entrypoint=cli; cch=00000;"},{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},{"type":"text","text":"Return a short title."}],"tools":[],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"},"max_tokens":32000,"thinking":{"type":"disabled"},"temperature":1,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}}},"stream":true}`)
-	headers := claudeNativeHelperHeaders(betas, "gzip, deflate, br, zstd", true)
+	headers := claudeNativeHelperHeaders(betas, "gzip, deflate, br, zstd")
 	executor := NewClaudeExecutor(&config.Config{})
 	result, errStream := executor.ExecuteStream(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1098,8 +1098,11 @@ func applyClaudeHeadersWithNativeProfile(
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	// identityHeader prefers the incoming value for a confirmed client, so a confirmed
 	// helper keeps its own native request ID and this fresh UUID only covers a caller
-	// that sent none. Helpers opt in on custom gateways too.
-	if isAnthropicBase || helperProfile {
+	// that sent none. Helpers opt in on custom gateways too, but only to carry the
+	// request ID they already sent: 2.1.258 attaches the header just for a first-party
+	// base URL, so a helper that arrived without one keeps it absent upstream rather
+	// than gaining a synthesized ID the real client would not have sent.
+	if isAnthropicBase || (helperProfile && helps.HeaderValueCaseInsensitive(incomingHeaders, "x-client-request-id") != "") {
 		identityHeader("x-client-request-id", uuid.New().String())
 	}
 	r.Header.Set("Connection", "keep-alive")

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -50,6 +50,7 @@ const (
 	claudeExtendedCacheTTLBeta       = "extended-cache-ttl-2025-04-11"
 	claudeCacheDiagnosisBeta         = "cache-diagnosis-2026-04-07"
 	claudeRedactThinkingBeta         = "redact-thinking-2026-02-12"
+	claudeAFKModeBeta                = "afk-mode-2026-01-31"
 )
 
 // claudeCodeCLIConstantBetas are the betas Claude Code sends on every
@@ -94,20 +95,21 @@ var claudeCodeTrailingBetas = []string{
 //	 8 prompt-caching-scope-2026-01-05
 //	 9 mid-conversation-system-2026-04-07  models accepting a role=system turn
 //	10 advisor-tool-2026-03-01             requests declaring advisor tools or requesting advisor beta
-//	11 advanced-tool-use-2025-11-20       requests with tools
+//	11 advanced-tool-use-2025-11-20       requests using tool search or another advanced tool-use feature
 //	12 effort-2025-11-24                  effort-supporting models with active thinking
 //	13 server-side-fallback-2026-06-01    requests with fallbacks or requested
 //	14 fallback-credit-2026-06-01         OAuth credentials
 //	15 structured-outputs-2025-12-15      structured output requests
 //	16 thinking-display-updates-2026-08-18 requests with thinking.display=updates
 //	17 fast-mode-2026-02-01               speed:fast requests only
-//	18 extended-cache-ttl-2025-04-11      OAuth credentials (omitted on subagent & probe)
-//	19 cache-diagnosis-2026-04-07         requests with diagnostics only
+//	18 afk-mode-2026-01-31                auto-mode sessions, forwarded when the caller sends it
+//	19 extended-cache-ttl-2025-04-11      OAuth credentials (omitted on subagent & probe)
+//	20 cache-diagnosis-2026-04-07         requests with diagnostics only
 //
 // An empty body keeps the optimistic role=system default, matching the cloaking
 // policy for unknown and future model IDs.
 func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool) string {
-	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+8)
+	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+9)
 	betas = append(betas, claudeCodeBeta)
 	if oauthToken {
 		betas = append(betas, claudeOAuthBeta)
@@ -128,7 +130,7 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	if requested[claudeAdvisorToolBeta] || claudeBodyHasAdvisorTool(body) {
 		betas = append(betas, claudeAdvisorToolBeta)
 	}
-	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() && len(tools.Array()) > 0 {
+	if requested[claudeAdvancedToolUseBeta] || claudeBodyUsesAdvancedToolUse(body) {
 		betas = append(betas, claudeAdvancedToolUseBeta)
 	}
 	if claudeRequestSupportsEffort(body, requested) {
@@ -155,6 +157,9 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	}
 	if claudeRequestUsesFastMode(body, requested) {
 		betas = append(betas, claudeFastModeBeta)
+	}
+	if requested[claudeAFKModeBeta] {
+		betas = append(betas, claudeAFKModeBeta)
 	}
 	if oauthToken && !helps.IsClaudeSubagentRequest(nil, body) && !isProbeOrHelper {
 		betas = append(betas, claudeExtendedCacheTTLBeta)
@@ -192,6 +197,31 @@ func claudeRequestSupportsEffort(body []byte, requested map[string]bool) bool {
 func claudeThinkingDisplayUpdates(body []byte) bool {
 	display := gjson.GetBytes(body, "thinking.display")
 	return display.Type == gjson.String && strings.EqualFold(strings.TrimSpace(display.String()), "updates")
+}
+
+// claudeBodyUsesAdvancedToolUse reports whether the request needs
+// advanced-tool-use-2025-11-20. Claude Code 2.1.258 adds the beta only while
+// tool search is active, which puts a tool_search_tool_* server tool and
+// defer_loading tools on the wire; plain tool declarations no longer carry it
+// (measured 2026-09-02: 158 inline tools, no beta). Tool use examples
+// (input_examples) and programmatic tool calling (allowed_callers) sit behind
+// the same beta and are just as visible in the body, so callers using them keep
+// working without requesting the beta explicitly.
+func claudeBodyUsesAdvancedToolUse(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+		if strings.HasPrefix(toolType, "tool_search_tool_") {
+			return true
+		}
+		if tool.Get("defer_loading").Bool() || tool.Get("input_examples").Exists() || tool.Get("allowed_callers").Exists() {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeBodyHasAdvisorTool reports whether the request body declares an
@@ -333,7 +363,9 @@ func withoutClaudeBeta(betas, removeBeta string) string {
 
 // withClaudeAdvisorToolBeta ensures advisor-tool-2026-03-01 is present when
 // the body declares an advisor server tool, placed at the observed wire position
-// before advanced-tool-use-2025-11-20 or effort-2025-11-24.
+// before advanced-tool-use-2025-11-20 or effort-2025-11-24. Every beta that
+// follows advisor on the wire, afk-mode-2026-01-31 included, is an insertion
+// boundary so a caller-supplied trailer never ends up ahead of it.
 func withClaudeAdvisorToolBeta(betas string) string {
 	if strings.TrimSpace(betas) == "" {
 		return claudeAdvisorToolBeta
@@ -354,6 +386,7 @@ func withClaudeAdvisorToolBeta(betas string) string {
 			beta == claudeFallbackCreditBeta ||
 			beta == claudeStructuredOutputsBeta ||
 			beta == claudeFastModeBeta ||
+			beta == claudeAFKModeBeta ||
 			beta == claudeExtendedCacheTTLBeta ||
 			beta == claudeCacheDiagnosisBeta {
 			insertAt = index
@@ -1071,14 +1104,13 @@ func applyClaudeHeadersWithNativeProfile(
 	}
 	r.Header.Set("Connection", "keep-alive")
 	// Regular Claude Code requests negotiate transport identically for streaming
-	// and non-streaming requests. Measured Haiku helpers are the exception: their
-	// minimal non-stream request offers gzip only, while the structured streaming
-	// helper offers the full compression set. Confirmed helpers preserve the
-	// incoming native values.
+	// and non-streaming requests. Claude Code 2.1.258 Haiku helpers offer the same
+	// full compression set as the main thread (2.1.220's minimal probe offered gzip
+	// only). Confirmed helpers preserve the incoming native values.
 	applyTransportNegotiation := func() {
 		if helperProfile {
 			identityHeader("Accept", "application/json")
-			identityHeader("Accept-Encoding", "gzip")
+			identityHeader("Accept-Encoding", "gzip, deflate, br, zstd")
 			return
 		}
 		if stream && !isAnthropicBase {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -7786,7 +7786,7 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name: "opus-5 1m variant reproduces the full observed order",
-			body: `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body: `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			requested: map[string]bool{
 				claudeContext1MBeta:          true,
 				claudeServerSideFallbackBeta: true,
@@ -7832,8 +7832,8 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants + ",effort-2025-11-24",
 		},
 		{
-			name:  "oauth uses advanced tools and the current cache TTL trailer",
-			body:  `{"model":"claude-opus-4-6","tools":[{"name":"Read"}]}`,
+			name:  "oauth uses tool search and the current cache TTL trailer",
+			body:  `{"model":"claude-opus-4-6","tools":[{"name":"Read","defer_loading":true}]}`,
 			oauth: true,
 			want: "claude-code-20250219,oauth-2025-04-20," +
 				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
@@ -7844,7 +7844,7 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name:  "oauth precedes context-1m",
-			body:  `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body:  `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			oauth: true,
 			requested: map[string]bool{
 				claudeContext1MBeta:          true,
@@ -7870,9 +7870,35 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants,
 		},
 		{
-			name: "legacy model with tools adds advanced tool use only",
+			name: "legacy model with inline tools no longer adds advanced tool use",
 			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read"}]}`,
+			want: constants + ",effort-2025-11-24",
+		},
+		{
+			name: "deferred tool adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","defer_loading":true}]}`,
 			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "tool search server tool adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"},{"name":"Read"}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "tool use examples add advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","input_examples":[{"path":"a.go"}]}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "programmatic tool calling adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","allowed_callers":["code_execution_20250825"]}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name:      "requested advanced tool use is honored for inline tools",
+			body:      `{"model":"claude-sonnet-4-6","tools":[{"name":"Read"}]}`,
+			requested: map[string]bool{claudeAdvancedToolUseBeta: true},
+			want:      constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
 			name: "role=system model without tools adds mid conversation system only",
@@ -7880,8 +7906,8 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants + ",mid-conversation-system-2026-04-07,effort-2025-11-24",
 		},
 		{
-			name: "role=system model with tools adds both in wire order",
-			body: `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			name: "role=system model with tool search adds both in wire order",
+			body: `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			want: constants + ",mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
@@ -7921,14 +7947,54 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name:      "advisor tool beta requested placed before advanced-tool-use",
-			body:      `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body:      `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			requested: map[string]bool{"advisor-tool-2026-03-01": true},
 			want:      constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
 			name: "body with advisor server tool automatically adds advisor-tool beta",
 			body: `{"model":"claude-opus-5","tools":[{"type":"advisor_20260301","name":"advisor"}]}`,
-			want: constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24",
+			want: constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
+		},
+		{
+			// Captured 2026-09-02 from Claude Code 2.1.258 (cli entrypoint, OAuth,
+			// auto mode on): 158 inline tools without tool search, advisor beta
+			// enabled for the account, thinking adaptive without display.
+			name:  "2.1.258 main thread capture with inline tools and afk-mode",
+			body:  `{"model":"claude-fable-5-1","tools":[{"name":"Read"}],"thinking":{"type":"adaptive"}}`,
+			oauth: true,
+			requested: map[string]bool{
+				claudeAdvisorToolBeta: true,
+				claudeAFKModeBeta:     true,
+			},
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01," +
+				"afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:      "afk-mode sits between fast-mode and extended-cache-ttl",
+			body:      `{"model":"claude-opus-5","speed":"fast"}`,
+			oauth:     true,
+			requested: map[string]bool{claudeAFKModeBeta: true},
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,fallback-credit-2026-06-01,fast-mode-2026-02-01," +
+				"afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "afk-mode is not added unless the caller sent it",
+			body:  `{"model":"claude-opus-5"}`,
+			oauth: true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,fallback-credit-2026-06-01,extended-cache-ttl-2025-04-11",
 		},
 		{
 			name: "thinking display updates emits thinking-display-updates beta and drops redact-thinking",
@@ -8000,6 +8066,47 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 // behaviour: a streaming request to api.anthropic.com negotiates exactly like a
 // non-streaming one, because Anthropic selects SSE from the body. Other
 // Anthropic-compatible upstreams keep the conservative SSE contract.
+
+// TestWithClaudeAdvisorToolBeta_InsertsBeforeTrailingBetas pins the advisor
+// insertion point against every beta that follows it on the 2.1.258 wire,
+// including a caller-supplied afk-mode-2026-01-31.
+func TestWithClaudeAdvisorToolBeta_InsertsBeforeTrailingBetas(t *testing.T) {
+	const head = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07"
+	tests := []struct {
+		name  string
+		betas string
+		want  string
+	}{
+		{
+			name:  "afk-mode only trailer",
+			betas: head + ",afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+			want:  head + ",advisor-tool-2026-03-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "effort ahead of afk-mode",
+			betas: head + ",effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+			want:  head + ",advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "already present stays put",
+			betas: head + ",advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31",
+			want:  head + ",advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31",
+		},
+		{
+			name:  "no trailer appends",
+			betas: head,
+			want:  head + ",advisor-tool-2026-03-01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := withClaudeAdvisorToolBeta(tt.betas); got != tt.want {
+				t.Fatalf("withClaudeAdvisorToolBeta() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyClaudeHeaders_StreamTransportNegotiation(t *testing.T) {
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-stream-accept"}}
 	body := []byte(`{"model":"claude-opus-4-6","stream":true}`)

--- a/internal/runtime/executor/claude_mid_system_model_test.go
+++ b/internal/runtime/executor/claude_mid_system_model_test.go
@@ -282,7 +282,7 @@ func TestClaudeExecutor_PayloadOverrideReconcilesRelocatedSystemPrompt(t *testin
 func TestClaudeExecutor_ConfirmedNativeLegacyMidSystemMessageForwarded(t *testing.T) {
 	upstream := &midSystemUpstream{}
 	ex := NewClaudeExecutor(midSystemConfig())
-	headers := claudeNativeHelperHeaders("claude-code-20250219,"+claudeNativeHelperCoreBetas, "gzip", false)
+	headers := claudeNativeHelperHeaders("claude-code-20250219,"+claudeNativeHelperCoreBetas, "gzip, deflate, br, zstd")
 
 	if _, err := ex.Execute(upstream.context(t, headers), midSystemAuth(), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",

--- a/internal/runtime/executor/helps/claude_client_detection.go
+++ b/internal/runtime/executor/helps/claude_client_detection.go
@@ -273,18 +273,24 @@ func measuredClaudeCodeHelperHeadersMatch(headers http.Header, cfg *config.Confi
 	if !meetsClaudeDeviceProfileBaseline(candidate, profile) {
 		return false
 	}
-	if async := headerValue(headers, "X-Stainless-Async"); (shape == claudeCodeHelperShapeStructured && async != "async") ||
-		(shape == claudeCodeHelperShapeMinimal && async != "") {
+	// Claude Code 2.1.258 (@anthropic-ai/sdk 0.112.1), measured 2026-09-02 on the
+	// quota probe and the session-title helper: X-Stainless-Async is never sent
+	// and both shapes offer the full compression set. x-client-request-id is
+	// attached only when the client's base URL is api.anthropic.com, so a client
+	// pointed at CPA through ANTHROPIC_BASE_URL sends none while one that reaches
+	// CPA through a transparent proxy still carries the UUID; both are accepted.
+	if headerValue(headers, "X-Stainless-Async") != "" {
 		return false
 	}
-	compression := headerValue(headers, "Accept-Encoding")
-	if (shape == claudeCodeHelperShapeStructured && compression != "gzip, deflate, br, zstd") ||
-		(shape == claudeCodeHelperShapeMinimal && compression != "gzip") {
+	if headerValue(headers, "Accept-Encoding") != "gzip, deflate, br, zstd" {
 		return false
 	}
-	requestID := headerValue(headers, "X-Client-Request-Id")
-	_, errRequestID := uuid.Parse(requestID)
-	return errRequestID == nil
+	if requestID := headerValue(headers, "X-Client-Request-Id"); requestID != "" {
+		if _, errRequestID := uuid.Parse(requestID); errRequestID != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func measuredClaudeCodeHelperSessionMatches(headers http.Header, payload []byte) bool {

--- a/internal/runtime/executor/helps/claude_client_detection_test.go
+++ b/internal/runtime/executor/helps/claude_client_detection_test.go
@@ -24,11 +24,11 @@ func confirmedClaudeCodeHeaders() http.Header {
 	}
 }
 
-func measuredClaudeCodeHelperHeaders(betaProfile string, structured bool) http.Header {
+func measuredClaudeCodeHelperHeaders(betaProfile string) http.Header {
 	profile := defaultClaudeDeviceProfile(&config.Config{})
 	headers := http.Header{
 		"Accept":            {"application/json"},
-		"Accept-Encoding":   {"gzip"},
+		"Accept-Encoding":   {"gzip, deflate, br, zstd"},
 		"Content-Type":      {"application/json"},
 		"User-Agent":        {profile.UserAgent},
 		"X-App":             {"cli"},
@@ -45,10 +45,6 @@ func measuredClaudeCodeHelperHeaders(betaProfile string, structured bool) http.H
 		"X-Stainless-Arch":                          {profile.Arch},
 		"X-Stainless-Retry-Count":                   {"0"},
 		"X-Stainless-Timeout":                       {"600"},
-	}
-	if structured {
-		headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
-		headers.Set("X-Stainless-Async", "async")
 	}
 	canonical := make(http.Header, len(headers))
 	for name, values := range headers {
@@ -174,10 +170,9 @@ func TestDetectClaudeCodeCountTokensAllowsMissingMetadata(t *testing.T) {
 
 func TestDetectClaudeCodeRequestRecognizesMeasuredHaikuHelpers(t *testing.T) {
 	tests := []struct {
-		name       string
-		beta       string
-		structured bool
-		payload    []byte
+		name    string
+		beta    string
+		payload []byte
 	}{
 		{
 			name:    "minimal with redact thinking",
@@ -190,34 +185,30 @@ func TestDetectClaudeCodeRequestRecognizesMeasuredHaikuHelpers(t *testing.T) {
 			payload: measuredClaudeCodeMinimalHelperPayload(),
 		},
 		{
-			name:       "structured title helper with advisor",
-			beta:       claudeCodeHelperBetaProfile(true, "advisor-tool-2026-03-01", "structured-outputs-2025-12-15", "cache-diagnosis-2026-04-07"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper with advisor",
+			beta:    claudeCodeHelperBetaProfile(true, "advisor-tool-2026-03-01", "structured-outputs-2025-12-15", "cache-diagnosis-2026-04-07"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 		{
-			name:       "structured title helper with fallback credit",
-			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15", "fallback-credit-2026-06-01"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper with fallback credit",
+			beta:    claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15", "fallback-credit-2026-06-01"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 		{
-			name:       "structured title helper with lowercase hex CCH",
-			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15"),
-			structured: true,
-			payload:    []byte(strings.Replace(string(measuredClaudeCodeStructuredHelperPayload()), "cch=00000", "cch=7ee87", 1)),
+			name:    "structured title helper with lowercase hex CCH",
+			beta:    claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15"),
+			payload: []byte(strings.Replace(string(measuredClaudeCodeStructuredHelperPayload()), "cch=00000", "cch=7ee87", 1)),
 		},
 		{
-			name:       "structured title helper without redact thinking",
-			beta:       claudeCodeHelperBetaProfile(false, "structured-outputs-2025-12-15"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper without redact thinking",
+			beta:    claudeCodeHelperBetaProfile(false, "structured-outputs-2025-12-15"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			detection := DetectClaudeCodeRequest(
-				measuredClaudeCodeHelperHeaders(test.beta, test.structured),
+				measuredClaudeCodeHelperHeaders(test.beta),
 				test.payload,
 				false,
 			)
@@ -244,7 +235,7 @@ func TestDetectClaudeCodeRequestRejectsMalformedStructuredHaikuHelpers(t *testin
 		{name: "open schema", payload: strings.Replace(basePayload, `"additionalProperties":false`, `"additionalProperties":true`, 1)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			detection := DetectClaudeCodeRequest(measuredClaudeCodeHelperHeaders(beta, true), []byte(test.payload), false)
+			detection := DetectClaudeCodeRequest(measuredClaudeCodeHelperHeaders(beta), []byte(test.payload), false)
 			if detection.Confirmed || detection.HelperProfile {
 				t.Fatalf("detection = %#v, want malformed structured helper rejected", detection)
 			}
@@ -277,7 +268,7 @@ func TestDetectClaudeCodeRequestRejectsNearMissHaikuHelpers(t *testing.T) {
 		{
 			name: "wrong compression profile",
 			mutate: func(headers http.Header) {
-				headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+				headers.Set("Accept-Encoding", "gzip")
 			},
 			payload: minimalPayload,
 		},
@@ -326,7 +317,7 @@ func TestDetectClaudeCodeRequestRejectsNearMissHaikuHelpers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			if test.mutate != nil {
 				test.mutate(headers)
 			}
@@ -374,7 +365,7 @@ func TestDetectClaudeCodeRequestAcceptsHelperSubagentParentSessionID(t *testing.
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
 
 	detection := DetectClaudeCodeRequest(
-		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true)),
 		payload,
 		false,
 	)
@@ -389,7 +380,7 @@ func TestDetectClaudeCodeRequestRejectsHelperIdentityWithUnknownKeys(t *testing.
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
 
 	detection := DetectClaudeCodeRequest(
-		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true)),
 		payload,
 		false,
 	)
@@ -408,7 +399,7 @@ func TestDetectClaudeCodeRequestAcceptsHelperFromNonBaselinePlatform(t *testing.
 		{"MacOS", "x64"},
 	} {
 		t.Run(platform.os+"/"+platform.arch, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Set("X-Stainless-OS", platform.os)
 			headers.Set("X-Stainless-Arch", platform.arch)
 
@@ -428,7 +419,7 @@ func TestDetectClaudeCodeRequestRejectsHelperWithoutPlatformHeaders(t *testing.T
 		"X-Stainless-Runtime-Version",
 	} {
 		t.Run("missing "+name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Del(name)
 
 			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
@@ -445,7 +436,7 @@ func TestDetectClaudeCodeRequestRejectsHelperWithForeignSoftwareTuple(t *testing
 		"X-Stainless-Runtime-Version": "v0.0.1",
 	} {
 		t.Run(name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Set(name, value)
 
 			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
@@ -489,7 +480,7 @@ func TestNormalizedClaudeBetaHeaderIsDeterministic(t *testing.T) {
 // detector on claude-header-defaults.timeout instead of the measured constant
 // therefore rejected every genuine helper whenever that value was customized.
 func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
-	headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+	headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 	payload := measuredClaudeCodeMinimalHelperPayload()
 	if got := headers.Get("X-Stainless-Timeout"); got != claudeDefaultStainlessTimeout {
 		t.Fatalf("measured helper timeout = %q, want %q", got, claudeDefaultStainlessTimeout)
@@ -521,7 +512,7 @@ func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
 	// The measured constant stays the only accepted value, so a caller that does not
 	// send it is still disqualified even when the operator default happens to match.
 	t.Run("foreign timeout stays rejected", func(t *testing.T) {
-		foreign := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+		foreign := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 		foreign.Set("X-Stainless-Timeout", "900")
 		if detection := DetectClaudeCodeRequest(foreign, payload, false, withTimeout("900")); detection.HelperProfile {
 			t.Fatalf("detection = %#v, want a non-measured timeout to disqualify the helper profile", detection)


### PR DESCRIPTION
On top of the 2.1.258 support in `dev`, this aligns the parts that still differed from the measured wire behavior.

### Changes

- `advanced-tool-use-2025-11-20`: previously attached whenever the request had tools. Now sent only while an advanced tool-use feature such as tool search is actually in use (`tool_search_tool_*`, `defer_loading`, `input_examples`, `allowed_callers`), or when the caller requests it. 2.1.258 did not attach this beta even to a request with 158 plain inline tools.
- `afk-mode-2026-01-31`: forwarded at its measured position between `fast-mode` and `extended-cache-ttl` when the caller sends it, and included as an insertion boundary for `advisor-tool`.
- Haiku helper transport: 2.1.258 helpers send the same `Accept-Encoding: gzip, deflate, br, zstd` as the main thread and never send `X-Stainless-Async`. `x-client-request-id` is attached only when the base URL is api.anthropic.com, so the check accepts an empty value or a valid UUID and rejects only a malformed one.

### Verification

- `gofmt -l .` clean, `go build ./cmd/server`, `go test ./...` pass on current `dev`.
- Built from this branch and run with `--local-model` and a Claude OAuth credential:
  - a `claude-fable-5-1` request returns `200`
  - a real Claude Code 2.1.258 pointed at the proxy through `ANTHROPIC_BASE_URL` responds normally in both `-p` and interactive mode, every request `200`
  - the request logs show no `advanced-tool-use` on requests with only inline tools, and `afk-mode` placed right before `extended-cache-ttl`
  - the helper request from the interactive session is recognized as native and its betas are kept as sent
