### PR TITLE
fix(codex): add optional HTTP/1.1 transport

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -239,6 +239,11 @@ codex:
   identity-confuse: false
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
+  # Use HTTP/1.1 for ChatGPT Codex HTTP/SSE requests while retaining the Chrome
+  # uTLS fingerprint. Enable this only when the configured proxy cannot reliably
+  # carry HTTP/2. Other upstream transports continue using their existing protocols.
+  # Default: false
+  force-http1: false
   # Hold back the initial handshake events (response.created, response.in_progress and the
   # websocket metadata frames) until the upstream emits its first generated event.
   # Why: the upstream smuggles `server_is_overloaded` rejections *inside* an HTTP 200 stream,

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -32,6 +32,9 @@ codex-header-defaults:
 	if cfg.Codex.DisableCodexCloaking {
 		t.Fatal("DisableCodexCloaking = true, want default false")
 	}
+	if cfg.Codex.ForceHTTP1 {
+		t.Fatal("ForceHTTP1 = true, want default false")
+	}
 }
 
 func TestLoadConfigOptional_CodexIdentityConfuse(t *testing.T) {
@@ -41,6 +44,7 @@ func TestLoadConfigOptional_CodexIdentityConfuse(t *testing.T) {
 codex:
   identity-confuse: true
   disable-codex-cloaking: true
+  force-http1: true
   optimize-multi-agent-v2: true
 `)
 	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
@@ -57,6 +61,9 @@ codex:
 	}
 	if !cfg.Codex.DisableCodexCloaking {
 		t.Fatal("DisableCodexCloaking = false, want true")
+	}
+	if !cfg.Codex.ForceHTTP1 {
+		t.Fatal("ForceHTTP1 = false, want true")
 	}
 	if !cfg.Codex.OptimizeMultiAgentV2 {
 		t.Fatalf("OptimizeMultiAgentV2 = false, want true")

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -148,6 +148,10 @@ type CodexConfig struct {
 	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
 	// DisableCodexCloaking disables forcing the official Codex identity headers on HTTP/SSE and WebSocket requests.
 	DisableCodexCloaking bool `yaml:"disable-codex-cloaking" json:"disable-codex-cloaking"`
+	// ForceHTTP1 makes ChatGPT Codex HTTP/SSE requests use HTTP/1.1 while retaining
+	// the Chrome uTLS fingerprint. Use it for proxy paths that cannot reliably carry
+	// HTTP/2. Other upstream transports are unaffected. Default is false.
+	ForceHTTP1 bool `yaml:"force-http1" json:"force-http1"`
 	// StreamBootstrapBuffering holds back initial handshake events (response.created,
 	// response.in_progress and the websocket metadata frames) until the first generated event
 	// arrives. The upstream delivers server_is_overloaded rejections inside an HTTP 200 stream

--- a/internal/runtime/executor/helps/chrome_http1_transport.go
+++ b/internal/runtime/executor/helps/chrome_http1_transport.go
@@ -1,0 +1,110 @@
+package helps
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	tls "github.com/refraction-networking/utls"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/proxy"
+)
+
+// newChromeHTTP1RoundTripper keeps the Chrome uTLS ClientHello while limiting
+// ALPN to HTTP/1.1. It is used only when codex.force-http1 is enabled.
+func newChromeHTTP1RoundTripper(proxyURL string) http.RoundTripper {
+	var dialer proxy.Dialer = proxy.Direct
+	if proxyURL != "" {
+		proxyDialer, mode, errBuild := proxyutil.BuildDialer(proxyURL)
+		if errBuild != nil {
+			log.Errorf("utls http1: failed to configure proxy dialer for %q: %v", proxyutil.Redact(proxyURL), errBuild)
+		} else if mode != proxyutil.ModeInherit && proxyDialer != nil {
+			dialer = proxyDialer
+		}
+	}
+
+	return &http.Transport{
+		DisableKeepAlives: true,
+		ForceAttemptHTTP2: false,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialChromeHTTP1(ctx, dialer, network, addr)
+		},
+	}
+}
+
+func dialChromeHTTP1(ctx context.Context, dialer proxy.Dialer, network, addr string) (net.Conn, error) {
+	contextDialer, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("utls http1: dialer does not support context cancellation")
+	}
+	conn, errDial := contextDialer.DialContext(ctx, network, addr)
+	if errDial != nil {
+		return nil, fmt.Errorf("utls http1: dial upstream: %w", errDial)
+	}
+
+	host, _, errSplit := net.SplitHostPort(addr)
+	if errSplit != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls http1: split upstream address: %w; close connection: %v", errSplit, errClose)
+		}
+		return nil, fmt.Errorf("utls http1: split upstream address: %w", errSplit)
+	}
+
+	clientHello, errSpec := chromeHTTP1ClientHelloSpec()
+	if errSpec != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls http1: build Chrome ClientHello: %w; close connection: %v", errSpec, errClose)
+		}
+		return nil, fmt.Errorf("utls http1: build Chrome ClientHello: %w", errSpec)
+	}
+
+	tlsConn := tls.UClient(conn, &tls.Config{ServerName: host}, tls.HelloCustom)
+	if errPreset := tlsConn.ApplyPreset(clientHello); errPreset != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls http1: apply Chrome ClientHello: %w; close connection: %v", errPreset, errClose)
+		}
+		return nil, fmt.Errorf("utls http1: apply Chrome ClientHello: %w", errPreset)
+	}
+	if errHandshake := tlsConn.HandshakeContext(ctx); errHandshake != nil {
+		if errClose := conn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls http1: TLS handshake: %w; close connection: %v", errHandshake, errClose)
+		}
+		return nil, fmt.Errorf("utls http1: TLS handshake: %w", errHandshake)
+	}
+	if negotiated := tlsConn.ConnectionState().NegotiatedProtocol; negotiated != "http/1.1" {
+		if errClose := tlsConn.Close(); errClose != nil {
+			return nil, fmt.Errorf("utls http1: negotiated protocol %q; close connection: %v", negotiated, errClose)
+		}
+		return nil, fmt.Errorf("utls http1: negotiated protocol %q", negotiated)
+	}
+	return tlsConn, nil
+}
+
+func chromeHTTP1ClientHelloSpec() (*tls.ClientHelloSpec, error) {
+	spec, errSpec := tls.UTLSIdToSpec(tls.HelloChrome_Auto)
+	if errSpec != nil {
+		return nil, errSpec
+	}
+
+	foundALPN := false
+	extensions := spec.Extensions[:0]
+	for _, extension := range spec.Extensions {
+		switch typed := extension.(type) {
+		case *tls.ALPNExtension:
+			typed.AlpnProtocols = []string{"http/1.1"}
+			foundALPN = true
+			extensions = append(extensions, extension)
+		case *tls.ApplicationSettingsExtension, *tls.ApplicationSettingsExtensionNew:
+			// Chrome advertises ALPS for h2. Drop it when h2 is not offered.
+		default:
+			extensions = append(extensions, extension)
+		}
+	}
+	if !foundALPN {
+		return nil, fmt.Errorf("Chrome ClientHello does not contain ALPN")
+	}
+	spec.Extensions = extensions
+	return &spec, nil
+}

--- a/internal/runtime/executor/helps/chrome_http1_transport_test.go
+++ b/internal/runtime/executor/helps/chrome_http1_transport_test.go
@@ -1,0 +1,95 @@
+package helps
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	tls "github.com/refraction-networking/utls"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestChromeHTTP1ClientHelloKeepsChromeProfileWithHTTP1ALPN(t *testing.T) {
+	original, errOriginal := tls.UTLSIdToSpec(tls.HelloChrome_Auto)
+	if errOriginal != nil {
+		t.Fatal(errOriginal)
+	}
+	modified, errModified := chromeHTTP1ClientHelloSpec()
+	if errModified != nil {
+		t.Fatal(errModified)
+	}
+
+	if !reflect.DeepEqual(modified.CipherSuites, original.CipherSuites) {
+		t.Fatal("Chrome cipher suites changed")
+	}
+	if !reflect.DeepEqual(modified.CompressionMethods, original.CompressionMethods) {
+		t.Fatal("Chrome compression methods changed")
+	}
+	originalTypes := make(map[reflect.Type]int, len(original.Extensions))
+	for _, extension := range original.Extensions {
+		switch extension.(type) {
+		case *tls.ApplicationSettingsExtension, *tls.ApplicationSettingsExtensionNew:
+			continue
+		default:
+			originalTypes[reflect.TypeOf(extension)]++
+		}
+	}
+	modifiedTypes := make(map[reflect.Type]int, len(modified.Extensions))
+	var alpn []string
+	for _, extension := range modified.Extensions {
+		switch extension.(type) {
+		case *tls.ApplicationSettingsExtension, *tls.ApplicationSettingsExtensionNew:
+			t.Fatalf("HTTP/1.1 ClientHello contains h2 ALPS extension %T", extension)
+		}
+		modifiedTypes[reflect.TypeOf(extension)]++
+		if typed, ok := extension.(*tls.ALPNExtension); ok {
+			alpn = append(alpn, typed.AlpnProtocols...)
+		}
+	}
+	if !reflect.DeepEqual(modifiedTypes, originalTypes) {
+		t.Fatalf("Chrome extension types = %v, want %v", modifiedTypes, originalTypes)
+	}
+	if want := []string{"http/1.1"}; !reflect.DeepEqual(alpn, want) {
+		t.Fatalf("ALPN = %v, want %v", alpn, want)
+	}
+}
+
+func TestNewUtlsHTTPClientForceHTTP1IsOptIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		wantHTTP1 bool
+	}{
+		{name: "nil config", cfg: nil, wantHTTP1: false},
+		{name: "default", cfg: &config.Config{}, wantHTTP1: false},
+		{name: "forced", cfg: &config.Config{Codex: config.CodexConfig{ForceHTTP1: true}}, wantHTTP1: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewUtlsHTTPClient(t.Context(), tt.cfg, nil, 0)
+			router, ok := client.Transport.(*fallbackRoundTripper)
+			if !ok {
+				t.Fatalf("transport type = %T, want *fallbackRoundTripper", client.Transport)
+			}
+
+			if tt.wantHTTP1 {
+				transport, ok := router.chrome.(*http.Transport)
+				if !ok {
+					t.Fatalf("ChatGPT transport type = %T, want *http.Transport", router.chrome)
+				}
+				if transport.ForceAttemptHTTP2 {
+					t.Fatal("ForceAttemptHTTP2 = true, want false")
+				}
+				if !transport.DisableKeepAlives {
+					t.Fatal("DisableKeepAlives = false, want one connection per request")
+				}
+				return
+			}
+
+			if _, ok := router.chrome.(*utlsRoundTripper); !ok {
+				t.Fatalf("default ChatGPT transport type = %T, want *utlsRoundTripper", router.chrome)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -380,7 +380,12 @@ func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyau
 		ctxRoundTripper, _ = ctx.Value("cliproxy.roundtripper").(http.RoundTripper)
 	}
 
-	var chromeRT http.RoundTripper = newUtlsRoundTripper(proxyURL)
+	var chromeRT http.RoundTripper
+	if cfg != nil && cfg.Codex.ForceHTTP1 {
+		chromeRT = newChromeHTTP1RoundTripper(proxyURL)
+	} else {
+		chromeRT = newUtlsRoundTripper(proxyURL)
+	}
 	var anthropicRT http.RoundTripper = cachedClaudeCodeRoundTripper(proxyURL)
 	var standardTransport http.RoundTripper = http.DefaultTransport
 	if proxyURL != "" {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -115,6 +115,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.DisableCodexCloaking != newCfg.Codex.DisableCodexCloaking {
 		changes = append(changes, fmt.Sprintf("codex.disable-codex-cloaking: %t -> %t", oldCfg.Codex.DisableCodexCloaking, newCfg.Codex.DisableCodexCloaking))
 	}
+	if oldCfg.Codex.ForceHTTP1 != newCfg.Codex.ForceHTTP1 {
+		changes = append(changes, fmt.Sprintf("codex.force-http1: %t -> %t", oldCfg.Codex.ForceHTTP1, newCfg.Codex.ForceHTTP1))
+	}
 	if oldCfg.Codex.StreamBootstrapBuffering != newCfg.Codex.StreamBootstrapBuffering {
 		changes = append(changes, fmt.Sprintf("codex.stream-bootstrap-buffering: %t -> %t", oldCfg.Codex.StreamBootstrapBuffering, newCfg.Codex.StreamBootstrapBuffering))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -39,7 +39,10 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	newCfg := &config.Config{
 		Port:    9090,
 		AuthDir: "/tmp/auth-new",
-		Codex:   config.CodexConfig{DisableCodexCloaking: true},
+		Codex: config.CodexConfig{
+			DisableCodexCloaking: true,
+			ForceHTTP1:           true,
+		},
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "old", BaseURL: "http://old", ExcludedModels: []string{"old-model", "extra"}},
 		},
@@ -80,6 +83,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	expectContains(t, details, "remote-management.disable-auto-update-panel: false -> true")
 	expectContains(t, details, "remote-management.secret-key: updated")
 	expectContains(t, details, "codex.disable-codex-cloaking: false -> true")
+	expectContains(t, details, "codex.force-http1: false -> true")
 	expectContains(t, details, "oauth-excluded-models[providera]: updated (1 -> 2 entries)")
 	expectContains(t, details, "oauth-excluded-models[providerb]: added (1 entries)")
 	expectContains(t, details, "openai-compatibility:")


### PR DESCRIPTION
## Problem

ChatGPT Codex requests currently use HTTP/2 over the Chrome uTLS transport. Some proxy paths can establish the TLS connection but cannot reliably carry HTTP/2, causing requests to fail with protocol errors such as:

```text
protocol error: received *http2.WindowUpdateFrame before a SETTINGS frame
connection error: PROTOCOL_ERROR
```

## Solution

Add an optional Codex setting that forces only ChatGPT Codex HTTP/SSE requests to use HTTP/1.1:

```yaml
codex:
  force-http1: true
```

The HTTP/1.1 path keeps the existing Chrome uTLS fingerprint and changes only the negotiated application protocol.

The option is disabled by default. Without it, ChatGPT Codex continues to use the existing HTTP/2 transport. Anthropic and all other upstream transports are unchanged.
