### PR TITLE
fix(openai): preserve tools on websocket transcript replacement

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -134,7 +134,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	var mergedInput []byte
 	if allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
 		log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
-		mergedInput = []byte(nextInput.Raw)
+		mergedInput = responsesWebsocketInputWithInheritedAdditionalTools(nextInput, lastRequest)
 	} else {
 		appendInputRaw := nextInput.Raw
 		if inputContainsFullTranscript(nextInput) {
@@ -310,8 +310,48 @@ func normalizeResponseTranscriptReplacement(rawJSON []byte, lastRequest []byte) 
 			normalized, _ = sjson.SetRawBytes(normalized, "instructions", []byte(instructions.Raw))
 		}
 	}
+	input := gjson.GetBytes(normalized, "input")
+	if input.IsArray() {
+		normalized, _ = sjson.SetRawBytes(normalized, "input", responsesWebsocketInputWithInheritedAdditionalTools(input, lastRequest))
+	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
 	return bytes.Clone(normalized)
+}
+
+// responsesWebsocketInputWithInheritedAdditionalTools keeps the current
+// connection's tool declarations when a client replaces the incremental
+// response state with a full transcript. Codex sends those declarations in
+// the prewarm request and omits them from later requests that reference the
+// prewarm response ID. HTTP upstreams cannot retain that response ID, so the
+// replacement transcript must carry the declarations explicitly.
+func responsesWebsocketInputWithInheritedAdditionalTools(input gjson.Result, lastRequest []byte) []byte {
+	if !input.IsArray() {
+		return []byte(input.Raw)
+	}
+	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == "additional_tools" {
+			return []byte(input.Raw)
+		}
+	}
+
+	previousInput := gjson.GetBytes(lastRequest, "input")
+	if !previousInput.IsArray() {
+		return []byte(input.Raw)
+	}
+
+	items := make([]string, 0, len(previousInput.Array())+len(input.Array()))
+	for _, item := range previousInput.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == "additional_tools" {
+			items = append(items, item.Raw)
+		}
+	}
+	if len(items) == 0 {
+		return []byte(input.Raw)
+	}
+	for _, item := range input.Array() {
+		items = append(items, item.Raw)
+	}
+	return []byte("[" + strings.Join(items, ",") + "]")
 }
 
 type responsesWebsocketInputItem struct {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -1611,6 +1611,120 @@ func TestNormalizeResponsesWebsocketRequestReplacesCodexLocalCompactionTranscrip
 	}
 }
 
+func TestNormalizeResponsesWebsocketRequestInheritsPrewarmToolsOnTranscriptReplacement(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.6-sol","stream":true,"instructions":"be helpful","input":[
+		{"type":"additional_tools","role":"developer","tools":[{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}]},
+		{"type":"message","role":"user","id":"prewarm","content":""}
+	]}`)
+	raw := []byte(`{"type":"response.create","previous_response_id":"resp-prewarm","input":[
+		{"type":"message","role":"user","id":"old-user","content":"old prompt"},
+		{"type":"custom_tool_call","id":"old-call","call_id":"call-1","name":"functions.exec","input":"text(true)"},
+		{"type":"custom_tool_call_output","id":"old-output","call_id":"call-1","output":"true"},
+		{"type":"compaction","id":"compact-1","encrypted_content":"summary"},
+		{"type":"message","role":"user","id":"new-user","content":"list files"}
+	]}`)
+
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, nil, false, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+		t.Fatalf("replacement request must not include previous_response_id: %s", normalized)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 6 {
+		t.Fatalf("replacement input len = %d, want 6: %s", len(input), normalized)
+	}
+	if got := input[0].Get("type").String(); got != "additional_tools" {
+		t.Fatalf("input[0].type = %q, want additional_tools: %s", got, normalized)
+	}
+	if got := input[0].Get("tools.0.tools.0.name").String(); got != "exec" {
+		t.Fatalf("inherited tool name = %q, want exec: %s", got, normalized)
+	}
+	if got := input[1].Get("id").String(); got != "old-user" {
+		t.Fatalf("input[1].id = %q, want old-user: %s", got, normalized)
+	}
+	if !bytes.Equal(next, normalized) {
+		t.Fatalf("next request snapshot should match replacement request")
+	}
+}
+
+func TestNormalizeResponsesWebsocketRequestInheritsPrewarmToolsOnUnpinnedReplacement(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[
+		{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},
+		{"type":"message","role":"user","id":"prewarm","content":""}
+	]}`)
+	raw := []byte(`{"type":"response.create","input":[
+		{"type":"message","role":"assistant","id":"assistant-1","content":"prior reply"},
+		{"type":"message","role":"user","id":"user-1","content":"continue"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequest(raw, lastRequest, nil)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("replacement input len = %d, want 3: %s", len(input), normalized)
+	}
+	if got := input[0].Get("type").String(); got != "additional_tools" {
+		t.Fatalf("input[0].type = %q, want additional_tools: %s", got, normalized)
+	}
+	if got := input[0].Get("tools.0.name").String(); got != "exec" {
+		t.Fatalf("inherited tool name = %q, want exec: %s", got, normalized)
+	}
+}
+
+func TestNormalizeResponsesWebsocketRequestInheritsPrewarmToolsOnCompactReplayBypass(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[
+		{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},
+		{"type":"message","role":"user","id":"prewarm","content":""}
+	]}`)
+	raw := []byte(`{"type":"response.append","input":[
+		{"type":"message","role":"user","id":"retained-user","content":"retained context"},
+		{"type":"compaction","id":"compact-1","encrypted_content":"summary"},
+		{"type":"message","role":"user","id":"new-user","content":"continue"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, nil, false, true)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 4 {
+		t.Fatalf("compact replay input len = %d, want 4: %s", len(input), normalized)
+	}
+	if got := input[0].Get("type").String(); got != "additional_tools" {
+		t.Fatalf("input[0].type = %q, want additional_tools: %s", got, normalized)
+	}
+	if got := input[0].Get("tools.0.name").String(); got != "exec" {
+		t.Fatalf("inherited tool name = %q, want exec: %s", got, normalized)
+	}
+}
+
+func TestNormalizeResponsesWebsocketRequestPrefersReplacementTools(t *testing.T) {
+	lastRequest := []byte(`{"model":"gpt-5.6-sol","stream":true,"input":[
+		{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"old_exec"}]}
+	]}`)
+	raw := []byte(`{"type":"response.create","input":[
+		{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"new_exec"}]},
+		{"type":"message","role":"assistant","id":"assistant-1","content":"prior reply"},
+		{"type":"message","role":"user","id":"user-1","content":"continue"}
+	]}`)
+
+	normalized, _, errMsg := normalizeResponsesWebsocketRequest(raw, lastRequest, nil)
+	if errMsg != nil {
+		t.Fatalf("unexpected error: %v", errMsg.Error)
+	}
+	input := gjson.GetBytes(normalized, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("replacement input len = %d, want 3: %s", len(input), normalized)
+	}
+	if got := input[0].Get("tools.0.name").String(); got != "new_exec" {
+		t.Fatalf("replacement tool name = %q, want new_exec: %s", got, normalized)
+	}
+}
+
 func TestShouldReplaceWebsocketTranscriptCodexLocalCompactionSemantics(t *testing.T) {
 	compactedInput := gjson.Parse(fmt.Sprintf(`[
 		{"type":"message","role":"developer","content":[{"type":"input_text","text":"initial context"}]},


### PR DESCRIPTION
## Summary

- preserve prewarm additional_tools when a downstream Responses WebSocket request replaces incremental state with a full transcript
- keep replacement-provided tool declarations authoritative
- cover transcript replacement, unpinned replacement, and compact replay bypass paths with regression tests

## Problem

Codex sends model-visible tool declarations in the WebSocket prewarm request. When resuming or forking an existing thread, the next request can carry a complete transcript and a prewarm previous_response_id while omitting additional_tools.

For an HTTP/SSE upstream, CLIProxyAPI cannot retain the synthetic prewarm response chain. It removes previous_response_id and forwards the replacement transcript, but previously discarded the prewarm tool declarations. The model then receives the full conversation without shell or other client tools and correctly reports that they are unavailable.

The fix prepends only the previous request additional_tools items when the replacement input does not already include them. It does not merge stale conversation items, and current declarations win when present.

Related reports:

- openai/codex#41265 describes the same user-visible loss of all tools after resume or fork through a custom Responses endpoint.
- #2596 covers the related WebSocket-to-HTTP previous_response_id continuity boundary.

## Validation

- go test ./sdk/api/handlers/openai
- go test ./...
- go build -o test-output ./cmd/server
- real Codex 0.149.0 fork of an affected old session through a temporary v7.2.147 build: the reconstructed upstream request started with additional_tools containing the exec custom tool, and the model successfully invoked it to run pwd and print a sentinel.