### PR TITLE
fix(claude): handle max-token Responses truncation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -836,6 +836,11 @@ nonstream-keepalive-interval: 0
 #           protocol: "codex" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex, antigravity
 #       params: # JSON path (gjson/sjson syntax) -> value
 #         "reasoning.effort": "high"
+#     - models:
+#         - name: "claude-fable-5-1"
+#           protocol: "claude"
+#       params:
+#         max_tokens: 128000 # override the final Claude Messages output budget after protocol translation
 #   override-raw: # Override raw rules always set parameters using raw JSON (must be valid JSON).
 #     - models:
 #         - name: "gpt-*" # Supports wildcards (e.g., "gpt-*")

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6117,9 +6117,46 @@ func TestClaudeExecutorPayloadOverrideReenablesThinking(t *testing.T) {
 	}
 }
 
-func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, payload []byte, stream bool) []byte {
+func TestClaudeExecutorPayloadOverrideMaxTokens(t *testing.T) {
+	const model = "claude-fable-5-1"
+	for _, test := range []struct {
+		name            string
+		stream          bool
+		maxOutputTokens int
+	}{
+		{name: "execute"},
+		{name: "execute stream", stream: true},
+		{name: "execute overrides client limit", maxOutputTokens: 32000},
+		{name: "execute stream overrides client limit", stream: true, maxOutputTokens: 32000},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: model, Protocol: "claude"}},
+				Params: map[string]any{"max_tokens": 128000},
+			}}}}
+			payload := []byte(`{"model":"claude-fable-5-1","input":"hi"}`)
+			if test.maxOutputTokens > 0 {
+				payload, _ = sjson.SetBytes(payload, "max_output_tokens", test.maxOutputTokens)
+			}
+			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, test.stream, sdktranslator.FormatOpenAIResponse)
+			if got := gjson.GetBytes(upstreamBody, "max_tokens").Int(); got != 128000 {
+				t.Fatalf("final upstream max_tokens = %d, want 128000; body=%s", got, upstreamBody)
+			}
+		})
+	}
+}
+
+func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, payload []byte, stream bool, sourceFormats ...sdktranslator.Format) []byte {
 	t.Helper()
 
+	sourceFormat := sdktranslator.FormatClaude
+	if len(sourceFormats) > 0 {
+		sourceFormat = sourceFormats[0]
+	}
+	model := gjson.GetBytes(payload, "model").String()
+	if model == "" {
+		model = "claude-opus-5"
+	}
 	var upstreamBody []byte
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		var errRead error
@@ -6143,8 +6180,8 @@ func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, pay
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
 	executor := NewClaudeExecutor(cfg)
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-payload-rule", "cloak_mode": "always"}}
-	request := cliproxyexecutor.Request{Model: "claude-opus-5", Payload: payload}
-	options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+	request := cliproxyexecutor.Request{Model: model, Payload: payload}
+	options := cliproxyexecutor.Options{SourceFormat: sourceFormat, ResponseFormat: sdktranslator.FormatClaude}
 
 	if stream {
 		result, errStream := executor.ExecuteStream(ctx, auth, request, options)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -14,6 +14,11 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const (
+	defaultClaudeResponsesMaxTokens = 32000
+	defaultFableResponsesMaxTokens  = 64000
+)
+
 // ConvertOpenAIResponsesRequestToClaude transforms an OpenAI Responses API request
 // into a Claude Messages API request using only gjson/sjson for JSON handling.
 // It supports:
@@ -43,6 +48,7 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	// Base Claude message payload
 	out := []byte(`{"model":"","max_tokens":32000,"messages":[],"metadata":{}}`)
 	out, _ = sjson.SetBytes(out, "metadata.user_id", userID)
+	out, _ = sjson.SetBytes(out, "max_tokens", defaultClaudeResponsesMaxTokensForModel(modelName))
 
 	root := gjson.ParseBytes(rawJSON)
 
@@ -566,6 +572,17 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 	}
 
 	return out
+}
+
+func defaultClaudeResponsesMaxTokensForModel(modelName string) int {
+	maxTokens := defaultClaudeResponsesMaxTokens
+	if strings.Contains(strings.ToLower(strings.TrimSpace(modelName)), "fable") {
+		maxTokens = defaultFableResponsesMaxTokens
+	}
+	if info := registry.LookupModelInfo(modelName, "claude"); info != nil && info.MaxCompletionTokens > 0 && info.MaxCompletionTokens < maxTokens {
+		return info.MaxCompletionTokens
+	}
+	return maxTokens
 }
 
 // isResponsesSystemLevelRole reports whether an input item carries system-level

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -42,6 +42,41 @@ func TestConvertOpenAIResponsesRequestToClaude_SanitizesToolCallIDsForClaude(t *
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToClaude_FableMaxTokens(t *testing.T) {
+	t.Run("defaults to 64k", func(t *testing.T) {
+		out := ConvertOpenAIResponsesRequestToClaude(
+			"claude-fable-5-1",
+			[]byte(`{"model":"claude-fable-5-1","input":"hello"}`),
+			true,
+		)
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != defaultFableResponsesMaxTokens {
+			t.Fatalf("max_tokens = %d, want %d; output=%s", got, defaultFableResponsesMaxTokens, out)
+		}
+	})
+
+	t.Run("preserves explicit 128k limit", func(t *testing.T) {
+		out := ConvertOpenAIResponsesRequestToClaude(
+			"claude-fable-5-1",
+			[]byte(`{"model":"claude-fable-5-1","max_output_tokens":128000,"input":"hello"}`),
+			true,
+		)
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != 128000 {
+			t.Fatalf("max_tokens = %d, want 128000; output=%s", got, out)
+		}
+	})
+
+	t.Run("does not exceed registered model maximum", func(t *testing.T) {
+		out := ConvertOpenAIResponsesRequestToClaude(
+			"claude-3-5-haiku-20241022",
+			[]byte(`{"model":"claude-3-5-haiku-20241022","input":"hello"}`),
+			true,
+		)
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != 8192 {
+			t.Fatalf("max_tokens = %d, want 8192; output=%s", got, out)
+		}
+	})
+}
+
 func TestConvertOpenAIResponsesRequestToClaude_ReasoningItemToThinkingBlock(t *testing.T) {
 	rawSignature, expectedSignature := testClaudeResponsesThinkingSignature(t)
 	raw := []byte(`{

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -49,6 +49,7 @@ type claudeToResponsesState struct {
 	WebSearchByBlock  map[int]*claudeResponsesWebSearchItem
 	WebSearchByToolID map[string]*claudeResponsesWebSearchItem
 	WebSearchItems    []*claudeResponsesWebSearchItem
+	StopReason        string
 	// usage aggregation
 	Usage claudeResponsesUsageTokens
 }
@@ -70,6 +71,7 @@ type claudeResponsesMessageItem struct {
 	OutputIndex int
 	Text        string
 	Annotations []any
+	Status      string
 }
 
 type claudeResponsesReasoningItem struct {
@@ -141,6 +143,28 @@ func (u claudeResponsesUsageTokens) OpenAIResponsesUsage() (inputTokens, outputT
 	outputTokens = u.OutputTokens
 	totalTokens = inputTokens + outputTokens
 	return inputTokens, outputTokens, totalTokens, cachedTokens
+}
+
+func claudeResponsesIncompleteDetails(stopReason string) ([]byte, bool) {
+	if strings.EqualFold(strings.TrimSpace(stopReason), "max_tokens") {
+		return []byte(`{"reason":"max_output_tokens"}`), true
+	}
+	return nil, false
+}
+
+func claudeResponsesOutputStatus(stopReason string) string {
+	if _, incomplete := claudeResponsesIncompleteDetails(stopReason); incomplete {
+		return "incomplete"
+	}
+	return "completed"
+}
+
+func claudeResponsesTerminalState(stopReason string) (eventType, status string, incompleteDetails []byte) {
+	incompleteDetails, incomplete := claudeResponsesIncompleteDetails(stopReason)
+	if incomplete {
+		return "response.incomplete", "incomplete", incompleteDetails
+	}
+	return "response.completed", "completed", nil
 }
 
 func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
@@ -228,6 +252,7 @@ func (st *claudeToResponsesState) finalizeAssistantMessage(nextSeq func() int) [
 	}
 	fullText := st.TextBuf.String()
 	outputIndex := st.messageOutputIndex()
+	status := claudeResponsesOutputStatus(st.StopReason)
 	var out [][]byte
 	done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
 	done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
@@ -250,6 +275,7 @@ func (st *claudeToResponsesState) finalizeAssistantMessage(nextSeq func() int) [
 	final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 	final, _ = sjson.SetBytes(final, "output_index", outputIndex)
 	final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
+	final, _ = sjson.SetBytes(final, "item.status", status)
 	final, _ = sjson.SetBytes(final, "item.content.0.text", fullText)
 	if len(st.MessageAnnotations) > 0 {
 		final, _ = sjson.SetBytes(final, "item.content.0.annotations", st.MessageAnnotations)
@@ -261,6 +287,7 @@ func (st *claudeToResponsesState) finalizeAssistantMessage(nextSeq func() int) [
 		OutputIndex: outputIndex,
 		Text:        fullText,
 		Annotations: append([]any(nil), st.MessageAnnotations...),
+		Status:      status,
 	})
 	st.InTextBlock = false
 	st.MessageOpen = false
@@ -327,6 +354,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			st.ReasoningSignature = ""
 			st.ReasoningIndex = -1
 			st.ReasoningItems = nil
+			st.StopReason = ""
 			st.FuncArgsBuf = make(map[int]*strings.Builder)
 			st.FuncNames = make(map[int]string)
 			st.FuncCallIDs = make(map[int]string)
@@ -620,6 +648,9 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 		return noSSEOutput(out)
 	case "message_delta":
 		st.Usage.Merge(root.Get("usage"))
+		if stopReason := root.Get("delta.stop_reason"); stopReason.Exists() {
+			st.StopReason = stopReason.String()
+		}
 		return [][]byte{}
 	case "message_stop":
 		out = append(out, st.finalizeAssistantMessage(nextSeq)...)
@@ -627,10 +658,16 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			out = append(out, st.finalizeWebSearch(item, nextSeq)...)
 		}
 
-		completed := []byte(`{"type":"response.completed","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null}}`)
+		eventType, responseStatus, incompleteDetails := claudeResponsesTerminalState(st.StopReason)
+		completed := []byte(`{"type":"","sequence_number":0,"response":{"id":"","object":"response","created_at":0,"status":"","background":false,"error":null}}`)
+		completed, _ = sjson.SetBytes(completed, "type", eventType)
 		completed, _ = sjson.SetBytes(completed, "sequence_number", nextSeq())
 		completed, _ = sjson.SetBytes(completed, "response.id", st.ResponseID)
 		completed, _ = sjson.SetBytes(completed, "response.created_at", st.CreatedAt)
+		completed, _ = sjson.SetBytes(completed, "response.status", responseStatus)
+		if len(incompleteDetails) > 0 {
+			completed, _ = sjson.SetRawBytes(completed, "response.incomplete_details", incompleteDetails)
+		}
 		// Inject original request fields into response as per docs/response.completed.json
 
 		reqBytes := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
@@ -712,8 +749,13 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 		}
 		// assistant message items
 		for _, message := range st.MessageItems {
+			status := message.Status
+			if status == "" {
+				status = "completed"
+			}
 			item := []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 			item, _ = sjson.SetBytes(item, "id", message.ID)
+			item, _ = sjson.SetBytes(item, "status", status)
 			item, _ = sjson.SetBytes(item, "content.0.text", message.Text)
 			if len(message.Annotations) > 0 {
 				item, _ = sjson.SetBytes(item, "content.0.annotations", message.Annotations)
@@ -789,7 +831,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				completed, _ = sjson.SetBytes(completed, "response.usage.total_tokens", totalTokens)
 			}
 		}
-		out = append(out, emitEvent("response.completed", completed))
+		out = append(out, emitEvent(eventType, completed))
 	}
 
 	return noSSEOutput(out)
@@ -831,6 +873,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	var (
 		responseID  string
 		createdAt   int64
+		stopReason  string
 		usageTokens claudeResponsesUsageTokens
 	)
 
@@ -994,12 +1037,20 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 
 		case "message_delta":
 			usageTokens.Merge(root.Get("usage"))
+			if value := root.Get("delta.stop_reason"); value.Exists() {
+				stopReason = value.String()
+			}
 		}
 	}
 
 	// Populate base fields
+	_, responseStatus, incompleteDetails := claudeResponsesTerminalState(stopReason)
 	out, _ = sjson.SetBytes(out, "id", responseID)
 	out, _ = sjson.SetBytes(out, "created_at", createdAt)
+	out, _ = sjson.SetBytes(out, "status", responseStatus)
+	if len(incompleteDetails) > 0 {
+		out, _ = sjson.SetRawBytes(out, "incomplete_details", incompleteDetails)
+	}
 
 	// Inject request echo fields as top-level (similar to streaming variant)
 	if len(reqBytes) > 0 {
@@ -1083,6 +1134,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 		case "message":
 			item = []byte(`{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}`)
 			item, _ = sjson.SetBytes(item, "id", outputItem.id)
+			item, _ = sjson.SetBytes(item, "status", claudeResponsesOutputStatus(stopReason))
 			item, _ = sjson.SetBytes(item, "content.0.text", outputItem.text.String())
 			if len(outputItem.annotations) > 0 {
 				item, _ = sjson.SetBytes(item, "content.0.annotations", outputItem.annotations)
@@ -1091,17 +1143,19 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 			if outputItem.itemType == "custom_tool_call" {
 				item = []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
 				item, _ = sjson.SetBytes(item, "id", outputItem.id)
+				item, _ = sjson.SetBytes(item, "status", claudeResponsesOutputStatus(stopReason))
 				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(outputItem.args.String()))
 				item, _ = sjson.SetBytes(item, "call_id", outputItem.callID)
 				item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, outputItem.name, "")
 				break
 			}
 			args := outputItem.args.String()
-			if args == "" {
+			if args == "" && responseStatus == "completed" {
 				args = "{}"
 			}
 			item = []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
 			item, _ = sjson.SetBytes(item, "id", outputItem.id)
+			item, _ = sjson.SetBytes(item, "status", claudeResponsesOutputStatus(stopReason))
 			item, _ = sjson.SetBytes(item, "arguments", args)
 			item, _ = sjson.SetBytes(item, "call_id", outputItem.callID)
 			item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, outputItem.name, "")

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -1167,3 +1167,73 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_RestoresNamespaceFuncti
 		t.Fatalf("non-stream output namespace = %q, want mcp__node_repl", got)
 	}
 }
+
+func TestConvertClaudeResponseToOpenAIResponses_MaxTokensEmitsIncomplete(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_max_tokens","usage":{"input_tokens":10,"output_tokens":0}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"unfinished reasoning"}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_max_tokens"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":64000}}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	var param any
+	var incomplete gjson.Result
+	for _, chunk := range chunks {
+		for _, output := range ConvertClaudeResponseToOpenAIResponses(context.Background(), "claude-fable-5-1", nil, nil, chunk, &param) {
+			event, data := parseClaudeResponsesSSEEvent(t, output)
+			if event == "response.completed" {
+				t.Fatalf("max_tokens response emitted response.completed: %s", output)
+			}
+			if event == "response.incomplete" {
+				incomplete = data
+			}
+		}
+	}
+
+	if !incomplete.Exists() {
+		t.Fatal("expected response.incomplete event")
+	}
+	if got := incomplete.Get("response.status").String(); got != "incomplete" {
+		t.Fatalf("response.status = %q, want incomplete", got)
+	}
+	if got := incomplete.Get("response.incomplete_details.reason").String(); got != "max_output_tokens" {
+		t.Fatalf("incomplete reason = %q, want max_output_tokens", got)
+	}
+	if got := incomplete.Get("response.output.0.type").String(); got != "reasoning" {
+		t.Fatalf("response.output.0.type = %q, want reasoning; response=%s", got, incomplete.Raw)
+	}
+	if got := incomplete.Get("response.output.0.summary.0.text").String(); got != "unfinished reasoning" {
+		t.Fatalf("reasoning summary = %q, want unfinished reasoning", got)
+	}
+	if got := incomplete.Get("response.usage.output_tokens").Int(); got != 64000 {
+		t.Fatalf("output_tokens = %d, want 64000", got)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAIResponsesNonStream_MaxTokensPreservesPartialText(t *testing.T) {
+	raw := []byte(strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg_partial","usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial answer"}}`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":64000}}`,
+		`data: {"type":"message_stop"}`,
+	}, "\n"))
+
+	out := ConvertClaudeResponseToOpenAIResponsesNonStream(context.Background(), "claude-fable-5-1", nil, nil, raw, nil)
+	root := gjson.ParseBytes(out)
+	if got := root.Get("status").String(); got != "incomplete" {
+		t.Fatalf("status = %q, want incomplete; response=%s", got, out)
+	}
+	if got := root.Get("incomplete_details.reason").String(); got != "max_output_tokens" {
+		t.Fatalf("incomplete reason = %q, want max_output_tokens", got)
+	}
+	if got := root.Get("output.0.status").String(); got != "incomplete" {
+		t.Fatalf("output.0.status = %q, want incomplete", got)
+	}
+	if got := root.Get("output.0.content.0.text").String(); got != "partial answer" {
+		t.Fatalf("partial text = %q, want partial answer", got)
+	}
+}


### PR DESCRIPTION
## Summary

- default Fable Responses requests to 64K output tokens while respecting lower registered model limits
- preserve explicit `max_output_tokens` and document model-scoped `payload.override` configuration for budgets such as 128K
- map Claude `stop_reason: max_tokens` to `response.incomplete` with `incomplete_details.reason: max_output_tokens`
- preserve partial reasoning/text and keep already completed message item statuses stable
- apply the terminal mapping to both streaming and non-streaming Responses paths

## Problem

Claude can consume the full output budget in reasoning without producing a visible assistant message. The Claude-to-Responses translator currently ignores `message_delta.delta.stop_reason` and always emits `response.completed`, so Codex can silently finalize the turn with no final answer.

## Configuration

```yaml
payload:
  override:
    - models:
        - name: "claude-fable-5-1"
          protocol: "claude"
      params:
        max_tokens: 128000
```

The override is applied after protocol translation and works for both OAuth and API-key Claude execution.

## Verification

- `go test ./internal/translator/claude/openai/responses -count=1`
- `go test ./internal/runtime/executor -run TestClaudeExecutorPayloadOverrideMaxTokens -count=1`
- `go build -o <temp>/cli-proxy-api ./cmd/server`
- real HTTP smoke: `/v1/responses` -> configured Claude upstream received `max_tokens: 128000`; downstream ended with `response.incomplete` and preserved reasoning output

`go test ./... -count=1` was also exercised. Changed packages pass; the existing XAI TTFT timing assertion can intermittently report `ttft = 0s` on Windows and passes independently.