### PR TITLE
fix(claude): treat the pinned Claude Code version as a floor, not a lock

### DIFF
--- a/internal/api/handlers/management/claude_client_versions.go
+++ b/internal/api/handlers/management/claude_client_versions.go
@@ -1,0 +1,19 @@
+package management
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+)
+
+// GetClaudeClientVersions reports the configured Claude Code User-Agent baseline
+// alongside the CLI versions actually observed per credential.
+//
+// The baseline in claude-header-defaults.user-agent is a floor rather than a
+// lock, so a client that auto-updated past it is still passed through. That is
+// exactly what makes a stale pin easy to miss: cloaked requests keep presenting
+// the configured constant. This read-only endpoint makes the drift inspectable.
+func (h *Handler) GetClaudeClientVersions(c *gin.Context) {
+	c.JSON(http.StatusOK, helps.ClaudeClientVersionReport(h.cfg))
+}

--- a/internal/api/server_claude_client_versions_test.go
+++ b/internal/api/server_claude_client_versions_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+)
+
+func TestManagementClaudeClientVersionsReportsObservedDrift(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+	helps.ResetClaudeClientVersionRegistry()
+	t.Cleanup(helps.ResetClaudeClientVersionRegistry)
+
+	cfg := &proxyconfig.Config{ClaudeHeaderDefaults: proxyconfig.ClaudeHeaderDefaults{
+		UserAgent: "claude-cli/2.1.252 (external, cli)",
+	}}
+	helps.ObserveClaudeClientVersion(nil, "sk-observed-credential", http.Header{
+		"User-Agent": {"claude-cli/2.1.259 (external, cli)"},
+	}, cfg)
+
+	server := newTestServer(t)
+	server.cfg.ClaudeHeaderDefaults = cfg.ClaudeHeaderDefaults
+	server.mgmt.SetConfig(server.cfg)
+
+	unauthorized := httptest.NewRequest(http.MethodGet, "/v0/management/claude-client-versions", nil)
+	unauthorizedRecorder := httptest.NewRecorder()
+	server.engine.ServeHTTP(unauthorizedRecorder, unauthorized)
+	if unauthorizedRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", unauthorizedRecorder.Code, http.StatusUnauthorized)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/claude-client-versions", nil)
+	req.Header.Set("Authorization", "Bearer test-management-key")
+	recorder := httptest.NewRecorder()
+	server.engine.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var report helps.ClaudeClientVersionsReport
+	if err := json.Unmarshal(recorder.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v body=%s", err, recorder.Body.String())
+	}
+	if report.ConfiguredVersion != "2.1.252" || report.ConfigKey != helps.ClaudeClientVersionConfigKey {
+		t.Fatalf("report = %#v, want the configured 2.1.252 baseline and config key", report)
+	}
+	if len(report.Credentials) != 1 {
+		t.Fatalf("credentials = %#v, want one", report.Credentials)
+	}
+	credential := report.Credentials[0]
+	if credential.HighestObservedVersion != "2.1.259" || !credential.Mismatched {
+		t.Fatalf("credential = %#v, want 2.1.259 flagged as mismatched", credential)
+	}
+	if credential.Credential == "api-key:sk-observed-credential" {
+		t.Fatalf("credential label %q leaks the raw API key", credential.Credential)
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -40,6 +40,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PUT("/plugins/:id/config", s.mgmt.PutPluginConfig)
 		mgmt.PATCH("/plugins/:id/config", s.mgmt.PatchPluginConfig)
 
+		mgmt.GET("/claude-client-versions", s.mgmt.GetClaudeClientVersions)
+
 		mgmt.GET("/debug", s.mgmt.GetDebug)
 		mgmt.PUT("/debug", s.mgmt.PutDebug)
 		mgmt.PATCH("/debug", s.mgmt.PutDebug)

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -774,14 +774,38 @@ func applyClaudeHeadersWithNativeProfile(
 			incomingHeaders = ginCtx.Request.Header
 		}
 	}
+	// The configured claude-header-defaults.user-agent is a floor, not a lock, so a
+	// client that has auto-updated past the pin is still passed through. Record the
+	// mismatch once per credential and version so the operator can move the pin.
+	if helps.ObserveClaudeClientVersion(auth, apiKey, incomingHeaders, cfg) {
+		log.Warnf(
+			"claude client version %q differs from the configured baseline %q; "+
+				"cloaked requests on this credential still present the configured version. "+
+				"Update %s to match, or inspect GET /v0/management/claude-client-versions",
+			strings.TrimSpace(incomingHeaders.Get("User-Agent")),
+			helps.ConfiguredClaudeUserAgent(cfg),
+			helps.ClaudeClientVersionConfigKey,
+		)
+	}
+
 	stabilizeDeviceProfile := helps.ClaudeDeviceProfileStabilizationEnabled(cfg)
 	var deviceProfile helps.ClaudeDeviceProfile
-	if stabilizeDeviceProfile && confirmedClaudeCode {
-		var errDeviceProfile error
-		deviceProfile, errDeviceProfile = helps.ResolveClaudeDeviceProfileRequired(r.Context(), auth, apiKey, incomingHeaders, cfg)
-		if errDeviceProfile != nil {
-			return errDeviceProfile
+	if confirmedClaudeCode {
+		if stabilizeDeviceProfile {
+			var errDeviceProfile error
+			deviceProfile, errDeviceProfile = helps.ResolveClaudeDeviceProfileRequired(r.Context(), auth, apiKey, incomingHeaders, cfg)
+			if errDeviceProfile != nil {
+				return errDeviceProfile
+			}
+		} else {
+			// Learn the confirmed client's profile even with stabilization off, so
+			// the cloaked branch below has a newest-observed value to present.
+			deviceProfile = helps.ResolveClaudeDeviceProfileBestEffort(r.Context(), auth, apiKey, incomingHeaders, cfg)
 		}
+	} else {
+		// nil headers: read the learned profile without letting an unconfirmed
+		// client contribute its own software profile to the credential.
+		deviceProfile = helps.ResolveClaudeDeviceProfileBestEffort(r.Context(), auth, apiKey, nil, cfg)
 	}
 
 	incomingBetas := strings.TrimSpace(strings.Join(incomingHeaders.Values("Anthropic-Beta"), ","))
@@ -1012,13 +1036,12 @@ func applyClaudeHeadersWithNativeProfile(
 	// Unconfirmed clients always receive the CLI baseline instead of being
 	// allowed to populate or reuse another client's software profile.
 	if stabilizeDeviceProfile {
-		if confirmedClaudeCode {
-			helps.ApplyClaudeDeviceProfileHeaders(r, deviceProfile)
-		} else {
-			helps.ApplyClaudeDefaultDeviceProfileHeaders(r, cfg)
-		}
+		// Both branches use deviceProfile: confirmed clients contribute their own
+		// software profile, unconfirmed clients receive the newest one already
+		// learned for this credential (the configured baseline when none exists).
+		helps.ApplyClaudeDeviceProfileHeaders(r, deviceProfile)
 	} else {
-		helps.ApplyClaudeLegacyDeviceHeaders(r, incomingHeaders, cfg, confirmedClaudeCode)
+		helps.ApplyClaudeLegacyDeviceHeaders(r, incomingHeaders, cfg, confirmedClaudeCode, deviceProfile)
 	}
 	var attrs map[string]string
 	if auth != nil {

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -780,7 +780,8 @@ func applyClaudeHeadersWithNativeProfile(
 	if helps.ObserveClaudeClientVersion(auth, apiKey, incomingHeaders, cfg) {
 		log.Warnf(
 			"claude client version %q differs from the configured baseline %q; "+
-				"cloaked requests on this credential still present the configured version. "+
+				"a client below the baseline is cloaked rather than passed through, and the "+
+				"configured version is what a credential presents until a newer client is seen. "+
 				"Update %s to match, or inspect GET /v0/management/claude-client-versions",
 			strings.TrimSpace(incomingHeaders.Get("User-Agent")),
 			helps.ConfiguredClaudeUserAgent(cfg),

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -217,7 +217,11 @@ func TestApplyClaudeHeaders_UsesConfiguredBaselineFingerprint(t *testing.T) {
 	}
 }
 
-func TestApplyClaudeHeaders_RejectsUnmeasuredClaudeCLIFingerprints(t *testing.T) {
+// The configured software tuple is a FLOOR: a confirmed Claude Code that has
+// auto-updated past the pin contributes its own profile, and the credential's
+// cloaked traffic then presents that newest observed profile instead of the
+// configured constant. Only a client BELOW the floor is rejected.
+func TestApplyClaudeHeaders_AdoptsClaudeCLIFingerprintsAtOrAboveBaselineFloor(t *testing.T) {
 	resetClaudeDeviceProfileCache()
 	stabilize := true
 
@@ -247,8 +251,10 @@ func TestApplyClaudeHeaders_RejectsUnmeasuredClaudeCLIFingerprints(t *testing.T)
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(firstReq, auth, "key-upgrade", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
+	// A cloaked third-party client now presents the newest profile learned for
+	// this credential rather than the stale configured constant.
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"lobe-chat/1.0"},
 		"X-Stainless-Package-Version": []string{"0.10.0"},
@@ -257,7 +263,7 @@ func TestApplyClaudeHeaders_RejectsUnmeasuredClaudeCLIFingerprints(t *testing.T)
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(thirdPartyReq, auth, "key-upgrade", false, nil, nil, cfg, nil, false)
-	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	higherReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"claude-cli/2.1.63 (external, cli)"},
@@ -267,8 +273,10 @@ func TestApplyClaudeHeaders_RejectsUnmeasuredClaudeCLIFingerprints(t *testing.T)
 		"X-Stainless-Arch":            []string{"arm64"},
 	})
 	applyClaudeHeaders(higherReq, auth, "key-upgrade", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, higherReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, higherReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 
+	// Above the floor but below what this credential already learned: the stored
+	// profile still wins, so the fingerprint never walks backwards.
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"claude-cli/2.1.61 (external, cli)"},
 		"X-Stainless-Package-Version": []string{"0.73.0"},
@@ -277,10 +285,24 @@ func TestApplyClaudeHeaders_RejectsUnmeasuredClaudeCLIFingerprints(t *testing.T)
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(lowerReq, auth, "key-upgrade", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
+
+	// Below the configured floor: a stale copied fingerprint is still rejected and
+	// replaced with the credential's learned profile.
+	staleReq := newClaudeHeaderTestRequest(t, http.Header{
+		"User-Agent":                  []string{"claude-cli/2.1.59 (external, cli)"},
+		"X-Stainless-Package-Version": []string{"0.69.0"},
+		"X-Stainless-Runtime-Version": []string{"v21.9.0"},
+		"X-Stainless-Os":              []string{"Windows"},
+		"X-Stainless-Arch":            []string{"x64"},
+	})
+	applyClaudeHeaders(staleReq, auth, "key-upgrade", false, nil, nil, cfg, nil, true)
+	assertClaudeFingerprint(t, staleReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 }
 
-func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClient(t *testing.T) {
+// A client older than the configured floor never drags the baseline down; a
+// client newer than it is adopted.
+func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineButAdoptsUpgrades(t *testing.T) {
 	resetClaudeDeviceProfileCache()
 	stabilize := true
 
@@ -319,7 +341,7 @@ func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClien
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(newerClaudeReq, auth, "key-baseline-floor", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, newerClaudeReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, newerClaudeReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 }
 
 func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvances(t *testing.T) {
@@ -362,7 +384,7 @@ func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvance
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(officialReq, auth, "key-baseline-reload", false, nil, nil, oldCfg, nil, true)
-	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"curl/8.7.1"},
@@ -574,7 +596,7 @@ func TestApplyClaudeHeaders_ThirdPartyBaselineThenOfficialUpgradeKeepsPinnedPlat
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(officialReq, auth, "key-third-party-then-official", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
 func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
@@ -606,8 +628,11 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
+	// Legacy mode: a confirmed client at or above the floor forwards its own
+	// software tuple and platform, exactly as a client pinned to the configured
+	// version already did.
 	applyClaudeHeaders(firstReq, auth, "key-disable-stability", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "Linux", "x64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"lobe-chat/1.0"},
@@ -616,8 +641,9 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
+	// Cloaked: the newest profile learned for this credential, platform pinned.
 	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, nil, cfg, nil, false)
-	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"claude-cli/2.1.61 (external, cli)"},
@@ -627,7 +653,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(lowerReq, auth, "key-disable-stability", false, nil, nil, cfg, nil, true)
-	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.61 (external, cli)", "0.73.0", "v24.2.0", "Windows", "x64")
 }
 
 func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForClaudeClients(t *testing.T) {
@@ -659,7 +685,9 @@ func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForCla
 	})
 	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, nil, cfg, nil, true)
 
-	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	// The credential's User-Agent override still wins; the rest of the tuple now
+	// comes from the confirmed client, which is above the configured floor.
+	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.74.0", "v24.3.0", "Linux", "x64")
 }
 
 func TestApplyClaudeHeaders_LegacyThirdPartyUsesStableConfiguredOSArch(t *testing.T) {

--- a/internal/runtime/executor/helps/claude_client_detection_test.go
+++ b/internal/runtime/executor/helps/claude_client_detection_test.go
@@ -85,8 +85,18 @@ func TestDetectClaudeCodeRequestAcceptsConfiguredMeasuredBaseline(t *testing.T) 
 	headers := confirmedClaudeCodeHeaders()
 	headers.Set("User-Agent", "claude-cli/2.2.0 (external, cli)")
 	payload := claudeCodeDetectionPayload(validClaudeCodeMetadataUserID)
-	if detection := DetectClaudeCodeRequest(headers, payload, false); detection.Confirmed {
-		t.Fatalf("default detection = %#v, want unconfigured 2.2.0 rejected", detection)
+
+	// The configured software tuple is a floor: a client past the pin is a genuine
+	// upgrade and must be confirmed even before the operator moves the pin.
+	if detection := DetectClaudeCodeRequest(headers, payload, false); !detection.Confirmed {
+		t.Fatalf("default detection = %#v, want 2.2.0 above the default floor confirmed", detection)
+	}
+
+	// A client BELOW the configured floor is a stale copy and stays unconfirmed.
+	stale := confirmedClaudeCodeHeaders()
+	stale.Set("User-Agent", "claude-cli/2.0.999 (external, cli)")
+	if detection := DetectClaudeCodeRequest(stale, payload, false); detection.Confirmed {
+		t.Fatalf("stale detection = %#v, want a below-floor user agent rejected", detection)
 	}
 
 	cfg := &config.Config{ClaudeHeaderDefaults: config.ClaudeHeaderDefaults{
@@ -96,6 +106,9 @@ func TestDetectClaudeCodeRequestAcceptsConfiguredMeasuredBaseline(t *testing.T) 
 	}}
 	if detection := DetectClaudeCodeRequest(headers, payload, false, cfg); !detection.Confirmed {
 		t.Fatalf("configured detection = %#v, want measured baseline confirmed", detection)
+	}
+	if detection := DetectClaudeCodeRequest(stale, payload, false, cfg); detection.Confirmed {
+		t.Fatalf("configured stale detection = %#v, want a below-floor user agent rejected", detection)
 	}
 }
 
@@ -349,7 +362,9 @@ func TestDetectClaudeCodeRequestRejectsMalformedNativeSignals(t *testing.T) {
 		{name: "uppercase device", headers: confirmedClaudeCodeHeaders(), userID: `{"device_id":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","account_uuid":"","session_id":"11111111-2222-4333-8444-555555555555"}`},
 		{name: "invalid session", headers: confirmedClaudeCodeHeaders(), userID: `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","account_uuid":"","session_id":"session"}`},
 		{name: "malformed user agent", headers: http.Header{"User-Agent": {"claude-cli/not-a-version (external, cli)"}, "X-App": {"cli"}, "Anthropic-Beta": {"claude-code-20250219"}}, userID: validClaudeCodeMetadataUserID},
-		{name: "unmeasured next-minor user agent", headers: http.Header{"User-Agent": {"claude-cli/2.2.0 (external, cli)"}, "X-App": {"cli"}, "Anthropic-Beta": {"claude-code-20250219"}}, userID: validClaudeCodeMetadataUserID},
+		// The configured version is a floor, so a NEWER client is now plausible and
+		// a stale copied User-Agent below the floor is what must be rejected.
+		{name: "stale prior-minor user agent", headers: http.Header{"User-Agent": {"claude-cli/2.0.999 (external, cli)"}, "X-App": {"cli"}, "Anthropic-Beta": {"claude-code-20250219"}}, userID: validClaudeCodeMetadataUserID},
 		{name: "implausible future user agent", headers: http.Header{"User-Agent": {"claude-cli/999.0.0 (external, cli)"}, "X-App": {"cli"}, "Anthropic-Beta": {"claude-code-20250219"}}, userID: validClaudeCodeMetadataUserID},
 		{name: "unrelated beta", headers: http.Header{"User-Agent": {"claude-cli/2.1.220 (external, cli)"}, "X-App": {"cli"}, "Anthropic-Beta": {"anything"}}, userID: validClaudeCodeMetadataUserID},
 	}

--- a/internal/runtime/executor/helps/claude_client_versions.go
+++ b/internal/runtime/executor/helps/claude_client_versions.go
@@ -1,0 +1,219 @@
+package helps
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// The Claude Code CLI version an operator pins in claude-header-defaults.user-agent
+// is a floor, not a lock (see plausibleClaudeCLIVersion). That makes an outdated pin
+// harmless for pass-through, but it also makes it invisible: nothing else in the
+// request path tells the operator that every client on a credential has moved past
+// the configured constant, which is still what cloaked requests present upstream.
+//
+// This registry records the Claude Code CLI versions actually observed per
+// credential so the mismatch can be warned about once and inspected later through
+// GET /v0/management/claude-client-versions.
+
+const claudeClientVersionsPerCredentialLimit = 32
+
+type claudeClientVersionObservation struct {
+	version   claudeCLIVersion
+	userAgent string
+	requests  int64
+	firstSeen time.Time
+	lastSeen  time.Time
+	warned    bool
+}
+
+type claudeClientVersionCredential struct {
+	label        string
+	requests     int64
+	observations map[string]*claudeClientVersionObservation
+}
+
+var (
+	claudeClientVersionsMu sync.Mutex
+	claudeClientVersions   = make(map[string]*claudeClientVersionCredential)
+)
+
+// ClaudeClientVersionObservationReport is one observed CLI version on a credential.
+type ClaudeClientVersionObservationReport struct {
+	Version   string `json:"version"`
+	UserAgent string `json:"user_agent"`
+	Requests  int64  `json:"requests"`
+	FirstSeen string `json:"first_seen"`
+	LastSeen  string `json:"last_seen"`
+	// AtOrAboveConfigured is false for a client older than the configured
+	// baseline; those requests are cloaked rather than passed through.
+	AtOrAboveConfigured bool `json:"at_or_above_configured"`
+}
+
+// ClaudeClientVersionCredentialReport summarizes one credential's observed clients.
+type ClaudeClientVersionCredentialReport struct {
+	Credential             string                                 `json:"credential"`
+	Requests               int64                                  `json:"requests"`
+	HighestObservedVersion string                                 `json:"highest_observed_version"`
+	HighestObservedAgent   string                                 `json:"highest_observed_user_agent"`
+	Mismatched             bool                                   `json:"mismatched"`
+	ObservedVersions       []ClaudeClientVersionObservationReport `json:"observed_versions"`
+}
+
+// ClaudeClientVersionsReport is the payload of GET /v0/management/claude-client-versions.
+type ClaudeClientVersionsReport struct {
+	ConfiguredUserAgent string                                `json:"configured_user_agent"`
+	ConfiguredVersion   string                                `json:"configured_version"`
+	ConfigKey           string                                `json:"config_key"`
+	Credentials         []ClaudeClientVersionCredentialReport `json:"credentials"`
+}
+
+// ClaudeClientVersionConfigKey names the setting an operator edits to move the pin.
+const ClaudeClientVersionConfigKey = "claude-header-defaults.user-agent"
+
+// ResetClaudeClientVersionRegistry clears every recorded observation. Tests only.
+func ResetClaudeClientVersionRegistry() {
+	claudeClientVersionsMu.Lock()
+	claudeClientVersions = make(map[string]*claudeClientVersionCredential)
+	claudeClientVersionsMu.Unlock()
+}
+
+func claudeClientVersionLabel(auth *cliproxyauth.Auth, apiKey string) string {
+	if auth != nil && strings.TrimSpace(auth.ID) != "" {
+		return "auth:" + strings.TrimSpace(auth.ID)
+	}
+	if key := strings.TrimSpace(apiKey); key != "" {
+		return "api-key:" + maskClaudeClientVersionSecret(key)
+	}
+	return "global"
+}
+
+// maskClaudeClientVersionSecret keeps the management response from echoing a
+// usable credential back to the caller.
+func maskClaudeClientVersionSecret(key string) string {
+	if len(key) <= 8 {
+		return strings.Repeat("*", len(key))
+	}
+	return key[:4] + "..." + key[len(key)-4:]
+}
+
+// ObserveClaudeClientVersion records the Claude Code CLI version carried by an
+// incoming request and reports whether the caller should emit the operator
+// warning. It returns true at most once per (credential, version) pair, and only
+// when the observed version differs from the configured baseline.
+func ObserveClaudeClientVersion(auth *cliproxyauth.Auth, apiKey string, headers http.Header, cfg *config.Config) bool {
+	userAgent := strings.TrimSpace(headerValue(headers, "User-Agent"))
+	if !claudeCodeNativeUserAgentPattern.MatchString(userAgent) {
+		return false
+	}
+	version, okVersion := parseClaudeCLIVersion(userAgent)
+	if !okVersion {
+		return false
+	}
+	baseline := defaultClaudeDeviceProfile(cfg)
+	if !baseline.hasVersion {
+		return false
+	}
+
+	scope := claudeDeviceProfileScopeKey(auth, apiKey)
+	now := time.Now().UTC()
+
+	claudeClientVersionsMu.Lock()
+	defer claudeClientVersionsMu.Unlock()
+
+	credential, found := claudeClientVersions[scope]
+	if !found {
+		credential = &claudeClientVersionCredential{
+			label:        claudeClientVersionLabel(auth, apiKey),
+			observations: make(map[string]*claudeClientVersionObservation),
+		}
+		claudeClientVersions[scope] = credential
+	}
+	credential.requests++
+
+	key := version.String()
+	observation, seen := credential.observations[key]
+	if !seen {
+		// Bound the per-credential map so a client spraying fabricated versions
+		// cannot grow the registry without limit.
+		if len(credential.observations) >= claudeClientVersionsPerCredentialLimit {
+			return false
+		}
+		observation = &claudeClientVersionObservation{
+			version:   version,
+			userAgent: userAgent,
+			firstSeen: now,
+		}
+		credential.observations[key] = observation
+	}
+	observation.requests++
+	observation.lastSeen = now
+
+	if version.Compare(baseline.version) == 0 || observation.warned {
+		return false
+	}
+	observation.warned = true
+	return true
+}
+
+// ClaudeClientVersionReport renders the registry alongside the configured baseline.
+func ClaudeClientVersionReport(cfg *config.Config) ClaudeClientVersionsReport {
+	baseline := defaultClaudeDeviceProfile(cfg)
+	report := ClaudeClientVersionsReport{
+		ConfiguredUserAgent: baseline.UserAgent,
+		ConfigKey:           ClaudeClientVersionConfigKey,
+		Credentials:         []ClaudeClientVersionCredentialReport{},
+	}
+	if baseline.hasVersion {
+		report.ConfiguredVersion = baseline.version.String()
+	}
+
+	claudeClientVersionsMu.Lock()
+	defer claudeClientVersionsMu.Unlock()
+
+	for _, credential := range claudeClientVersions {
+		entry := ClaudeClientVersionCredentialReport{
+			Credential:       credential.label,
+			Requests:         credential.requests,
+			ObservedVersions: []ClaudeClientVersionObservationReport{},
+		}
+		var highest *claudeClientVersionObservation
+		for _, observation := range credential.observations {
+			entry.ObservedVersions = append(entry.ObservedVersions, ClaudeClientVersionObservationReport{
+				Version:             observation.version.String(),
+				UserAgent:           observation.userAgent,
+				Requests:            observation.requests,
+				FirstSeen:           observation.firstSeen.Format(time.RFC3339),
+				LastSeen:            observation.lastSeen.Format(time.RFC3339),
+				AtOrAboveConfigured: baseline.hasVersion && observation.version.Compare(baseline.version) >= 0,
+			})
+			if highest == nil || observation.version.Compare(highest.version) > 0 {
+				highest = observation
+			}
+		}
+		sort.Slice(entry.ObservedVersions, func(i, j int) bool {
+			return entry.ObservedVersions[i].Version < entry.ObservedVersions[j].Version
+		})
+		if highest != nil {
+			entry.HighestObservedVersion = highest.version.String()
+			entry.HighestObservedAgent = highest.userAgent
+			entry.Mismatched = baseline.hasVersion && highest.version.Compare(baseline.version) != 0
+		}
+		report.Credentials = append(report.Credentials, entry)
+	}
+	sort.Slice(report.Credentials, func(i, j int) bool {
+		return report.Credentials[i].Credential < report.Credentials[j].Credential
+	})
+	return report
+}
+
+// ConfiguredClaudeUserAgent returns the operator-configured Claude Code
+// User-Agent baseline, for log messages that tell the operator what to change.
+func ConfiguredClaudeUserAgent(cfg *config.Config) string {
+	return defaultClaudeDeviceProfile(cfg).UserAgent
+}

--- a/internal/runtime/executor/helps/claude_device_profile.go
+++ b/internal/runtime/executor/helps/claude_device_profile.go
@@ -28,6 +28,10 @@ const (
 	claudeDeviceProfileTTL                 = 7 * 24 * time.Hour
 	claudeDeviceProfileLockTTL             = 5 * time.Second
 	claudeDeviceProfileCleanupPeriod       = time.Hour
+	// claudeMaxPlausibleMajorDrift bounds how far ahead of the configured baseline
+	// a client User-Agent may claim to be before it stops being a believable
+	// upgrade and starts looking like a fabricated version string.
+	claudeMaxPlausibleMajorDrift = 1
 )
 
 var (
@@ -79,6 +83,10 @@ func (v claudeCLIVersion) Compare(other claudeCLIVersion) int {
 	default:
 		return 0
 	}
+}
+
+func (v claudeCLIVersion) String() string {
+	return strconv.Itoa(v.major) + "." + strconv.Itoa(v.minor) + "." + strconv.Itoa(v.patch)
 }
 
 type ClaudeDeviceProfile struct {
@@ -212,8 +220,56 @@ func shouldUpgradeClaudeDeviceProfile(candidate, current ClaudeDeviceProfile) bo
 	return candidate.version.Compare(current.version) > 0
 }
 
+// plausibleClaudeCLIVersion treats the configured baseline as a FLOOR rather than
+// a lock. Claude Code auto-updates, so an equality gate silently reclassified every
+// genuine client as foreign the moment the operator pin fell behind, and real native
+// requests were cloaked as a result. A candidate at or above the baseline is
+// plausible; anything older is a stale copied User-Agent and stays implausible.
+//
+// claudeMaxPlausibleMajorDrift keeps a ceiling on that floor: a client one major
+// ahead of the pin is a believable upgrade, "claude-cli/999.0.0" is not.
 func plausibleClaudeCLIVersion(candidate, baseline claudeCLIVersion) bool {
-	return candidate.Compare(baseline) == 0
+	if candidate.major > baseline.major+claudeMaxPlausibleMajorDrift {
+		return false
+	}
+	return candidate.Compare(baseline) >= 0
+}
+
+// atLeastDottedVersion applies the same floor rule to the Stainless package and
+// Node runtime versions. Both move independently of the CLI version, so demanding
+// equality would re-create the identical silent downgrade the next time the bundled
+// SDK or Node build is bumped. An unparseable value on either side falls back to
+// exact equality so a malformed header cannot slip past the check.
+func atLeastDottedVersion(candidate, baseline string) bool {
+	candidateParts, okCandidate := parseDottedVersion(candidate)
+	baselineParts, okBaseline := parseDottedVersion(baseline)
+	if !okCandidate || !okBaseline {
+		return strings.TrimSpace(candidate) == strings.TrimSpace(baseline)
+	}
+	for index := range candidateParts {
+		if candidateParts[index] != baselineParts[index] {
+			return candidateParts[index] > baselineParts[index]
+		}
+	}
+	return true
+}
+
+// parseDottedVersion accepts "0.112.1" and "v26.3.0" alike.
+func parseDottedVersion(value string) ([3]int, bool) {
+	var parts [3]int
+	trimmed := strings.TrimPrefix(strings.TrimSpace(value), "v")
+	fields := strings.Split(trimmed, ".")
+	if len(fields) != 3 {
+		return parts, false
+	}
+	for index, field := range fields {
+		number, errParse := strconv.Atoi(field)
+		if errParse != nil || number < 0 {
+			return parts, false
+		}
+		parts[index] = number
+	}
+	return parts, true
 }
 
 func meetsClaudeDeviceProfileBaseline(candidate, baseline ClaudeDeviceProfile) bool {
@@ -224,8 +280,8 @@ func meetsClaudeDeviceProfileBaseline(candidate, baseline ClaudeDeviceProfile) b
 		return false
 	}
 	return plausibleClaudeCLIVersion(candidate.version, baseline.version) &&
-		candidate.PackageVersion == baseline.PackageVersion &&
-		candidate.RuntimeVersion == baseline.RuntimeVersion
+		atLeastDottedVersion(candidate.PackageVersion, baseline.PackageVersion) &&
+		atLeastDottedVersion(candidate.RuntimeVersion, baseline.RuntimeVersion)
 }
 
 func pinClaudeDeviceProfilePlatform(profile, baseline ClaudeDeviceProfile) ClaudeDeviceProfile {
@@ -360,6 +416,24 @@ func purgeExpiredClaudeDeviceProfiles() {
 func ResolveClaudeDeviceProfile(auth *cliproxyauth.Auth, apiKey string, headers http.Header, cfg *config.Config) ClaudeDeviceProfile {
 	profile, errProfile := ResolveClaudeDeviceProfileRequired(context.Background(), auth, apiKey, headers, cfg)
 	if errProfile != nil {
+		return defaultClaudeDeviceProfile(cfg)
+	}
+	return profile
+}
+
+// ResolveClaudeDeviceProfileBestEffort resolves the per-credential device profile
+// without ever failing the request. It is used on two paths that must not turn a
+// profile-store error into a user-visible failure:
+//
+//   - learning a confirmed client's profile when header stabilization is OFF, so a
+//     later cloaked request on the same credential can present the newest observed
+//     Claude Code version instead of the configured constant;
+//   - reading that learned profile for an unconfirmed client. Passing nil headers
+//     makes the read side-effect free: there is no candidate to store, so an
+//     unconfirmed client can never contribute its own software profile.
+func ResolveClaudeDeviceProfileBestEffort(ctx context.Context, auth *cliproxyauth.Auth, apiKey string, headers http.Header, cfg *config.Config) ClaudeDeviceProfile {
+	profile, errProfile := ResolveClaudeDeviceProfileRequired(ctx, auth, apiKey, headers, cfg)
+	if errProfile != nil || strings.TrimSpace(profile.UserAgent) == "" {
 		return defaultClaudeDeviceProfile(cfg)
 	}
 	return profile
@@ -597,11 +671,23 @@ func ApplyClaudeDefaultDeviceProfileHeaders(r *http.Request, cfg *config.Config)
 	ApplyClaudeDeviceProfileHeaders(r, defaultClaudeDeviceProfile(cfg))
 }
 
-func ApplyClaudeLegacyDeviceHeaders(r *http.Request, ginHeaders http.Header, cfg *config.Config, confirmedClaudeCode bool) {
+// ApplyClaudeLegacyDeviceHeaders applies the pre-stabilization header contract.
+// An optional learned profile may be supplied; when it is at or above the
+// configured baseline it replaces the config constant, so a cloaked request
+// presents the newest Claude Code version actually seen on this credential.
+func ApplyClaudeLegacyDeviceHeaders(r *http.Request, ginHeaders http.Header, cfg *config.Config, confirmedClaudeCode bool, learned ...ClaudeDeviceProfile) {
 	if r == nil {
 		return
 	}
-	profile := defaultClaudeDeviceProfile(cfg)
+	baseline := defaultClaudeDeviceProfile(cfg)
+	// The configured tuple is a floor. A confirmed client at or above it keeps its
+	// own software versions; only an unconfirmed client falls back, and it falls
+	// back to the newest profile already learned for this credential rather than
+	// to the configured constant.
+	profile := baseline
+	if len(learned) > 0 && meetsClaudeDeviceProfileBaseline(learned[0], baseline) {
+		profile = pinClaudeDeviceProfilePlatform(learned[0], baseline)
+	}
 	miscEnsure := func(name, fallback string, valid func(string) bool) {
 		if current := strings.TrimSpace(r.Header.Get(name)); current != "" && (valid == nil || valid(current)) {
 			return
@@ -614,8 +700,12 @@ func ApplyClaudeLegacyDeviceHeaders(r *http.Request, ginHeaders http.Header, cfg
 	}
 
 	if confirmedClaudeCode {
-		miscEnsure("X-Stainless-Runtime-Version", profile.RuntimeVersion, func(value string) bool { return value == profile.RuntimeVersion })
-		miscEnsure("X-Stainless-Package-Version", profile.PackageVersion, func(value string) bool { return value == profile.PackageVersion })
+		miscEnsure("X-Stainless-Runtime-Version", profile.RuntimeVersion, func(value string) bool {
+			return atLeastDottedVersion(value, baseline.RuntimeVersion)
+		})
+		miscEnsure("X-Stainless-Package-Version", profile.PackageVersion, func(value string) bool {
+			return atLeastDottedVersion(value, baseline.PackageVersion)
+		})
 		miscEnsure("X-Stainless-Os", mapStainlessOS(), nil)
 		miscEnsure("X-Stainless-Arch", mapStainlessArch(), nil)
 		if clientUA := strings.TrimSpace(ginHeaders.Get("User-Agent")); plausibleClaudeCodeUserAgent(clientUA, cfg) {

--- a/internal/runtime/executor/helps/claude_device_profile_test.go
+++ b/internal/runtime/executor/helps/claude_device_profile_test.go
@@ -272,7 +272,7 @@ func TestResolveClaudeDeviceProfileRequiredHomeNormalizesUnmeasuredCachedProfile
 	auth := &cliproxyauth.Auth{ID: "auth-1"}
 	key := claudeDeviceProfileKVKey(auth, "api-key", ClaudeDeviceProfile{})
 	client.values[key] = mustClaudeDeviceProfileJSON(t, claudeDeviceProfileKVValue{
-		UserAgent:      "claude-cli/2.4.0 (external, cli)",
+		UserAgent:      "claude-cli/2.1.100 (external, cli)",
 		PackageVersion: "0.90.0",
 		RuntimeVersion: "v24.5.0",
 		OS:             "Windows",
@@ -280,7 +280,9 @@ func TestResolveClaudeDeviceProfileRequiredHomeNormalizesUnmeasuredCachedProfile
 	})
 	useFakeClaudeDeviceProfileKVClient(t, client, true, nil)
 
-	profile, errProfile := ResolveClaudeDeviceProfileRequired(context.Background(), auth, "api-key", claudeDeviceHeaders("claude-cli/2.3.0 (external, cli)"), nil)
+	// Both the cached profile and the incoming candidate sit BELOW the configured
+	// floor, so neither may replace the baseline.
+	profile, errProfile := ResolveClaudeDeviceProfileRequired(context.Background(), auth, "api-key", claudeDeviceHeaders("claude-cli/2.1.99 (external, cli)"), nil)
 	if errProfile != nil {
 		t.Fatalf("ResolveClaudeDeviceProfileRequired() error = %v", errProfile)
 	}

--- a/internal/runtime/executor/helps/claude_version_floor_test.go
+++ b/internal/runtime/executor/helps/claude_version_floor_test.go
@@ -1,0 +1,208 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func mustParseClaudeCLIVersion(t *testing.T, userAgent string) claudeCLIVersion {
+	t.Helper()
+	version, ok := parseClaudeCLIVersion(userAgent)
+	if !ok {
+		t.Fatalf("parseClaudeCLIVersion(%q) failed", userAgent)
+	}
+	return version
+}
+
+// The configured claude-header-defaults.user-agent is a FLOOR, not a lock: a
+// genuine Claude Code that upgraded past the pin must stay plausible, while a
+// stale copied User-Agent below the pin stays implausible.
+func TestPlausibleClaudeCLIVersionTreatsBaselineAsFloor(t *testing.T) {
+	baseline := mustParseClaudeCLIVersion(t, "claude-cli/2.1.252 (external, cli)")
+	for _, test := range []struct {
+		name      string
+		userAgent string
+		want      bool
+	}{
+		{name: "newer patch", userAgent: "claude-cli/2.1.259 (external, cli)", want: true},
+		{name: "exact baseline", userAgent: "claude-cli/2.1.252 (external, cli)", want: true},
+		{name: "older patch", userAgent: "claude-cli/2.1.240 (external, cli)", want: false},
+		{name: "newer minor", userAgent: "claude-cli/2.2.0 (external, cli)", want: true},
+		{name: "next major", userAgent: "claude-cli/3.0.0 (external, cli)", want: true},
+		{name: "older minor", userAgent: "claude-cli/2.0.999 (external, cli)", want: false},
+		{name: "absurd future major", userAgent: "claude-cli/999.0.0 (external, cli)", want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := mustParseClaudeCLIVersion(t, test.userAgent)
+			if got := plausibleClaudeCLIVersion(candidate, baseline); got != test.want {
+				t.Fatalf("plausibleClaudeCLIVersion(%q, 2.1.252) = %t, want %t", test.userAgent, got, test.want)
+			}
+		})
+	}
+}
+
+// The Stainless package and Node runtime versions move independently of the CLI
+// version, so they are floors too. Equality there would re-create the same
+// silent downgrade the next time the bundled SDK or Node build is bumped.
+func TestMeetsClaudeDeviceProfileBaselineTreatsSoftwareTupleAsFloor(t *testing.T) {
+	baseline := defaultClaudeDeviceProfile(&config.Config{ClaudeHeaderDefaults: config.ClaudeHeaderDefaults{
+		UserAgent:      "claude-cli/2.1.252 (external, cli)",
+		PackageVersion: "0.112.1",
+		RuntimeVersion: "v26.3.0",
+	}})
+	newProfile := func(userAgent, packageVersion, runtimeVersion string) ClaudeDeviceProfile {
+		profile := ClaudeDeviceProfile{
+			UserAgent:      userAgent,
+			PackageVersion: packageVersion,
+			RuntimeVersion: runtimeVersion,
+		}
+		if version, ok := parseClaudeCLIVersion(userAgent); ok {
+			profile.version = version
+			profile.hasVersion = true
+		}
+		return profile
+	}
+	for _, test := range []struct {
+		name    string
+		profile ClaudeDeviceProfile
+		want    bool
+	}{
+		{name: "exact baseline", profile: newProfile("claude-cli/2.1.252 (external, cli)", "0.112.1", "v26.3.0"), want: true},
+		{name: "newer cli", profile: newProfile("claude-cli/2.1.259 (external, cli)", "0.112.1", "v26.3.0"), want: true},
+		{name: "newer package", profile: newProfile("claude-cli/2.1.259 (external, cli)", "0.113.0", "v26.3.0"), want: true},
+		{name: "newer runtime", profile: newProfile("claude-cli/2.1.259 (external, cli)", "0.112.1", "v27.0.0"), want: true},
+		{name: "older package", profile: newProfile("claude-cli/2.1.259 (external, cli)", "0.111.9", "v26.3.0"), want: false},
+		{name: "older runtime", profile: newProfile("claude-cli/2.1.259 (external, cli)", "0.112.1", "v25.9.9"), want: false},
+		{name: "older cli", profile: newProfile("claude-cli/2.1.240 (external, cli)", "0.112.1", "v26.3.0"), want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := meetsClaudeDeviceProfileBaseline(test.profile, baseline); got != test.want {
+				t.Fatalf("meetsClaudeDeviceProfileBaseline(%#v) = %t, want %t", test.profile, got, test.want)
+			}
+		})
+	}
+}
+
+func versionGateBaselineConfig() *config.Config {
+	return &config.Config{ClaudeHeaderDefaults: config.ClaudeHeaderDefaults{
+		UserAgent:      "claude-cli/2.1.252 (external, cli)",
+		PackageVersion: "0.112.1",
+		RuntimeVersion: "v26.3.0",
+		OS:             "MacOS",
+		Arch:           "arm64",
+	}}
+}
+
+// A real Claude Code 2.1.259 against a 2.1.252 pin must be confirmed, so it is
+// passed through rather than cloaked.
+func TestDetectClaudeCodeRequestConfirmsUpgradedNativeClient(t *testing.T) {
+	cfg := versionGateBaselineConfig()
+	payload := claudeCodeDetectionPayload(validClaudeCodeMetadataUserID)
+
+	headers := confirmedClaudeCodeHeaders()
+	headers.Set("User-Agent", "claude-cli/2.1.259 (external, cli)")
+	headers.Set("X-Stainless-Package-Version", "0.112.1")
+	headers.Set("X-Stainless-Runtime-Version", "v26.3.0")
+	if detection := DetectClaudeCodeRequest(headers, payload, false, cfg); !detection.Confirmed {
+		t.Fatalf("detection = %#v, want confirmed for 2.1.259 against a 2.1.252 baseline", detection)
+	}
+
+	stale := confirmedClaudeCodeHeaders()
+	stale.Set("User-Agent", "claude-cli/2.1.240 (external, cli)")
+	if detection := DetectClaudeCodeRequest(stale, payload, false, cfg); detection.Confirmed {
+		t.Fatalf("detection = %#v, want unconfirmed for a stale 2.1.240 user agent", detection)
+	}
+}
+
+// Once the gate accepts a newer client, the learned per-credential profile must
+// adopt it so cloaked requests on the same credential stop presenting the
+// configured constant.
+func TestResolveClaudeDeviceProfileAdoptsUpgradedClientVersion(t *testing.T) {
+	ResetClaudeDeviceProfileCache()
+	t.Cleanup(ResetClaudeDeviceProfileCache)
+
+	cfg := versionGateBaselineConfig()
+	headers := http.Header{
+		"User-Agent":                  {"claude-cli/2.1.259 (external, cli)"},
+		"X-Stainless-Package-Version": {"0.112.1"},
+		"X-Stainless-Runtime-Version": {"v26.3.0"},
+		"X-Stainless-Os":              {"MacOS"},
+		"X-Stainless-Arch":            {"arm64"},
+	}
+	learned := resolveClaudeDeviceProfileLocal(nil, "version-gate-key", headers, cfg)
+	if learned.UserAgent != "claude-cli/2.1.259 (external, cli)" {
+		t.Fatalf("learned profile user agent = %q, want the upgraded 2.1.259", learned.UserAgent)
+	}
+
+	cloaked := resolveClaudeDeviceProfileLocal(nil, "version-gate-key", nil, cfg)
+	if cloaked.UserAgent != "claude-cli/2.1.259 (external, cli)" {
+		t.Fatalf("cloaked profile user agent = %q, want the learned 2.1.259", cloaked.UserAgent)
+	}
+
+	// A stale client on the same credential must not drag the learned profile back.
+	staleHeaders := http.Header{
+		"User-Agent":                  {"claude-cli/2.1.240 (external, cli)"},
+		"X-Stainless-Package-Version": {"0.112.1"},
+		"X-Stainless-Runtime-Version": {"v26.3.0"},
+	}
+	if profile := resolveClaudeDeviceProfileLocal(nil, "version-gate-key", staleHeaders, cfg); profile.UserAgent != "claude-cli/2.1.259 (external, cli)" {
+		t.Fatalf("profile after stale request = %q, want the learned 2.1.259", profile.UserAgent)
+	}
+}
+
+func TestObserveClaudeClientVersionRecordsAndReports(t *testing.T) {
+	ResetClaudeClientVersionRegistry()
+	t.Cleanup(ResetClaudeClientVersionRegistry)
+
+	cfg := versionGateBaselineConfig()
+	headers := http.Header{"User-Agent": {"claude-cli/2.1.259 (external, cli)"}}
+
+	if warn := ObserveClaudeClientVersion(nil, "version-gate-key", headers, cfg); !warn {
+		t.Fatal("first mismatched observation = false, want a warning")
+	}
+	if warn := ObserveClaudeClientVersion(nil, "version-gate-key", headers, cfg); warn {
+		t.Fatal("repeat observation = true, want the warning suppressed")
+	}
+
+	report := ClaudeClientVersionReport(cfg)
+	if report.ConfiguredUserAgent != "claude-cli/2.1.252 (external, cli)" {
+		t.Fatalf("configured user agent = %q", report.ConfiguredUserAgent)
+	}
+	if report.ConfiguredVersion != "2.1.252" {
+		t.Fatalf("configured version = %q, want 2.1.252", report.ConfiguredVersion)
+	}
+	if len(report.Credentials) != 1 {
+		t.Fatalf("credentials = %#v, want exactly one", report.Credentials)
+	}
+	credential := report.Credentials[0]
+	if credential.HighestObservedVersion != "2.1.259" {
+		t.Fatalf("highest observed = %q, want 2.1.259", credential.HighestObservedVersion)
+	}
+	if !credential.Mismatched || credential.Requests != 2 {
+		t.Fatalf("credential = %#v, want mismatched with 2 requests", credential)
+	}
+	if len(credential.ObservedVersions) != 1 || credential.ObservedVersions[0].Version != "2.1.259" {
+		t.Fatalf("observed versions = %#v", credential.ObservedVersions)
+	}
+
+	// A second, higher version on the same credential warns again and wins.
+	newer := http.Header{"User-Agent": {"claude-cli/2.2.1 (external, cli)"}}
+	if warn := ObserveClaudeClientVersion(nil, "version-gate-key", newer, cfg); !warn {
+		t.Fatal("new version observation = false, want a warning")
+	}
+	if got := ClaudeClientVersionReport(cfg).Credentials[0].HighestObservedVersion; got != "2.2.1" {
+		t.Fatalf("highest observed after upgrade = %q, want 2.2.1", got)
+	}
+
+	// A client at the configured baseline is recorded but never warns.
+	ResetClaudeClientVersionRegistry()
+	atBaseline := http.Header{"User-Agent": {"claude-cli/2.1.252 (external, cli)"}}
+	if warn := ObserveClaudeClientVersion(nil, "other-key", atBaseline, cfg); warn {
+		t.Fatal("baseline observation = true, want no warning")
+	}
+	if report := ClaudeClientVersionReport(cfg); report.Credentials[0].Mismatched {
+		t.Fatalf("credential = %#v, want no mismatch at the configured baseline", report.Credentials[0])
+	}
+}


### PR DESCRIPTION

Branch: `feat/claude-client-version-floor` — 2 commits off `dev` (18e01a76), HEAD `8f366cb5`.

## Summary

`plausibleClaudeCLIVersion` required the incoming `claude-cli/<ver>` User-Agent to be *equal* to `claude-header-defaults.user-agent`. Any client newer than the pin failed native-client detection, so `resolveClaudeWirePolicy` treated a genuine Claude Code request as an unknown third-party caller and rewrote it before forwarding. Because Claude Code auto-updates and the pinned constant does not, every user was silently cloaked from the first client release after each proxy release. This makes the pinned version a floor: `candidate >= baseline` passes native detection, anything older still cloaks (a stale copied User-Agent is exactly what the check should catch), and a ceiling of one major above the pin keeps `999.0.0` implausible. The Stainless package version and the Node runtime version are floors on the same reasoning, since they move independently of the CLI and equality there would recreate the same silent downgrade on the next SDK bump. A drift WARN and a management endpoint make the gap between the pin and reality visible instead of invisible.

See the issue for what the cloaking actually does to the outbound request.

## Diff

10 files, +704 / −36.

| File | + | − |
| --- | --- | --- |
| `internal/runtime/executor/helps/claude_client_versions.go` (new) | 219 | 0 |
| `internal/runtime/executor/helps/claude_version_floor_test.go` (new) | 208 | 0 |
| `internal/runtime/executor/helps/claude_device_profile.go` | 97 | 7 |
| `internal/api/server_claude_client_versions_test.go` (new) | 61 | 0 |
| `internal/runtime/executor/claude_executor_test.go` | 41 | 13 |
| `internal/runtime/executor/claude_executor_request.go` | 35 | 11 |
| `internal/runtime/executor/helps/claude_client_detection_test.go` | 18 | 3 |
| `internal/api/handlers/management/claude_client_versions.go` (new) | 19 | 0 |
| `internal/runtime/executor/helps/claude_device_profile_test.go` | 4 | 2 |
| `internal/api/server_management.go` | 2 | 0 |

Nine existing tests encoded equality semantics and were updated; each commit message says which and why.

## Behaviour

- Version is a floor. `candidate >= baseline` passes; older still cloaks; more than one major above the pin is rejected as implausible.
- The per-credential device-profile learning path was unreachable behind the equality gate. It runs now, so cloaked third-party requests present the newest *observed* version rather than the config constant.
- Confirmed clients above the floor forward their own package and runtime tuple upstream, giving a coherent fingerprint instead of a new-CLI User-Agent paired with an old-SDK version.
- WARN once per (credential, version) on drift, naming `claude-header-defaults.user-agent`.

## Config

No new config keys. The existing pin is unchanged and keeps its meaning, only its comparison changes:

```yaml
claude-header-defaults:
  user-agent: "claude-cli/2.1.252 (external, cli)"
```

New management route:

```
GET /v0/management/claude-client-versions
```

Returns the configured baseline, the highest version observed per credential (masked), and a `mismatched` flag.

## Verification

```
go build ./...   ok
go vet ./...     ok
go test ./...    ok
```

122 packages: 92 with tests, all passing; 30 with no test files; 0 failures.

Behaviour verified on a scratch instance against api.anthropic.com with the pin left at 2.1.252:

- Client 2.1.259: `system`, `tools` and `messages` byte-identical upstream, User-Agent 2.1.259, betas correct, drift WARN logged once, endpoint reports `configured 2.1.252 / observed 2.1.259 / mismatched: true`.
- Client 2.1.240: still cloaked, tools still aliased.
- Cloaking behaviour for genuinely non-native clients is unchanged.

Why: see https://github.com/ArshansGithub/claude-code-fable-usage

Fixes #5443.
