### PR TITLE
fix(claude): recognize model-free native thinking signatures and warn on unknown generations

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -123,6 +123,14 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 	var unknownGenerationDrops []unknownGenerationDrop
 	unknownGenerationDropIndex := make(map[string]int)
 	for _, decision := range report.Decisions {
+		// Only a dropped block can be an unknown-generation drop. A preserved
+		// decision's reason (claudeCompatibleSignatureReason) echoes the
+		// signature's own attacker-controlled model_text, which can contain
+		// this marker's prose as a substring; classifying before this filter
+		// would misreport that preserved block as dropped.
+		if decision.Action != sigcompat.SignatureActionDropBlock {
+			continue
+		}
 		reason, ok := sigcompat.ClassifyUnknownCAISGeneration(decision.Reason)
 		if !ok {
 			continue

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -112,7 +112,6 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 	}
 
 	logger := helps.LogWithRequestID(ctx)
-	const unknownGenerationMarker = "invalid Claude model-free CAIS signature: unknown "
 	type unknownGenerationDrop struct {
 		reason           string
 		firstOccurrence  string
@@ -124,11 +123,10 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 	var unknownGenerationDrops []unknownGenerationDrop
 	unknownGenerationDropIndex := make(map[string]int)
 	for _, decision := range report.Decisions {
-		markerIndex := strings.Index(decision.Reason, unknownGenerationMarker)
-		if markerIndex < 0 {
+		reason, ok := sigcompat.ClassifyUnknownCAISGeneration(decision.Reason)
+		if !ok {
 			continue
 		}
-		reason := decision.Reason[markerIndex:]
 		if index, ok := unknownGenerationDropIndex[reason]; ok {
 			unknownGenerationDrops[index].count++
 			continue

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -112,21 +112,50 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 	}
 
 	logger := helps.LogWithRequestID(ctx)
-	for index, decision := range report.Decisions {
-		if !strings.Contains(decision.Reason, "invalid Claude model-free CAIS signature: unknown ") {
+	const unknownGenerationMarker = "invalid Claude model-free CAIS signature: unknown "
+	type unknownGenerationDrop struct {
+		reason           string
+		firstOccurrence  string
+		blockKind        sigcompat.SignatureBlockKind
+		detectedProvider sigcompat.SignatureProvider
+		signatureAction  sigcompat.SignatureCompatibilityAction
+		count            int
+	}
+	var unknownGenerationDrops []unknownGenerationDrop
+	unknownGenerationDropIndex := make(map[string]int)
+	for _, decision := range report.Decisions {
+		markerIndex := strings.Index(decision.Reason, unknownGenerationMarker)
+		if markerIndex < 0 {
 			continue
 		}
+		reason := decision.Reason[markerIndex:]
+		if index, ok := unknownGenerationDropIndex[reason]; ok {
+			unknownGenerationDrops[index].count++
+			continue
+		}
+		unknownGenerationDropIndex[reason] = len(unknownGenerationDrops)
+		unknownGenerationDrops = append(unknownGenerationDrops, unknownGenerationDrop{
+			reason:           reason,
+			firstOccurrence:  decision.Reason,
+			blockKind:        decision.BlockKind,
+			detectedProvider: decision.DetectedProvider,
+			signatureAction:  decision.Action,
+			count:            1,
+		})
+	}
+	for _, drop := range unknownGenerationDrops {
 		logger.WithFields(log.Fields{
-			"component":         "signature_sanitizer",
-			"executor":          "claude",
-			"action":            "drop_unknown_claude_cais_generation",
-			"target_provider":   string(report.TargetProvider),
-			"target_model":      baseModel,
-			"decision_index":    index,
-			"block_kind":        string(decision.BlockKind),
-			"detected_provider": string(decision.DetectedProvider),
-			"signature_action":  string(decision.Action),
-			"reason":            decision.Reason,
+			"component":           "signature_sanitizer",
+			"executor":            "claude",
+			"action":              "drop_unknown_claude_cais_generation",
+			"target_provider":     string(report.TargetProvider),
+			"target_model":        baseModel,
+			"block_kind":          string(drop.blockKind),
+			"detected_provider":   string(drop.detectedProvider),
+			"signature_action":    string(drop.signatureAction),
+			"reason":              drop.reason,
+			"first_occurrence":    drop.firstOccurrence,
+			"dropped_block_count": drop.count,
 		}).Warn("claude executor: dropped signed history for unknown CAIS generation")
 	}
 

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -111,6 +111,25 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 		return
 	}
 
+	logger := helps.LogWithRequestID(ctx)
+	for index, decision := range report.Decisions {
+		if !strings.Contains(decision.Reason, "invalid Claude model-free CAIS signature: unknown ") {
+			continue
+		}
+		logger.WithFields(log.Fields{
+			"component":         "signature_sanitizer",
+			"executor":          "claude",
+			"action":            "drop_unknown_claude_cais_generation",
+			"target_provider":   string(report.TargetProvider),
+			"target_model":      baseModel,
+			"decision_index":    index,
+			"block_kind":        string(decision.BlockKind),
+			"detected_provider": string(decision.DetectedProvider),
+			"signature_action":  string(decision.Action),
+			"reason":            decision.Reason,
+		}).Warn("claude executor: dropped signed history for unknown CAIS generation")
+	}
+
 	fields := log.Fields{
 		"component":           "signature_sanitizer",
 		"executor":            "claude",
@@ -129,7 +148,7 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 		fields["first_reason"] = decision.Reason
 	}
 
-	helps.LogWithRequestID(ctx).WithFields(fields).Debug("claude executor: sanitized signature history before upstream")
+	logger.WithFields(fields).Debug("claude executor: sanitized signature history before upstream")
 }
 
 // Anthropic-compatible upstreams may reject or even crash when Claude models

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -26,8 +26,11 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func resetClaudeDeviceProfileCache() {
@@ -45,6 +48,22 @@ func claudeOAuthTestMetadata() map[string]any {
 
 func malformedClaudeTreeSignatureForClaudeExecutorTest() string {
 	return base64.StdEncoding.EncodeToString([]byte{0x12, 0xFF, 0xFE, 0xFD})
+}
+
+func unknownGenerationClaudeCAISSignatureForExecutorTest() string {
+	channel := protowire.AppendTag(nil, 1, protowire.VarintType)
+	channel = protowire.AppendVarint(channel, 17)
+
+	container := protowire.AppendTag(nil, 1, protowire.BytesType)
+	container = protowire.AppendBytes(container, channel)
+	container = protowire.AppendTag(container, 5, protowire.BytesType)
+	container = protowire.AppendBytes(container, []byte("synthetic-model-free-carrier"))
+
+	payload := protowire.AppendTag(nil, 1, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, 5)
+	payload = protowire.AppendTag(payload, 2, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, container)
+	return base64.StdEncoding.EncodeToString(payload)
 }
 
 func newClaudeHeaderTestRequest(t *testing.T, incoming http.Header) *http.Request {
@@ -3192,6 +3211,92 @@ func TestClaudeExecutor_ExecuteSanitizesSignaturesBeforeUpstream(t *testing.T) {
 			t.Fatalf("tool_use.%s should be removed before upstream: %s", path, seenBody)
 		}
 	}
+}
+
+func TestClaudeExecutor_ExecuteWarnsForUnknownCAISGenerationAtDefaultInfo(t *testing.T) {
+	logger := log.StandardLogger()
+	previousLevel := logger.GetLevel()
+	previousOutput := logger.Out
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	logger.SetLevel(log.InfoLevel)
+	logger.SetOutput(io.Discard)
+	hook := logtest.NewLocal(logger)
+	t.Cleanup(func() {
+		hook.Reset()
+		logger.ReplaceHooks(previousHooks)
+		logger.SetOutput(previousOutput)
+		logger.SetLevel(previousLevel)
+	})
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = bytes.Clone(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	run := func(t *testing.T, signature string) ([]*log.Entry, []byte) {
+		t.Helper()
+		hook.Reset()
+		seenBody = nil
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"signed history","signature":"` + signature + `"},{"type":"text","text":"answer"}]},{"role":"user","content":[{"type":"text","text":"next"}]}]}`)
+		if _, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "claude-fable-5-1",
+			Payload: payload,
+		}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}); err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		if len(seenBody) == 0 {
+			t.Fatal("expected executor to send an upstream request")
+		}
+		return hook.AllEntries(), bytes.Clone(seenBody)
+	}
+
+	const warningMessage = "claude executor: dropped signed history for unknown CAIS generation"
+	t.Run("unknown generation is visible at default info", func(t *testing.T) {
+		signature := unknownGenerationClaudeCAISSignatureForExecutorTest()
+		entries, body := run(t, signature)
+		if bytes.Contains(body, []byte(signature)) {
+			t.Fatal("unknown-generation thinking signature reached upstream")
+		}
+
+		var warning *log.Entry
+		for _, entry := range entries {
+			if entry.Message == warningMessage {
+				warning = entry
+				break
+			}
+		}
+		if warning == nil {
+			t.Fatalf("default info logging emitted no unknown-generation diagnosis; entries=%v", entries)
+		}
+		if warning.Level != log.WarnLevel {
+			t.Fatalf("unknown-generation diagnosis level = %s, want warning", warning.Level)
+		}
+		reason := fmt.Sprint(warning.Data["reason"])
+		if !strings.Contains(reason, "unknown envelope version 5") {
+			t.Fatalf("warning reason = %q, want exact unknown-generation diagnosis", reason)
+		}
+	})
+
+	t.Run("ordinary drop stays below default info", func(t *testing.T) {
+		entries, body := run(t, "gAAAAABopenai-encrypted-content")
+		if bytes.Contains(body, []byte("gAAAAABopenai-encrypted-content")) {
+			t.Fatal("ordinary incompatible thinking signature reached upstream")
+		}
+		for _, entry := range entries {
+			if entry.Data["component"] == "signature_sanitizer" {
+				t.Fatalf("ordinary sanitize report escaped debug logging: level=%s message=%q fields=%v", entry.Level, entry.Message, entry.Data)
+			}
+		}
+	})
 }
 
 func TestClaudeExecutor_Execute_InvalidGzipErrorBodyReturnsDecodeMessage(t *testing.T) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -63,6 +64,42 @@ func modelFreeClaudeCAISSignatureForExecutorTest(envelopeVersion, channelID uint
 	payload = protowire.AppendVarint(payload, envelopeVersion)
 	payload = protowire.AppendTag(payload, 2, protowire.BytesType)
 	payload = protowire.AppendBytes(payload, container)
+	return base64.StdEncoding.EncodeToString(payload)
+}
+
+// modelTaggedClaudeCAISSignatureForExecutorTest builds a structurally valid,
+// Claude-target-compatible (preserve path) CAIS signature carrying modelText
+// as its channel field 6 model_text. It mirrors the wire layout the signature
+// package's defaultClaudeCAISParts/claudeCAISParts.encode fixture confirmed
+// against real claude-fable-5/claude-opus-5 captures (top-level field 1
+// envelope=2, field 2 container -> channel block field 1 channel_id=16, field
+// 3 channel version=2, field 5 a non-empty signature blob, field 6
+// model_text, top-level field 3 trailer=1), so InspectClaudeCAISSignature
+// classifies it as a genuine model-tagged signature and
+// DecideSignatureCompatibilityForModel takes the preserve branch rather than
+// the drop branch. modelText must start with "claude-"
+// (claudeCAISModelTextPrefix) to pass validation; everything after that
+// prefix is free-form, mirroring how a real model_text field carries an
+// attacker-observable value the sanitizer never authenticates.
+func modelTaggedClaudeCAISSignatureForExecutorTest(modelText string) string {
+	channelBlock := protowire.AppendTag(nil, 1, protowire.VarintType)
+	channelBlock = protowire.AppendVarint(channelBlock, 16)
+	channelBlock = protowire.AppendTag(channelBlock, 3, protowire.VarintType)
+	channelBlock = protowire.AppendVarint(channelBlock, 2)
+	channelBlock = protowire.AppendTag(channelBlock, 5, protowire.BytesType)
+	channelBlock = protowire.AppendBytes(channelBlock, make([]byte, 64))
+	channelBlock = protowire.AppendTag(channelBlock, 6, protowire.BytesType)
+	channelBlock = protowire.AppendBytes(channelBlock, []byte(modelText))
+
+	container := protowire.AppendTag(nil, 1, protowire.BytesType)
+	container = protowire.AppendBytes(container, channelBlock)
+
+	payload := protowire.AppendTag(nil, 1, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, 2)
+	payload = protowire.AppendTag(payload, 2, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, container)
+	payload = protowire.AppendTag(payload, 3, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, 1)
 	return base64.StdEncoding.EncodeToString(payload)
 }
 
@@ -3340,6 +3377,133 @@ func TestClaudeExecutor_ExecuteWarnsForUnknownCAISGenerationAtDefaultInfo(t *tes
 			}
 		}
 	})
+
+	// A model-tagged CAIS signature's model_text is attacker-controlled past
+	// its required "claude-" prefix. claudeCompatibleSignatureReason copies
+	// model_text verbatim into a PRESERVED decision's reason, so an attacker
+	// can make that reason contain the unknown-generation marker's prose even
+	// though the block was never dropped. These two cases pin that such a
+	// preserved decision is never misclassified as a drop: paired with a real
+	// drop, it must not be counted as (or alongside) that drop's warning; and
+	// alone, it must not produce a warning at all.
+	const embeddedMarkerModelText = "claude-x invalid Claude model-free CAIS signature: unknown envelope version 9"
+	t.Run("preserved decision echoing marker text is not misclassified as a drop", func(t *testing.T) {
+		preservedSignature := modelTaggedClaudeCAISSignatureForExecutorTest(embeddedMarkerModelText)
+		droppedSignature := modelFreeClaudeCAISSignatureForExecutorTest(5, 17)
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"preserved with embedded marker","signature":"` + preservedSignature + `"},{"type":"text","text":"answer 0"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 0"}]},` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"real drop","signature":"` + droppedSignature + `"},{"type":"text","text":"answer 1"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 1"}]}]}`)
+		entries, body := run(t, payload)
+		if !bytes.Contains(body, []byte(preservedSignature)) {
+			t.Fatal("preserved CAIS signature with embedded marker text was not sent upstream")
+		}
+		if bytes.Contains(body, []byte(droppedSignature)) {
+			t.Fatal("unknown-generation thinking signature reached upstream")
+		}
+		assertUnknownWarnings(t, entries, map[string]int{unknownEnvelopeReason: 1})
+	})
+
+	t.Run("marker text only in a preserved decision emits no warning", func(t *testing.T) {
+		// Pair the preserved marker-bearing signature with an ordinary foreign
+		// drop (unrelated reason text) rather than sending it alone: alone,
+		// report.DroppedBlocks/DroppedSignatures/ReplacedSignatures would all
+		// be zero and logClaudeSignatureSanitizeReport would return before
+		// ever reaching the decisions loop, passing regardless of whether the
+		// classifier is anchored. The ordinary drop reaches that loop without
+		// itself being an unknown-generation reason.
+		const ordinarySignature = "gAAAAABopenai-encrypted-content"
+		preservedSignature := modelTaggedClaudeCAISSignatureForExecutorTest(embeddedMarkerModelText)
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"preserved with embedded marker","signature":"` + preservedSignature + `"},{"type":"text","text":"answer 0"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 0"}]},` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"ordinary foreign drop","signature":"` + ordinarySignature + `"},{"type":"text","text":"answer 1"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 1"}]}]}`)
+		entries, body := run(t, payload)
+		if !bytes.Contains(body, []byte(preservedSignature)) {
+			t.Fatal("preserved CAIS signature with embedded marker text was not sent upstream")
+		}
+		if bytes.Contains(body, []byte(ordinarySignature)) {
+			t.Fatal("ordinary incompatible thinking signature reached upstream")
+		}
+		assertUnknownWarnings(t, entries, map[string]int{})
+	})
+}
+
+// TestLogClaudeSignatureSanitizeReport_FiltersNonDropDecisionsBeforeClassifying
+// isolates logClaudeSignatureSanitizeReport's own Action == SignatureActionDropBlock
+// filter, independent of sigcompat.ClassifyUnknownCAISGeneration's anchoring
+// (which TestClaudeExecutor_ExecuteWarnsForUnknownCAISGenerationAtDefaultInfo's
+// "preserved decision echoing marker text" subtest already covers via the real
+// sanitizer). The real sanitizer never produces a preserve decision whose
+// Reason equals the unknown-generation marker verbatim — claudeCompatibleSignatureReason
+// always prepends its own fixed "valid Claude..." lead-in text first, which
+// the classifier's anchoring alone is enough to reject — so this builds the
+// report directly to construct the one case that isolates the filter: a
+// preserve decision whose Reason, if classified, WOULD pass the anchored
+// classifier. Without the filter this still logs a second, spurious warning;
+// with it, only the genuine drop is reported.
+func TestLogClaudeSignatureSanitizeReport_FiltersNonDropDecisionsBeforeClassifying(t *testing.T) {
+	logger := log.StandardLogger()
+	previousLevel := logger.GetLevel()
+	previousOutput := logger.Out
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	logger.SetLevel(log.InfoLevel)
+	logger.SetOutput(io.Discard)
+	hook := logtest.NewLocal(logger)
+	t.Cleanup(func() {
+		hook.Reset()
+		logger.ReplaceHooks(previousHooks)
+		logger.SetOutput(previousOutput)
+		logger.SetLevel(previousLevel)
+	})
+
+	const realDropReason = "invalid Claude model-free CAIS signature: unknown envelope version 5"
+	const notADropReason = "invalid Claude model-free CAIS signature: unknown channel_id 18"
+
+	report := sigcompat.SignatureSanitizeReport{
+		TargetProvider: sigcompat.SignatureProviderClaude,
+		Preserved:      1,
+		DroppedBlocks:  1,
+		Decisions: []sigcompat.SignatureCompatibilityDecision{
+			{
+				Action:    sigcompat.SignatureActionDropBlock,
+				Reason:    "messages[0].content[0]: " + realDropReason,
+				BlockKind: sigcompat.SignatureBlockKindClaudeThinking,
+			},
+			{
+				// Constructed directly, not via the real sanitizer: a
+				// preserve decision whose Reason is exactly a position
+				// prefix plus the unknown-generation marker, with nothing
+				// else around it, so ClassifyUnknownCAISGeneration alone
+				// would say ok=true for it. Only the Action filter can
+				// catch this one.
+				Action:    sigcompat.SignatureActionPreserve,
+				Reason:    "messages[1].content[0]: " + notADropReason,
+				BlockKind: sigcompat.SignatureBlockKindClaudeThinking,
+			},
+		},
+	}
+
+	logClaudeSignatureSanitizeReport(context.Background(), "claude-fable-5-1", report)
+
+	const warningMessage = "claude executor: dropped signed history for unknown CAIS generation"
+	var warnings []*log.Entry
+	for _, entry := range hook.AllEntries() {
+		if entry.Message == warningMessage {
+			warnings = append(warnings, entry)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("unknown-generation warning count = %d, want 1; entries=%v", len(warnings), warnings)
+	}
+	if got := fmt.Sprint(warnings[0].Data["reason"]); got != realDropReason {
+		t.Fatalf("warning reason = %q, want %q (the preserved decision must not be classified)", got, realDropReason)
+	}
+	if got := fmt.Sprint(warnings[0].Data["signature_action"]); got != string(sigcompat.SignatureActionDropBlock) {
+		t.Fatalf("warning signature_action = %q, want %q", got, sigcompat.SignatureActionDropBlock)
+	}
 }
 
 func TestClaudeExecutor_Execute_InvalidGzipErrorBodyReturnsDecodeMessage(t *testing.T) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -50,9 +50,9 @@ func malformedClaudeTreeSignatureForClaudeExecutorTest() string {
 	return base64.StdEncoding.EncodeToString([]byte{0x12, 0xFF, 0xFE, 0xFD})
 }
 
-func unknownGenerationClaudeCAISSignatureForExecutorTest() string {
+func modelFreeClaudeCAISSignatureForExecutorTest(envelopeVersion, channelID uint64) string {
 	channel := protowire.AppendTag(nil, 1, protowire.VarintType)
-	channel = protowire.AppendVarint(channel, 17)
+	channel = protowire.AppendVarint(channel, channelID)
 
 	container := protowire.AppendTag(nil, 1, protowire.BytesType)
 	container = protowire.AppendBytes(container, channel)
@@ -60,7 +60,7 @@ func unknownGenerationClaudeCAISSignatureForExecutorTest() string {
 	container = protowire.AppendBytes(container, []byte("synthetic-model-free-carrier"))
 
 	payload := protowire.AppendTag(nil, 1, protowire.VarintType)
-	payload = protowire.AppendVarint(payload, 5)
+	payload = protowire.AppendVarint(payload, envelopeVersion)
 	payload = protowire.AppendTag(payload, 2, protowire.BytesType)
 	payload = protowire.AppendBytes(payload, container)
 	return base64.StdEncoding.EncodeToString(payload)
@@ -3242,11 +3242,10 @@ func TestClaudeExecutor_ExecuteWarnsForUnknownCAISGenerationAtDefaultInfo(t *tes
 		"api_key":  "key-123",
 		"base_url": server.URL,
 	}}
-	run := func(t *testing.T, signature string) ([]*log.Entry, []byte) {
+	run := func(t *testing.T, payload []byte) ([]*log.Entry, []byte) {
 		t.Helper()
 		hook.Reset()
 		seenBody = nil
-		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"signed history","signature":"` + signature + `"},{"type":"text","text":"answer"}]},{"role":"user","content":[{"type":"text","text":"next"}]}]}`)
 		if _, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 			Model:   "claude-fable-5-1",
 			Payload: payload,
@@ -3260,35 +3259,79 @@ func TestClaudeExecutor_ExecuteWarnsForUnknownCAISGenerationAtDefaultInfo(t *tes
 	}
 
 	const warningMessage = "claude executor: dropped signed history for unknown CAIS generation"
-	t.Run("unknown generation is visible at default info", func(t *testing.T) {
-		signature := unknownGenerationClaudeCAISSignatureForExecutorTest()
-		entries, body := run(t, signature)
+	assertUnknownWarnings := func(t *testing.T, entries []*log.Entry, want map[string]int) {
+		t.Helper()
+		got := make(map[string]int)
+		for _, entry := range entries {
+			if entry.Message != warningMessage {
+				continue
+			}
+			if entry.Level != log.WarnLevel {
+				t.Fatalf("unknown-generation diagnosis level = %s, want warning", entry.Level)
+			}
+			reason := fmt.Sprint(entry.Data["reason"])
+			if _, duplicate := got[reason]; duplicate {
+				t.Fatalf("unknown-generation reason %q emitted more than once instead of being aggregated", reason)
+			}
+			count, ok := entry.Data["dropped_block_count"].(int)
+			if !ok {
+				t.Fatalf("warning for %q has dropped_block_count=%#v, want integer", reason, entry.Data["dropped_block_count"])
+			}
+			got[reason] = count
+		}
+		if len(got) != len(want) {
+			t.Fatalf("unknown-generation warning reasons = %v, want %v; entries=%v", got, want, entries)
+		}
+		for reason, count := range want {
+			if got[reason] != count {
+				t.Fatalf("warning count for %q = %d, want %d; all=%v", reason, got[reason], count, got)
+			}
+		}
+	}
+
+	const unknownEnvelopeReason = "invalid Claude model-free CAIS signature: unknown envelope version 5"
+	const unknownChannelReason = "invalid Claude model-free CAIS signature: unknown channel_id 18"
+	t.Run("sole unknown generation is visible at default info", func(t *testing.T) {
+		signature := modelFreeClaudeCAISSignatureForExecutorTest(5, 17)
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"signed history","signature":"` + signature + `"},{"type":"text","text":"answer"}]},{"role":"user","content":[{"type":"text","text":"next"}]}]}`)
+		entries, body := run(t, payload)
 		if bytes.Contains(body, []byte(signature)) {
 			t.Fatal("unknown-generation thinking signature reached upstream")
 		}
-
-		var warning *log.Entry
-		for _, entry := range entries {
-			if entry.Message == warningMessage {
-				warning = entry
-				break
-			}
-		}
-		if warning == nil {
-			t.Fatalf("default info logging emitted no unknown-generation diagnosis; entries=%v", entries)
-		}
-		if warning.Level != log.WarnLevel {
-			t.Fatalf("unknown-generation diagnosis level = %s, want warning", warning.Level)
-		}
-		reason := fmt.Sprint(warning.Data["reason"])
-		if !strings.Contains(reason, "unknown envelope version 5") {
-			t.Fatalf("warning reason = %q, want exact unknown-generation diagnosis", reason)
-		}
+		assertUnknownWarnings(t, entries, map[string]int{unknownEnvelopeReason: 1})
 	})
 
-	t.Run("ordinary drop stays below default info", func(t *testing.T) {
-		entries, body := run(t, "gAAAAABopenai-encrypted-content")
-		if bytes.Contains(body, []byte("gAAAAABopenai-encrypted-content")) {
+	t.Run("later unknown generations are aggregated at default info", func(t *testing.T) {
+		recognized := modelFreeClaudeCAISSignatureForExecutorTest(4, 17)
+		unknownEnvelope := modelFreeClaudeCAISSignatureForExecutorTest(5, 17)
+		unknownChannel := modelFreeClaudeCAISSignatureForExecutorTest(4, 18)
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"recognized","signature":"` + recognized + `"},{"type":"text","text":"answer 0"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 0"}]},` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"unknown envelope one","signature":"` + unknownEnvelope + `"},{"type":"text","text":"answer 1"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 1"}]},` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"unknown envelope two","signature":"` + unknownEnvelope + `"},{"type":"text","text":"answer 2"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 2"}]},` +
+			`{"role":"assistant","content":[{"type":"thinking","thinking":"unknown channel","signature":"` + unknownChannel + `"},{"type":"text","text":"answer 3"}]},` +
+			`{"role":"user","content":[{"type":"text","text":"next 3"}]}]}`)
+		entries, body := run(t, payload)
+		if !bytes.Contains(body, []byte(recognized)) {
+			t.Fatal("recognized CAIS signature was not preserved ahead of later rejections")
+		}
+		if bytes.Contains(body, []byte(unknownEnvelope)) || bytes.Contains(body, []byte(unknownChannel)) {
+			t.Fatal("later unknown-generation thinking signature reached upstream")
+		}
+		assertUnknownWarnings(t, entries, map[string]int{
+			unknownEnvelopeReason: 2,
+			unknownChannelReason:  1,
+		})
+	})
+
+	t.Run("ordinary drop emits no warning", func(t *testing.T) {
+		const ordinarySignature = "gAAAAABopenai-encrypted-content"
+		payload := []byte(`{"model":"claude-fable-5-1","max_tokens":16,"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"foreign history","signature":"` + ordinarySignature + `"},{"type":"text","text":"answer"}]},{"role":"user","content":[{"type":"text","text":"next"}]}]}`)
+		entries, body := run(t, payload)
+		if bytes.Contains(body, []byte(ordinarySignature)) {
 			t.Fatal("ordinary incompatible thinking signature reached upstream")
 		}
 		for _, entry := range entries {

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -1033,6 +1033,79 @@ func TestClaudeModelFreeCAISSignature_UnknownGenerationReasonIsSpecific(t *testi
 	}
 }
 
+// TestClassifyUnknownCAISGeneration pins the exported classifier that callers
+// (the Claude executor's sanitize-report logger) must use instead of
+// re-matching claudeCAISUnknownGenerationError's prose themselves.
+func TestClassifyUnknownCAISGeneration(t *testing.T) {
+	t.Run("bare reason", func(t *testing.T) {
+		err := &claudeCAISUnknownGenerationError{identifier: "channel_id", value: 99}
+		normalized, ok := ClassifyUnknownCAISGeneration(err.Error())
+		if !ok {
+			t.Fatalf("ClassifyUnknownCAISGeneration(%q) ok = false, want true", err.Error())
+		}
+		if normalized != err.Error() {
+			t.Fatalf("normalized = %q, want %q unchanged (no position prefix to strip)", normalized, err.Error())
+		}
+	})
+
+	t.Run("position-prefixed reason", func(t *testing.T) {
+		err := &claudeCAISUnknownGenerationError{identifier: "envelope version", value: 7}
+		prefixed := "messages[2].content[5]: " + err.Error()
+		normalized, ok := ClassifyUnknownCAISGeneration(prefixed)
+		if !ok {
+			t.Fatalf("ClassifyUnknownCAISGeneration(%q) ok = false, want true", prefixed)
+		}
+		if normalized != err.Error() {
+			t.Fatalf("normalized = %q, want %q (sanitizer position prefix must be stripped)", normalized, err.Error())
+		}
+	})
+
+	t.Run("non-matching reason", func(t *testing.T) {
+		for _, reason := range []string{
+			"",
+			"Claude has no cross-provider bypass sentinel for thinking blocks",
+			"GPT reasoning encrypted_content cannot be synthesized from another provider signature",
+		} {
+			if normalized, ok := ClassifyUnknownCAISGeneration(reason); ok {
+				t.Fatalf("ClassifyUnknownCAISGeneration(%q) = (%q, true), want ok=false", reason, normalized)
+			}
+		}
+	})
+
+	// The motivating case: classify a reason produced end to end by the real
+	// sanitizer (SanitizeClaudeMessagesForClaudeUpstream ->
+	// DecideSignatureCompatibilityForModel -> claudeCAISUnknownGenerationError.Error()),
+	// not a hand-typed string on either side of the comparison. This is the
+	// assertion that fails if someone rewords claudeCAISUnknownGenerationError.Error()
+	// without updating claudeCAISUnknownGenerationPrefix: ok would become false
+	// (the classifier no longer recognizes the real error's prose), which the
+	// t.Fatalf below on "ok = false" catches directly.
+	t.Run("agrees with the real sanitizer-produced reason", func(t *testing.T) {
+		parts := defaultClaudeModelFreeCAISParts()
+		parts.envelopeVersion = 5
+		signature := parts.encode()
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + signature + `"},{"type":"text","text":"answer"}]}]}`)
+
+		_, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-fable-5-1")
+		if len(report.Decisions) != 1 {
+			t.Fatalf("decision count = %d, want 1; report=%+v", len(report.Decisions), report)
+		}
+		decision := report.Decisions[0]
+		if !strings.HasPrefix(decision.Reason, "messages[0].content[0]: ") {
+			t.Fatalf("decision.Reason = %q, want a sanitizer position prefix so this test exercises prefix tolerance", decision.Reason)
+		}
+
+		want := (&claudeCAISUnknownGenerationError{identifier: "envelope version", value: 5}).Error()
+		normalized, ok := ClassifyUnknownCAISGeneration(decision.Reason)
+		if !ok {
+			t.Fatalf("ClassifyUnknownCAISGeneration(%q) ok = false, want true", decision.Reason)
+		}
+		if normalized != want {
+			t.Fatalf("normalized = %q, want %q (must agree with the real claudeCAISUnknownGenerationError value)", normalized, want)
+		}
+	})
+}
+
 func TestClaudeModelFreeCAISSignature_RejectsLegacyOnlyChannelID(t *testing.T) {
 	parts := defaultClaudeModelFreeCAISParts()
 	parts.channelID = 11

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -271,6 +271,120 @@ func testClaudeCAISSignature(model string) string {
 	return defaultClaudeCAISParts(model).encode()
 }
 
+// claudeModelFreeCAISParts builds only synthetic model-free CAIS envelopes. The
+// envelope and channel identifiers, field numbers, wire types, and field
+// presence constants were confirmed against all 8 real captures on 2026-09-02;
+// no captured signature bytes are embedded in this test fixture.
+type claudeModelFreeCAISParts struct {
+	envelopeVersion       uint64
+	channelID             uint64
+	includeChannelVersion bool
+	channelVersion        uint64
+	includeField7         bool
+	field7                uint64
+	blockKind             string
+	contextID             string
+	includeTopTrailer     bool
+	topTrailer            uint64
+	includeCarrier        bool
+	carrierLen            int
+}
+
+func defaultClaudeModelFreeCAISParts() claudeModelFreeCAISParts {
+	return claudeModelFreeCAISParts{
+		envelopeVersion:       4,
+		channelID:             17,
+		includeChannelVersion: true,
+		channelVersion:        2,
+		includeField7:         true,
+		field7:                1,
+		blockKind:             "thinking",
+		includeTopTrailer:     true,
+		topTrailer:            1,
+		includeCarrier:        true,
+		carrierLen:            96,
+	}
+}
+
+func syntheticSignatureBytes(length int, salt byte) []byte {
+	value := make([]byte, length)
+	for i := range value {
+		value[i] = byte(i*73 + int(salt))
+	}
+	return value
+}
+
+func (p claudeModelFreeCAISParts) encode() string {
+	var channelBlock []byte
+	channelBlock = protowire.AppendTag(channelBlock, 1, protowire.VarintType)
+	channelBlock = protowire.AppendVarint(channelBlock, p.channelID)
+	if p.includeChannelVersion {
+		channelBlock = protowire.AppendTag(channelBlock, 3, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, p.channelVersion)
+	}
+	if p.includeField7 {
+		channelBlock = protowire.AppendTag(channelBlock, 7, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, p.field7)
+	}
+	if p.blockKind != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 8, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.blockKind)
+	}
+	if p.contextID != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 11, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.contextID)
+	}
+
+	var container []byte
+	container = protowire.AppendTag(container, 1, protowire.BytesType)
+	container = protowire.AppendBytes(container, channelBlock)
+	container = protowire.AppendTag(container, 2, protowire.BytesType)
+	container = protowire.AppendBytes(container, syntheticSignatureBytes(12, 0x21))
+	container = protowire.AppendTag(container, 3, protowire.BytesType)
+	container = protowire.AppendBytes(container, syntheticSignatureBytes(12, 0x43))
+	container = protowire.AppendTag(container, 4, protowire.BytesType)
+	container = protowire.AppendBytes(container, syntheticSignatureBytes(48, 0x65))
+	if p.includeCarrier {
+		container = protowire.AppendTag(container, 5, protowire.BytesType)
+		container = protowire.AppendBytes(container, syntheticSignatureBytes(p.carrierLen, 0x87))
+	}
+
+	var payload []byte
+	payload = protowire.AppendTag(payload, 1, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, p.envelopeVersion)
+	payload = protowire.AppendTag(payload, 2, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, container)
+	if p.includeTopTrailer {
+		payload = protowire.AppendTag(payload, 3, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, p.topTrailer)
+	}
+	return base64.StdEncoding.EncodeToString(payload)
+}
+
+func syntheticOpaqueProviderSignature(decodedLen int) string {
+	payload := syntheticSignatureBytes(decodedLen, 0xfc)
+	if len(payload) > 0 {
+		payload[0] = 0xfc
+	}
+	return base64.RawStdEncoding.EncodeToString(payload)
+}
+
+// hasGrokOpaqueTransportShapeWithoutEnvelopeExclusions checks only the opaque
+// payload properties that the Grok validator enforces. It must not
+// call InspectGrokEncryptedContent: that validator rejects recognized Claude
+// envelopes by invoking the Claude predicate under test, which would make a
+// negative assertion circular.
+func hasGrokOpaqueTransportShapeWithoutEnvelopeExclusions(raw string) bool {
+	if raw == "" || raw != strings.TrimSpace(raw) || len(raw) > MaxGrokEncryptedContentLen || strings.Contains(raw, "=") {
+		return false
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(raw)
+	if err != nil || len(decoded) < MinGrokEncryptedContentDecodedLen {
+		return false
+	}
+	return byteEntropyRatio(decoded) >= MinGrokEncryptedContentEntropyRatio
+}
+
 func TestClaudeCAISSignature_ObservedFable5Sample(t *testing.T) {
 	if !IsValidClaudeCAISSignature(observedFable5Sample) {
 		t.Fatal("IsValidClaudeCAISSignature(observedFable5Sample) = false, want true")
@@ -637,5 +751,261 @@ func TestCompatibleAntigravityClaudeThinkingSignature_RejectsClaudeCAIS(t *testi
 	}
 	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("claude-cais#" + observedFable5Sample); ok || normalized != "" {
 		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(claude-cais#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_PreservesSignedHistory(t *testing.T) {
+	signature := defaultClaudeModelFreeCAISParts().encode()
+	input := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"before"}]},{"role":"system","content":[{"type":"text","text":"directive"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + signature + `"}]},{"role":"user","content":[{"type":"text","text":"after"}]}]}`)
+
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-fable-5-1")
+	if got := gjson.GetBytes(output, "messages.#").Int(); got != 4 {
+		t.Errorf("messages.# = %d, want 4; body=%s", got, output)
+	}
+
+	messages := gjson.GetBytes(output, "messages").Array()
+	wantRoles := []string{"user", "system", "assistant", "user"}
+	if len(messages) == len(wantRoles) {
+		for i, want := range wantRoles {
+			if got := messages[i].Get("role").String(); got != want {
+				t.Errorf("messages[%d].role = %q, want %q; body=%s", i, got, want, output)
+			}
+		}
+	}
+	for i, message := range messages {
+		if message.Get("role").String() != "system" || i == len(messages)-1 {
+			continue
+		}
+		if got := messages[i+1].Get("role").String(); got != "assistant" {
+			t.Errorf("messages[%d] role=system is followed by %q, want assistant; body=%s", i, got, output)
+		}
+	}
+	if got := gjson.GetBytes(output, "messages.2.content.0.signature").String(); got != signature {
+		t.Errorf("model-free thinking signature was not preserved; body=%s", output)
+	}
+	if report.Preserved != 1 || report.DroppedBlocks != 0 {
+		t.Errorf("report = %+v, want one preserved block and no drops; body=%s", report, output)
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_UsesStructuralGenerationRecognition(t *testing.T) {
+	accepted := []struct {
+		name  string
+		parts claudeModelFreeCAISParts
+	}{
+		{"captured field shape", defaultClaudeModelFreeCAISParts()},
+		// The generation allowlists are deliberately Cartesian. These cases pin
+		// every currently accepted pair without claiming that every pair has
+		// appeared in model-free captures.
+		{"known envelope 2 with channel 17", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.envelopeVersion = 2
+			return p
+		}()},
+		{"envelope 4 with known channel 16", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.channelID = 16
+			return p
+		}()},
+		{"known envelope 2 with channel 16", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.envelopeVersion = 2
+			p.channelID = 16
+			return p
+		}()},
+		{"channel version absent", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.includeChannelVersion = false
+			return p
+		}()},
+		{"channel version changed", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.channelVersion = 99
+			return p
+		}()},
+		{"field 7 absent", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.includeField7 = false
+			return p
+		}()},
+		{"field 7 changed", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.field7 = 123
+			return p
+		}()},
+		{"trailer absent", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.includeTopTrailer = false
+			return p
+		}()},
+		{"trailer changed", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.topTrailer = 7
+			return p
+		}()},
+		{"tool use block kind", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.blockKind = "tool_use"
+			return p
+		}()},
+		{"context id present", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.contextID = "00000000-0000-4000-8000-000000000001"
+			return p
+		}()},
+		{"one-byte carrier", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.carrierLen = 1
+			return p
+		}()},
+		{"200 KiB carrier", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.carrierLen = 200 * 1024
+			return p
+		}()},
+	}
+	for _, tc := range accepted {
+		signature := tc.parts.encode()
+		if got := DetectSignatureProviderForBlock(signature, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+			t.Errorf("%s: provider = %q, want %q", tc.name, got, SignatureProviderClaude)
+		}
+	}
+
+	rejected := []struct {
+		name  string
+		parts claudeModelFreeCAISParts
+	}{
+		{"unknown envelope version", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.envelopeVersion = 5
+			return p
+		}()},
+		{"unknown channel id", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.channelID = 18
+			return p
+		}()},
+		{"legacy-only channel id", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.channelID = 11
+			return p
+		}()},
+		{"missing carrier", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.includeCarrier = false
+			return p
+		}()},
+		{"empty carrier", func() claudeModelFreeCAISParts {
+			p := defaultClaudeModelFreeCAISParts()
+			p.carrierLen = 0
+			return p
+		}()},
+	}
+	for _, tc := range rejected {
+		signature := tc.parts.encode()
+		if got := DetectSignatureProviderForBlock(signature, SignatureBlockKindClaudeThinking); got == SignatureProviderClaude {
+			t.Errorf("%s: provider = %q, want non-Claude", tc.name, got)
+		}
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_UsesEnvelopeClassificationWithOpaqueOverlap(t *testing.T) {
+	claudeSignature := defaultClaudeModelFreeCAISParts().encode()
+	if got := DetectSignatureProviderForBlock(claudeSignature, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+		t.Errorf("model-free CAIS provider = %q, want %q", got, SignatureProviderClaude)
+	}
+	// Grok has no provider-distinguishing payload envelope. This synthetic CAIS
+	// fixture also satisfies Grok's opaque base64, size, and entropy properties.
+	// Classification must therefore come from the CAIS tree, not from a false
+	// claim that the transport shapes are disjoint.
+	if !hasGrokOpaqueTransportShapeWithoutEnvelopeExclusions(claudeSignature) {
+		t.Error("model-free CAIS fixture no longer exercises the Grok transport-shape overlap")
+	}
+
+	// No Kimi or Grok provider corpus is present locally. These ordinary controls
+	// reproduce their documented opaque transport shapes with deterministic
+	// high-entropy bytes rather than embedding captured values. The Kimi value is
+	// not adversarially CAIS-shaped: it only proves the residual fixed-length path
+	// remains reachable after the self-describing envelope probes decline.
+	kimiSignature := syntheticOpaqueProviderSignature(KimiThinkingSignatureStreamingLen * 3 / 4)
+	if len(kimiSignature) != KimiThinkingSignatureStreamingLen || !IsValidKimiThinkingSignature(kimiSignature) {
+		t.Fatal("synthetic Kimi control does not satisfy Kimi's streaming transport shape")
+	}
+	grokSignature := syntheticOpaqueProviderSignature(257)
+	if !IsValidGrokEncryptedContent(grokSignature) {
+		t.Fatal("synthetic Grok control does not satisfy Grok's transport shape")
+	}
+
+	controls := []struct {
+		name      string
+		signature string
+		provider  SignatureProvider
+	}{
+		{"Gemini protobuf envelope", testGeminiThoughtSignatureEnvelope(), SignatureProviderGemini},
+		{"GPT Fernet envelope", testGPTReasoningSignature(), SignatureProviderGPT},
+		{"Kimi streaming transport", kimiSignature, SignatureProviderKimi},
+		{"Grok opaque transport", grokSignature, SignatureProviderUnknown},
+	}
+	for _, control := range controls {
+		if IsValidClaudeCAISSignature(control.signature) {
+			t.Errorf("%s was claimed as Claude CAIS", control.name)
+		}
+		if got := DetectSignatureProviderForBlock(control.signature, SignatureBlockKindClaudeThinking); got != control.provider {
+			t.Errorf("%s provider = %q, want %q", control.name, got, control.provider)
+		}
+	}
+}
+
+func TestClaudeCAISSignature_RejectsInvalidUTF8BlockKind(t *testing.T) {
+	parts := defaultClaudeCAISParts("claude-opus-5")
+	parts.blockKind = string([]byte{0xff, 0xfe})
+	signature := parts.encode()
+
+	if IsValidClaudeCAISSignature(signature) {
+		t.Fatal("model-tagged CAIS accepted invalid UTF-8 in channel field 8")
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_UnknownGenerationReasonIsSpecific(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*claudeModelFreeCAISParts)
+		want   string
+	}{
+		{"channel id", func(parts *claudeModelFreeCAISParts) { parts.channelID = 18 }, "unknown channel_id 18"},
+		{"envelope version", func(parts *claudeModelFreeCAISParts) { parts.envelopeVersion = 5 }, "unknown envelope version 5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := defaultClaudeModelFreeCAISParts()
+			tc.mutate(&parts)
+			signature := parts.encode()
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + signature + `"},{"type":"text","text":"answer"}]}]}`)
+
+			_, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-fable-5-1")
+			if len(report.Decisions) != 1 {
+				t.Fatalf("decision count = %d, want 1; report=%+v", len(report.Decisions), report)
+			}
+			decision := report.Decisions[0]
+			if decision.Action != SignatureActionDropBlock || decision.DetectedProvider != SignatureProviderUnknown {
+				t.Fatalf("decision = %+v, want unknown provider and dropped block", decision)
+			}
+			if !strings.Contains(decision.Reason, tc.want) {
+				t.Fatalf("reason = %q, want specific diagnosis containing %q", decision.Reason, tc.want)
+			}
+			if strings.Contains(decision.Reason, "cross-provider") {
+				t.Fatalf("reason = %q, must not claim a cross-provider mismatch", decision.Reason)
+			}
+		})
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_RejectsLegacyOnlyChannelID(t *testing.T) {
+	parts := defaultClaudeModelFreeCAISParts()
+	parts.channelID = 11
+	signature := parts.encode()
+
+	if got := DetectSignatureProviderForBlock(signature, SignatureBlockKindClaudeThinking); got != SignatureProviderUnknown {
+		t.Fatalf("channel_id 11 provider = %q, want %q because 11 is unobserved under CAIS", got, SignatureProviderUnknown)
 	}
 }

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -289,6 +289,7 @@ type claudeModelFreeCAISParts struct {
 	topTrailer            uint64
 	includeCarrier        bool
 	carrierLen            int
+	carrierTypes          []protowire.Type
 }
 
 func defaultClaudeModelFreeCAISParts() claudeModelFreeCAISParts {
@@ -304,6 +305,7 @@ func defaultClaudeModelFreeCAISParts() claudeModelFreeCAISParts {
 		topTrailer:            1,
 		includeCarrier:        true,
 		carrierLen:            96,
+		carrierTypes:          []protowire.Type{protowire.BytesType},
 	}
 }
 
@@ -346,8 +348,17 @@ func (p claudeModelFreeCAISParts) encode() string {
 	container = protowire.AppendTag(container, 4, protowire.BytesType)
 	container = protowire.AppendBytes(container, syntheticSignatureBytes(48, 0x65))
 	if p.includeCarrier {
-		container = protowire.AppendTag(container, 5, protowire.BytesType)
-		container = protowire.AppendBytes(container, syntheticSignatureBytes(p.carrierLen, 0x87))
+		for _, carrierType := range p.carrierTypes {
+			container = protowire.AppendTag(container, 5, carrierType)
+			switch carrierType {
+			case protowire.BytesType:
+				container = protowire.AppendBytes(container, syntheticSignatureBytes(p.carrierLen, 0x87))
+			case protowire.VarintType:
+				container = protowire.AppendVarint(container, 1)
+			default:
+				panic("unsupported synthetic carrier wire type")
+			}
+		}
 	}
 
 	var payload []byte
@@ -1227,6 +1238,38 @@ func TestClaudeModelFreeCAISSignature_CarrierValidatedBeforeGeneration(t *testin
 			t.Fatalf("err = %v, want *claudeCAISUnknownGenerationError when the carrier is well-formed", err)
 		}
 	})
+}
+
+func TestClaudeModelFreeCAISSignature_RejectsAnyWrongWireCarrierOccurrence(t *testing.T) {
+	tests := []struct {
+		name         string
+		carrierTypes []protowire.Type
+		wantValid    bool
+	}{
+		{name: "wrong then valid", carrierTypes: []protowire.Type{protowire.VarintType, protowire.BytesType}},
+		{name: "valid then wrong", carrierTypes: []protowire.Type{protowire.BytesType, protowire.VarintType}},
+		{name: "valid then valid", carrierTypes: []protowire.Type{protowire.BytesType, protowire.BytesType}, wantValid: true},
+		{name: "single wrong", carrierTypes: []protowire.Type{protowire.VarintType}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parts := defaultClaudeModelFreeCAISParts()
+			parts.carrierTypes = tc.carrierTypes
+			_, err := InspectClaudeCAISSignature(parts.encode())
+			if tc.wantValid {
+				if err != nil {
+					t.Fatalf("InspectClaudeCAISSignature() error = %v, want accepted", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("InspectClaudeCAISSignature() error = nil, want wrong-wire rejection")
+			}
+			if !strings.Contains(err.Error(), "container field 5 carrier must be bytes") {
+				t.Fatalf("error = %q, want container field 5 wrong-wire error", err)
+			}
+		})
+	}
 }
 
 func TestClaudeModelFreeCAISSignature_RejectsLegacyOnlyChannelID(t *testing.T) {

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -2,6 +2,7 @@ package signature
 
 import (
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 
@@ -1102,6 +1103,68 @@ func TestClassifyUnknownCAISGeneration(t *testing.T) {
 		}
 		if normalized != want {
 			t.Fatalf("normalized = %q, want %q (must agree with the real claudeCAISUnknownGenerationError value)", normalized, want)
+		}
+	})
+}
+
+// TestClaudeModelFreeCAISSignature_CarrierValidatedBeforeGeneration pins the
+// order of the model-free CAIS switch: a malformed container carrier (field 5)
+// must be reported as a structural defect, never as
+// claudeCAISUnknownGenerationError, even when the envelope version or
+// channel_id is also unrecognized. Otherwise malformed client input produces
+// a false stale-allowlist warning instead of naming the carrier defect that
+// actually caused rejection.
+func TestClaudeModelFreeCAISSignature_CarrierValidatedBeforeGeneration(t *testing.T) {
+	t.Run("unknown envelope version with missing carrier reports the carrier defect", func(t *testing.T) {
+		parts := defaultClaudeModelFreeCAISParts()
+		parts.envelopeVersion = 5
+		parts.includeCarrier = false
+		signature := parts.encode()
+
+		_, err := InspectClaudeCAISSignature(signature)
+		if err == nil {
+			t.Fatal("InspectClaudeCAISSignature err = nil, want a carrier error")
+		}
+		var unknownGeneration *claudeCAISUnknownGenerationError
+		if errors.As(err, &unknownGeneration) {
+			t.Fatalf("err = %v, must not classify as unknown-generation when the carrier is missing", err)
+		}
+		if !strings.Contains(err.Error(), "container field 5") {
+			t.Fatalf("err = %q, want it to mention container field 5", err.Error())
+		}
+	})
+
+	t.Run("unknown channel_id with empty carrier reports the carrier defect", func(t *testing.T) {
+		parts := defaultClaudeModelFreeCAISParts()
+		parts.channelID = 18
+		parts.carrierLen = 0
+		signature := parts.encode()
+
+		_, err := InspectClaudeCAISSignature(signature)
+		if err == nil {
+			t.Fatal("InspectClaudeCAISSignature err = nil, want a carrier error")
+		}
+		var unknownGeneration *claudeCAISUnknownGenerationError
+		if errors.As(err, &unknownGeneration) {
+			t.Fatalf("err = %v, must not classify as unknown-generation when the carrier is empty", err)
+		}
+		if !strings.Contains(err.Error(), "container field 5") {
+			t.Fatalf("err = %q, want it to mention container field 5", err.Error())
+		}
+	})
+
+	t.Run("unknown envelope version with a valid carrier still reports unknown generation", func(t *testing.T) {
+		parts := defaultClaudeModelFreeCAISParts()
+		parts.envelopeVersion = 5
+		signature := parts.encode()
+
+		_, err := InspectClaudeCAISSignature(signature)
+		if err == nil {
+			t.Fatal("InspectClaudeCAISSignature err = nil, want an unknown-generation error")
+		}
+		var unknownGeneration *claudeCAISUnknownGenerationError
+		if !errors.As(err, &unknownGeneration) {
+			t.Fatalf("err = %v, want *claudeCAISUnknownGenerationError when the carrier is well-formed", err)
 		}
 	})
 }

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -385,6 +385,21 @@ func hasGrokOpaqueTransportShapeWithoutEnvelopeExclusions(raw string) bool {
 	return byteEntropyRatio(decoded) >= MinGrokEncryptedContentEntropyRatio
 }
 
+// hasKimiStreamingTransportShapeWithoutEnvelopeExclusions checks only Kimi's
+// fixed streaming length, base64 form, and entropy floor. It must not call the
+// Kimi validator because that validator invokes the Claude predicate under test
+// to reject self-describing foreign envelopes.
+func hasKimiStreamingTransportShapeWithoutEnvelopeExclusions(raw string) bool {
+	if len(raw) != KimiThinkingSignatureStreamingLen || raw != strings.TrimSpace(raw) || strings.Contains(raw, "=") {
+		return false
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(raw)
+	if err != nil {
+		return false
+	}
+	return byteEntropyRatio(decoded) >= MinKimiThinkingSignatureEntropyRatio
+}
+
 func TestClaudeCAISSignature_ObservedFable5Sample(t *testing.T) {
 	if !IsValidClaudeCAISSignature(observedFable5Sample) {
 		t.Fatal("IsValidClaudeCAISSignature(observedFable5Sample) = false, want true")
@@ -953,6 +968,24 @@ func TestClaudeModelFreeCAISSignature_UsesEnvelopeClassificationWithOpaqueOverla
 		if got := DetectSignatureProviderForBlock(control.signature, SignatureBlockKindClaudeThinking); got != control.provider {
 			t.Errorf("%s provider = %q, want %q", control.name, got, control.provider)
 		}
+	}
+}
+
+func TestClaudeModelFreeCAISSignature_UsesEnvelopeClassificationAtKimiStreamingLength(t *testing.T) {
+	parts := defaultClaudeModelFreeCAISParts()
+	parts.carrierLen = 3149 // 3,255 decoded bytes encode to Kimi's 4,340-character streaming length.
+	signature := parts.encode()
+
+	// This deliberately pads a syntactically valid CAIS envelope to Kimi's
+	// streaming dimensions. The overlap is outside the threat model because it
+	// requires an authenticated client to build the envelope against its own
+	// request. Anthropic still authenticates the carried signature, so matching
+	// Kimi's transport dimensions cannot make foreign reasoning authentic.
+	if !hasKimiStreamingTransportShapeWithoutEnvelopeExclusions(signature) {
+		t.Fatalf("synthetic CAIS length = %d, want independent Kimi streaming transport overlap", len(signature))
+	}
+	if got := DetectSignatureProviderForBlock(signature, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+		t.Fatalf("Kimi-dimension CAIS provider = %q, want %q", got, SignatureProviderClaude)
 	}
 }
 

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -1073,6 +1073,66 @@ func TestClassifyUnknownCAISGeneration(t *testing.T) {
 		}
 	})
 
+	// A model-tagged CAIS signature's model_text is attacker-controlled past its
+	// required "claude-" prefix, and claudeCompatibleSignatureReason
+	// (provider_compatibility.go) copies model_text verbatim into a PRESERVED
+	// decision's reason. These cases pin that such a reason must never
+	// classify as an unknown-generation drop, no matter where the marker text
+	// sits inside it or whether the sanitizer's position prefix is present,
+	// while a genuine drop reason with that same position prefix still
+	// classifies correctly (positive control alongside the negative ones).
+	t.Run("marker text embedded in unrelated prose is not misclassified as a drop", func(t *testing.T) {
+		const embeddedMarkerReason = "valid Claude CAIS signature with embedded model claude-x invalid Claude model-free CAIS signature: unknown envelope version 9 is compatible with any Claude target"
+		genuineDrop := (&claudeCAISUnknownGenerationError{identifier: "envelope version", value: 9}).Error()
+
+		cases := []struct {
+			name           string
+			reason         string
+			wantOK         bool
+			wantNormalized string
+		}{
+			{
+				name:   "bare preserved reason with embedded marker",
+				reason: embeddedMarkerReason,
+				wantOK: false,
+			},
+			{
+				name:   "position-prefixed preserved reason with embedded marker",
+				reason: "messages[2].content[0]: " + embeddedMarkerReason,
+				wantOK: false,
+			},
+			{
+				// The extra ".signature" segment makes this not match
+				// claudeSignaturePositionPrefixPattern at all (that pattern
+				// only recognizes the thinking-block shape; see its doc
+				// comment for why the tool-use shape is deliberately not
+				// included). It must fall back to the bare-reason path and
+				// still reject, since the full string does not start with
+				// the marker either.
+				name:   "reason with an unrecognized-shaped prefix and embedded marker",
+				reason: "messages[2].content[0].signature: " + embeddedMarkerReason,
+				wantOK: false,
+			},
+			{
+				name:           "genuine drop reason with the real position prefix (positive control)",
+				reason:         "messages[3].content[1]: " + genuineDrop,
+				wantOK:         true,
+				wantNormalized: genuineDrop,
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				normalized, ok := ClassifyUnknownCAISGeneration(tc.reason)
+				if ok != tc.wantOK {
+					t.Fatalf("ClassifyUnknownCAISGeneration(%q) ok = %v, want %v (normalized=%q)", tc.reason, ok, tc.wantOK, normalized)
+				}
+				if ok && normalized != tc.wantNormalized {
+					t.Fatalf("ClassifyUnknownCAISGeneration(%q) normalized = %q, want %q", tc.reason, normalized, tc.wantNormalized)
+				}
+			})
+		}
+	})
+
 	// The motivating case: classify a reason produced end to end by the real
 	// sanitizer (SanitizeClaudeMessagesForClaudeUpstream ->
 	// DecideSignatureCompatibilityForModel -> claudeCAISUnknownGenerationError.Error()),

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -122,11 +122,19 @@
 // payload-only discriminator for model-free CAIS is both generation-stable and
 // provider-distinguishing. Proof of origin requires trusted provenance from the
 // response path or cache envelope, so this result must never be treated as
-// authentication. In adversarial fuzz controls, the relaxed skeleton alone
-// accepted 0 of 200,000 uniform-random blobs forced to start with 0x08 and 0 of
-// 200,000 random well-formed protobuf trees starting with 0x08. Gemini and GPT
-// are unreachable here by their 0x12 and 0x80 envelope markers; Kimi and Grok
-// have no protobuf tree.
+// authentication. Measured adversarial controls for the predicate that ships:
+//
+//	uniform-random, first byte forced 0x08       n=1,000,000  shipped=0      spine-only=0
+//	random well-formed protobuf, 0x08 first      n=1,000,000  shipped=0      spine-only=25
+//	spine-shaped, identifiers randomised         n=200,000    shipped=4,754  (the {2,4}x{16,17} product)
+//	spine-shaped, exactly one identifier bumped  n=200,000    shipped=0
+//
+// The allowlist earns the small measured exclusion over the bare structure in
+// the second row. The last row is its residual cost: a future identifier bump
+// drops signed history until the list is amended. The executor emits that event
+// at operator-visible warning severity with the rejected identifier. Gemini and
+// GPT are unreachable here by their 0x12 and 0x80 envelope markers; Kimi and
+// Grok have no protobuf tree.
 //
 // # Which provider emits which envelope
 //

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -840,7 +840,6 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 	}
 
 	var channelBlock, containerCarrier []byte
-	var containerCarrierType protowire.Type
 	var haveContainerCarrier bool
 	err = walkClaudeProtobufFields(container, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
@@ -851,15 +850,12 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 			}
 			channelBlock = value
 		case 5:
-			haveContainerCarrier = true
-			containerCarrierType = typ
-			if typ == protowire.BytesType {
-				value, errField := decodeClaudeBytesField(raw, "CAIS container field 5 carrier")
-				if errField != nil {
-					return errField
-				}
-				containerCarrier = value
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 5 carrier")
+			if errField != nil {
+				return errField
 			}
+			haveContainerCarrier = true
+			containerCarrier = value
 		}
 		return nil
 	})
@@ -956,8 +952,6 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing envelope version")
 	case !haveContainerCarrier:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing container field 5 carrier")
-	case containerCarrierType != protowire.BytesType:
-		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must be bytes")
 	case len(containerCarrier) == 0:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must not be empty")
 	case !isKnownClaudeCAISIdentifier(knownClaudeCAISEnvelopeVersions[:], info.EnvelopeVersion):

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -775,11 +775,27 @@ func IsValidClaudeCAISSignature(rawSignature string) bool {
 	return err == nil
 }
 
+// IsStructurallyCompleteClaudeCAISEnvelope reports whether rawSignature is a
+// complete Claude CAIS envelope, including generations not yet allowlisted.
+// It does not verify cryptographic authenticity.
+func IsStructurallyCompleteClaudeCAISEnvelope(rawSignature string) bool {
+	_, err := inspectClaudeCAISSignature(rawSignature, base64.RawStdEncoding)
+	if err == nil {
+		return true
+	}
+	var unknownGeneration *claudeCAISUnknownGenerationError
+	return errors.As(err, &unknownGeneration)
+}
+
 // InspectClaudeCAISSignature decodes and classifies a Claude CAIS thinking
 // signature syntactically. See the CAIS envelope section in this file's package
 // comment for the layout and for why recognition is structural rather than
 // exact. This function does not verify cryptographic authenticity.
 func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, error) {
+	return inspectClaudeCAISSignature(rawSignature, base64.StdEncoding)
+}
+
+func inspectClaudeCAISSignature(rawSignature string, encoding *base64.Encoding) (*ClaudeCAISSignatureInfo, error) {
 	sig := stripClaudeSignaturePrefix(rawSignature)
 	if sig == "" {
 		return nil, fmt.Errorf("empty signature")
@@ -795,7 +811,7 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 		return nil, fmt.Errorf("invalid Claude CAIS signature: expected 'C' prefix, got %q", string(sig[0]))
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(sig)
+	decoded, err := encoding.DecodeString(sig)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Claude CAIS signature: base64 decode failed: %w", err)
 	}

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -49,53 +49,94 @@
 // double-layer (R) encodings are supported. Historical cache-mode modelGroup#
 // prefixes are stripped.
 //
-// # CAIS envelope (newest Claude Code models)
+// # CAIS envelopes (newer Claude Code models)
 //
 // Newer Claude Code models wrap the channel block in a CAIS envelope whose
 // decoded payload starts with 0x08 (top-level field 1 varint) instead of 0x12,
-// so the base64 string starts with 'C' instead of 'E'/'R'. The envelope version
-// varint in top-level field 1 is the ONLY structural difference from the layout
-// above; everything below it is unchanged.
+// so the base64 string starts with 'C' instead of 'E'/'R'. For the model-tagged
+// generation, the envelope version varint in top-level field 1 is the only
+// structural difference from the classic layout above; everything below it is
+// unchanged.
 //
-// The channel block itself belongs to a newer schema generation that is shared
-// by both envelopes: channel_id 16, no infra field 2, plus a block kind (field
-// 8) and a context id (field 11). Observed traffic confirms this schema
-// appears under the classic 0x12 envelope too (opus-4-6/4-7/4-8, sonnet-5) and
-// under the CAIS envelope (opus-5, fable-5), so envelope form and channel schema
-// generation vary independently and must not be inferred from each other:
+// The model-tagged channel generation is shared by both envelopes: channel_id
+// 16, no infra field 2, plus a block kind (field 8) and a context id (field 11).
+// Observed traffic confirms this schema appears under the classic 0x12 envelope
+// (opus-4-6/4-7/4-8, sonnet-5) and the CAIS envelope (opus-5, fable-5), so
+// envelope form and channel schema generation vary independently and must not be
+// inferred from each other:
 //
-//	Top-level protobuf
+//	Model-tagged CAIS protobuf
 //	|- Field 1 (varint): envelope version [required marker, observed as 2]
 //	|- Field 2 (bytes): container [required]
-//	|  `- Field 1 (bytes): channel block [required]
-//	|     |- Field 1  (varint): channel_id [required, observed as 16]
-//	|     |- Field 3  (varint): version [optional, observed as 2]
-//	|     |- Field 5  (bytes):  ECDSA signature [required, observed as 64B]
-//	|     |- Field 6  (bytes):  model_text [required, "claude-" prefixed]
-//	|     |- Field 7  (varint): unknown [optional, observed as 1]
-//	|     |- Field 8  (bytes):  block kind [optional, observed as "thinking"]
-//	|     `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	|  |- Field 1 (bytes): channel block [required]
+//	|  |  |- Field 1  (varint): channel_id [required, observed as 16]
+//	|  |  |- Field 3  (varint): version [optional, observed as 2]
+//	|  |  |- Field 5  (bytes):  opaque signature bytes [required, observed as 64B]
+//	|  |  |- Field 6  (bytes):  model_text [required, "claude-" prefixed]
+//	|  |  |- Field 7  (varint): unknown [optional, observed as 1]
+//	|  |  |- Field 8  (bytes):  block kind [optional, observed as "thinking"]
+//	|  |  `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	|  |- Field 2 (bytes): nonce [observed as 12B, not required]
+//	|  |- Field 3 (bytes): session [observed as 12B, not required]
+//	|  |- Field 4 (bytes): digest [observed as 48B, not required]
+//	|  `- Field 5 (bytes): opaque carrier [observed non-empty, not required]
 //	`- Field 3 (varint): trailer [optional, observed as 1]
+//
+// The model-free generation keeps the same outer container wire layout but
+// removes the two channel fields that carried signature bytes and model text.
+// Its opaque carrier remains in container field 5. Independent captures of both
+// generations corroborate the same field-1 channel spine, 12/12/48 field widths,
+// and non-empty field 5; the widths remain descriptive rather than load-bearing:
+//
+//	Model-free CAIS protobuf
+//	|- Field 1 (varint): envelope version [required, known generation set]
+//	|- Field 2 (bytes): container [required]
+//	|  |- Field 1 (bytes): channel block [required]
+//	|  |  |- Field 1  (varint): channel_id [required, known generation set]
+//	|  |  |- Field 3  (varint): version [optional]
+//	|  |  |- Field 5  (bytes):  ABSENT
+//	|  |  |- Field 6  (bytes):  ABSENT
+//	|  |  |- Field 7  (varint): unknown [optional]
+//	|  |  |- Field 8  (bytes):  block kind [optional]
+//	|  |  `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	|  |- Field 2 (bytes): nonce [observed as 12B, not required]
+//	|  |- Field 3 (bytes): session [observed as 12B, not required]
+//	|  |- Field 4 (bytes): digest [observed as 48B, not required]
+//	|  `- Field 5 (bytes): opaque signing carrier [required, non-empty]
+//	`- Field 3 (varint): trailer [optional]
 //
 // CAIS validation is structural rather than an exact replay of the observed
 // bytes. The payload is an opaque upstream-issued blob and rejecting it drops
-// the whole thinking block, so only the fields that actually identify the format
-// are required: the 0x08 marker, the nested container/channel block, the
-// signature bytes, and the "claude-" model text. Observed-but-incidental values
-// such as channel_id 16 or the "thinking" block kind are recorded for debugging
-// and checked only for wire type, so an upstream field bump cannot silently
-// erase conversation history.
+// the whole thinking block. Model-tagged envelopes retain their literal
+// "claude-" classification marker. Model-free envelopes instead require the
+// complete container/channel tree, absent channel fields 5 and 6, a non-empty
+// container field 5 carrier, and known envelope/channel generation identifiers.
+// Observed-but-incidental channel-version, field-7, and trailer values are
+// checked only for wire type. Block kind accepts any value but must remain
+// well-formed UTF-8 text. An upstream value bump therefore cannot silently erase
+// conversation history.
+//
+// This parser performs no cryptographic verification. The model-tagged branch
+// checks only that opaque signature bytes and the model marker are present, and
+// the model-free branch is likewise a narrow syntactic heuristic. No
+// payload-only discriminator for model-free CAIS is both generation-stable and
+// provider-distinguishing. Proof of origin requires trusted provenance from the
+// response path or cache envelope, so this result must never be treated as
+// authentication. In adversarial fuzz controls, the relaxed skeleton alone
+// accepted 0 of 200,000 uniform-random blobs forced to start with 0x08 and 0 of
+// 200,000 random well-formed protobuf trees starting with 0x08. Gemini and GPT
+// are unreachable here by their 0x12 and 0x80 envelope markers; Kimi and Grok
+// have no protobuf tree.
 //
 // # Which provider emits which envelope
 //
 // Three providers serve Claude models, and the envelope depends on the model
 // generation rather than on the provider:
 //
-//   - Claude Code OAuth subscription (Claude Code Max): opus-4-5, sonnet-4-6 and
-//     every later model up to opus-5 and fable-5. Emits the CAIS envelope for
-//     the newest models (opus-5, fable-5) and the single-layer E envelope for the
-//     opus-4-6/4-7/4-8 and sonnet-5 generation — but both carry the same
-//     channel_id 16 channel schema, so only the envelope differs.
+//   - Claude Code OAuth subscription (Claude Code Max): opus-4-5, sonnet-4-6,
+//     and later models. Opus-5 and fable-5 emit model-tagged CAIS, fable-5-1
+//     emits model-free CAIS, and the opus-4-6/4-7/4-8 and sonnet-5 generation
+//     emits the single-layer E envelope.
 //   - Claude Messages API: the full Claude model range, same envelopes as the
 //     Claude Code OAuth subscription.
 //   - Antigravity: only opus-4-6-think and sonnet-4-6, and always the
@@ -111,6 +152,7 @@ package signature
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -576,13 +618,59 @@ func decodeClaudeBytesField(raw []byte, label string) ([]byte, error) {
 	return value, nil
 }
 
-// claudeCAISSignatureMarker is the decoded first byte identifying the CAIS
-// envelope (protobuf tag for top-level field 1, varint).
-const claudeCAISSignatureMarker = 0x08
+const (
+	// claudeCAISSignatureMarker is the decoded first byte identifying the CAIS
+	// envelope (protobuf tag for top-level field 1, varint).
+	claudeCAISSignatureMarker = 0x08
 
-// claudeCAISModelTextPrefix is the model_text prefix that distinguishes a CAIS
-// channel block from an arbitrary protobuf payload.
-const claudeCAISModelTextPrefix = "claude-"
+	// claudeCAISModelTextPrefix is the model_text prefix that distinguishes a
+	// model-tagged CAIS channel block from an arbitrary protobuf payload.
+	claudeCAISModelTextPrefix = "claude-"
+)
+
+// Model-free CAIS envelopes use explicit known-generation allowlists in
+// addition to the structural spine. This is release bookkeeping, not
+// cryptographic verification or the source of cross-provider separation. The
+// two lists deliberately form a Cartesian product. This policy allows the two
+// separately versioned protobuf layers to roll independently; pair-locking would
+// instead drop signed history during a staggered rollout. It accepts combinations
+// not yet seen in a model-free capture, but only when both identifiers are
+// independently observed CAIS generations and the complete model-free spine is
+// present. When Anthropic
+// adds a generation, confirm its complete protobuf tree against captures, then
+// add its envelope version or channel id here. Channel id 11 is intentionally
+// absent because it has only been observed under the legacy 0x12 envelope, never
+// under CAIS.
+var (
+	knownClaudeCAISEnvelopeVersions = [...]uint64{2, 4}
+	knownClaudeCAISChannelIDs       = [...]uint64{16, 17}
+)
+
+type claudeCAISUnknownGenerationError struct {
+	identifier string
+	value      uint64
+}
+
+func (e *claudeCAISUnknownGenerationError) Error() string {
+	return fmt.Sprintf("invalid Claude model-free CAIS signature: unknown %s %d", e.identifier, e.value)
+}
+
+func claudeCAISUnknownGenerationReason(err error) string {
+	var unknownGeneration *claudeCAISUnknownGenerationError
+	if errors.As(err, &unknownGeneration) {
+		return unknownGeneration.Error()
+	}
+	return ""
+}
+
+func isKnownClaudeCAISIdentifier(known []uint64, value uint64) bool {
+	for _, candidate := range known {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
 
 // ClaudeCAISSignatureInfo describes the locally inspected structure of a Claude
 // CAIS thinking signature.
@@ -597,16 +685,18 @@ type ClaudeCAISSignatureInfo struct {
 	SignatureLen int
 }
 
-// IsValidClaudeCAISSignature returns whether rawSignature is a valid Claude CAIS
-// thinking signature.
+// IsValidClaudeCAISSignature reports whether rawSignature has a recognized
+// Claude CAIS thinking-signature format. It does not verify cryptographic
+// authenticity.
 func IsValidClaudeCAISSignature(rawSignature string) bool {
 	_, err := InspectClaudeCAISSignature(rawSignature)
 	return err == nil
 }
 
-// InspectClaudeCAISSignature decodes and validates a Claude CAIS thinking
-// signature. See the CAIS envelope section in this file's package comment for
-// the layout and for why validation is structural rather than exact.
+// InspectClaudeCAISSignature decodes and classifies a Claude CAIS thinking
+// signature syntactically. See the CAIS envelope section in this file's package
+// comment for the layout and for why recognition is structural rather than
+// exact. This function does not verify cryptographic authenticity.
 func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, error) {
 	sig := stripClaudeSignaturePrefix(rawSignature)
 	if sig == "" {
@@ -637,6 +727,7 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 	info := &ClaudeCAISSignatureInfo{FirstByte: decoded[0]}
 
 	var container []byte
+	var haveEnvelopeVersion bool
 	err = walkClaudeProtobufFields(decoded, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1:
@@ -645,6 +736,7 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 				return errField
 			}
 			info.EnvelopeVersion = value
+			haveEnvelopeVersion = true
 		case 2:
 			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS top-level field 2 container")
 			if errField != nil {
@@ -665,16 +757,28 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 		return nil, fmt.Errorf("invalid Claude CAIS signature: missing top-level field 2 container")
 	}
 
-	var channelBlock []byte
+	var channelBlock, containerCarrier []byte
+	var containerCarrierType protowire.Type
+	var haveContainerCarrier bool
 	err = walkClaudeProtobufFields(container, func(num protowire.Number, typ protowire.Type, raw []byte) error {
-		if num != 1 {
-			return nil
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
+			if errField != nil {
+				return errField
+			}
+			channelBlock = value
+		case 5:
+			haveContainerCarrier = true
+			containerCarrierType = typ
+			if typ == protowire.BytesType {
+				value, errField := decodeClaudeBytesField(raw, "CAIS container field 5 carrier")
+				if errField != nil {
+					return errField
+				}
+				containerCarrier = value
+			}
 		}
-		value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
-		if errField != nil {
-			return errField
-		}
-		channelBlock = value
 		return nil
 	})
 	if err != nil {
@@ -743,13 +847,39 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 	if err != nil {
 		return nil, err
 	}
-	switch {
-	case !haveChannelID:
+	if !haveChannelID {
 		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 1 channel_id")
-	case !haveSignatureBytes:
-		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 5 signature bytes")
-	case !haveModelText:
-		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 6 model_text")
+	}
+
+	// Model-tagged CAIS keeps its established syntactic classifier: non-empty
+	// opaque signature bytes plus claude-prefixed model text. Neither field is
+	// cryptographically verified, so callers must not treat recognition as proof.
+	if haveSignatureBytes || haveModelText {
+		switch {
+		case !haveSignatureBytes:
+			return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 5 signature bytes")
+		case !haveModelText:
+			return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 6 model_text")
+		}
+		return info, nil
+	}
+
+	// Model-free CAIS has no provider literal. Require its moved carrier and both
+	// known generation identifiers, while retaining the model-tagged sibling's
+	// tolerance for incidental varint values and optional fields.
+	switch {
+	case !haveEnvelopeVersion:
+		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing envelope version")
+	case !isKnownClaudeCAISIdentifier(knownClaudeCAISEnvelopeVersions[:], info.EnvelopeVersion):
+		return nil, &claudeCAISUnknownGenerationError{identifier: "envelope version", value: info.EnvelopeVersion}
+	case !isKnownClaudeCAISIdentifier(knownClaudeCAISChannelIDs[:], info.ChannelID):
+		return nil, &claudeCAISUnknownGenerationError{identifier: "channel_id", value: info.ChannelID}
+	case !haveContainerCarrier:
+		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing container field 5 carrier")
+	case containerCarrierType != protowire.BytesType:
+		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must be bytes")
+	case len(containerCarrier) == 0:
+		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must not be empty")
 	}
 
 	return info, nil

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -903,20 +903,22 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 
 	// Model-free CAIS has no provider literal. Require its moved carrier and both
 	// known generation identifiers, while retaining the model-tagged sibling's
-	// tolerance for incidental varint values and optional fields.
+	// tolerance for incidental varint values and optional fields. The carrier is
+	// validated before the generation identifiers so malformed input never
+	// reports as an unknown generation.
 	switch {
 	case !haveEnvelopeVersion:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing envelope version")
-	case !isKnownClaudeCAISIdentifier(knownClaudeCAISEnvelopeVersions[:], info.EnvelopeVersion):
-		return nil, &claudeCAISUnknownGenerationError{identifier: "envelope version", value: info.EnvelopeVersion}
-	case !isKnownClaudeCAISIdentifier(knownClaudeCAISChannelIDs[:], info.ChannelID):
-		return nil, &claudeCAISUnknownGenerationError{identifier: "channel_id", value: info.ChannelID}
 	case !haveContainerCarrier:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: missing container field 5 carrier")
 	case containerCarrierType != protowire.BytesType:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must be bytes")
 	case len(containerCarrier) == 0:
 		return nil, fmt.Errorf("invalid Claude model-free CAIS signature: container field 5 carrier must not be empty")
+	case !isKnownClaudeCAISIdentifier(knownClaudeCAISEnvelopeVersions[:], info.EnvelopeVersion):
+		return nil, &claudeCAISUnknownGenerationError{identifier: "envelope version", value: info.EnvelopeVersion}
+	case !isKnownClaudeCAISIdentifier(knownClaudeCAISChannelIDs[:], info.ChannelID):
+		return nil, &claudeCAISUnknownGenerationError{identifier: "channel_id", value: info.ChannelID}
 	}
 
 	return info, nil

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -671,6 +671,35 @@ func claudeCAISUnknownGenerationReason(err error) string {
 	return ""
 }
 
+// claudeCAISUnknownGenerationPrefix is the fixed prose fragment that opens
+// every claudeCAISUnknownGenerationError.Error() value. It exists so
+// ClassifyUnknownCAISGeneration has a single, named string to match against
+// instead of a copy of the error's literal text; it is not read by Error()
+// itself, so a reword of Error() must update this constant too or the
+// classifier stops recognizing real errors (see the test in claude_test.go
+// that runs the sanitizer end to end and checks agreement).
+const claudeCAISUnknownGenerationPrefix = "invalid Claude model-free CAIS signature: unknown "
+
+// ClassifyUnknownCAISGeneration reports whether reason describes an unknown
+// model-free CAIS generation drop (an unknown envelope version or unknown
+// channel_id, as produced by claudeCAISUnknownGenerationError.Error()).
+//
+// Callers such as the Claude executor's sanitize-report logger receive
+// SignatureCompatibilityDecision.Reason strings that the sanitizer may have
+// prefixed with a "messages[i].content[j]: " position marker; this tolerates
+// that prefix and returns the reason from the unknown-generation marker
+// onward, which is stable across occurrences of the same underlying cause and
+// is what callers should group/aggregate by. Do not re-match this prose
+// directly elsewhere — go through this function so there is exactly one place
+// that knows the contract between the error text and its classification.
+func ClassifyUnknownCAISGeneration(reason string) (normalized string, ok bool) {
+	markerIndex := strings.Index(reason, claudeCAISUnknownGenerationPrefix)
+	if markerIndex < 0 {
+		return "", false
+	}
+	return reason[markerIndex:], true
+}
+
 func isKnownClaudeCAISIdentifier(known []uint64, value uint64) bool {
 	for _, candidate := range known {
 		if candidate == value {

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -162,6 +162,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -680,25 +681,69 @@ func claudeCAISUnknownGenerationReason(err error) string {
 // that runs the sanitizer end to end and checks agreement).
 const claudeCAISUnknownGenerationPrefix = "invalid Claude model-free CAIS signature: unknown "
 
+// claudeSignaturePositionPrefixPattern matches the optional position marker
+// that claude_messages_sanitize.go's thinking-block loop prepends to a
+// SignatureCompatibilityDecision.Reason before appending it to
+// SignatureSanitizeReport.Decisions: "messages[i].content[j]: ", where i and j
+// are sanitizer-owned loop indices, never attacker input, so anchoring on
+// this shape is safe. The pattern is anchored with ^, so a match (if any)
+// always starts at reason[0].
+//
+// sanitizeClaudeToolUseSignature (claude_messages_sanitize.go) composes a
+// second, longer shape ("messages[i].content[j].path: ") for tool-use
+// signature fields, but SanitizeClaudeMessagesForClaudeUpstream — the only
+// caller that feeds a report to ClassifyUnknownCAISGeneration via the Claude
+// executor's sanitize-report logger — hardcodes DropToolSignatures: true, so
+// that function is never called on the Claude-target path and this pattern
+// deliberately does not match its shape. If a future caller reaches this
+// classifier with DropToolSignatures: false, extend this pattern (and add a
+// positive control that exercises sanitizeClaudeToolUseSignature end to end,
+// the way the "agrees with the real sanitizer-produced reason" test does for
+// the thinking-block shape) rather than assuming the untested shape still
+// matches.
+var claudeSignaturePositionPrefixPattern = regexp.MustCompile(`^messages\[\d+\]\.content\[\d+\]: `)
+
 // ClassifyUnknownCAISGeneration reports whether reason describes an unknown
 // model-free CAIS generation drop (an unknown envelope version or unknown
 // channel_id, as produced by claudeCAISUnknownGenerationError.Error()).
 //
 // Callers such as the Claude executor's sanitize-report logger receive
 // SignatureCompatibilityDecision.Reason strings that the sanitizer may have
-// prefixed with a "messages[i].content[j]: " position marker; this tolerates
-// that prefix and returns the reason from the unknown-generation marker
-// onward, which is stable across occurrences of the same underlying cause and
-// is what callers should group/aggregate by. Do not re-match this prose
-// directly elsewhere — go through this function so there is exactly one place
-// that knows the contract between the error text and its classification.
+// prefixed with a "messages[i].content[j]: " position marker (see
+// claudeSignaturePositionPrefixPattern); this strips that prefix, if present,
+// and requires the unknown-generation marker to occupy the complete remainder
+// — not merely appear somewhere inside it. That anchoring matters because a
+// *preserved* decision's reason (claudeCompatibleSignatureReason) echoes the
+// signature's own attacker-controlled model_text, which can itself contain
+// this marker's prose as a substring; a preserved decision is never a drop,
+// so an unanchored substring search misreports it as one (it must never
+// return ok=true for such a reason). Do not re-match this prose directly
+// elsewhere — go through this function so there is exactly one place that
+// knows the contract between the error text and its classification.
 func ClassifyUnknownCAISGeneration(reason string) (normalized string, ok bool) {
-	markerIndex := strings.Index(reason, claudeCAISUnknownGenerationPrefix)
-	if markerIndex < 0 {
+	rest := reason
+	if loc := claudeSignaturePositionPrefixPattern.FindStringIndex(reason); loc != nil {
+		rest = reason[loc[1]:]
+	}
+	if !strings.HasPrefix(rest, claudeCAISUnknownGenerationPrefix) {
 		return "", false
 	}
-	return reason[markerIndex:], true
+	// claudeCAISUnknownGenerationError.Error() ends in "%s %d" (identifier,
+	// then its numeric value) with nothing appended after it by any caller
+	// today; require that shape all the way to the end of rest so trailing
+	// prose glued on after a genuine-looking marker cannot slip through
+	// either.
+	if !claudeCAISUnknownGenerationTrailingShape.MatchString(rest) {
+		return "", false
+	}
+	return rest, true
 }
+
+// claudeCAISUnknownGenerationTrailingShape matches a complete
+// claudeCAISUnknownGenerationError.Error() value: the fixed prefix, then a
+// non-empty identifier, a single space, and the decimal value running to the
+// end of the string (see claudeCAISUnknownGenerationError.Error()'s "%s %d").
+var claudeCAISUnknownGenerationTrailingShape = regexp.MustCompile(`^` + regexp.QuoteMeta(claudeCAISUnknownGenerationPrefix) + `.+ \d+$`)
 
 func isKnownClaudeCAISIdentifier(known []uint64, value uint64) bool {
 	for _, candidate := range known {

--- a/internal/signature/grok_validation.go
+++ b/internal/signature/grok_validation.go
@@ -77,7 +77,7 @@ func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) 
 		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
 			return nil, fmt.Errorf("Grok encrypted_content looks like Claude thinking signature")
 		}
-		if IsValidClaudeCAISSignature(sig) {
+		if IsStructurallyCompleteClaudeCAISEnvelope(sig) {
 			return nil, fmt.Errorf("Grok encrypted_content looks like Claude CAIS thinking signature")
 		}
 		if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {

--- a/internal/signature/grok_validation_test.go
+++ b/internal/signature/grok_validation_test.go
@@ -138,6 +138,55 @@ func TestInspectGrokEncryptedContent_RejectsAntigravityClaudeThinkingSignature(t
 	}
 }
 
+func TestInspectGrokEncryptedContent_RejectsStructurallyCompleteUnknownClaudeCAISGeneration(t *testing.T) {
+	parts := defaultClaudeModelFreeCAISParts()
+	parts.envelopeVersion = 5
+	signature := parts.encode()
+
+	if IsValidClaudeCAISSignature(signature) {
+		t.Fatal("unknown-generation CAIS unexpectedly passed the generation allowlist")
+	}
+	if !IsStructurallyCompleteClaudeCAISEnvelope(signature) {
+		t.Fatal("unknown-generation CAIS was not recognized as structurally complete")
+	}
+	if _, err := InspectGrokEncryptedContent(signature); err == nil || !strings.Contains(err.Error(), "Claude CAIS") {
+		t.Fatalf("InspectGrokEncryptedContent() error = %v, want Claude CAIS exclusion", err)
+	}
+}
+
+func TestStructurallyCompleteClaudeCAISEnvelope_RejectsMalformedInputs(t *testing.T) {
+	valid := defaultClaudeModelFreeCAISParts()
+	valid.envelopeVersion = 5
+
+	wrongWire := valid
+	wrongWire.carrierTypes = []protowire.Type{protowire.VarintType}
+
+	padded := valid
+	padded.carrierLen--
+	paddedSignature := padded.encode()
+	if !strings.Contains(paddedSignature, "=") {
+		t.Fatal("padded fixture contains no padding")
+	}
+
+	nonProtobuf := base64.RawStdEncoding.EncodeToString([]byte{claudeCAISSignatureMarker, 0xff, 0xff})
+	tests := []struct {
+		name      string
+		signature string
+	}{
+		{name: "wrong wire", signature: wrongWire.encode()},
+		{name: "truncated", signature: valid.encode()[:len(valid.encode())-1]},
+		{name: "non protobuf", signature: nonProtobuf},
+		{name: "padded", signature: paddedSignature},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsStructurallyCompleteClaudeCAISEnvelope(tc.signature) {
+				t.Fatal("malformed input was recognized as a structurally complete Claude CAIS envelope")
+			}
+		})
+	}
+}
+
 // TestInspectGrokEncryptedContent_RejectsClaudeCAISSignature covers the CAIS
 // envelope emitted by the newest Claude Code models. CAIS payloads are
 // high-entropy standard base64 and drop their padding whenever the decoded

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -148,50 +148,72 @@ func DetectSignatureProvider(rawSignature string) SignatureProvider {
 	return DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindUnknown)
 }
 
+type signatureProviderDetection struct {
+	provider        SignatureProvider
+	rejectionReason string
+}
+
+func unknownSignatureProviderDetection(reason string) signatureProviderDetection {
+	return signatureProviderDetection{
+		provider:        SignatureProviderUnknown,
+		rejectionReason: reason,
+	}
+}
+
 // DetectSignatureProviderForBlock classifies rawSignature with block-kind
 // context. UUID-shaped payloads are deliberately not classified as replay-safe
 // provider signatures; callers targeting Gemini should replace them with the
 // bypass sentinel.
 func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlockKind) SignatureProvider {
+	return detectSignatureProviderForBlock(rawSignature, blockKind).provider
+}
+
+func detectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlockKind) signatureProviderDetection {
 	sig := strings.TrimSpace(rawSignature)
 	if sig == "" {
-		return SignatureProviderUnknown
+		return unknownSignatureProviderDetection("")
 	}
 
 	if prefixedProvider, unprefixed, ok := SplitSignatureProviderPrefix(sig); ok {
 		switch prefixedProvider {
 		case SignatureProviderGemini:
 			if IsGeminiThoughtSignatureBypass(unprefixed) {
-				return SignatureProviderGeminiBypass
+				return signatureProviderDetection{provider: SignatureProviderGeminiBypass}
 			}
 			if isRecognizedGeminiProviderSignature(unprefixed, blockKind) {
-				return SignatureProviderGemini
+				return signatureProviderDetection{provider: SignatureProviderGemini}
 			}
 		case SignatureProviderClaude:
-			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) || IsValidClaudeCAISSignature(unprefixed) {
-				return SignatureProviderClaude
+			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) {
+				return signatureProviderDetection{provider: SignatureProviderClaude}
+			}
+			if _, err := InspectClaudeCAISSignature(unprefixed); err == nil {
+				return signatureProviderDetection{provider: SignatureProviderClaude}
+			} else if reason := claudeCAISUnknownGenerationReason(err); reason != "" {
+				return unknownSignatureProviderDetection(reason)
 			}
 		case SignatureProviderGPT:
 			if IsValidGPTReasoningSignature(unprefixed) {
-				return SignatureProviderGPT
+				return signatureProviderDetection{provider: SignatureProviderGPT}
 			}
 		}
-		return SignatureProviderUnknown
+		return unknownSignatureProviderDetection("")
 	}
 	if strings.Contains(sig, "#") {
-		return SignatureProviderUnknown
+		return unknownSignatureProviderDetection("")
 	}
 
 	// The bypass sentinel is a plain literal rather than an envelope, so it must
 	// be matched before the structural pre-filter below rejects it.
 	if IsGeminiThoughtSignatureBypass(sig) {
-		return SignatureProviderGeminiBypass
+		return signatureProviderDetection{provider: SignatureProviderGeminiBypass}
 	}
 	// Probes run from the strongest marker to the weakest:
 	//   1. GPT carries the literal "gAAAA" prefix, which pins both the version
 	//      byte and the high timestamp bytes.
-	//   2. Claude CAIS carries marker 0x08 plus a literal "claude-" model text.
-	//   3. Claude single/double-layer carries marker 0x12 plus the same literal.
+	//   2. Claude CAIS carries marker 0x08 plus either a literal "claude-"
+	//      model text or the model-free channel/container structure.
+	//   3. Claude single/double-layer carries marker 0x12 plus its strict tree.
 	//   4. Gemini validates wire shape only and has no literal to anchor on, so
 	//      it is the weakest judge and goes last.
 	//
@@ -207,19 +229,28 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 	// early, because Kimi's uniformly distributed base64 starts with one of
 	// "CERg" about 6% of the time and would otherwise be dropped by whichever
 	// side of the gate it happened to land on.
+	var claudeRejectionReason string
 	if maybeSelfDescribingSignatureEnvelope(sig) {
 		if IsValidGPTReasoningSignature(sig) {
-			return SignatureProviderGPT
+			return signatureProviderDetection{provider: SignatureProviderGPT}
 		}
-		if IsValidClaudeCAISSignature(sig) {
-			return SignatureProviderClaude
+		if _, err := InspectClaudeCAISSignature(sig); err == nil {
+			return signatureProviderDetection{provider: SignatureProviderClaude}
+		} else {
+			claudeRejectionReason = claudeCAISUnknownGenerationReason(err)
 		}
 		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
-			return SignatureProviderClaude
+			return signatureProviderDetection{provider: SignatureProviderClaude}
 		}
 		if isRecognizedGeminiProviderSignature(sig, blockKind) {
-			return SignatureProviderGemini
+			return signatureProviderDetection{provider: SignatureProviderGemini}
 		}
+	}
+	// A complete model-free CAIS tree with a new generation identifier is stronger
+	// evidence than Kimi's residual length match. Keep it unclassified but retain
+	// its precise rejection so callers can surface the stale known-set diagnosis.
+	if claudeRejectionReason != "" {
+		return unknownSignatureProviderDetection(claudeRejectionReason)
 	}
 	// Kimi carries no envelope, so it can only be claimed once every
 	// self-describing probe above has declined. Ordering it last means a length
@@ -227,9 +258,9 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 	// drift in Kimi's sizes costs Kimi its own identification rather than
 	// corrupting a neighbouring family.
 	if IsValidKimiThinkingSignature(sig) {
-		return SignatureProviderKimi
+		return signatureProviderDetection{provider: SignatureProviderKimi}
 	}
-	return SignatureProviderUnknown
+	return unknownSignatureProviderDetection("")
 }
 
 func IsSignatureCompatibleWithProvider(targetProvider SignatureProvider, rawSignature string) bool {
@@ -251,7 +282,8 @@ func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targ
 		blockKind = SignatureBlockKindUnknown
 	}
 
-	detected := DetectSignatureProviderForBlock(rawSignature, blockKind)
+	detection := detectSignatureProviderForBlock(rawSignature, blockKind)
+	detected := detection.provider
 	decision := SignatureCompatibilityDecision{
 		TargetProvider:   targetProvider,
 		DetectedProvider: detected,
@@ -279,7 +311,11 @@ func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targ
 		decision.Reason = "signature is not compatible with Gemini and this block is not a bypass-safe Gemini model part"
 	case SignatureProviderClaude:
 		decision.Action = SignatureActionDropBlock
-		decision.Reason = "Claude has no cross-provider bypass sentinel for thinking blocks"
+		if detection.rejectionReason != "" {
+			decision.Reason = detection.rejectionReason
+		} else {
+			decision.Reason = "Claude has no cross-provider bypass sentinel for thinking blocks"
+		}
 	case SignatureProviderGPT:
 		decision.Action = SignatureActionDropBlock
 		decision.Reason = "GPT reasoning encrypted_content cannot be synthesized from another provider signature"
@@ -380,9 +416,8 @@ func CompatibleAntigravityClaudeThinkingSignature(rawSignature string) (string, 
 }
 
 // claudeCompatibleSignatureReason explains why a matching signature is
-// replayable. Claude CAIS signatures carry the issuing model inside the payload,
-// so the embedded model and the target model are both reported to make signature
-// decisions traceable in debug logs.
+// replayable. Model-tagged CAIS signatures report their issuing model;
+// model-free CAIS signatures report their structural classification.
 func claudeCompatibleSignatureReason(targetProvider SignatureProvider, rawSignature, targetModel string) string {
 	const genericReason = "signature provider matches target provider"
 	if targetProvider != SignatureProviderClaude {
@@ -391,6 +426,9 @@ func claudeCompatibleSignatureReason(targetProvider SignatureProvider, rawSignat
 	info, err := InspectClaudeCAISSignature(SignaturePayloadWithoutProviderPrefix(rawSignature))
 	if err != nil {
 		return genericReason
+	}
+	if info.ModelText == "" {
+		return "valid Claude model-free CAIS thinking signature is compatible with any Claude target"
 	}
 	reason := "valid Claude CAIS signature with embedded model " + info.ModelText + " is compatible with any Claude target"
 	if trimmedModel := strings.TrimSpace(targetModel); trimmedModel != "" {

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestConvertClaudeRequestToCodex_SystemMessageScenarios(t *testing.T) {
@@ -661,6 +663,35 @@ func TestConvertClaudeRequestToCodex_PreservesContentOrderAcrossToolAndReasoning
 	}
 }
 
+func TestConvertClaudeRequestToCodex_OmitsClaudeCAISForGrokTarget(t *testing.T) {
+	tests := []struct {
+		name                string
+		envelopeVersion     uint64
+		wantAllowlistedCAIS bool
+	}{
+		{name: "known generation unchanged", envelopeVersion: 4, wantAllowlistedCAIS: true},
+		{name: "unknown generation", envelopeVersion: 5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			signature := testModelFreeClaudeCAISSignature(tc.envelopeVersion)
+			if got := sigcompat.IsValidClaudeCAISSignature(signature); got != tc.wantAllowlistedCAIS {
+				t.Fatalf("IsValidClaudeCAISSignature() = %t, want %t", got, tc.wantAllowlistedCAIS)
+			}
+			payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"summary","signature":""},{"type":"text","text":"answer"}]},{"role":"user","content":"next"}]}`)
+			payload, _ = sjson.SetBytes(payload, "messages.0.content.0.signature", signature)
+
+			out := ConvertClaudeRequestToCodex("grok-4.5", payload, false)
+			if got := countRequestInputItemsByType(out, "reasoning"); got != 0 {
+				t.Fatalf("got %d reasoning items, want Claude CAIS omitted; output=%s", got, out)
+			}
+			if got := gjson.GetBytes(out, "input.0.content.0.text").String(); got != "answer" {
+				t.Fatalf("assistant output text = %q, want unchanged answer; output=%s", got, out)
+			}
+		})
+	}
+}
+
 func TestConvertClaudeRequestToCodex_AssistantGrokSignatureToReasoningItem(t *testing.T) {
 	signature := "HmlYdr2aCAqCYP/m9mr8PS6KOsdMs72FGDigmydR+Jsmuv8KX97yWPlbOwmXJgWn0CbHaCacdQD3+n5EvpgLfPNmafS3kdICBjRuDf4bzHy7uBiUhNVhqPtp/ee1y9q4imPE4LYgD1VZ4J+bp9mTeqA1+nC9Oue58CiNEMV9SVaGenCD+aBnVuSTzQhD32Y+68i6HLJW0Dx6ifaRfb8hxYtA/sPM+/FTvAMW11nRho5a2BBSkpnzfqqAz/e/vGJ77/bygpXM823QA9wL9i0X"
 	payload := []byte(`{"model":"grok-4.5","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"summary","signature":""},{"type":"text","text":"answer"}]},{"role":"user","content":"next"}]}`)
@@ -761,6 +792,44 @@ func countRequestInputItemsByType(result []byte, itemType string) int {
 		return true
 	})
 	return count
+}
+
+func testModelFreeClaudeCAISSignature(envelopeVersion uint64) string {
+	appendBytesField := func(dst []byte, number protowire.Number, value []byte) []byte {
+		dst = protowire.AppendTag(dst, number, protowire.BytesType)
+		return protowire.AppendBytes(dst, value)
+	}
+	synthetic := func(length int, salt byte) []byte {
+		value := make([]byte, length)
+		for i := range value {
+			value[i] = byte(i*73 + int(salt))
+		}
+		return value
+	}
+
+	var channel []byte
+	channel = protowire.AppendTag(channel, 1, protowire.VarintType)
+	channel = protowire.AppendVarint(channel, 17)
+	channel = protowire.AppendTag(channel, 3, protowire.VarintType)
+	channel = protowire.AppendVarint(channel, 2)
+	channel = protowire.AppendTag(channel, 7, protowire.VarintType)
+	channel = protowire.AppendVarint(channel, 1)
+	channel = appendBytesField(channel, 8, []byte("thinking"))
+
+	var container []byte
+	container = appendBytesField(container, 1, channel)
+	container = appendBytesField(container, 2, synthetic(12, 0x21))
+	container = appendBytesField(container, 3, synthetic(12, 0x43))
+	container = appendBytesField(container, 4, synthetic(48, 0x65))
+	container = appendBytesField(container, 5, synthetic(96, 0x87))
+
+	var payload []byte
+	payload = protowire.AppendTag(payload, 1, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, envelopeVersion)
+	payload = appendBytesField(payload, 2, container)
+	payload = protowire.AppendTag(payload, 3, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, 1)
+	return base64.StdEncoding.EncodeToString(payload)
 }
 
 func validCodexReasoningSignature() string {


### PR DESCRIPTION
## Problem

Claude Code replays `thinking` blocks from earlier turns. The current generation of
Anthropic thinking signatures is not recognised by `DetectSignatureProviderForBlock`,
so every such block is classified `unknown`, judged incompatible with the Claude
target, and dropped before the request is forwarded.

Two consequences, both measured against captured request bodies from a live proxy:

1. **Signed history is corrupted.** A thinking signature binds the conversation prefix
   that produced it, and each block chains to the previous one. Blocks may be removed
   from the front of a history but not from the middle. Dropping one mid-history
   invalidates every later block.
2. **The request can become structurally invalid.** When a dropped block was an
   assistant turn's only content, the sanitizer removes the whole message. A real
   28-message request became 27, collapsing `system → assistant → user` into
   `system → user`, which the API rejects:
   `400 messages.4: role 'system' must precede an 'assistant' message or end the array`.

## Cause

These signatures use the CAIS envelope but omit channel fields 5 and 6; their opaque
signing material lives in container field 5 instead. `InspectClaudeCAISSignature`
requires both channel fields, so validation fails at field 5 and never reaches the
model-text check.

## Fix

Recognise the model-free CAIS generation structurally. The predicate requires the
container tree, a channel block, channel fields 5 and 6 absent, a non-empty container
field 5, and an envelope version and channel id from known sets. It deliberately does
not constrain channel version, field 7, trailer, block-kind value, context-id presence,
container field widths, or carrier size, matching what the model-tagged path already
tolerates.

Unrecognised generations are now visible rather than silent: each distinct
unknown-generation reason is emitted at `Warn` with a block count, aggregated across
all decisions rather than sampling the first.

The message sanitizer is unchanged.

## Measurements

Fuzzed against the shipped predicate:

| adversary | n | shipped | structure only |
|---|---:|---:|---:|
| uniform-random, first byte forced `0x08` | 1,000,000 | 0 | 0 |
| random well-formed protobuf, `0x08` first | 1,000,000 | 0 | 25 |
| spine-shaped, identifiers randomised | 200,000 | 4,754 | 200,000 |
| spine-shaped, exactly one identifier bumped | 200,000 | 0 | 200,000 |

Zero accepted out of 2,000,000 on the two realistic adversaries. The known-set check
earns the small residual exclusion over the bare structure.

Replay of a captured failing request: base drops 8 of 8 blocks and emits 27 messages;
this branch preserves 8 of 8 and emits 28, with role adjacency intact. A known-good
signature is preserved on both sides and an invalid one is dropped on both, so the
comparison has controls in each direction.

## Known limits, stated plainly

- **This is syntactic recognition, not authentication.** No signature is
  cryptographically verified here, and none was before: the model-tagged path only ever
  checked that its signature field was present. Proof of origin would require trusted
  provenance from the response path.
- **A future generation still drops history until the sets are amended** — the last
  fuzz row is that cost, 200,000 of 200,000 rejected when one identifier changes. It is
  no longer silent: the drop names the unrecognised identifier at `Warn`.
- **The envelope shape overlaps other providers' opaque transport shapes.** Tests assert
  this rather than implying disjointness. Reaching it requires deliberately constructing
  the envelope against one's own request, and the upstream API still authenticates the
  carried signature.
- Three of the four accepted identifier pairings are policy rather than observation;
  only one appeared in captured traffic. Comments say so.
- **The fuzz figures above were measured during review and no harness in this branch
  reproduces them.** They are a point-in-time result, not something a future maintainer
  can refresh after changing the predicate. Happy to contribute the harness if wanted.

## Tests

Nine new test functions (18 test cases including subtests). Each was run against the unmodified base first and fails there; failure output is in the commit messages. PR CI builds but does not run `go test`, so, measured locally: `go test ./...` on this branch passes 8312 test cases across 91 packages with 0 failures; base passes 8294.

Captured signature material is not included in this branch.

## Relationship to open work

- #3715 / #3663 propose dropping signed `thinking` blocks whose text is empty. On Claude Fable 5 and 5.1 that is the documented default shape: the raw reasoning is never returned, `thinking.display` defaults to omitted, and the block carries a valid signature with empty text. These models also bind each signature to the conversation prefix, so removing such a block mid-history invalidates every later block. This change preserves them by recognising the signature generation; it does not touch the sanitizer's drop logic.
- #5150 reworks the compat sanitizer boundary and keeps the existing preservation path for CAIS-compatible signatures, which is exactly what this change widens to the current generation. The two compose; no file overlap in `internal/signature/claude_messages_sanitize.go`.
- #5412 / #5402 add the model catalog entry and client fingerprint for Fable 5.1. The 400 in this report was first observed while testing #5412 and traced to base behaviour; this change is independent of #5412 and does not depend on it landing first. Both were exercised together on a private gateway build before submission: Fable 5.1 requests with replayed thinking blocks forward the blocks unchanged.

## Provenance

Three independent adversarial reviews (Opus, Fable, and a second model family) were run against the frozen commits before submission, with byte-diff reproduction of the failing request and fuzzing of the predicate; the numbers in the code comments are from those runs. Merges cleanly onto current `dev`.
