### PR TITLE
fix(translator): hoist tool-result content part cache_control to the block

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -208,7 +208,7 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 					contentBlocks = append(contentBlocks, part)
 				} else if contentResult.Exists() && contentResult.IsArray() {
 					contentResult.ForEach(func(_, part gjson.Result) bool {
-						claudePart := convertOpenAIContentPartToClaudePart(part)
+						claudePart := convertOpenAIContentPartToClaudePart(part, true)
 						if claudePart != "" {
 							contentBlocks = append(contentBlocks, []byte(claudePart))
 						}
@@ -286,6 +286,13 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 					msg, _ = sjson.SetRawBytes(msg, "content.0.content", []byte(toolResultContent))
 				} else {
 					msg, _ = sjson.SetBytes(msg, "content.0.content", toolResultContent)
+				}
+				// Anthropic rejects cache_control inside tool_result.content, so
+				// the first source part marker is hoisted onto the tool_result
+				// block. Setting it before AttachMessageCacheControl keeps the
+				// part-level marker winning over a message-level one.
+				if cc := firstPartCacheControl(toolContentResult); cc != "" {
+					msg, _ = sjson.SetRawBytes(msg, "content.0.cache_control", []byte(cc))
 				}
 				msg = common.AttachMessageCacheControl(msg, targetMsg)
 				messageAccumulator.Append(msg)
@@ -376,7 +383,7 @@ func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream,
 	return out
 }
 
-func convertOpenAIContentPartToClaudePart(part gjson.Result) string {
+func convertOpenAIContentPartToClaudePart(part gjson.Result, allowCacheControl bool) string {
 	var claudePart []byte
 	switch part.Get("type").String() {
 	case "text":
@@ -405,6 +412,11 @@ func convertOpenAIContentPartToClaudePart(part gjson.Result) string {
 
 	if len(claudePart) == 0 {
 		return ""
+	}
+	if !allowCacheControl {
+		// tool_result.content parts reject cache_control upstream; the marker
+		// is hoisted onto the tool_result block by the caller instead.
+		return string(claudePart)
 	}
 	return string(common.AttachCacheControl(claudePart, part))
 }
@@ -456,7 +468,7 @@ func convertOpenAIToolResultContent(content gjson.Result) (string, bool) {
 				return true
 			}
 
-			claudePart := convertOpenAIContentPartToClaudePart(part)
+			claudePart := convertOpenAIContentPartToClaudePart(part, false)
 			if claudePart != "" {
 				claudeParts = append(claudeParts, []byte(claudePart))
 			}
@@ -471,7 +483,7 @@ func convertOpenAIToolResultContent(content gjson.Result) (string, bool) {
 	}
 
 	if content.IsObject() {
-		claudePart := convertOpenAIContentPartToClaudePart(content)
+		claudePart := convertOpenAIContentPartToClaudePart(content, false)
 		if claudePart != "" {
 			return string(common.JoinRawArray([][]byte{[]byte(claudePart)})), true
 		}
@@ -479,6 +491,28 @@ func convertOpenAIToolResultContent(content gjson.Result) (string, bool) {
 	}
 
 	return content.Raw, false
+}
+
+// firstPartCacheControl returns the raw cache_control object from the first
+// content part that carries one, or "" when none does.
+func firstPartCacheControl(content gjson.Result) string {
+	if content.IsArray() {
+		var raw string
+		content.ForEach(func(_, part gjson.Result) bool {
+			if cc := part.Get("cache_control"); cc.Exists() && cc.IsObject() {
+				raw = cc.Raw
+				return false
+			}
+			return true
+		})
+		return raw
+	}
+	if content.IsObject() {
+		if cc := content.Get("cache_control"); cc.Exists() && cc.IsObject() {
+			return cc.Raw
+		}
+	}
+	return ""
 }
 
 // firstExisting returns the first result that exists, or an empty result.

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
@@ -974,3 +974,46 @@ func TestConvertOpenAIRequestToClaude_ResponseFormatAbsentOrTextNoOp(t *testing.
 		})
 	}
 }
+
+// Anthropic only accepts cache_control on the tool_result block itself, never
+// inside tool_result.content. A part-level marker on an OpenAI tool message
+// must be hoisted to the block, while ordinary message parts keep theirs.
+func TestConvertOpenAIRequestToClaude_ToolResultPartCacheControlHoisted(t *testing.T) {
+	inputJSON := []byte(`{
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"Use calc for 2+2.","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"calc","arguments":"{\"expr\":\"2+2\"}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":[{"type":"text","text":"4","cache_control":{"type":"ephemeral"}}]}
+		],
+		"tools":[{"type":"function","function":{"name":"calc","description":"calc","parameters":{"type":"object","properties":{"expr":{"type":"string"}},"required":["expr"]}}}]
+	}`)
+	out := ConvertOpenAIRequestToClaude("claude-test", inputJSON, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("message count = %d, want 3. Output: %s", len(messages), string(out))
+	}
+
+	// Ordinary user content parts keep their part-level cache_control.
+	firstText := messages[0].Get("content.0")
+	if got := firstText.Get("cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("user text part cache_control.type = %q, want ephemeral (must not be stripped). Output: %s", got, string(out))
+	}
+
+	// The tool_result block carries the hoisted marker.
+	toolResult := messages[2].Get("content.0")
+	if got := toolResult.Get("type").String(); got != "tool_result" {
+		t.Fatalf("messages[2].content[0].type = %q, want tool_result. Output: %s", got, string(out))
+	}
+	if got := toolResult.Get("cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tool_result block cache_control.type = %q, want ephemeral (hoisted from the part). Output: %s", got, string(out))
+	}
+
+	// ... and the inner content parts carry no cache_control.
+	innerParts := toolResult.Get("content").Array()
+	for i, part := range innerParts {
+		if part.Get("cache_control").Exists() {
+			t.Fatalf("tool_result.content[%d] must not carry cache_control. Output: %s", i, string(out))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Anthropic only accepts `cache_control` on the `tool_result` block itself; a marker inside `tool_result.content[*]` is rejected with `400 invalid_request_error` (report + wire dump in #5429).
- The OpenAI-to-Claude request translator ran tool message content parts through the same converter as regular message parts, which copies part-level `cache_control` onto every converted part. Clients that attach `cache_control` to tool output parts got the marker emitted in two places: on the `tool_result` block (correct) and nested inside `tool_result.content[0]` (rejected), so every tool-calling turn 400'd on Claude models.
- Fix: strip the marker from parts converted inside `tool_result.content`, and hoist the first source part's `cache_control` onto the `tool_result` block before `AttachMessageCacheControl` runs, so a part-level marker still wins over a message-level one, matching the existing priority. Regular message parts keep their part-level `cache_control` (unchanged behavior).

## Verification

| Check | Result |
| --- | --- |
| New `TestConvertOpenAIRequestToClaude_ToolResultPartCacheControlHoisted` (minimal 3-message sequence from #5429) | fails before fix (`tool_result block cache_control.type = ""`, inner marker present), passes after |
| User text part keeps its part-level `cache_control` (asserted in the same test) | pass |
| `go test ./internal/translator/claude/openai/chat-completions/` (all existing tests incl. cache_control cases) | pass |
| `go test ./internal/translator/... ./sdk/...` | pass |
| `go build ./cmd/server` | pass |
| `gofmt` | clean |

## AI use

Implemented by GLM-5.3-Flash (ZCode) from the reproduction in #5429, reviewed and verified locally by a human.

## Checklist

- [x] Regression test included (failing before the fix)
- [x] Regular-part `cache_control` behavior preserved (asserted)
- [x] No unrelated changes; translator-only diff