### PR TITLE
fix(auth): map home billing errors to 402 and 429

### DIFF
--- a/sdk/cliproxy/auth/home_concurrency.go
+++ b/sdk/cliproxy/auth/home_concurrency.go
@@ -253,6 +253,10 @@ func decodeHomeDispatchError(raw []byte) error {
 	case "credential_concurrency_exceeded", "credential_model_concurrency_exceeded":
 		result.HTTPStatus = http.StatusTooManyRequests
 		return newHomeConcurrencyBusyError(result, time.Duration(detail.RetryAfterMS)*time.Millisecond)
+	case "user_credits_insufficient":
+		result.HTTPStatus = http.StatusPaymentRequired
+	case "user_period_limit_exceeded":
+		result.HTTPStatus = http.StatusTooManyRequests
 	case "auth_not_found", "auth_unavailable", "refresh_temporarily_unavailable", "home_unavailable",
 		"concurrency_protocol_required", "concurrency_tracker_unavailable", "concurrency_node_unavailable":
 		result.HTTPStatus = http.StatusServiceUnavailable

--- a/sdk/cliproxy/auth/home_concurrency_test.go
+++ b/sdk/cliproxy/auth/home_concurrency_test.go
@@ -396,6 +396,25 @@ func TestHomeNoCandidateErrorsMapToServiceUnavailable(t *testing.T) {
 	}
 }
 
+func TestHomeBillingErrorsMapTo402And429(t *testing.T) {
+	cases := []struct {
+		code string
+		want int
+	}{
+		{"user_credits_insufficient", http.StatusPaymentRequired},
+		{"user_period_limit_exceeded", http.StatusTooManyRequests},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			errDispatch := decodeHomeDispatchError([]byte(fmt.Sprintf(`{"error":{"type":%q,"message":"limited"}}`, tc.code)))
+			var authErr *Error
+			if !errors.As(errDispatch, &authErr) || authErr.Code != tc.code || authErr.HTTPStatus != tc.want {
+				t.Fatalf("decodeHomeDispatchError(%s) = %#v, want HTTP %d", tc.code, errDispatch, tc.want)
+			}
+		})
+	}
+}
+
 func TestHomeConcurrencyTupleAuthMismatchEndsScope(t *testing.T) {
 	dispatcher := &fixtureHomeDispatcher{payload: []byte(`{"concurrency":{"accounted":true,"credential_id":"cred-1","model":"gpt"},"auth_index":"other","auth":{"id":"cred-1","provider":"codex"}}`)}
 	manager := newHomeSelectionTestManager(t, dispatcher)


### PR DESCRIPTION
## Summary

- Home rejects dispatch requests for billing and period limits with structured error envelopes (`user_credits_insufficient`, `user_period_limit_exceeded`), but `decodeHomeDispatchError` in `sdk/cliproxy/auth/home_concurrency.go` has no case for either code, so both fall through to the default `HTTP 502` and downstream clients see an `internal_server_error` envelope for what is a billing/limit problem (analysis and proposed switch cases in #5170).
- Map `user_credits_insufficient` to `402 Payment Required` and `user_period_limit_exceeded` to `429 Too Many Requests`, as proposed in the issue. No concurrency-busy semantics are added for the 429 case — that stays specific to the `credential_concurrency_exceeded` family.

## Verification

| Check | Result |
| --- | --- |
| New `TestHomeBillingErrorsMapTo402And429` (table-driven, both codes) | fails before fix (both 502), passes after |
| `go test ./sdk/cliproxy/auth/` (all existing home dispatch/concurrency tests) | pass |
| `go build ./cmd/server` | pass |
| `gofmt` | clean |

## AI use

Implemented by GLM-5.3-Flash (ZCode) from the analysis in #5170, reviewed and verified locally by a human.

## Checklist

- [x] Regression test included (failing before the fix)
- [x] Existing error-code mappings untouched
- [x] No unrelated changes