### PR TITLE
fix(claude): short-circuit max_tokens=1 probe requests

### DIFF
--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -84,6 +84,10 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 	// Decode claude-fable-5-dd-<reversed> model IDs back to the real model name for routing.
 	rawJSON = rewriteClaudeDDModelInBody(rawJSON)
 
+	if h.writeClaudeMaxTokensOneProbeResponse(c, rawJSON) {
+		return
+	}
+
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if !streamResult.Exists() || streamResult.Type == gjson.False {
@@ -147,6 +151,79 @@ func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
 		return rawJSON
 	}
 	return updated
+}
+
+func (h *ClaudeCodeAPIHandler) writeClaudeMaxTokensOneProbeResponse(c *gin.Context, rawJSON []byte) bool {
+	if !isClaudeMaxTokensOneProbe(rawJSON) {
+		return false
+	}
+
+	streamResult := gjson.GetBytes(rawJSON, "stream")
+	if streamResult.Exists() && streamResult.Type == gjson.True {
+		h.writeClaudeMaxTokensOneProbeStream(c, rawJSON)
+		return true
+	}
+
+	body := claudeMaxTokensOneProbeBody(rawJSON)
+	appendClaudeAPIResponse(c, body)
+	c.Header("Content-Type", "application/json")
+	c.Status(http.StatusOK)
+	_, _ = c.Writer.Write(body)
+	return true
+}
+
+func isClaudeMaxTokensOneProbe(rawJSON []byte) bool {
+	maxTokens := gjson.GetBytes(rawJSON, "max_tokens")
+	return maxTokens.Exists() && maxTokens.Type == gjson.Number && maxTokens.Int() == 1
+}
+
+func claudeMaxTokensOneProbeBody(rawJSON []byte) []byte {
+	body := []byte(`{"id":"msg_cli_proxy_probe","type":"message","role":"assistant","model":"","content":[{"type":"text","text":"ok"}],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}`)
+	if model := gjson.GetBytes(rawJSON, "model").String(); model != "" {
+		if updated, err := sjson.SetBytes(body, "model", model); err == nil {
+			body = updated
+		}
+	}
+	return body
+}
+
+func (h *ClaudeCodeAPIHandler) writeClaudeMaxTokensOneProbeStream(c *gin.Context, rawJSON []byte) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("Access-Control-Allow-Origin", "*")
+
+	model := gjson.GetBytes(rawJSON, "model").String()
+	messageStart := []byte(`{"type":"message_start","message":{"id":"msg_cli_proxy_probe","type":"message","role":"assistant","model":"","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}`)
+	if model != "" {
+		if updated, err := sjson.SetBytes(messageStart, "message.model", model); err == nil {
+			messageStart = updated
+		}
+	}
+
+	var stream bytes.Buffer
+	appendClaudeSSEEvent(&stream, "message_start", messageStart)
+	appendClaudeSSEEvent(&stream, "content_block_start", []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`))
+	appendClaudeSSEEvent(&stream, "content_block_delta", []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`))
+	appendClaudeSSEEvent(&stream, "content_block_stop", []byte(`{"type":"content_block_stop","index":0}`))
+	appendClaudeSSEEvent(&stream, "message_delta", []byte(`{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`))
+	appendClaudeSSEEvent(&stream, "message_stop", []byte(`{"type":"message_stop"}`))
+
+	body := stream.Bytes()
+	appendClaudeAPIResponse(c, body)
+	c.Status(http.StatusOK)
+	_, _ = c.Writer.Write(body)
+	if flusher, ok := c.Writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func appendClaudeSSEEvent(buf *bytes.Buffer, event string, payload []byte) {
+	_, _ = buf.WriteString("event: ")
+	_, _ = buf.WriteString(event)
+	_, _ = buf.WriteString("\ndata: ")
+	_, _ = buf.Write(payload)
+	_, _ = buf.WriteString("\n\n")
 }
 
 // ClaudeModels handles the Claude models listing endpoint.

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -1,0 +1,59 @@
+package claude
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeMessagesMaxTokensOneProbeReturnsOKContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := `{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":[{"type":"text","text":"."}]}]}`
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	handler := NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{})
+
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	respBody := recorder.Body.Bytes()
+	if got := gjson.GetBytes(respBody, "content.0.type").String(); got != "text" {
+		t.Fatalf("content.0.type = %q, want text; body=%s", got, respBody)
+	}
+	if got := gjson.GetBytes(respBody, "content.0.text").String(); got != "ok" {
+		t.Fatalf("content.0.text = %q, want ok; body=%s", got, respBody)
+	}
+	if got := gjson.GetBytes(respBody, "stop_reason").String(); got != "max_tokens" {
+		t.Fatalf("stop_reason = %q, want max_tokens; body=%s", got, respBody)
+	}
+}
+
+func TestClaudeMessagesMaxTokensOneProbeStreamsOKDelta(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := `{"model":"claude-opus-4-6","max_tokens":1,"stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"."}]}]}`
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	handler := NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{})
+
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	respBody := recorder.Body.String()
+	if !strings.Contains(respBody, `"text":"ok"`) {
+		t.Fatalf("stream body missing ok delta: %s", respBody)
+	}
+	if !strings.Contains(respBody, `"stop_reason":"max_tokens"`) {
+		t.Fatalf("stream body missing max_tokens stop reason: %s", respBody)
+	}
+}


### PR DESCRIPTION
  ## Summary

  Some clients frequently send Claude-compatible `max_tokens=1` requests as availability
  probes. Forwarding these requests upstream creates unnecessary traffic and may cause
  upstream `429 Too Many Requests` responses.

  This PR handles these probe requests locally instead of passing them through upstream.

  ## Changes

  - Return a minimal `"ok"` response for `max_tokens=1` requests
  - Support both JSON and streaming SSE responses
  - Add tests for both response modes
