### PR TITLE
feat(antigravity): add Gemini 3.8 Flash support

### DIFF
--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -46,35 +46,45 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 }
 
 func TestAntigravityModelsIncludeGemini38Flash(t *testing.T) {
-	const modelID = "gemini-3.8-flash-high"
-
-	var got *ModelInfo
+	modelsByID := make(map[string]*ModelInfo)
 	for _, model := range GetAntigravityModels() {
-		if model != nil && model.ID == modelID {
-			got = model
-			break
+		if model != nil {
+			modelsByID[model.ID] = model
 		}
 	}
-	if got == nil {
-		t.Fatalf("Antigravity models do not contain %q", modelID)
+
+	tests := []struct {
+		id          string
+		description string
+	}{
+		{id: "gemini-3.8-flash-high", description: "Gemini 3.8 Flash (High)"},
+		{id: "gemini-3.8-flash-medium", description: "Gemini 3.8 Flash (Medium)"},
 	}
-	if got.OwnedBy != "antigravity" || got.Type != "antigravity" || got.Name != modelID || got.DisplayName != "Gemini 3.8 Flash" {
-		t.Fatalf("Gemini 3.8 Flash identity metadata = %+v", got)
-	}
-	if got.ContextLength != 1048576 || got.MaxCompletionTokens != 65536 {
-		t.Fatalf("Gemini 3.8 Flash token limits = %d/%d, want 1048576/65536", got.ContextLength, got.MaxCompletionTokens)
-	}
-	if got.Thinking == nil || got.Thinking.Min != 1 || got.Thinking.Max != 65535 || !got.Thinking.DynamicAllowed {
-		t.Fatalf("Gemini 3.8 Flash thinking metadata = %+v", got.Thinking)
-	}
-	if want := []string{"low", "medium", "high"}; !slices.Equal(got.Thinking.Levels, want) {
-		t.Fatalf("Gemini 3.8 Flash thinking levels = %v, want %v", got.Thinking.Levels, want)
-	}
-	if want := []string{"text", "image", "audio", "video"}; !slices.Equal(got.SupportedInputModalities, want) {
-		t.Fatalf("Gemini 3.8 Flash input modalities = %v, want %v", got.SupportedInputModalities, want)
-	}
-	if want := []string{"text"}; !slices.Equal(got.SupportedOutputModalities, want) {
-		t.Fatalf("Gemini 3.8 Flash output modalities = %v, want %v", got.SupportedOutputModalities, want)
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			got := modelsByID[tt.id]
+			if got == nil {
+				t.Fatalf("Antigravity models do not contain %q", tt.id)
+			}
+			if got.OwnedBy != "antigravity" || got.Type != "antigravity" || got.Name != tt.id || got.DisplayName != "Gemini 3.8 Flash" || got.Description != tt.description {
+				t.Fatalf("Gemini 3.8 Flash identity metadata = %+v", got)
+			}
+			if got.ContextLength != 1048576 || got.MaxCompletionTokens != 65536 {
+				t.Fatalf("Gemini 3.8 Flash token limits = %d/%d, want 1048576/65536", got.ContextLength, got.MaxCompletionTokens)
+			}
+			if got.Thinking == nil || got.Thinking.Min != 1 || got.Thinking.Max != 65535 || !got.Thinking.DynamicAllowed {
+				t.Fatalf("Gemini 3.8 Flash thinking metadata = %+v", got.Thinking)
+			}
+			if want := []string{"low", "medium", "high"}; !slices.Equal(got.Thinking.Levels, want) {
+				t.Fatalf("Gemini 3.8 Flash thinking levels = %v, want %v", got.Thinking.Levels, want)
+			}
+			if want := []string{"text", "image", "audio", "video"}; !slices.Equal(got.SupportedInputModalities, want) {
+				t.Fatalf("Gemini 3.8 Flash input modalities = %v, want %v", got.SupportedInputModalities, want)
+			}
+			if want := []string{"text"}; !slices.Equal(got.SupportedOutputModalities, want) {
+				t.Fatalf("Gemini 3.8 Flash output modalities = %v, want %v", got.SupportedOutputModalities, want)
+			}
+		})
 	}
 }
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestGetStaticModelDefinitionsByChannelSupportsGeminiInteractions(t *testing.T) {
 	models := GetStaticModelDefinitionsByChannel("gemini-interactions")
@@ -40,6 +43,39 @@ func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	}
 
 	t.Fatalf("Vertex models do not contain %q", releaseID)
+}
+
+func TestAntigravityModelsIncludeGemini38Flash(t *testing.T) {
+	const modelID = "gemini-3.8-flash-high"
+
+	var got *ModelInfo
+	for _, model := range GetAntigravityModels() {
+		if model != nil && model.ID == modelID {
+			got = model
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("Antigravity models do not contain %q", modelID)
+	}
+	if got.OwnedBy != "antigravity" || got.Type != "antigravity" || got.Name != modelID || got.DisplayName != "Gemini 3.8 Flash" {
+		t.Fatalf("Gemini 3.8 Flash identity metadata = %+v", got)
+	}
+	if got.ContextLength != 1048576 || got.MaxCompletionTokens != 65536 {
+		t.Fatalf("Gemini 3.8 Flash token limits = %d/%d, want 1048576/65536", got.ContextLength, got.MaxCompletionTokens)
+	}
+	if got.Thinking == nil || got.Thinking.Min != 1 || got.Thinking.Max != 65535 || !got.Thinking.DynamicAllowed {
+		t.Fatalf("Gemini 3.8 Flash thinking metadata = %+v", got.Thinking)
+	}
+	if want := []string{"low", "medium", "high"}; !slices.Equal(got.Thinking.Levels, want) {
+		t.Fatalf("Gemini 3.8 Flash thinking levels = %v, want %v", got.Thinking.Levels, want)
+	}
+	if want := []string{"text", "image", "audio", "video"}; !slices.Equal(got.SupportedInputModalities, want) {
+		t.Fatalf("Gemini 3.8 Flash input modalities = %v, want %v", got.SupportedInputModalities, want)
+	}
+	if want := []string{"text"}; !slices.Equal(got.SupportedOutputModalities, want) {
+		t.Fatalf("Gemini 3.8 Flash output modalities = %v, want %v", got.SupportedOutputModalities, want)
+	}
 }
 
 func TestWithXAIBuiltinsIncludesImage20(t *testing.T) {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -3446,6 +3446,36 @@
       ]
     },
     {
+      "id": "gemini-3.8-flash-high",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.8 Flash",
+      "name": "gemini-3.8-flash-high",
+      "description": "Gemini 3.8 Flash (High)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 1,
+        "max": 65535,
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
       "id": "gemini-3-flash",
       "object": "model",
       "owned_by": "antigravity",

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -3476,6 +3476,36 @@
       ]
     },
     {
+      "id": "gemini-3.8-flash-medium",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.8 Flash",
+      "name": "gemini-3.8-flash-medium",
+      "description": "Gemini 3.8 Flash (Medium)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 1,
+        "max": 65535,
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
       "id": "gemini-3-flash",
       "object": "model",
       "owned_by": "antigravity",


### PR DESCRIPTION
## Summary
- register the official Antigravity `gemini-3.8-flash-high` and `gemini-3.8-flash-medium` routes
- publish the 1,048,576-token context limit, 65,536-token output limit, and supported text/image/audio/video inputs for both routes
- expose exactly the supported `low`, `medium`, and `high` thinking levels; Gemini 3.8 Flash rejects `minimal`
- add registry contract tests covering both route identities and capabilities

## Source distinction
- CLIProxyAPI's canonical remote catalog already contains `gemini-3.8-flash-high`; this change synchronizes that metadata into the embedded catalog.
- Google Antigravity's Headless documentation additionally lists `gemini-3.8-flash-medium`. The paired [models catalog PR #50](https://github.com/router-for-me/models/pull/50) adds that official slug to the remote source so startup and periodic catalog refreshes preserve it.

## First-party model facts
- Google Antigravity lists Gemini 3.8 Flash with Low, Medium, and High reasoning levels.
- Google's Sep 1 launch post lists pricing at $0.75 per million input tokens and $3.75 per million output tokens.

## Sources
- [Google Antigravity model availability and reasoning levels](https://www.antigravity.google/docs/models/)
- [Google Antigravity Sep 1 launch post](https://www.antigravity.google/blog/gemini-3-8-flash-in-google-antigravity)
- [Google Antigravity Headless model slugs](https://www.antigravity.google/docs/cli/headless/)
- [Gemini 3.8 Flash model capabilities](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash)
- [CLIProxy canonical models catalog](https://raw.githubusercontent.com/router-for-me/models/refs/heads/main/models.json)

## Verification
- `go test ./internal/registry`
- `go test -run TestRegisterModelsForAuth_AntigravityFetchesWebSearchCapability ./sdk/cliproxy`
- `go build -o test-output ./cmd/server && rm test-output`

Related to #5421 (currently open).