### PR TITLE
feat(claude-code): agent-aware prompt-cache keepalive

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ PackyCode provides special discounts for our software users: register using <a h
 - Grok Build multi-account load balancing
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
+- Agent-aware prompt-cache keepalive for Claude Code sessions on the 1h cache pool (see `docs/cache-keepalive.md`)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ PackyCode provides special discounts for our software users: register using <a h
 - Grok Build multi-account load balancing
 - OpenAI-compatible upstream providers via config (e.g., OpenRouter)
 - Reusable Go SDK for embedding the proxy (see `docs/sdk-usage.md`)
-- Agent-aware prompt-cache keepalive for Claude Code sessions on the 1h cache pool (see `docs/cache-keepalive.md`)
+- Agent-aware prompt-cache keepalive for Claude Code sessions, on the 1h cache pool and on the 5m pool for models with cheap cache reads (see `docs/cache-keepalive.md`)
 
 ## Getting Started
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,6 +190,10 @@ claude-code:
 
   # Agent-aware prompt-cache keepalive.
   #
+  # State is visible at GET /v0/management/cache-keepalive and in the log, where
+  # every line is prefixed "cache-keepalive:". A probe that itself found nothing
+  # cached logs at WARN: that is the malfunction signal.
+  #
   # An orchestrator session that blocks on a subagent for longer than the prompt cache
   # TTL pays a full cache write on the return turn instead of a read. On the 1h pool
   # that write costs roughly ten times the read it replaces, so refreshing the entry

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,6 +188,55 @@ claude-code:
   # When true, return original model IDs in Anthropic model list responses instead of cloaked IDs.
   disable-cloaking-model-list: false
 
+  # Agent-aware prompt-cache keepalive.
+  #
+  # An orchestrator session that blocks on a subagent for longer than the prompt cache
+  # TTL pays a full cache write on the return turn instead of a read. On the 1h pool
+  # that write costs roughly ten times the read it replaces, so refreshing the entry
+  # with one minimal request per window is close to free.
+  #
+  # The proxy holds the last request body, the credential, and the session-to-account
+  # binding, so its probe warms the same per-account entry the next real request hits.
+  # A client-side hook cannot guarantee the account.
+  #
+  # Only requests from a confirmed Claude Code client that carried an explicit
+  # cache_control ttl of "1h" are ever probed. A 5m request is never probed: on that
+  # pool the thirteen reads an hour cost more than the single write they avoid.
+  cache-keepalive:
+    # Opt-in. Default false.
+    enabled: false
+
+    # Fire the probe at (request start + ttl - before-expiry). Default 5m.
+    before-expiry: 5m
+
+    # Probe only while a task of that session is still running. A session idling on
+    # human input is never probed: that wait is unbounded, and the guarantee that
+    # another turn is coming is what makes the probe pay for itself. Default true.
+    only-when-agents-active: true
+
+    # Liveness strategy.
+    #   claude-code-tasks  read Claude Code's on-disk task state (default)
+    #   always             no liveness check; for clients whose agent state the proxy
+    #                      cannot see. Costs up to max-probes reads per idle session.
+    liveness: claude-code-tasks
+
+    # Stop after this many consecutive probes without an intervening real request.
+    # Bounds the cost of an abandoned session to max-probes reads of its prefix.
+    # Default 6.
+    max-probes: 6
+
+    # max_tokens the probe body carries. Default 1.
+    max-tokens: 1
+
+    # Where the claude-code-tasks liveness check looks. Both default to the paths
+    # Claude Code uses; "~" and "<uid>" are expanded.
+    # A session directory is matched as either the full session UUID or
+    # "session-" plus its first eight characters.
+    # task-state-dirs:
+    #   - "~/.claude/tasks"
+    # task-output-dirs:
+    #   - "/private/tmp/claude-<uid>"
+
 # disable-image-generation supports: false (default), true, "chat", or "passthrough".
 # - true: disable image_generation everywhere (also returns 404 for /v1/images/generations and /v1/images/edits).
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -203,15 +203,42 @@ claude-code:
   # binding, so its probe warms the same per-account entry the next real request hits.
   # A client-side hook cannot guarantee the account.
   #
-  # Only requests from a confirmed Claude Code client that carried an explicit
-  # cache_control ttl of "1h" are ever probed. A 5m request is never probed: on that
-  # pool the thirteen reads an hour cost more than the single write they avoid.
+  # Only requests from a confirmed Claude Code client are ever observed. Which cache
+  # pool is probed depends on the tier: a request that spelled out cache_control ttl
+  # "1h" is always eligible, while a 5m request is governed by probe-5m below.
   cache-keepalive:
     # Opt-in. Default false.
     enabled: false
 
-    # Fire the probe at (request start + ttl - before-expiry). Default 5m.
+    # Fire the probe at (request start + ttl - before-expiry) on the 1h pool.
+    # Default 5m.
     before-expiry: 5m
+
+    # The same lead time for the 5m pool. Default 45s. The TTL clock runs from the
+    # start of the request that wrote the entry and generation time counts against
+    # it, so this margin has to cover a slow turn plus the probe's own round trip
+    # and still land inside the window. Must be below 5m.
+    before-expiry-5m: 45s
+
+    # When to probe a session on the 5m pool.
+    #   auto    probe only when the request model's cache reads are cheap enough
+    #           for the arithmetic to work out (default). A probe buys one read and
+    #           avoids one write: at the usual 0.1x-base read against a 1.25x-base
+    #           write, the ~12 reads an hour a 5m window needs are a wash, but
+    #           claude-fable-5-1 and claude-mythos-5-1 read at 0.025x base
+    #           ($0.25/MTok against $10/MTok input), so the same 12 reads cost about
+    #           a third of the write they avoid.
+    #   always  probe every confirmed session regardless of model.
+    #   never   probe only 1h sessions, the original behaviour.
+    probe-5m: auto
+
+    # Replaces the built-in cheap-cache-read list "auto" matches the request model
+    # against. Entries match case-insensitively as substrings, so a provider-prefixed
+    # or suffixed spelling still resolves. Empty means the built-in list
+    # (claude-fable-5-1, claude-mythos-5-1).
+    # probe-5m-models:
+    #   - claude-fable-5-1
+    #   - claude-mythos-5-1
 
     # Probe only while a task of that session is still running. A session idling on
     # human input is never probed: that wait is unbounded, and the guarantee that
@@ -236,10 +263,16 @@ claude-code:
     # this above the longest silence worth paying a probe for.
     agent-idle-window: 10m
 
-    # Stop after this many consecutive probes without an intervening real request.
-    # Bounds the cost of an abandoned session to max-probes reads of its prefix.
-    # Default 6.
+    # Stop after this many consecutive probes without an intervening real request
+    # on the 1h pool. Bounds the cost of an abandoned session to max-probes reads
+    # of its prefix. Default 6.
     max-probes: 6
+
+    # The same cap for the 5m pool, where each probe buys only one short window:
+    # 6 probes would cover 25 minutes there against 6 hours on the 1h pool.
+    # Default 30, about two hours of idle. The liveness check above is what
+    # actually bounds the spend on a live session; this bounds an abandoned one.
+    max-probes-5m: 30
 
     # max_tokens the probe body carries. Default 1.
     max-tokens: 1

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -219,10 +219,22 @@ claude-code:
     only-when-agents-active: true
 
     # Liveness strategy.
-    #   claude-code-tasks  read Claude Code's on-disk task state (default)
+    #   claude-code-tasks  read Claude Code's on-disk agent state (default). The
+    #                      primary signal is <task-output-dir>/<project-slug>/<session>/tasks/*.output,
+    #                      one file per background agent or shell, symlink-resolved:
+    #                      the session is live while any of them was written inside
+    #                      agent-idle-window. The TodoWrite state files are a
+    #                      secondary fallback only; they are the user-facing todo
+    #                      list, not subagent state.
     #   always             no liveness check; for clients whose agent state the proxy
     #                      cannot see. Costs up to max-probes reads per idle session.
     liveness: claude-code-tasks
+
+    # How long an agent may be silent and still count as running. Default 10m.
+    # Deliberately not the cache TTL: an agent that has written nothing for an hour
+    # is finished, not busy. Timestamps only advance when the process writes, so set
+    # this above the longest silence worth paying a probe for.
+    agent-idle-window: 10m
 
     # Stop after this many consecutive probes without an intervening real request.
     # Bounds the cost of an abandoned session to max-probes reads of its prefix.

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -168,7 +168,7 @@ cache-diagnosis beta and the upstream supplied one. Two cases count as a miss:
   the first check.
 
 ```
-cache-keepalive: probe MISSED | session=4463ede6... auth=<id> model=<model> status=miss cache_read_input_tokens=0 cache_creation_input_tokens=161937 baseline_read_input_tokens=161937 duration=743ms probes_sent=2 consecutive_probes=2 rescheduled=true next_probe_at=... cache_miss_reason="messages_changed"
+cache-keepalive: probe MISSED | session=4463ede6... auth=<id> model=<model> status=miss cache_read_input_tokens=0 cache_creation_input_tokens=25154 baseline_read_input_tokens=161937 duration=743ms probes_sent=2 consecutive_probes=2 rescheduled=true next_probe_at=... cache_miss_reason="messages_changed" cache_missed_input_tokens=25154
 ```
 
 A probe request that fails outright logs at warning with `status=error`.
@@ -225,8 +225,12 @@ route. It returns the live scheduler state:
 ```
 
 `status` is `hit`, `miss`, `error`, or `skipped`; a skipped entry carries
-`skipped_reason`, and a miss carries `diagnosis` when the upstream supplied one.
-Misses are counted under `counters.misses`.
+`skipped_reason`, and a miss carries `diagnosis` and `cache_missed_input_tokens`
+when the upstream supplied them. Misses are counted under `counters.misses`.
+
+The diagnostics come from `diagnostics.cache_miss_reason`, which a non-streaming
+body carries beside `usage` and a streaming response carries inside the
+`message_start` event's `message`. Both shapes are read.
 
 A session that has stopped probing stays listed with `active: false`, a
 `retired_at` timestamp and a `retired_reason`, so an operator can tell "nothing

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -1,0 +1,118 @@
+# Agent-aware prompt-cache keepalive
+
+`claude-code.cache-keepalive` keeps a Claude Code session's prompt cache warm
+while one of its subagents is still running.
+
+## Why
+
+An orchestrator session that dispatches a subagent frequently blocks on it for
+longer than the prompt cache TTL. When the subagent returns, the next request is
+a full re-write of the whole context at the cache-write premium instead of a read
+at a tenth of the base rate.
+
+On the 5m pool a refresh is not worth it: thirteen reads an hour cost more than
+the single write they avoid. On the 1h pool the arithmetic reverses, and one read
+per hour is close to free next to a re-write of a large prefix.
+
+The proxy is the right place for the refresh. It holds the last request body, the
+credential, and the session-to-account binding, so its probe warms the same
+per-account entry the next real request will hit. A client-side hook cannot
+guarantee which account the refresh lands on.
+
+## Policy
+
+A probe is only sent while a task belonging to that session is still running. A
+session idling on human input is never probed: that wait is unbounded, and the
+guarantee that another turn is coming is what makes the probe pay for itself.
+
+## How it works
+
+1. **Observe.** Every request that a confirmed Claude Code client sent with an
+   explicit `cache_control` `ttl` of `1h` is recorded against its session id, taken
+   from `metadata.user_id` or the `X-Claude-Code-Session-Id` header. The scheduler
+   stores the client body, the headers, and the credential that served it, then
+   arms a timer for `request start + ttl - before-expiry`. A request carrying only
+   a 5m marker never schedules anything.
+
+2. **Fire.** At the timer, in order:
+   - a newer request for that session supersedes the probe, which is dropped;
+   - the liveness check must report a running task, unless
+     `only-when-agents-active` is false;
+   - the session must still be bound to the same credential. If the binding is
+     gone, because of a cooldown or a rotation, the probe is skipped: a probe on a
+     different account warms nothing useful. With session-sticky routing turned
+     off there is no binding to check and the probe proceeds.
+   - the stored body is replayed through the ordinary execution path with the
+     credential pinned, so it receives the same translation, cloaking, header and
+     `cache_control` handling a real request does. Only `max_tokens`, `stream` and
+     `thinking` are rewritten; tools, system, messages and every `cache_control`
+     marker stay byte-identical, and the request keeps the observed
+     `Anthropic-Beta` list including `extended-cache-ttl-2025-04-11`.
+
+3. **Reschedule.** The next probe is measured from this probe's own start time.
+   After `max-probes` consecutive probes with no real request in between, the
+   session is dropped.
+
+## Liveness
+
+`liveness: claude-code-tasks` reads Claude Code's on-disk task state. A session
+counts as live when either signal holds:
+
+- a file under `<task-state-dir>/<session>/*.json` has a `status` that is not
+  `completed`, `failed`, `cancelled`, `killed`, or another terminal value;
+- a file under `<task-output-dir>/<project>/<session>/tasks/*.output` was modified
+  within the TTL window.
+
+A session directory is matched as either the full session UUID or `session-` plus
+its first eight characters, because Claude Code uses both spellings. An
+unrecognised status counts as live: a false negative silently disables the
+feature, while a false positive costs one cheap read.
+
+`liveness: always` skips the check. It exists for clients whose agent state the
+proxy cannot see, and it will keep probing an idle session until `max-probes`.
+
+## Cost
+
+One read of the prefix per `ttl - before-expiry` while agents run. With a 400k
+prefix on the 1h pool that is roughly 40k token-equivalents an hour, against the
+~800k a re-write would cost. `max-probes` bounds an abandoned session.
+
+## Safety
+
+Probe bodies are held in memory only, one per session, replaced on every real
+request and dropped when the session stops qualifying or exhausts its budget.
+They are never written to disk and never sent to a credential other than the one
+the session is bound to.
+
+## Configuration
+
+```yaml
+claude-code:
+  cache-keepalive:
+    enabled: false                 # opt-in
+    before-expiry: 5m              # fire at ttl - before-expiry
+    only-when-agents-active: true
+    liveness: claude-code-tasks    # or: always
+    max-probes: 6
+    max-tokens: 1
+    # task-state-dirs:
+    #   - "~/.claude/tasks"
+    # task-output-dirs:
+    #   - "/private/tmp/claude-<uid>"
+```
+
+The block hot-reloads with the rest of the configuration. `~` and `<uid>` are
+expanded in both path lists.
+
+## Logs
+
+At info level, one line per event:
+
+```
+cache-keepalive: scheduled | session=4463ede6... auth=<id> model=<model> ttl=1h0m0s fires_in=55m0s
+cache-keepalive: fired     | session=4463ede6... auth=<id> model=<model> cache_read_input_tokens=161937 probes=1 rescheduled=true
+cache-keepalive: skipped   | session=4463ede6... reason=no-live-agents
+```
+
+`reason` is one of `superseded`, `max-probes`, `no-live-agents`,
+`auth-binding-lost`, `no-prober`, or `probe-body-build-failed`.

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -185,7 +185,9 @@ route. It returns the live scheduler state:
 `skipped_reason`, and a miss carries `diagnosis` when the upstream supplied one.
 
 A session that has stopped probing stays listed with `active: false`, a
-`retired_at` timestamp, and the reason, so an operator can tell "nothing to do"
-apart from "silently broken". The retired history is capped at 64 sessions.
+`retired_at` timestamp and a `retired_reason`, so an operator can tell "nothing
+to do" apart from "silently broken". `retired_reason` is separate from
+`last_probe` on purpose: ending a session never erases the result of the last
+probe it actually sent. The retired history is capped at 64 sessions.
 Retiring a session drops its stored request body immediately, so no request
 content is ever reachable through this endpoint.

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -156,12 +156,19 @@ cache-keepalive: probe | session=4463ede6... auth=<id> model=<model> status=hit 
 cache-keepalive: skipped | session=4463ede6... auth=<id> model=<model> reason=no-live-agents
 ```
 
-A probe that finds nothing cached is the malfunction signal: the entry it was
-meant to refresh had already expired, so it is logged at **warning** level with
-the upstream diagnosis when the account has the cache-diagnosis beta.
+A probe that fails to refresh the entry is the malfunction signal, logged at
+**warning** level with `diagnostics.cache_miss_reason` when the account has the
+cache-diagnosis beta and the upstream supplied one. Two cases count as a miss:
+
+- the probe read nothing at all, so the entry had already expired;
+- the probe read less than half of what the observed real request read, so most
+  of the prefix it was meant to keep warm was already gone. The real request's
+  read is recorded as `baseline_read_input_tokens`; a zero baseline, which is the
+  normal case on the streaming path where usage is not yet available, leaves only
+  the first check.
 
 ```
-cache-keepalive: probe missed, the cached prefix was already gone | session=4463ede6... auth=<id> model=<model> status=miss cache_read_input_tokens=0 cache_creation_input_tokens=161937 duration=743ms probes_sent=2 consecutive_probes=2 rescheduled=true next_probe_at=... diagnosis="messages_changed"
+cache-keepalive: probe MISSED | session=4463ede6... auth=<id> model=<model> status=miss cache_read_input_tokens=0 cache_creation_input_tokens=161937 baseline_read_input_tokens=161937 duration=743ms probes_sent=2 consecutive_probes=2 rescheduled=true next_probe_at=... cache_miss_reason="messages_changed"
 ```
 
 A probe request that fails outright logs at warning with `status=error`.
@@ -219,6 +226,7 @@ route. It returns the live scheduler state:
 
 `status` is `hit`, `miss`, `error`, or `skipped`; a skipped entry carries
 `skipped_reason`, and a miss carries `diagnosis` when the upstream supplied one.
+Misses are counted under `counters.misses`.
 
 A session that has stopped probing stays listed with `active: false`, a
 `retired_at` timestamp and a `retired_reason`, so an operator can tell "nothing

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -104,15 +104,88 @@ claude-code:
 The block hot-reloads with the rest of the configuration. `~` and `<uid>` are
 expanded in both path lists.
 
-## Logs
+## Observability
 
-At info level, one line per event:
+The feature is not a black box. Everything it does is visible two ways.
+
+### Logs
+
+Every line is prefixed `cache-keepalive:`, so `grep cache-keepalive main.log`
+tells the whole story with no other source.
 
 ```
-cache-keepalive: scheduled | session=4463ede6... auth=<id> model=<model> ttl=1h0m0s fires_in=55m0s
-cache-keepalive: fired     | session=4463ede6... auth=<id> model=<model> cache_read_input_tokens=161937 probes=1 rescheduled=true
-cache-keepalive: skipped   | session=4463ede6... reason=no-live-agents
+cache-keepalive: enabled | before-expiry=5m0s only-when-agents-active=true liveness=claude-code-tasks max-probes=6 max-tokens=1
+cache-keepalive: scheduled | session=4463ede6... auth=<id> model=<model> ttl=1h0m0s fires_in=55m0s next_probe_at=2026-09-02T20:51:57-07:00
+cache-keepalive: probe | session=4463ede6... auth=<id> model=<model> status=hit cache_read_input_tokens=161937 cache_creation_input_tokens=0 duration=612ms probes_sent=1 consecutive_probes=1 rescheduled=true next_probe_at=2026-09-02T21:46:57-07:00
+cache-keepalive: skipped | session=4463ede6... auth=<id> model=<model> reason=no-live-agents
 ```
+
+A probe that finds nothing cached is the malfunction signal: the entry it was
+meant to refresh had already expired, so it is logged at **warning** level with
+the upstream diagnosis when the account has the cache-diagnosis beta.
+
+```
+cache-keepalive: probe missed, the cached prefix was already gone | session=4463ede6... auth=<id> model=<model> status=miss cache_read_input_tokens=0 cache_creation_input_tokens=161937 duration=743ms probes_sent=2 consecutive_probes=2 rescheduled=true next_probe_at=... diagnosis="messages_changed"
+```
+
+A probe request that fails outright logs at warning with `status=error`.
 
 `reason` is one of `superseded`, `max-probes`, `no-live-agents`,
-`auth-binding-lost`, `no-prober`, or `probe-body-build-failed`.
+`auth-binding-lost`, `probe-error`, `no-prober`, or `probe-body-build-failed`.
+
+### Management endpoint
+
+```
+GET /v0/management/cache-keepalive
+```
+
+Read-only, no parameters, same authentication as every other `/v0/management`
+route. It returns the live scheduler state:
+
+```json
+{
+  "enabled": true,
+  "before_expiry": "58m0s",
+  "only_when_agents_active": false,
+  "max_probes": 2,
+  "max_tokens": 1,
+  "sessions": [
+    {
+      "session_id": "aa11bb22-cc33-dd44-ee55-ff6677889900",
+      "auth_id": "claude-account.json",
+      "provider": "mixed",
+      "model": "claude-haiku-4-5-20251001",
+      "ttl": "1h0m0s",
+      "ttl_seconds": 3600,
+      "last_request_at": "2026-09-02T20:31:12-07:00",
+      "next_probe_at": "2026-09-02T20:35:11-07:00",
+      "probes_sent": 1,
+      "consecutive_probes": 1,
+      "active": true,
+      "last_probe": {
+        "at": "2026-09-02T20:33:11-07:00",
+        "status": "hit",
+        "cache_read_input_tokens": 12468,
+        "cache_creation_input_tokens": 0
+      }
+    }
+  ],
+  "counters": {
+    "scheduled": 1,
+    "fired": 1,
+    "hits": 1,
+    "misses": 0,
+    "errors": 0,
+    "skipped_by_reason": {}
+  }
+}
+```
+
+`status` is `hit`, `miss`, `error`, or `skipped`; a skipped entry carries
+`skipped_reason`, and a miss carries `diagnosis` when the upstream supplied one.
+
+A session that has stopped probing stays listed with `active: false`, a
+`retired_at` timestamp, and the reason, so an operator can tell "nothing to do"
+apart from "silently broken". The retired history is capped at 64 sessions.
+Retiring a session drops its stored request body immediately, so no request
+content is ever reachable through this endpoint.

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -10,29 +10,63 @@ longer than the prompt cache TTL. When the subagent returns, the next request is
 a full re-write of the whole context at the cache-write premium instead of a read
 at a tenth of the base rate.
 
-On the 5m pool a refresh is not worth it: thirteen reads an hour cost more than
-the single write they avoid. On the 1h pool the arithmetic reverses, and one read
-per hour is close to free next to a re-write of a large prefix.
+On the 1h pool the arithmetic is easy: one read per hour is close to free next to
+a re-write of a large prefix. On the 5m pool it depends on the model, which the
+next section works out.
 
 The proxy is the right place for the refresh. It holds the last request body, the
 credential, and the session-to-account binding, so its probe warms the same
 per-account entry the next real request will hit. A client-side hook cannot
 guarantee which account the refresh lands on.
 
+## Why 5m sessions are worth probing on Fable 5.1
+
+The break-even is the cache-read multiple of base input, because a probe buys one
+read and avoids one write.
+
+| | cache read | cache write (1h) | 12 reads/hour | vs. the write |
+|---|---|---|---|---|
+| most Claude models | 0.1x base | 1.25x base | 1.2x | a wash |
+| claude-fable-5-1, claude-mythos-5-1 | 0.025x base | 1.25x base | 0.3x | ~4x cheaper |
+
+On Fable 5.1 a cache read is $0.25/MTok against $10/MTok base input, so holding a
+5m entry open costs about a third of what letting it expire and re-writing costs.
+That is why `probe-5m` defaults to `auto` and probes exactly those models.
+Anthropic's prompt-caching guidance makes the same point from the other side: on
+these models prefer a keepalive on the 5m tier over paying the 1h TTL premium,
+unless pauses regularly approach an hour.
+
+The list of models lives in `CheapCacheReadModels` in
+`internal/runtime/keepalive/probe_5m.go` and is matched case-insensitively as a
+substring, so `us.anthropic.claude-fable-5-1-v1:0` and `claude-fable-5-1[1m]`
+both resolve. `probe-5m-models` replaces it without a rebuild when a new model
+lands first.
+
+`probe-5m: always` probes every confirmed session regardless of model, and
+`probe-5m: never` restores the original 1h-only rule.
+
 ## Policy
 
 A probe is only sent while a task belonging to that session is still running. A
 session idling on human input is never probed: that wait is unbounded, and the
 guarantee that another turn is coming is what makes the probe pay for itself.
+That gate, not the probe count, is what bounds the spend on either tier.
 
 ## How it works
 
-1. **Observe.** Every request that a confirmed Claude Code client sent with an
-   explicit `cache_control` `ttl` of `1h` is recorded against its session id, taken
-   from `metadata.user_id` or the `X-Claude-Code-Session-Id` header. The scheduler
-   stores the client body, the headers, and the credential that served it, then
-   arms a timer for `request start + ttl - before-expiry`. A request carrying only
-   a 5m marker never schedules anything.
+1. **Observe.** Every request that a confirmed Claude Code client sent with a
+   `cache_control` marker is recorded against its session id, taken from
+   `metadata.user_id` or the `X-Claude-Code-Session-Id` header. A marker with an
+   explicit `ttl` of `1h` puts the session on the 1h tier; anything else, a bare
+   `{"type":"ephemeral"}` included, is the 5m tier and is scheduled only when
+   `probe-5m` allows it. The scheduler stores the client body, the headers, and
+   the credential that served it, then arms a timer for
+   `request start + ttl - before-expiry`, using `before-expiry-5m` on the 5m tier.
+
+   The clock starts at the **request's** start, not the response's, and
+   generation time counts against the TTL. That is why the 5m lead time defaults
+   to 45s: the margin has to cover a slow turn plus the probe's own round trip
+   and still land inside the window.
 
 2. **Fire.** At the timer, in order:
    - a newer request for that session supersedes the probe, which is dropped;
@@ -49,9 +83,11 @@ guarantee that another turn is coming is what makes the probe pay for itself.
      marker stay byte-identical, and the request keeps the observed
      `Anthropic-Beta` list including `extended-cache-ttl-2025-04-11`.
 
-3. **Reschedule.** The next probe is measured from this probe's own start time.
-   After `max-probes` consecutive probes with no real request in between, the
-   session is dropped.
+3. **Reschedule.** The next probe is measured from this probe's own start time,
+   again with the tier's lead time. After `max-probes` consecutive probes with no
+   real request in between, the session is dropped; the 5m tier uses
+   `max-probes-5m`, because six probes buy six hours on the 1h pool and only 25
+   minutes here. The default of 30 covers about two hours of idle.
 
 ## Liveness
 
@@ -110,7 +146,10 @@ state the proxy cannot see, and it will keep probing an idle session until
 
 One read of the prefix per `ttl - before-expiry` while agents run. With a 400k
 prefix on the 1h pool that is roughly 40k token-equivalents an hour, against the
-~800k a re-write would cost. `max-probes` bounds an abandoned session.
+~800k a re-write would cost. On the 5m pool the same prefix on Fable 5.1 costs
+about 120k token-equivalents an hour against that same ~500k write. `max-probes`
+and `max-probes-5m` bound an abandoned session, and the liveness gate bounds a
+live one.
 
 ## Safety
 
@@ -125,11 +164,17 @@ the session is bound to.
 claude-code:
   cache-keepalive:
     enabled: false                 # opt-in
-    before-expiry: 5m              # fire at ttl - before-expiry
+    before-expiry: 5m              # 1h pool: fire at ttl - before-expiry
+    before-expiry-5m: 45s          # 5m pool: same, measured from the request start
+    probe-5m: auto                 # auto | always | never
+    # probe-5m-models:             # replaces the built-in cheap-cache-read list
+    #   - claude-fable-5-1
+    #   - claude-mythos-5-1
     only-when-agents-active: true
     liveness: claude-code-tasks    # or: always
     agent-idle-window: 10m         # how long an agent may be silent and still count as running
-    max-probes: 6
+    max-probes: 6                  # 1h pool
+    max-probes-5m: 30              # 5m pool, ~2h of idle
     max-tokens: 1
     # task-state-dirs:
     #   - "~/.claude/tasks"
@@ -150,11 +195,19 @@ Every line is prefixed `cache-keepalive:`, so `grep cache-keepalive main.log`
 tells the whole story with no other source.
 
 ```
-cache-keepalive: enabled | before-expiry=5m0s only-when-agents-active=true liveness=claude-code-tasks max-probes=6 max-tokens=1
-cache-keepalive: scheduled | session=4463ede6... auth=<id> model=<model> ttl=1h0m0s fires_in=55m0s next_probe_at=2026-09-02T20:51:57-07:00
-cache-keepalive: probe | session=4463ede6... auth=<id> model=<model> status=hit cache_read_input_tokens=161937 cache_creation_input_tokens=0 duration=612ms probes_sent=1 consecutive_probes=1 rescheduled=true next_probe_at=2026-09-02T21:46:57-07:00
-cache-keepalive: skipped | session=4463ede6... auth=<id> model=<model> reason=no-live-agents
+cache-keepalive: enabled | before-expiry=5m0s before-expiry-5m=45s probe-5m=auto only-when-agents-active=true liveness=claude-code-tasks agent-idle-window=10m0s max-probes=6 max-probes-5m=30 max-tokens=1
+cache-keepalive: scheduled | session=4463ede6... auth=<id> model=<model> ttl=1h0m0s ttl_tier=1h probe_5m=n/a fires_in=55m0s next_probe_at=2026-09-02T20:51:57-07:00
+cache-keepalive: scheduled | session=8f21ac03... auth=<id> model=claude-fable-5-1 ttl=5m0s ttl_tier=5m probe_5m=model-auto fires_in=4m15s next_probe_at=2026-09-02T20:36:12-07:00
+cache-keepalive: probe | session=4463ede6... auth=<id> model=<model> ttl_tier=1h probe_5m=n/a status=hit cache_read_input_tokens=161937 cache_creation_input_tokens=0 duration=612ms probes_sent=1 consecutive_probes=1 rescheduled=true next_probe_at=2026-09-02T21:46:57-07:00
+cache-keepalive: skipped | session=4463ede6... auth=<id> model=<model> ttl_tier=1h reason=no-live-agents
 ```
+
+`ttl_tier` is `5m` or `1h`, and `probe_5m` is the tier decision: `model-auto`
+when `auto` matched the request model, `always`, `skipped-never`,
+`skipped-model`, or `n/a` on the 1h pool where the policy does not apply. The two
+skips are logged at debug level, since a proxy serving mixed models emits one per
+request, and are counted under `counters.skipped_by_reason` where they stay
+visible at any log level.
 
 A probe that fails to refresh the entry is the malfunction signal, logged at
 **warning** level with `diagnostics.cache_miss_reason` when the account has the
@@ -189,8 +242,12 @@ route. It returns the live scheduler state:
 {
   "enabled": true,
   "before_expiry": "58m0s",
+  "before_expiry_5m": "45s",
+  "probe_5m": "auto",
+  "probe_5m_models": ["claude-fable-5-1", "claude-mythos-5-1"],
   "only_when_agents_active": false,
   "max_probes": 2,
+  "max_probes_5m": 30,
   "max_tokens": 1,
   "sessions": [
     {
@@ -200,6 +257,8 @@ route. It returns the live scheduler state:
       "model": "claude-haiku-4-5-20251001",
       "ttl": "1h0m0s",
       "ttl_seconds": 3600,
+      "ttl_tier": "1h",
+      "probe_5m_decision": "n/a",
       "last_request_at": "2026-09-02T20:31:12-07:00",
       "next_probe_at": "2026-09-02T20:35:11-07:00",
       "probes_sent": 1,
@@ -223,6 +282,10 @@ route. It returns the live scheduler state:
   }
 }
 ```
+
+`ttl_tier` and `probe_5m_decision` say which pool the session is on and why it is
+being probed, so a session missing from the list is explained by the counters
+rather than by guesswork.
 
 `status` is `hit`, `miss`, `error`, or `skipped`; a skipped entry carries
 `skipped_reason`, and a miss carries `diagnosis` and `cache_missed_input_tokens`

--- a/docs/cache-keepalive.md
+++ b/docs/cache-keepalive.md
@@ -36,7 +36,7 @@ guarantee that another turn is coming is what makes the probe pay for itself.
 
 2. **Fire.** At the timer, in order:
    - a newer request for that session supersedes the probe, which is dropped;
-   - the liveness check must report a running task, unless
+   - the liveness check must report a running agent, unless
      `only-when-agents-active` is false;
    - the session must still be bound to the same credential. If the binding is
      gone, because of a cooldown or a rotation, the probe is skipped: a probe on a
@@ -55,21 +55,56 @@ guarantee that another turn is coming is what makes the probe pay for itself.
 
 ## Liveness
 
-`liveness: claude-code-tasks` reads Claude Code's on-disk task state. A session
-counts as live when either signal holds:
+`liveness: claude-code-tasks` reads Claude Code's on-disk agent state.
 
-- a file under `<task-state-dir>/<session>/*.json` has a `status` that is not
-  `completed`, `failed`, `cancelled`, `killed`, or another terminal value;
-- a file under `<task-output-dir>/<project>/<session>/tasks/*.output` was modified
-  within the TTL window.
+**The primary signal is the per-agent task output file:**
 
-A session directory is matched as either the full session UUID or `session-` plus
-its first eight characters, because Claude Code uses both spellings. An
+```
+<task-output-dir>/<project-slug>/<session-uuid>/tasks/*.output
+```
+
+Every background agent and shell of a session has one, and a running agent keeps
+writing to it. The session is live when any of those files was modified inside
+`agent-idle-window`. The project slug is the client's working directory with
+every `/` replaced by `-`, so `/Users/me/src` becomes `-Users-me-src`; the proxy
+matches it with a wildcard rather than deriving it, since it does not know the
+client's directory.
+
+Some of these files are symlinks into
+`~/.claude/projects/<slug>/<session>/subagents/agent-*.jsonl`, where the real
+writes land. The symlink's own timestamp lags the target's, so the check follows
+the link and reads the target. Reading the link's own timestamp would report a
+busy agent as gone.
+
+**The TodoWrite state files are a secondary fallback only.** A file under
+`<task-state-dir>/<session>/*.json` whose `status` is not `completed`, `failed`,
+`cancelled`, `killed` or another terminal value also counts as live. These files
+are the user-facing todo list, not subagent state: a session with a running
+subagent frequently has no todo file at all, and a stale todo left at
+`in_progress` would keep a finished session looking alive. Never rely on it
+alone.
+
+A session directory is matched as either the full session UUID or `session-`
+plus its first eight characters, because Claude Code uses both spellings. An
 unrecognised status counts as live: a false negative silently disables the
 feature, while a false positive costs one cheap read.
 
-`liveness: always` skips the check. It exists for clients whose agent state the
-proxy cannot see, and it will keep probing an idle session until `max-probes`.
+### The idle window
+
+`agent-idle-window` (default 10m) is how long an agent may be silent and still
+count as running. It is deliberately **not** the cache TTL: an agent that has
+written nothing for an hour is finished, not busy, and probing for it would
+burn the budget on a dead session.
+
+The flip side is that an agent doing long work that emits nothing looks idle
+once the window passes. Timestamps only advance when the process actually
+writes, so a background step that prints nothing for twenty minutes will not
+hold the session live under a 10m window. Set the window above the longest
+silence worth paying a probe for.
+
+`liveness: always` skips the check entirely. It exists for clients whose agent
+state the proxy cannot see, and it will keep probing an idle session until
+`max-probes`.
 
 ## Cost
 
@@ -93,6 +128,7 @@ claude-code:
     before-expiry: 5m              # fire at ttl - before-expiry
     only-when-agents-active: true
     liveness: claude-code-tasks    # or: always
+    agent-idle-window: 10m         # how long an agent may be silent and still count as running
     max-probes: 6
     max-tokens: 1
     # task-state-dirs:

--- a/internal/api/handlers/management/cache_keepalive.go
+++ b/internal/api/handlers/management/cache_keepalive.go
@@ -1,0 +1,26 @@
+package management
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
+)
+
+// GetCacheKeepalive reports the state of the Claude Code prompt-cache keepalive
+// scheduler: every tracked session with its probe history, plus the process-wide
+// counters.
+//
+// It is read-only and takes no parameters. Sessions that have stopped probing
+// stay listed with the reason, so an operator can tell "nothing to do" apart
+// from "silently broken". Request bodies are dropped the moment a session
+// retires and are never exposed here.
+//
+//	GET /v0/management/cache-keepalive
+func (h *Handler) GetCacheKeepalive(c *gin.Context) {
+	if h == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
+		return
+	}
+	c.JSON(http.StatusOK, keepalive.Default().Snapshot())
+}

--- a/internal/api/handlers/management/cache_keepalive_test.go
+++ b/internal/api/handlers/management/cache_keepalive_test.go
@@ -1,0 +1,111 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
+)
+
+type keepaliveTestProber struct{ result keepalive.ProbeResult }
+
+func (p keepaliveTestProber) Probe(context.Context, keepalive.ProbeRequest) (keepalive.ProbeResult, error) {
+	return p.result, nil
+}
+
+type keepaliveTestTimer struct{}
+
+func (keepaliveTestTimer) Stop() bool { return true }
+
+func getCacheKeepalive(t *testing.T) (int, keepalive.Snapshot) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/cache-keepalive", nil)
+	(&Handler{}).GetCacheKeepalive(c)
+
+	var snapshot keepalive.Snapshot
+	if errDecode := json.Unmarshal(recorder.Body.Bytes(), &snapshot); errDecode != nil {
+		t.Fatalf("response is not valid JSON: %v (%s)", errDecode, recorder.Body.String())
+	}
+	return recorder.Code, snapshot
+}
+
+func TestGetCacheKeepaliveWithNoScheduler(t *testing.T) {
+	keepalive.SetDefault(nil)
+	status, snapshot := getCacheKeepalive(t)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if snapshot.Enabled {
+		t.Fatalf("enabled = true with no scheduler installed")
+	}
+	if snapshot.Sessions == nil || snapshot.Counters.SkippedByReason == nil {
+		t.Fatalf("empty snapshot must still be well formed: %+v", snapshot)
+	}
+}
+
+func TestGetCacheKeepaliveReportsSessionsAndCounters(t *testing.T) {
+	scheduler := keepalive.New(keepalive.Config{
+		Enabled:              true,
+		BeforeExpiry:         5 * time.Minute,
+		OnlyWhenAgentsActive: false,
+		MaxProbes:            6,
+		MaxTokens:            1,
+	})
+	var fire func()
+	scheduler.SetTimerFactory(func(_ time.Duration, run func()) keepalive.Timer {
+		fire = run
+		return keepaliveTestTimer{}
+	})
+	scheduler.SetProber(keepaliveTestProber{result: keepalive.ProbeResult{CacheReadInputTokens: 12468, CacheCreationInputTokens: 4}})
+	keepalive.SetDefault(scheduler)
+	t.Cleanup(func() { keepalive.SetDefault(nil) })
+
+	scheduler.Observe(keepalive.ObserveInput{
+		SessionID: "aa11bb22-cc33-dd44-ee55-ff6677889900",
+		AuthID:    "claude-account.json",
+		Provider:  "mixed",
+		Model:     "claude-haiku-4-5-20251001",
+		Body:      []byte(`{"system":[{"cache_control":{"type":"ephemeral","ttl":"1h"}}]}`),
+		TTL:       time.Hour,
+		StartedAt: time.Now(),
+	})
+	if fire == nil {
+		t.Fatalf("Observe did not schedule a probe")
+	}
+	fire()
+
+	status, snapshot := getCacheKeepalive(t)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !snapshot.Enabled || snapshot.MaxProbes != 6 || snapshot.BeforeExpiry != "5m0s" {
+		t.Fatalf("snapshot config = %+v", snapshot)
+	}
+	if len(snapshot.Sessions) != 1 {
+		t.Fatalf("sessions = %+v, want 1", snapshot.Sessions)
+	}
+	session := snapshot.Sessions[0]
+	if session.SessionID != "aa11bb22-cc33-dd44-ee55-ff6677889900" || session.AuthID != "claude-account.json" {
+		t.Fatalf("session identity = %+v", session)
+	}
+	if session.ProbesSent != 1 || session.ConsecutiveProbes != 1 {
+		t.Fatalf("probe counts = %+v", session)
+	}
+	if session.LastProbe == nil || session.LastProbe.Status != keepalive.ProbeStatusHit {
+		t.Fatalf("last probe = %+v", session.LastProbe)
+	}
+	if session.LastProbe.CacheReadInputTokens != 12468 || session.LastProbe.CacheCreationInputTokens != 4 {
+		t.Fatalf("last probe tokens = %+v", session.LastProbe)
+	}
+	if snapshot.Counters.Scheduled != 1 || snapshot.Counters.Fired != 1 || snapshot.Counters.Hits != 1 {
+		t.Fatalf("counters = %+v", snapshot.Counters)
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -83,6 +83,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/api-key-usage", s.mgmt.GetAPIKeyUsage)
 		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
 
+		mgmt.GET("/cache-keepalive", s.mgmt.GetCacheKeepalive)
+
 		mgmt.GET("/gemini-api-key", s.mgmt.GetGeminiKeys)
 		mgmt.PUT("/gemini-api-key", s.mgmt.PutGeminiKeys)
 		mgmt.PATCH("/gemini-api-key", s.mgmt.PatchGeminiKey)

--- a/internal/config/claude_cache_keepalive.go
+++ b/internal/config/claude_cache_keepalive.go
@@ -18,15 +18,37 @@ const (
 	ClaudeCodeKeepaliveLivenessAlways = "always"
 )
 
+// Claude Code cache keepalive 5m-pool probing modes.
+const (
+	// ClaudeCodeKeepaliveProbe5mAuto probes a 5m session only when the request
+	// model's cache reads are cheap enough for the arithmetic to work out.
+	ClaudeCodeKeepaliveProbe5mAuto = "auto"
+	// ClaudeCodeKeepaliveProbe5mAlways probes every confirmed session.
+	ClaudeCodeKeepaliveProbe5mAlways = "always"
+	// ClaudeCodeKeepaliveProbe5mNever probes only 1h sessions.
+	ClaudeCodeKeepaliveProbe5mNever = "never"
+)
+
 const (
 	defaultClaudeCodeKeepaliveBeforeExpiry    = 5 * time.Minute
 	defaultClaudeCodeKeepaliveAgentIdleWindow = 10 * time.Minute
 	defaultClaudeCodeKeepaliveMaxProbes       = 6
 	defaultClaudeCodeKeepaliveMaxTokens       = 1
+
+	// defaultClaudeCodeKeepaliveBeforeExpiry5m is the lead time on the 5m pool.
+	// The TTL clock runs from the start of the request that wrote the entry and
+	// generation time counts against it, so the margin has to cover a slow turn
+	// plus the probe's own round trip while still leaving the probe inside the
+	// window.
+	defaultClaudeCodeKeepaliveBeforeExpiry5m = 45 * time.Second
+	// defaultClaudeCodeKeepaliveMaxProbes5m covers about two hours of idle. The
+	// 1h default of 6 probes would cover only 25 minutes on this pool, which is
+	// shorter than the subagent waits the feature exists for.
+	defaultClaudeCodeKeepaliveMaxProbes5m = 30
 )
 
 // ClaudeCodeCacheKeepaliveConfig configures agent-aware prompt-cache keepalive
-// probes for Claude Code sessions that requested the 1h cache pool.
+// probes for Claude Code sessions.
 //
 // The feature is opt-in: a zero-value config keeps it disabled. Every other
 // field falls back to the documented default when the operator omits it, so a
@@ -35,8 +57,22 @@ type ClaudeCodeCacheKeepaliveConfig struct {
 	// Enabled turns the keepalive scheduler on. Default false.
 	Enabled bool `yaml:"enabled" json:"enabled"`
 
-	// BeforeExpiry fires the probe at t_start + ttl - BeforeExpiry. Default 5m.
+	// BeforeExpiry fires the probe at t_start + ttl - BeforeExpiry on the 1h
+	// pool. Default 5m.
 	BeforeExpiry time.Duration `yaml:"before-expiry" json:"before-expiry"`
+
+	// BeforeExpiry5m is the same lead time for the 5m pool. Default 45s.
+	BeforeExpiry5m time.Duration `yaml:"before-expiry-5m" json:"before-expiry-5m"`
+
+	// Probe5m selects when a session on the 5m pool is probed: "auto"
+	// (default), "always" or "never". "auto" probes only models whose cache
+	// reads are priced low enough for probing to beat expiry.
+	Probe5m string `yaml:"probe-5m" json:"probe-5m"`
+
+	// Probe5mModels overrides the built-in cheap-cache-read model list "auto"
+	// matches against. Entries match case-insensitively as substrings. Empty
+	// means the built-in list.
+	Probe5mModels []string `yaml:"probe-5m-models" json:"probe-5m-models,omitempty"`
 
 	// OnlyWhenAgentsActive gates every probe on the liveness check. Default true.
 	OnlyWhenAgentsActive bool `yaml:"only-when-agents-active" json:"only-when-agents-active"`
@@ -49,8 +85,13 @@ type ClaudeCodeCacheKeepaliveConfig struct {
 	// has written nothing for an hour is finished, not busy.
 	AgentIdleWindow time.Duration `yaml:"agent-idle-window" json:"agent-idle-window"`
 
-	// MaxProbes caps consecutive probes without an intervening real request. Default 6.
+	// MaxProbes caps consecutive probes without an intervening real request on
+	// the 1h pool. Default 6.
 	MaxProbes int `yaml:"max-probes" json:"max-probes"`
+
+	// MaxProbes5m is the same cap for the 5m pool, where each probe buys only
+	// one short window. Default 30, about two hours of idle.
+	MaxProbes5m int `yaml:"max-probes-5m" json:"max-probes-5m"`
 
 	// MaxTokens is the max_tokens the probe body carries. Default 1.
 	MaxTokens int `yaml:"max-tokens" json:"max-tokens"`
@@ -65,6 +106,9 @@ type ClaudeCodeCacheKeepaliveConfig struct {
 
 	enabledPresent              bool
 	beforeExpiryPresent         bool
+	beforeExpiry5mPresent       bool
+	probe5mPresent              bool
+	maxProbes5mPresent          bool
 	onlyWhenAgentsActivePresent bool
 	livenessPresent             bool
 	agentIdleWindowPresent      bool
@@ -78,10 +122,14 @@ func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
 	type rawClaudeCodeCacheKeepaliveConfig struct {
 		Enabled              bool          `yaml:"enabled"`
 		BeforeExpiry         time.Duration `yaml:"before-expiry"`
+		BeforeExpiry5m       time.Duration `yaml:"before-expiry-5m"`
+		Probe5m              string        `yaml:"probe-5m"`
+		Probe5mModels        []string      `yaml:"probe-5m-models"`
 		OnlyWhenAgentsActive bool          `yaml:"only-when-agents-active"`
 		Liveness             string        `yaml:"liveness"`
 		AgentIdleWindow      time.Duration `yaml:"agent-idle-window"`
 		MaxProbes            int           `yaml:"max-probes"`
+		MaxProbes5m          int           `yaml:"max-probes-5m"`
 		MaxTokens            int           `yaml:"max-tokens"`
 		TaskStateDirs        []string      `yaml:"task-state-dirs"`
 		TaskOutputDirs       []string      `yaml:"task-output-dirs"`
@@ -95,15 +143,22 @@ func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
 	*c = ClaudeCodeCacheKeepaliveConfig{
 		Enabled:                     raw.Enabled,
 		BeforeExpiry:                raw.BeforeExpiry,
+		BeforeExpiry5m:              raw.BeforeExpiry5m,
+		Probe5m:                     strings.TrimSpace(raw.Probe5m),
+		Probe5mModels:               raw.Probe5mModels,
 		OnlyWhenAgentsActive:        raw.OnlyWhenAgentsActive,
 		Liveness:                    strings.TrimSpace(raw.Liveness),
 		AgentIdleWindow:             raw.AgentIdleWindow,
 		MaxProbes:                   raw.MaxProbes,
+		MaxProbes5m:                 raw.MaxProbes5m,
 		MaxTokens:                   raw.MaxTokens,
 		TaskStateDirs:               raw.TaskStateDirs,
 		TaskOutputDirs:              raw.TaskOutputDirs,
 		enabledPresent:              claudeCodeKeepaliveFieldPresent(value, "enabled"),
 		beforeExpiryPresent:         claudeCodeKeepaliveFieldPresent(value, "before-expiry"),
+		beforeExpiry5mPresent:       claudeCodeKeepaliveFieldPresent(value, "before-expiry-5m"),
+		probe5mPresent:              claudeCodeKeepaliveFieldPresent(value, "probe-5m"),
+		maxProbes5mPresent:          claudeCodeKeepaliveFieldPresent(value, "max-probes-5m"),
 		onlyWhenAgentsActivePresent: claudeCodeKeepaliveFieldPresent(value, "only-when-agents-active"),
 		livenessPresent:             claudeCodeKeepaliveFieldPresent(value, "liveness"),
 		agentIdleWindowPresent:      claudeCodeKeepaliveFieldPresent(value, "agent-idle-window"),
@@ -130,6 +185,16 @@ func (c ClaudeCodeCacheKeepaliveConfig) WithDefaults() ClaudeCodeCacheKeepaliveC
 	if !c.beforeExpiryPresent && c.BeforeExpiry == 0 {
 		c.BeforeExpiry = defaultClaudeCodeKeepaliveBeforeExpiry
 	}
+	if !c.beforeExpiry5mPresent && c.BeforeExpiry5m == 0 {
+		c.BeforeExpiry5m = defaultClaudeCodeKeepaliveBeforeExpiry5m
+	}
+	if !c.probe5mPresent && strings.TrimSpace(c.Probe5m) == "" {
+		c.Probe5m = ClaudeCodeKeepaliveProbe5mAuto
+	}
+	c.Probe5m = strings.ToLower(strings.TrimSpace(c.Probe5m))
+	if c.Probe5m == "" {
+		c.Probe5m = ClaudeCodeKeepaliveProbe5mAuto
+	}
 	if !c.onlyWhenAgentsActivePresent {
 		c.OnlyWhenAgentsActive = true
 	}
@@ -146,6 +211,9 @@ func (c ClaudeCodeCacheKeepaliveConfig) WithDefaults() ClaudeCodeCacheKeepaliveC
 	if !c.maxProbesPresent && c.MaxProbes == 0 {
 		c.MaxProbes = defaultClaudeCodeKeepaliveMaxProbes
 	}
+	if !c.maxProbes5mPresent && c.MaxProbes5m == 0 {
+		c.MaxProbes5m = defaultClaudeCodeKeepaliveMaxProbes5m
+	}
 	if !c.maxTokensPresent && c.MaxTokens == 0 {
 		c.MaxTokens = defaultClaudeCodeKeepaliveMaxTokens
 	}
@@ -159,6 +227,22 @@ func (c ClaudeCodeCacheKeepaliveConfig) Validate() error {
 	}
 	if c.BeforeExpiry <= 0 {
 		return fmt.Errorf("claude-code.cache-keepalive.before-expiry must be positive")
+	}
+	switch c.Probe5m {
+	case ClaudeCodeKeepaliveProbe5mAuto, ClaudeCodeKeepaliveProbe5mAlways, ClaudeCodeKeepaliveProbe5mNever:
+	default:
+		return fmt.Errorf("claude-code.cache-keepalive.probe-5m must be %q, %q or %q, got %q",
+			ClaudeCodeKeepaliveProbe5mAuto, ClaudeCodeKeepaliveProbe5mAlways, ClaudeCodeKeepaliveProbe5mNever, c.Probe5m)
+	}
+	if c.Probe5m != ClaudeCodeKeepaliveProbe5mNever {
+		// A lead time at or above the 5m TTL leaves no window to schedule in, so
+		// every 5m session would be silently dropped.
+		if c.BeforeExpiry5m <= 0 || c.BeforeExpiry5m >= 5*time.Minute {
+			return fmt.Errorf("claude-code.cache-keepalive.before-expiry-5m must be positive and below 5m, got %s", c.BeforeExpiry5m)
+		}
+		if c.MaxProbes5m <= 0 {
+			return fmt.Errorf("claude-code.cache-keepalive.max-probes-5m must be positive")
+		}
 	}
 	switch c.Liveness {
 	case ClaudeCodeKeepaliveLivenessClaudeCodeTasks, ClaudeCodeKeepaliveLivenessAlways:

--- a/internal/config/claude_cache_keepalive.go
+++ b/internal/config/claude_cache_keepalive.go
@@ -19,9 +19,10 @@ const (
 )
 
 const (
-	defaultClaudeCodeKeepaliveBeforeExpiry = 5 * time.Minute
-	defaultClaudeCodeKeepaliveMaxProbes    = 6
-	defaultClaudeCodeKeepaliveMaxTokens    = 1
+	defaultClaudeCodeKeepaliveBeforeExpiry    = 5 * time.Minute
+	defaultClaudeCodeKeepaliveAgentIdleWindow = 10 * time.Minute
+	defaultClaudeCodeKeepaliveMaxProbes       = 6
+	defaultClaudeCodeKeepaliveMaxTokens       = 1
 )
 
 // ClaudeCodeCacheKeepaliveConfig configures agent-aware prompt-cache keepalive
@@ -43,6 +44,11 @@ type ClaudeCodeCacheKeepaliveConfig struct {
 	// Liveness selects the liveness strategy. Default "claude-code-tasks".
 	Liveness string `yaml:"liveness" json:"liveness"`
 
+	// AgentIdleWindow is how long an agent may be silent and still count as
+	// running. Default 10m. It is deliberately not the cache TTL: an agent that
+	// has written nothing for an hour is finished, not busy.
+	AgentIdleWindow time.Duration `yaml:"agent-idle-window" json:"agent-idle-window"`
+
 	// MaxProbes caps consecutive probes without an intervening real request. Default 6.
 	MaxProbes int `yaml:"max-probes" json:"max-probes"`
 
@@ -61,6 +67,7 @@ type ClaudeCodeCacheKeepaliveConfig struct {
 	beforeExpiryPresent         bool
 	onlyWhenAgentsActivePresent bool
 	livenessPresent             bool
+	agentIdleWindowPresent      bool
 	maxProbesPresent            bool
 	maxTokensPresent            bool
 }
@@ -73,6 +80,7 @@ func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
 		BeforeExpiry         time.Duration `yaml:"before-expiry"`
 		OnlyWhenAgentsActive bool          `yaml:"only-when-agents-active"`
 		Liveness             string        `yaml:"liveness"`
+		AgentIdleWindow      time.Duration `yaml:"agent-idle-window"`
 		MaxProbes            int           `yaml:"max-probes"`
 		MaxTokens            int           `yaml:"max-tokens"`
 		TaskStateDirs        []string      `yaml:"task-state-dirs"`
@@ -89,6 +97,7 @@ func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
 		BeforeExpiry:                raw.BeforeExpiry,
 		OnlyWhenAgentsActive:        raw.OnlyWhenAgentsActive,
 		Liveness:                    strings.TrimSpace(raw.Liveness),
+		AgentIdleWindow:             raw.AgentIdleWindow,
 		MaxProbes:                   raw.MaxProbes,
 		MaxTokens:                   raw.MaxTokens,
 		TaskStateDirs:               raw.TaskStateDirs,
@@ -97,6 +106,7 @@ func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
 		beforeExpiryPresent:         claudeCodeKeepaliveFieldPresent(value, "before-expiry"),
 		onlyWhenAgentsActivePresent: claudeCodeKeepaliveFieldPresent(value, "only-when-agents-active"),
 		livenessPresent:             claudeCodeKeepaliveFieldPresent(value, "liveness"),
+		agentIdleWindowPresent:      claudeCodeKeepaliveFieldPresent(value, "agent-idle-window"),
 		maxProbesPresent:            claudeCodeKeepaliveFieldPresent(value, "max-probes"),
 		maxTokensPresent:            claudeCodeKeepaliveFieldPresent(value, "max-tokens"),
 	}
@@ -130,6 +140,9 @@ func (c ClaudeCodeCacheKeepaliveConfig) WithDefaults() ClaudeCodeCacheKeepaliveC
 	if c.Liveness == "" {
 		c.Liveness = ClaudeCodeKeepaliveLivenessClaudeCodeTasks
 	}
+	if !c.agentIdleWindowPresent && c.AgentIdleWindow == 0 {
+		c.AgentIdleWindow = defaultClaudeCodeKeepaliveAgentIdleWindow
+	}
 	if !c.maxProbesPresent && c.MaxProbes == 0 {
 		c.MaxProbes = defaultClaudeCodeKeepaliveMaxProbes
 	}
@@ -152,6 +165,9 @@ func (c ClaudeCodeCacheKeepaliveConfig) Validate() error {
 	default:
 		return fmt.Errorf("claude-code.cache-keepalive.liveness must be %q or %q, got %q",
 			ClaudeCodeKeepaliveLivenessClaudeCodeTasks, ClaudeCodeKeepaliveLivenessAlways, c.Liveness)
+	}
+	if c.AgentIdleWindow <= 0 && c.Liveness == ClaudeCodeKeepaliveLivenessClaudeCodeTasks {
+		return fmt.Errorf("claude-code.cache-keepalive.agent-idle-window must be positive")
 	}
 	if c.MaxProbes <= 0 {
 		return fmt.Errorf("claude-code.cache-keepalive.max-probes must be positive")

--- a/internal/config/claude_cache_keepalive.go
+++ b/internal/config/claude_cache_keepalive.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Claude Code cache keepalive liveness strategies.
+const (
+	// ClaudeCodeKeepaliveLivenessClaudeCodeTasks probes only while a Claude Code
+	// task belonging to the session is still running.
+	ClaudeCodeKeepaliveLivenessClaudeCodeTasks = "claude-code-tasks"
+	// ClaudeCodeKeepaliveLivenessAlways skips the liveness check entirely. It is
+	// intended for non-Claude-Code clients whose agent state the proxy cannot see.
+	ClaudeCodeKeepaliveLivenessAlways = "always"
+)
+
+const (
+	defaultClaudeCodeKeepaliveBeforeExpiry = 5 * time.Minute
+	defaultClaudeCodeKeepaliveMaxProbes    = 6
+	defaultClaudeCodeKeepaliveMaxTokens    = 1
+)
+
+// ClaudeCodeCacheKeepaliveConfig configures agent-aware prompt-cache keepalive
+// probes for Claude Code sessions that requested the 1h cache pool.
+//
+// The feature is opt-in: a zero-value config keeps it disabled. Every other
+// field falls back to the documented default when the operator omits it, so a
+// config that only sets `enabled: true` is a complete configuration.
+type ClaudeCodeCacheKeepaliveConfig struct {
+	// Enabled turns the keepalive scheduler on. Default false.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// BeforeExpiry fires the probe at t_start + ttl - BeforeExpiry. Default 5m.
+	BeforeExpiry time.Duration `yaml:"before-expiry" json:"before-expiry"`
+
+	// OnlyWhenAgentsActive gates every probe on the liveness check. Default true.
+	OnlyWhenAgentsActive bool `yaml:"only-when-agents-active" json:"only-when-agents-active"`
+
+	// Liveness selects the liveness strategy. Default "claude-code-tasks".
+	Liveness string `yaml:"liveness" json:"liveness"`
+
+	// MaxProbes caps consecutive probes without an intervening real request. Default 6.
+	MaxProbes int `yaml:"max-probes" json:"max-probes"`
+
+	// MaxTokens is the max_tokens the probe body carries. Default 1.
+	MaxTokens int `yaml:"max-tokens" json:"max-tokens"`
+
+	// TaskStateDirs are the roots searched for Claude Code task state JSON files.
+	// Empty means the built-in default (~/.claude/tasks).
+	TaskStateDirs []string `yaml:"task-state-dirs" json:"task-state-dirs,omitempty"`
+
+	// TaskOutputDirs are the roots searched for Claude Code task output files.
+	// Empty means the built-in default (/private/tmp/claude-<uid>).
+	TaskOutputDirs []string `yaml:"task-output-dirs" json:"task-output-dirs,omitempty"`
+
+	enabledPresent              bool
+	beforeExpiryPresent         bool
+	onlyWhenAgentsActivePresent bool
+	livenessPresent             bool
+	maxProbesPresent            bool
+	maxTokensPresent            bool
+}
+
+// UnmarshalYAML preserves field presence so an explicitly configured false or
+// zero is not silently replaced by the default.
+func (c *ClaudeCodeCacheKeepaliveConfig) UnmarshalYAML(value *yaml.Node) error {
+	type rawClaudeCodeCacheKeepaliveConfig struct {
+		Enabled              bool          `yaml:"enabled"`
+		BeforeExpiry         time.Duration `yaml:"before-expiry"`
+		OnlyWhenAgentsActive bool          `yaml:"only-when-agents-active"`
+		Liveness             string        `yaml:"liveness"`
+		MaxProbes            int           `yaml:"max-probes"`
+		MaxTokens            int           `yaml:"max-tokens"`
+		TaskStateDirs        []string      `yaml:"task-state-dirs"`
+		TaskOutputDirs       []string      `yaml:"task-output-dirs"`
+	}
+
+	var raw rawClaudeCodeCacheKeepaliveConfig
+	if errDecode := value.Decode(&raw); errDecode != nil {
+		return errDecode
+	}
+
+	*c = ClaudeCodeCacheKeepaliveConfig{
+		Enabled:                     raw.Enabled,
+		BeforeExpiry:                raw.BeforeExpiry,
+		OnlyWhenAgentsActive:        raw.OnlyWhenAgentsActive,
+		Liveness:                    strings.TrimSpace(raw.Liveness),
+		MaxProbes:                   raw.MaxProbes,
+		MaxTokens:                   raw.MaxTokens,
+		TaskStateDirs:               raw.TaskStateDirs,
+		TaskOutputDirs:              raw.TaskOutputDirs,
+		enabledPresent:              claudeCodeKeepaliveFieldPresent(value, "enabled"),
+		beforeExpiryPresent:         claudeCodeKeepaliveFieldPresent(value, "before-expiry"),
+		onlyWhenAgentsActivePresent: claudeCodeKeepaliveFieldPresent(value, "only-when-agents-active"),
+		livenessPresent:             claudeCodeKeepaliveFieldPresent(value, "liveness"),
+		maxProbesPresent:            claudeCodeKeepaliveFieldPresent(value, "max-probes"),
+		maxTokensPresent:            claudeCodeKeepaliveFieldPresent(value, "max-tokens"),
+	}
+	return nil
+}
+
+func claudeCodeKeepaliveFieldPresent(value *yaml.Node, field string) bool {
+	if value == nil || value.Kind != yaml.MappingNode {
+		return false
+	}
+	for index := 0; index+1 < len(value.Content); index += 2 {
+		if value.Content[index].Value == field {
+			return true
+		}
+	}
+	return false
+}
+
+// WithDefaults fills in every field the operator left out.
+func (c ClaudeCodeCacheKeepaliveConfig) WithDefaults() ClaudeCodeCacheKeepaliveConfig {
+	if !c.beforeExpiryPresent && c.BeforeExpiry == 0 {
+		c.BeforeExpiry = defaultClaudeCodeKeepaliveBeforeExpiry
+	}
+	if !c.onlyWhenAgentsActivePresent {
+		c.OnlyWhenAgentsActive = true
+	}
+	if !c.livenessPresent && strings.TrimSpace(c.Liveness) == "" {
+		c.Liveness = ClaudeCodeKeepaliveLivenessClaudeCodeTasks
+	}
+	c.Liveness = strings.ToLower(strings.TrimSpace(c.Liveness))
+	if c.Liveness == "" {
+		c.Liveness = ClaudeCodeKeepaliveLivenessClaudeCodeTasks
+	}
+	if !c.maxProbesPresent && c.MaxProbes == 0 {
+		c.MaxProbes = defaultClaudeCodeKeepaliveMaxProbes
+	}
+	if !c.maxTokensPresent && c.MaxTokens == 0 {
+		c.MaxTokens = defaultClaudeCodeKeepaliveMaxTokens
+	}
+	return c
+}
+
+// Validate rejects a configuration that would schedule probes that cannot help.
+func (c ClaudeCodeCacheKeepaliveConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.BeforeExpiry <= 0 {
+		return fmt.Errorf("claude-code.cache-keepalive.before-expiry must be positive")
+	}
+	switch c.Liveness {
+	case ClaudeCodeKeepaliveLivenessClaudeCodeTasks, ClaudeCodeKeepaliveLivenessAlways:
+	default:
+		return fmt.Errorf("claude-code.cache-keepalive.liveness must be %q or %q, got %q",
+			ClaudeCodeKeepaliveLivenessClaudeCodeTasks, ClaudeCodeKeepaliveLivenessAlways, c.Liveness)
+	}
+	if c.MaxProbes <= 0 {
+		return fmt.Errorf("claude-code.cache-keepalive.max-probes must be positive")
+	}
+	if c.MaxTokens <= 0 {
+		return fmt.Errorf("claude-code.cache-keepalive.max-tokens must be positive")
+	}
+	return nil
+}

--- a/internal/config/claude_cache_keepalive_test.go
+++ b/internal/config/claude_cache_keepalive_test.go
@@ -29,6 +29,18 @@ func TestParseConfigBytesClaudeCodeCacheKeepaliveDefaults(t *testing.T) {
 	if keepalive.MaxTokens != 1 {
 		t.Fatalf("MaxTokens = %d, want 1", keepalive.MaxTokens)
 	}
+	if keepalive.BeforeExpiry5m != 45*time.Second {
+		t.Fatalf("BeforeExpiry5m = %s, want 45s", keepalive.BeforeExpiry5m)
+	}
+	if keepalive.Probe5m != ClaudeCodeKeepaliveProbe5mAuto {
+		t.Fatalf("Probe5m = %q, want %q", keepalive.Probe5m, ClaudeCodeKeepaliveProbe5mAuto)
+	}
+	if len(keepalive.Probe5mModels) != 0 {
+		t.Fatalf("Probe5mModels = %v, want empty so the built-in list applies", keepalive.Probe5mModels)
+	}
+	if keepalive.MaxProbes5m != 30 {
+		t.Fatalf("MaxProbes5m = %d, want 30", keepalive.MaxProbes5m)
+	}
 }
 
 func TestParseConfigBytesClaudeCodeCacheKeepaliveOverrides(t *testing.T) {
@@ -40,6 +52,11 @@ func TestParseConfigBytesClaudeCodeCacheKeepaliveOverrides(t *testing.T) {
 		"    liveness: always\n" +
 		"    max-probes: 2\n" +
 		"    max-tokens: 4\n" +
+		"    before-expiry-5m: 20s\n" +
+		"    probe-5m: always\n" +
+		"    max-probes-5m: 12\n" +
+		"    probe-5m-models:\n" +
+		"      - claude-experimental-9\n" +
 		"    task-state-dirs:\n" +
 		"      - /tmp/state\n" +
 		"    task-output-dirs:\n" +
@@ -73,6 +90,18 @@ func TestParseConfigBytesClaudeCodeCacheKeepaliveOverrides(t *testing.T) {
 	if len(keepalive.TaskOutputDirs) != 1 || keepalive.TaskOutputDirs[0] != "/tmp/output" {
 		t.Fatalf("TaskOutputDirs = %v, want [/tmp/output]", keepalive.TaskOutputDirs)
 	}
+	if keepalive.BeforeExpiry5m != 20*time.Second {
+		t.Fatalf("BeforeExpiry5m = %s, want 20s", keepalive.BeforeExpiry5m)
+	}
+	if keepalive.Probe5m != ClaudeCodeKeepaliveProbe5mAlways {
+		t.Fatalf("Probe5m = %q, want %q", keepalive.Probe5m, ClaudeCodeKeepaliveProbe5mAlways)
+	}
+	if keepalive.MaxProbes5m != 12 {
+		t.Fatalf("MaxProbes5m = %d, want 12", keepalive.MaxProbes5m)
+	}
+	if len(keepalive.Probe5mModels) != 1 || keepalive.Probe5mModels[0] != "claude-experimental-9" {
+		t.Fatalf("Probe5mModels = %v, want [claude-experimental-9]", keepalive.Probe5mModels)
+	}
 }
 
 func TestClaudeCodeCacheKeepaliveValidate(t *testing.T) {
@@ -104,6 +133,26 @@ func TestClaudeCodeCacheKeepaliveValidate(t *testing.T) {
 		{
 			name:    "enabled with defaults accepted",
 			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n",
+			wantErr: false,
+		},
+		{
+			name:    "unknown probe-5m rejected when enabled",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    probe-5m: sometimes\n",
+			wantErr: true,
+		},
+		{
+			name:    "before-expiry-5m at or above the 5m ttl rejected",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    before-expiry-5m: 5m\n",
+			wantErr: true,
+		},
+		{
+			name:    "non-positive max-probes-5m rejected",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    max-probes-5m: 0\n",
+			wantErr: true,
+		},
+		{
+			name:    "probe-5m never ignores the 5m knobs",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    probe-5m: never\n    max-probes-5m: 0\n",
 			wantErr: false,
 		},
 	}

--- a/internal/config/claude_cache_keepalive_test.go
+++ b/internal/config/claude_cache_keepalive_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseConfigBytesClaudeCodeCacheKeepaliveDefaults(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte("port: 8317\n"))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	keepalive := cfg.ClaudeCode.CacheKeepalive
+	if keepalive.Enabled {
+		t.Fatalf("Enabled = true, want false by default")
+	}
+	if keepalive.BeforeExpiry != 5*time.Minute {
+		t.Fatalf("BeforeExpiry = %s, want 5m", keepalive.BeforeExpiry)
+	}
+	if !keepalive.OnlyWhenAgentsActive {
+		t.Fatalf("OnlyWhenAgentsActive = false, want true by default")
+	}
+	if keepalive.Liveness != ClaudeCodeKeepaliveLivenessClaudeCodeTasks {
+		t.Fatalf("Liveness = %q, want %q", keepalive.Liveness, ClaudeCodeKeepaliveLivenessClaudeCodeTasks)
+	}
+	if keepalive.MaxProbes != 6 {
+		t.Fatalf("MaxProbes = %d, want 6", keepalive.MaxProbes)
+	}
+	if keepalive.MaxTokens != 1 {
+		t.Fatalf("MaxTokens = %d, want 1", keepalive.MaxTokens)
+	}
+}
+
+func TestParseConfigBytesClaudeCodeCacheKeepaliveOverrides(t *testing.T) {
+	yaml := "claude-code:\n" +
+		"  cache-keepalive:\n" +
+		"    enabled: true\n" +
+		"    before-expiry: 58m\n" +
+		"    only-when-agents-active: false\n" +
+		"    liveness: always\n" +
+		"    max-probes: 2\n" +
+		"    max-tokens: 4\n" +
+		"    task-state-dirs:\n" +
+		"      - /tmp/state\n" +
+		"    task-output-dirs:\n" +
+		"      - /tmp/output\n"
+	cfg, errParse := ParseConfigBytes([]byte(yaml))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	keepalive := cfg.ClaudeCode.CacheKeepalive
+	if !keepalive.Enabled {
+		t.Fatalf("Enabled = false, want true")
+	}
+	if keepalive.BeforeExpiry != 58*time.Minute {
+		t.Fatalf("BeforeExpiry = %s, want 58m", keepalive.BeforeExpiry)
+	}
+	if keepalive.OnlyWhenAgentsActive {
+		t.Fatalf("OnlyWhenAgentsActive = true, want the explicit false to survive defaults")
+	}
+	if keepalive.Liveness != ClaudeCodeKeepaliveLivenessAlways {
+		t.Fatalf("Liveness = %q, want %q", keepalive.Liveness, ClaudeCodeKeepaliveLivenessAlways)
+	}
+	if keepalive.MaxProbes != 2 {
+		t.Fatalf("MaxProbes = %d, want 2", keepalive.MaxProbes)
+	}
+	if keepalive.MaxTokens != 4 {
+		t.Fatalf("MaxTokens = %d, want 4", keepalive.MaxTokens)
+	}
+	if len(keepalive.TaskStateDirs) != 1 || keepalive.TaskStateDirs[0] != "/tmp/state" {
+		t.Fatalf("TaskStateDirs = %v, want [/tmp/state]", keepalive.TaskStateDirs)
+	}
+	if len(keepalive.TaskOutputDirs) != 1 || keepalive.TaskOutputDirs[0] != "/tmp/output" {
+		t.Fatalf("TaskOutputDirs = %v, want [/tmp/output]", keepalive.TaskOutputDirs)
+	}
+}
+
+func TestClaudeCodeCacheKeepaliveValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name:    "disabled skips validation",
+			yaml:    "claude-code:\n  cache-keepalive:\n    liveness: nonsense\n",
+			wantErr: false,
+		},
+		{
+			name:    "unknown liveness rejected when enabled",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    liveness: nonsense\n",
+			wantErr: true,
+		},
+		{
+			name:    "non-positive max-probes rejected",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    max-probes: 0\n",
+			wantErr: true,
+		},
+		{
+			name:    "non-positive before-expiry rejected",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n    before-expiry: 0s\n",
+			wantErr: true,
+		},
+		{
+			name:    "enabled with defaults accepted",
+			yaml:    "claude-code:\n  cache-keepalive:\n    enabled: true\n",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errParse := ParseConfigBytes([]byte(tt.yaml))
+			if tt.wantErr && errParse == nil {
+				t.Fatalf("ParseConfigBytes() error = nil, want an error")
+			}
+			if !tt.wantErr && errParse != nil {
+				t.Fatalf("ParseConfigBytes() error = %v, want nil", errParse)
+			}
+		})
+	}
+}

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -89,6 +89,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
+	cfg.ClaudeCode.CacheKeepalive = cfg.ClaudeCode.CacheKeepalive.WithDefaults()
+	if errValidate := cfg.ClaudeCode.CacheKeepalive.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
 		return nil, errValidate
 	}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -43,6 +43,10 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	}
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
+	cfg.ClaudeCode.CacheKeepalive = cfg.ClaudeCode.CacheKeepalive.WithDefaults()
+	if errValidate := cfg.ClaudeCode.CacheKeepalive.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
 		return nil, errValidate
 	}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -67,6 +67,9 @@ type SDKConfig struct {
 type ClaudeCodeConfig struct {
 	// DisableCloakingModelList disables model ID cloaking in Anthropic model list responses.
 	DisableCloakingModelList bool `yaml:"disable-cloaking-model-list" json:"disable-cloaking-model-list"`
+
+	// CacheKeepalive configures agent-aware prompt-cache keepalive probes.
+	CacheKeepalive ClaudeCodeCacheKeepaliveConfig `yaml:"cache-keepalive" json:"cache-keepalive"`
 }
 
 // StreamingConfig holds server streaming behavior configuration.

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -344,6 +344,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		Headers:             incomingHeaders,
 		Metadata:            opts.Metadata,
 		StartedAt:           requestStartedAt,
+		// The baseline a later probe is measured against: a probe that reads far
+		// less than the real request did refreshed only part of the prefix.
+		CacheReadInputTokens: gjson.GetBytes(data, "usage.cache_read_input_tokens").Int(),
 	})
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -20,6 +21,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	requestStartedAt := time.Now()
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)
 
@@ -333,6 +335,16 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if responseFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
+	helps.ObserveClaudeCacheKeepalive(ctx, helps.ClaudeCacheKeepaliveObservation{
+		ConfirmedClaudeCode: confirmedClaudeCode,
+		AuthID:              authID,
+		AuthProvider:        e.Identifier(),
+		Model:               baseModel,
+		OriginalPayload:     originalPayload,
+		Headers:             incomingHeaders,
+		Metadata:            opts.Metadata,
+		StartedAt:           requestStartedAt,
+	})
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
 }

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -22,6 +23,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	requestStartedAt := time.Now()
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)
 
@@ -421,6 +423,16 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
 		}
 	}()
+	helps.ObserveClaudeCacheKeepalive(ctx, helps.ClaudeCacheKeepaliveObservation{
+		ConfirmedClaudeCode: confirmedClaudeCode,
+		AuthID:              authID,
+		AuthProvider:        e.Identifier(),
+		Model:               baseModel,
+		OriginalPayload:     originalPayload,
+		Headers:             incomingHeaders,
+		Metadata:            opts.Metadata,
+		StartedAt:           requestStartedAt,
+	})
 	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}
 	if replayScope.valid() {
 		result = wrapClaudeThinkingReplayStream(ctx, result, replayScope)

--- a/internal/runtime/executor/helps/claude_cache_keepalive.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive.go
@@ -33,6 +33,10 @@ type ClaudeCacheKeepaliveObservation struct {
 	Metadata map[string]any
 	// StartedAt is when the request began.
 	StartedAt time.Time
+	// CacheReadInputTokens is what this request read from the cache, the
+	// baseline a later probe is judged against. Zero means unknown, which is
+	// the normal case on the streaming path where usage is not yet available.
+	CacheReadInputTokens int64
 }
 
 // ObserveClaudeCacheKeepalive records a completed request with the keepalive
@@ -64,15 +68,16 @@ func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKee
 	}
 	provider, model := claudeCacheKeepaliveAffinityKey(observation)
 	scheduler.Observe(keepalive.ObserveInput{
-		SessionID:        sessionID,
-		BindingSessionID: claudeCacheKeepaliveMetadataString(observation.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey),
-		AuthID:           observation.AuthID,
-		Provider:         provider,
-		Model:            model,
-		Body:             observation.OriginalPayload,
-		Headers:          observation.Headers,
-		TTL:              ttl,
-		StartedAt:        observation.StartedAt,
+		SessionID:            sessionID,
+		BindingSessionID:     claudeCacheKeepaliveMetadataString(observation.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey),
+		AuthID:               observation.AuthID,
+		Provider:             provider,
+		Model:                model,
+		Body:                 observation.OriginalPayload,
+		Headers:              observation.Headers,
+		TTL:                  ttl,
+		StartedAt:            observation.StartedAt,
+		CacheReadInputTokens: observation.CacheReadInputTokens,
 	})
 }
 

--- a/internal/runtime/executor/helps/claude_cache_keepalive.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive.go
@@ -27,8 +27,9 @@ type ClaudeCacheKeepaliveObservation struct {
 	OriginalPayload []byte
 	// Headers are the inbound client headers, carrying the Anthropic-Beta list.
 	Headers http.Header
-	// Metadata is the shared execution metadata map, which carries the session
-	// affinity namespace the binding check must be keyed by.
+	// Metadata is the shared execution metadata map. Credential selection
+	// publishes the affinity namespace and the canonical session identity into
+	// it, and the binding check must be keyed by exactly those.
 	Metadata map[string]any
 	// StartedAt is when the request began.
 	StartedAt time.Time
@@ -58,14 +59,15 @@ func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKee
 	}
 	provider, model := claudeCacheKeepaliveAffinityKey(observation)
 	scheduler.Observe(keepalive.ObserveInput{
-		SessionID: sessionID,
-		AuthID:    observation.AuthID,
-		Provider:  provider,
-		Model:     model,
-		Body:      observation.OriginalPayload,
-		Headers:   observation.Headers,
-		TTL:       ttl,
-		StartedAt: observation.StartedAt,
+		SessionID:        sessionID,
+		BindingSessionID: claudeCacheKeepaliveMetadataString(observation.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey),
+		AuthID:           observation.AuthID,
+		Provider:         provider,
+		Model:            model,
+		Body:             observation.OriginalPayload,
+		Headers:          observation.Headers,
+		TTL:              ttl,
+		StartedAt:        observation.StartedAt,
 	})
 }
 

--- a/internal/runtime/executor/helps/claude_cache_keepalive.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive.go
@@ -42,9 +42,10 @@ type ClaudeCacheKeepaliveObservation struct {
 // ObserveClaudeCacheKeepalive records a completed request with the keepalive
 // scheduler when it qualifies.
 //
-// A request qualifies only when it came from a confirmed Claude Code client and
-// carried an explicit 1h cache_control TTL. A 5m request never schedules a probe:
-// on that pool the thirteen reads an hour cost more than the write they avoid.
+// A request qualifies when it came from a confirmed Claude Code client and
+// selected a cache pool at all. Which pools are actually probed is the
+// scheduler's decision, not this hook's: it holds the probe-5m policy and the
+// counters that make a skipped tier visible.
 func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKeepaliveObservation) {
 	scheduler := keepalive.Default()
 	if !scheduler.Enabled() {
@@ -58,8 +59,8 @@ func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKee
 	if keepalive.IsProbeExecution(observation.Metadata) {
 		return
 	}
-	ttl := keepalive.ExtendedCacheTTL(observation.OriginalPayload)
-	if !keepalive.IsExtendedCacheTTL(ttl) {
+	ttl := keepalive.RequestCacheTTL(observation.OriginalPayload)
+	if ttl <= 0 {
 		return
 	}
 	sessionID := ExtractClaudeCodeSessionID(ctx, observation.OriginalPayload, observation.Headers)

--- a/internal/runtime/executor/helps/claude_cache_keepalive.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive.go
@@ -1,0 +1,97 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// ClaudeCacheKeepaliveObservation describes one completed Claude request for the
+// prompt-cache keepalive scheduler.
+type ClaudeCacheKeepaliveObservation struct {
+	// ConfirmedClaudeCode reports whether the request passed native Claude Code
+	// detection. Only a confirmed client has the on-disk task state the liveness
+	// check reads, so nothing else is observed.
+	ConfirmedClaudeCode bool
+	// AuthID is the credential that served the request.
+	AuthID string
+	// AuthProvider is the credential's provider, normally "claude".
+	AuthProvider string
+	// Model is the model the request executed against.
+	Model string
+	// OriginalPayload is the inbound client body, before translation.
+	OriginalPayload []byte
+	// Headers are the inbound client headers, carrying the Anthropic-Beta list.
+	Headers http.Header
+	// Metadata is the shared execution metadata map, which carries the session
+	// affinity namespace the binding check must be keyed by.
+	Metadata map[string]any
+	// StartedAt is when the request began.
+	StartedAt time.Time
+}
+
+// ObserveClaudeCacheKeepalive records a completed request with the keepalive
+// scheduler when it qualifies.
+//
+// A request qualifies only when it came from a confirmed Claude Code client and
+// carried an explicit 1h cache_control TTL. A 5m request never schedules a probe:
+// on that pool the thirteen reads an hour cost more than the write they avoid.
+func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKeepaliveObservation) {
+	scheduler := keepalive.Default()
+	if !scheduler.Enabled() {
+		return
+	}
+	if !observation.ConfirmedClaudeCode || strings.TrimSpace(observation.AuthID) == "" || len(observation.OriginalPayload) == 0 {
+		return
+	}
+	ttl := keepalive.ExtendedCacheTTL(observation.OriginalPayload)
+	if !keepalive.IsExtendedCacheTTL(ttl) {
+		return
+	}
+	sessionID := ExtractClaudeCodeSessionID(ctx, observation.OriginalPayload, observation.Headers)
+	if sessionID == "" {
+		return
+	}
+	provider, model := claudeCacheKeepaliveAffinityKey(observation)
+	scheduler.Observe(keepalive.ObserveInput{
+		SessionID: sessionID,
+		AuthID:    observation.AuthID,
+		Provider:  provider,
+		Model:     model,
+		Body:      observation.OriginalPayload,
+		Headers:   observation.Headers,
+		TTL:       ttl,
+		StartedAt: observation.StartedAt,
+	})
+}
+
+// claudeCacheKeepaliveAffinityKey resolves the provider and model the session
+// affinity cache was keyed by, so the later binding check reads the same entry
+// selection wrote. Selection publishes both into the shared metadata map; the
+// credential's own provider and the executed model are the fallback.
+func claudeCacheKeepaliveAffinityKey(observation ClaudeCacheKeepaliveObservation) (string, string) {
+	provider := claudeCacheKeepaliveMetadataString(observation.Metadata, cliproxyexecutor.SessionAffinityProviderMetadataKey)
+	if provider == "" {
+		provider = strings.TrimSpace(observation.AuthProvider)
+	}
+	model := claudeCacheKeepaliveMetadataString(observation.Metadata, cliproxyexecutor.SessionAffinityModelMetadataKey)
+	if model == "" {
+		model = strings.TrimSpace(observation.Model)
+	}
+	return provider, model
+}
+
+func claudeCacheKeepaliveMetadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	value, ok := metadata[key].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/internal/runtime/executor/helps/claude_cache_keepalive.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive.go
@@ -49,6 +49,11 @@ func ObserveClaudeCacheKeepalive(ctx context.Context, observation ClaudeCacheKee
 	if !observation.ConfirmedClaudeCode || strings.TrimSpace(observation.AuthID) == "" || len(observation.OriginalPayload) == 0 {
 		return
 	}
+	// A probe travels this same path. Observing it would reset the session's
+	// consecutive-probe budget on every probe and defeat max-probes.
+	if keepalive.IsProbeExecution(observation.Metadata) {
+		return
+	}
 	ttl := keepalive.ExtendedCacheTTL(observation.OriginalPayload)
 	if !keepalive.IsExtendedCacheTTL(ttl) {
 		return

--- a/internal/runtime/executor/helps/claude_cache_keepalive_test.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive_test.go
@@ -121,3 +121,13 @@ func TestClaudeCacheKeepaliveAffinityKeyPrefersSelectionMetadata(t *testing.T) {
 		t.Fatalf("affinity key fallback = (%q, %q)", provider, model)
 	}
 }
+
+func TestObserveClaudeCacheKeepaliveIgnoresItsOwnProbe(t *testing.T) {
+	scheduled := installKeepaliveScheduler(t)
+	observation := baseObservation(keepaliveBody("1h"))
+	observation.Metadata = map[string]any{keepalive.ProbeMetadataKey: true}
+	ObserveClaudeCacheKeepalive(context.Background(), observation)
+	if len(*scheduled) != 0 {
+		t.Fatalf("scheduled %d probes for a probe execution, want 0: a probe must not reset its own budget", len(*scheduled))
+	}
+}

--- a/internal/runtime/executor/helps/claude_cache_keepalive_test.go
+++ b/internal/runtime/executor/helps/claude_cache_keepalive_test.go
@@ -1,0 +1,123 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type countingProber struct{ calls int }
+
+func (p *countingProber) Probe(context.Context, keepalive.ProbeRequest) (keepalive.ProbeResult, error) {
+	p.calls++
+	return keepalive.ProbeResult{}, nil
+}
+
+type stubTimer struct{}
+
+func (stubTimer) Stop() bool { return true }
+
+const keepaliveSession = "4463ede6-1111-2222-3333-444455556666"
+
+func keepaliveBody(ttl string) []byte {
+	return []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":100,` +
+		`"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral","ttl":"` + ttl + `"}}],` +
+		`"messages":[{"role":"user","content":"hi"}],` +
+		`"metadata":{"user_id":"{\"session_id\":\"` + keepaliveSession + `\"}"}}`)
+}
+
+// installKeepaliveScheduler installs a scheduler whose timers never fire, so the
+// test observes only whether a probe was scheduled.
+func installKeepaliveScheduler(t *testing.T) *[]time.Duration {
+	t.Helper()
+	scheduler := keepalive.New(keepalive.Config{
+		Enabled:              true,
+		BeforeExpiry:         5 * time.Minute,
+		OnlyWhenAgentsActive: true,
+		MaxProbes:            6,
+		MaxTokens:            1,
+	})
+	scheduler.SetProber(&countingProber{})
+	var scheduled []time.Duration
+	scheduler.SetTimerFactory(func(d time.Duration, _ func()) keepalive.Timer {
+		scheduled = append(scheduled, d)
+		return stubTimer{}
+	})
+	keepalive.SetDefault(scheduler)
+	t.Cleanup(func() { keepalive.SetDefault(nil) })
+	return &scheduled
+}
+
+func baseObservation(body []byte) ClaudeCacheKeepaliveObservation {
+	return ClaudeCacheKeepaliveObservation{
+		ConfirmedClaudeCode: true,
+		AuthID:              "auth-a",
+		AuthProvider:        "claude",
+		Model:               "claude-haiku-4-5-20251001",
+		OriginalPayload:     body,
+		Headers:             http.Header{"Anthropic-Beta": []string{"claude-code-20250219"}},
+		StartedAt:           time.Now(),
+	}
+}
+
+func TestObserveClaudeCacheKeepaliveSchedulesOneHourRequest(t *testing.T) {
+	scheduled := installKeepaliveScheduler(t)
+	ObserveClaudeCacheKeepalive(context.Background(), baseObservation(keepaliveBody("1h")))
+	if len(*scheduled) != 1 {
+		t.Fatalf("scheduled %d probes for a 1h request, want 1", len(*scheduled))
+	}
+}
+
+func TestObserveClaudeCacheKeepaliveIgnoresFiveMinuteRequest(t *testing.T) {
+	scheduled := installKeepaliveScheduler(t)
+	ObserveClaudeCacheKeepalive(context.Background(), baseObservation(keepaliveBody("5m")))
+	if len(*scheduled) != 0 {
+		t.Fatalf("scheduled %d probes for a 5m request, want 0", len(*scheduled))
+	}
+}
+
+func TestObserveClaudeCacheKeepaliveIgnoresUnconfirmedClient(t *testing.T) {
+	scheduled := installKeepaliveScheduler(t)
+	observation := baseObservation(keepaliveBody("1h"))
+	observation.ConfirmedClaudeCode = false
+	ObserveClaudeCacheKeepalive(context.Background(), observation)
+	if len(*scheduled) != 0 {
+		t.Fatalf("scheduled %d probes for an unconfirmed client, want 0", len(*scheduled))
+	}
+}
+
+func TestObserveClaudeCacheKeepaliveIgnoresRequestWithoutSession(t *testing.T) {
+	scheduled := installKeepaliveScheduler(t)
+	observation := baseObservation([]byte(`{"model":"m","messages":[],"system":[{"cache_control":{"ttl":"1h"}}]}`))
+	ObserveClaudeCacheKeepalive(context.Background(), observation)
+	if len(*scheduled) != 0 {
+		t.Fatalf("scheduled %d probes without a session id, want 0", len(*scheduled))
+	}
+}
+
+func TestObserveClaudeCacheKeepaliveNoSchedulerInstalled(t *testing.T) {
+	keepalive.SetDefault(nil)
+	ObserveClaudeCacheKeepalive(context.Background(), baseObservation(keepaliveBody("1h")))
+}
+
+func TestClaudeCacheKeepaliveAffinityKeyPrefersSelectionMetadata(t *testing.T) {
+	observation := baseObservation(keepaliveBody("1h"))
+	observation.Metadata = map[string]any{
+		cliproxyexecutor.SessionAffinityProviderMetadataKey: "mixed",
+		cliproxyexecutor.SessionAffinityModelMetadataKey:    "claude-sonnet-5",
+	}
+	provider, model := claudeCacheKeepaliveAffinityKey(observation)
+	if provider != "mixed" || model != "claude-sonnet-5" {
+		t.Fatalf("affinity key = (%q, %q), want the values selection published", provider, model)
+	}
+
+	observation.Metadata = nil
+	provider, model = claudeCacheKeepaliveAffinityKey(observation)
+	if provider != "claude" || model != "claude-haiku-4-5-20251001" {
+		t.Fatalf("affinity key fallback = (%q, %q)", provider, model)
+	}
+}

--- a/internal/runtime/keepalive/default.go
+++ b/internal/runtime/keepalive/default.go
@@ -1,0 +1,28 @@
+package keepalive
+
+import "sync"
+
+var (
+	defaultMu        sync.RWMutex
+	defaultScheduler *Scheduler
+)
+
+// Default returns the process-wide scheduler, or nil when the runtime has not
+// installed one. Every Scheduler method tolerates a nil receiver, so callers on
+// the request path can call Observe unconditionally.
+func Default() *Scheduler {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return defaultScheduler
+}
+
+// SetDefault installs the process-wide scheduler and stops the one it replaces.
+func SetDefault(scheduler *Scheduler) {
+	defaultMu.Lock()
+	previous := defaultScheduler
+	defaultScheduler = scheduler
+	defaultMu.Unlock()
+	if previous != nil && previous != scheduler {
+		previous.Stop()
+	}
+}

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -96,9 +96,12 @@ type ProbeResult struct {
 	// CacheCreationInputTokens is cache_creation_input_tokens from the probe
 	// response. A probe that writes rather than reads has already lost the race.
 	CacheCreationInputTokens int64
-	// Diagnosis carries the upstream cache-miss explanation when the account has
-	// the cache-diagnosis beta and the response supplied one.
+	// Diagnosis is diagnostics.cache_miss_reason.type from the response, when
+	// the account has the cache-diagnosis beta and the response supplied one.
 	Diagnosis string
+	// CacheMissedInputTokens is diagnostics.cache_miss_reason.cache_missed_input_tokens:
+	// how much of the prefix the upstream had to re-read.
+	CacheMissedInputTokens int64
 }
 
 // Prober sends a probe through the same execution path a real request uses.
@@ -200,6 +203,7 @@ type ProbeOutcome struct {
 	BaselineReadInputTokens int64  `json:"baseline_read_input_tokens,omitempty"`
 	Error                   string `json:"error,omitempty"`
 	Diagnosis               string `json:"diagnosis,omitempty"`
+	CacheMissedInputTokens  int64  `json:"cache_missed_input_tokens,omitempty"`
 }
 
 // Probe outcome statuses.
@@ -578,6 +582,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		CacheCreationInputTokens: result.CacheCreationInputTokens,
 		BaselineReadInputTokens:  baselineRead,
 		Diagnosis:                result.Diagnosis,
+		CacheMissedInputTokens:   result.CacheMissedInputTokens,
 	}
 	if probeMissed(result.CacheReadInputTokens, baselineRead) {
 		outcome.Status = ProbeStatusMiss
@@ -644,8 +649,8 @@ func (s *Scheduler) logProbe(sessionID, authID, model string, outcome ProbeOutco
 		elapsed.Round(time.Millisecond), total, consecutive, rescheduled, next,
 	}
 	if outcome.Status == ProbeStatusMiss {
-		fields += " cache_miss_reason=%q"
-		args = append(args, outcome.Diagnosis)
+		fields += " cache_miss_reason=%q cache_missed_input_tokens=%d"
+		args = append(args, outcome.Diagnosis, outcome.CacheMissedInputTokens)
 		log.Warnf("cache-keepalive: probe MISSED | "+fields, args...)
 		return
 	}

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -261,6 +261,19 @@ type Snapshot struct {
 	Counters             Counters          `json:"counters"`
 }
 
+// Cache TTL tiers. Every observed session belongs to exactly one of them, and
+// the tier decides the lead time, the probe budget, and whether the session is
+// eligible at all.
+const (
+	// TTLTier5m is the default ephemeral pool.
+	TTLTier5m = "5m"
+	// TTLTier1h is the extended pool a client opts into with ttl: "1h".
+	TTLTier1h = "1h"
+)
+
+// defaultCacheTTL is the pool a bare {"type":"ephemeral"} marker selects.
+const defaultCacheTTL = 5 * time.Minute
+
 // defaultAgentIdleWindow is the fallback when no idle window is configured.
 const defaultAgentIdleWindow = 10 * time.Minute
 
@@ -866,13 +879,14 @@ func removeThinkingDependentContextManagement(body []byte) ([]byte, error) {
 // or zero when the body carries no explicit TTL.
 //
 // A bare {"type":"ephemeral"} marker is the 5m wire default and returns zero:
-// only a TTL the client wrote out is treated as an opt-in to the long pool.
+// only a TTL the client wrote out is reported here. Use RequestCacheTTL to get
+// the pool the request actually selected.
 func ExtendedCacheTTL(body []byte) time.Duration {
 	if len(body) == 0 || !json.Valid(body) {
 		return 0
 	}
 	var longest time.Duration
-	walkCacheControlTTLs(gjson.ParseBytes(body), func(ttl time.Duration) {
+	walkCacheControl(gjson.ParseBytes(body), func(ttl time.Duration) {
 		if ttl > longest {
 			longest = ttl
 		}
@@ -880,22 +894,51 @@ func ExtendedCacheTTL(body []byte) time.Duration {
 	return longest
 }
 
-func walkCacheControlTTLs(value gjson.Result, visit func(time.Duration)) {
+// RequestCacheTTL returns the cache TTL the body actually selected, resolving
+// the wire default.
+//
+// A marker that spells out a ttl selects that pool. A bare
+// {"type":"ephemeral"} marker selects the 5m default, so any body carrying a
+// cache_control marker selects at least 5m. A body with no marker caches
+// nothing and returns zero.
+func RequestCacheTTL(body []byte) time.Duration {
+	if len(body) == 0 || !json.Valid(body) {
+		return 0
+	}
+	var longest time.Duration
+	var marked bool
+	walkCacheControl(gjson.ParseBytes(body), func(ttl time.Duration) {
+		marked = true
+		if ttl > longest {
+			longest = ttl
+		}
+	})
+	switch {
+	case longest > 0:
+		return longest
+	case marked:
+		return defaultCacheTTL
+	default:
+		return 0
+	}
+}
+
+// walkCacheControl visits every cache_control marker in the body, passing the
+// marker's explicit TTL or zero when it carries none.
+func walkCacheControl(value gjson.Result, visit func(time.Duration)) {
 	switch {
 	case value.IsObject():
 		value.ForEach(func(key, child gjson.Result) bool {
 			if key.String() == "cache_control" && child.IsObject() {
-				if ttl := parseCacheTTL(child.Get("ttl").String()); ttl > 0 {
-					visit(ttl)
-				}
+				visit(parseCacheTTL(child.Get("ttl").String()))
 				return true
 			}
-			walkCacheControlTTLs(child, visit)
+			walkCacheControl(child, visit)
 			return true
 		})
 	case value.IsArray():
 		value.ForEach(func(_, child gjson.Result) bool {
-			walkCacheControlTTLs(child, visit)
+			walkCacheControl(child, visit)
 			return true
 		})
 	}
@@ -920,9 +963,16 @@ func truncateSession(sessionID string) string {
 }
 
 // IsExtendedCacheTTL reports whether a TTL selects the long cache pool.
-//
-// Keepalive is only economical there. On the 5m pool a probe every window costs
-// thirteen reads an hour, which is more than the single write it avoids.
 func IsExtendedCacheTTL(ttl time.Duration) bool {
 	return ttl >= time.Hour
+}
+
+// TTLTier names the cache pool a TTL belongs to. It is what the logs and the
+// management snapshot report, and it selects the lead time and probe budget the
+// session is scheduled with.
+func TTLTier(ttl time.Duration) string {
+	if IsExtendedCacheTTL(ttl) {
+		return TTLTier1h
+	}
+	return TTLTier5m
 }

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -99,16 +99,25 @@ const (
 )
 
 // Binding reports the credential a session is currently bound to.
+//
+// bindingSessionID is the identity credential selection keyed the binding by,
+// which is not the bare Claude Code session id: selection canonicalizes it, for
+// example to "claude:<session>:agent:main".
 type Binding interface {
-	SessionBinding(provider, sessionID, model string) (authID string, state BindingState)
+	SessionBinding(provider, bindingSessionID, model string) (authID string, state BindingState)
 }
 
 // ObserveInput describes one completed real request.
 type ObserveInput struct {
+	// SessionID is the Claude Code session id. It keys the scheduler and the
+	// liveness check, which reads that session's on-disk task state.
 	SessionID string
-	AuthID    string
-	Provider  string
-	Model     string
+	// BindingSessionID is the identity credential selection keyed the session
+	// affinity binding by. Empty disables the binding check.
+	BindingSessionID string
+	AuthID           string
+	Provider         string
+	Model            string
 	// Body is the inbound client body, stored verbatim so the probe reproduces
 	// the same prefix the next real request will send.
 	Body []byte
@@ -121,15 +130,16 @@ type ObserveInput struct {
 }
 
 type sessionState struct {
-	generation uint64
-	authID     string
-	provider   string
-	model      string
-	body       []byte
-	headers    http.Header
-	ttl        time.Duration
-	probes     int
-	timer      Timer
+	generation       uint64
+	bindingSessionID string
+	authID           string
+	provider         string
+	model            string
+	body             []byte
+	headers          http.Header
+	ttl              time.Duration
+	probes           int
+	timer            Timer
 }
 
 // Scheduler keeps one pending keepalive probe per Claude Code session.
@@ -315,13 +325,14 @@ func (s *Scheduler) Observe(in ObserveInput) {
 		generation = previous.generation + 1
 	}
 	state := &sessionState{
-		generation: generation,
-		authID:     in.AuthID,
-		provider:   in.Provider,
-		model:      in.Model,
-		body:       body,
-		headers:    headers,
-		ttl:        in.TTL,
+		generation:       generation,
+		bindingSessionID: in.BindingSessionID,
+		authID:           in.AuthID,
+		provider:         in.Provider,
+		model:            in.Model,
+		body:             body,
+		headers:          headers,
+		ttl:              in.TTL,
 		// A real request resets the consecutive-probe budget.
 		probes: 0,
 	}
@@ -356,6 +367,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	binding := s.binding
 	prober := s.prober
 	authID := state.authID
+	bindingSessionID := state.bindingSessionID
 	provider := state.provider
 	model := state.model
 	ttl := state.ttl
@@ -370,8 +382,8 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 			return
 		}
 	}
-	if binding != nil {
-		boundAuthID, state := binding.SessionBinding(provider, sessionID, model)
+	if binding != nil && bindingSessionID != "" {
+		boundAuthID, state := binding.SessionBinding(provider, bindingSessionID, model)
 		if state == BindingLost || (state == BindingBound && boundAuthID != authID) {
 			s.drop(sessionID, generation)
 			log.Infof("cache-keepalive: skipped | session=%s reason=auth-binding-lost want_auth=%s bound_auth=%s",

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -87,6 +88,12 @@ type ProbeResult struct {
 	// CacheReadInputTokens is cache_read_input_tokens from the probe response.
 	// A value greater than zero means the probe hit the cached prefix.
 	CacheReadInputTokens int64
+	// CacheCreationInputTokens is cache_creation_input_tokens from the probe
+	// response. A probe that writes rather than reads has already lost the race.
+	CacheCreationInputTokens int64
+	// Diagnosis carries the upstream cache-miss explanation when the account has
+	// the cache-diagnosis beta and the response supplied one.
+	Diagnosis string
 }
 
 // Prober sends a probe through the same execution path a real request uses.
@@ -157,7 +164,85 @@ type sessionState struct {
 	ttl              time.Duration
 	probes           int
 	timer            Timer
+
+	// Observability. These outlive the probe body: a retired session keeps its
+	// history so the management endpoint can explain what happened, but drops
+	// the body and headers immediately.
+	lastRequestAt time.Time
+	nextProbeAt   time.Time
+	probesSent    int
+	lastProbe     *ProbeOutcome
+	retired       bool
+	retiredAt     time.Time
 }
+
+// ProbeOutcome records what happened on one probe attempt.
+type ProbeOutcome struct {
+	At                       time.Time `json:"at"`
+	Status                   string    `json:"status"`
+	CacheReadInputTokens     int64     `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64     `json:"cache_creation_input_tokens"`
+	SkippedReason            string    `json:"skipped_reason,omitempty"`
+	Error                    string    `json:"error,omitempty"`
+	Diagnosis                string    `json:"diagnosis,omitempty"`
+}
+
+// Probe outcome statuses.
+const (
+	// ProbeStatusHit means the probe read the cached prefix, which is the
+	// working state.
+	ProbeStatusHit = "hit"
+	// ProbeStatusMiss means the probe itself found no cached prefix. The entry it
+	// was meant to refresh was already gone, so keepalive is not working for that
+	// session.
+	ProbeStatusMiss = "miss"
+	// ProbeStatusError means the probe request failed.
+	ProbeStatusError = "error"
+	// ProbeStatusSkipped means the probe was deliberately not sent.
+	ProbeStatusSkipped = "skipped"
+)
+
+// SessionSnapshot is the read-only view of one tracked session.
+type SessionSnapshot struct {
+	SessionID         string        `json:"session_id"`
+	AuthID            string        `json:"auth_id"`
+	Provider          string        `json:"provider"`
+	Model             string        `json:"model"`
+	TTL               string        `json:"ttl"`
+	TTLSeconds        float64       `json:"ttl_seconds"`
+	LastRequestAt     *time.Time    `json:"last_request_at"`
+	NextProbeAt       *time.Time    `json:"next_probe_at"`
+	ProbesSent        int           `json:"probes_sent"`
+	ConsecutiveProbes int           `json:"consecutive_probes"`
+	Active            bool          `json:"active"`
+	RetiredAt         *time.Time    `json:"retired_at,omitempty"`
+	LastProbe         *ProbeOutcome `json:"last_probe"`
+}
+
+// Counters are the process-wide keepalive totals.
+type Counters struct {
+	Scheduled       uint64            `json:"scheduled"`
+	Fired           uint64            `json:"fired"`
+	Hits            uint64            `json:"hits"`
+	Misses          uint64            `json:"misses"`
+	Errors          uint64            `json:"errors"`
+	SkippedByReason map[string]uint64 `json:"skipped_by_reason"`
+}
+
+// Snapshot is the read-only view of the whole scheduler.
+type Snapshot struct {
+	Enabled              bool              `json:"enabled"`
+	BeforeExpiry         string            `json:"before_expiry"`
+	OnlyWhenAgentsActive bool              `json:"only_when_agents_active"`
+	MaxProbes            int               `json:"max_probes"`
+	MaxTokens            int               `json:"max_tokens"`
+	Sessions             []SessionSnapshot `json:"sessions"`
+	Counters             Counters          `json:"counters"`
+}
+
+// maxRetiredSessions bounds the retired-session history the snapshot exposes.
+// Retired records hold no request body, only counters and the last outcome.
+const maxRetiredSessions = 64
 
 // Scheduler keeps one pending keepalive probe per Claude Code session.
 //
@@ -176,6 +261,8 @@ type Scheduler struct {
 
 	newTimer func(time.Duration, func()) Timer
 	now      func() time.Time
+
+	counters Counters
 }
 
 // New creates a scheduler with the given configuration.
@@ -183,6 +270,7 @@ func New(cfg Config) *Scheduler {
 	return &Scheduler{
 		cfg:      cfg,
 		sessions: make(map[string]*sessionState),
+		counters: Counters{SkippedByReason: make(map[string]uint64)},
 		newTimer: func(d time.Duration, f func()) Timer { return time.AfterFunc(d, f) },
 		now:      time.Now,
 	}
@@ -353,14 +441,28 @@ func (s *Scheduler) Observe(in ObserveInput) {
 		// A real request resets the consecutive-probe budget.
 		probes: 0,
 	}
+	now := s.now()
+	state.lastRequestAt = in.StartedAt
+	if state.lastRequestAt.IsZero() {
+		state.lastRequestAt = now
+	}
+	state.nextProbeAt = now.Add(delay)
+	// A session that had already probed keeps its lifetime probe count; only the
+	// consecutive budget resets on a real request.
+	if previous != nil {
+		state.probesSent = previous.probesSent
+		state.lastProbe = previous.lastProbe
+	}
 	s.sessions[in.SessionID] = state
+	s.pruneRetiredLocked()
+	s.counters.Scheduled++
 	sessionID := in.SessionID
 	state.timer = s.newTimer(delay, func() { s.fire(sessionID, generation) })
 	s.mu.Unlock()
 
 	stopTimer(previous)
-	log.Infof("cache-keepalive: scheduled | session=%s auth=%s model=%s ttl=%s fires_in=%s",
-		truncateSession(sessionID), in.AuthID, in.Model, in.TTL, delay.Round(time.Second))
+	log.Infof("cache-keepalive: scheduled | session=%s auth=%s model=%s ttl=%s fires_in=%s next_probe_at=%s",
+		truncateSession(sessionID), in.AuthID, in.Model, in.TTL, delay.Round(time.Second), state.nextProbeAt.Format(time.RFC3339))
 }
 
 func (s *Scheduler) fire(sessionID string, generation uint64) {
@@ -375,9 +477,9 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		return
 	}
 	if state.probes >= cfg.MaxProbes {
-		delete(s.sessions, sessionID)
 		s.mu.Unlock()
-		log.Infof("cache-keepalive: skipped | session=%s reason=max-probes probes=%d", truncateSession(sessionID), state.probes)
+		s.retire(sessionID, generation, "max-probes")
+		log.Infof("cache-keepalive: skipped | session=%s reason=max-probes consecutive_probes=%d", truncateSession(sessionID), state.probes)
 		return
 	}
 	liveness := s.liveness
@@ -394,29 +496,29 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 
 	if cfg.OnlyWhenAgentsActive {
 		if liveness == nil || !liveness.Live(sessionID, ttl) {
-			s.drop(sessionID, generation)
-			log.Infof("cache-keepalive: skipped | session=%s reason=no-live-agents", truncateSession(sessionID))
+			s.retire(sessionID, generation, "no-live-agents")
+			log.Infof("cache-keepalive: skipped | session=%s auth=%s model=%s reason=no-live-agents", truncateSession(sessionID), authID, model)
 			return
 		}
 	}
 	if binding != nil && bindingSessionID != "" {
 		boundAuthID, state := binding.SessionBinding(provider, bindingSessionID, model)
 		if state == BindingLost || (state == BindingBound && boundAuthID != authID) {
-			s.drop(sessionID, generation)
-			log.Infof("cache-keepalive: skipped | session=%s reason=auth-binding-lost want_auth=%s bound_auth=%s",
-				truncateSession(sessionID), authID, boundAuthID)
+			s.retire(sessionID, generation, "auth-binding-lost")
+			log.Infof("cache-keepalive: skipped | session=%s auth=%s model=%s reason=auth-binding-lost want_auth=%s bound_auth=%s",
+				truncateSession(sessionID), authID, model, authID, boundAuthID)
 			return
 		}
 	}
 	if prober == nil {
-		s.drop(sessionID, generation)
+		s.retire(sessionID, generation, "no-prober")
 		log.Warnf("cache-keepalive: skipped | session=%s reason=no-prober", truncateSession(sessionID))
 		return
 	}
 
 	probeBody, errBody := ProbeBody(body, cfg.MaxTokens)
 	if errBody != nil {
-		s.drop(sessionID, generation)
+		s.retire(sessionID, generation, "probe-body-build-failed")
 		log.Warnf("cache-keepalive: skipped | session=%s reason=probe-body-build-failed error=%v", truncateSession(sessionID), errBody)
 		return
 	}
@@ -430,49 +532,227 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		Body:      probeBody,
 		Headers:   headers.Clone(),
 	})
+	elapsed := s.now().Sub(probeStart)
 	if errProbe != nil {
-		s.drop(sessionID, generation)
-		log.Warnf("cache-keepalive: probe failed | session=%s auth=%s model=%s error=%v",
-			truncateSession(sessionID), authID, model, errProbe)
+		s.recordProbe(sessionID, generation, ProbeOutcome{
+			At:     probeStart,
+			Status: ProbeStatusError,
+			Error:  errProbe.Error(),
+		})
+		s.retire(sessionID, generation, "probe-error")
+		log.Warnf("cache-keepalive: probe | session=%s auth=%s model=%s status=error duration=%s error=%v",
+			truncateSession(sessionID), authID, model, elapsed.Round(time.Millisecond), errProbe)
 		return
 	}
 
+	outcome := ProbeOutcome{
+		At:                       probeStart,
+		Status:                   ProbeStatusHit,
+		CacheReadInputTokens:     result.CacheReadInputTokens,
+		CacheCreationInputTokens: result.CacheCreationInputTokens,
+		Diagnosis:                result.Diagnosis,
+	}
+	if result.CacheReadInputTokens <= 0 {
+		outcome.Status = ProbeStatusMiss
+	}
+	s.recordProbe(sessionID, generation, outcome)
+
 	// Reschedule from the probe's own start time so the next window is measured
 	// against the entry the probe just refreshed.
-	next := ttl - cfg.BeforeExpiry - s.now().Sub(probeStart)
+	next := ttl - cfg.BeforeExpiry - elapsed
 	s.mu.Lock()
 	current := s.sessions[sessionID]
 	if s.stopped || !s.cfg.Enabled || current == nil || current.generation != generation {
 		s.mu.Unlock()
-		log.Infof("cache-keepalive: fired | session=%s auth=%s model=%s cache_read_input_tokens=%d rescheduled=false",
-			truncateSession(sessionID), authID, model, result.CacheReadInputTokens)
+		s.logProbe(sessionID, authID, model, outcome, elapsed, 0, 0, false, time.Time{})
 		return
 	}
 	current.probes++
-	probes := current.probes
+	current.probesSent++
+	consecutive := current.probes
+	total := current.probesSent
 	rescheduled := false
-	if probes < s.cfg.MaxProbes && next > 0 {
+	var nextProbeAt time.Time
+	if consecutive < s.cfg.MaxProbes && next > 0 {
 		current.timer = s.newTimer(next, func() { s.fire(sessionID, generation) })
+		nextProbeAt = s.now().Add(next)
+		current.nextProbeAt = nextProbeAt
 		rescheduled = true
 	} else {
-		delete(s.sessions, sessionID)
+		s.retireLocked(current, sessionID, "max-probes")
 	}
 	s.mu.Unlock()
 
-	log.Infof("cache-keepalive: fired | session=%s auth=%s model=%s cache_read_input_tokens=%d probes=%d rescheduled=%t",
-		truncateSession(sessionID), authID, model, result.CacheReadInputTokens, probes, rescheduled)
+	s.logProbe(sessionID, authID, model, outcome, elapsed, total, consecutive, rescheduled, nextProbeAt)
 }
 
-func (s *Scheduler) drop(sessionID string, generation uint64) {
+// logProbe emits the single line that tells the whole story of one probe, so
+// `grep cache-keepalive` needs no other source.
+//
+// A probe that found nothing cached is the malfunction signal: the entry it was
+// meant to refresh had already expired, so it is logged at warning level.
+func (s *Scheduler) logProbe(sessionID, authID, model string, outcome ProbeOutcome, elapsed time.Duration, total, consecutive int, rescheduled bool, nextProbeAt time.Time) {
+	next := "none"
+	if !nextProbeAt.IsZero() {
+		next = nextProbeAt.Format(time.RFC3339)
+	}
+	fields := "session=%s auth=%s model=%s status=%s cache_read_input_tokens=%d cache_creation_input_tokens=%d duration=%s probes_sent=%d consecutive_probes=%d rescheduled=%t next_probe_at=%s"
+	args := []any{
+		truncateSession(sessionID), authID, model, outcome.Status,
+		outcome.CacheReadInputTokens, outcome.CacheCreationInputTokens,
+		elapsed.Round(time.Millisecond), total, consecutive, rescheduled, next,
+	}
+	if outcome.Status == ProbeStatusMiss {
+		fields += " diagnosis=%q"
+		args = append(args, outcome.Diagnosis)
+		log.Warnf("cache-keepalive: probe missed, the cached prefix was already gone | "+fields, args...)
+		return
+	}
+	log.Infof("cache-keepalive: probe | "+fields, args...)
+}
+
+// recordProbe stores the outcome against the session and updates the counters.
+func (s *Scheduler) recordProbe(sessionID string, generation uint64, outcome ProbeOutcome) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.counters.Fired++
+	switch outcome.Status {
+	case ProbeStatusHit:
+		s.counters.Hits++
+	case ProbeStatusMiss:
+		s.counters.Misses++
+	case ProbeStatusError:
+		s.counters.Errors++
+	}
+	if state := s.sessions[sessionID]; state != nil && state.generation == generation {
+		stored := outcome
+		state.lastProbe = &stored
+	}
+}
+
+// retire ends a session's scheduling and keeps its history for the snapshot.
+func (s *Scheduler) retire(sessionID string, generation uint64, reason string) {
 	s.mu.Lock()
 	state := s.sessions[sessionID]
-	if state != nil && state.generation == generation {
-		delete(s.sessions, sessionID)
-	} else {
-		state = nil
+	if state == nil || state.generation != generation {
+		s.mu.Unlock()
+		return
 	}
+	s.retireLocked(state, sessionID, reason)
 	s.mu.Unlock()
 	stopTimer(state)
+}
+
+// retireLocked drops the stored body and marks the session inactive. The record
+// stays visible to the snapshot so an operator can see why probing stopped, but
+// it never keeps the request body: those live in memory only, for as long as a
+// probe might still need them.
+func (s *Scheduler) retireLocked(state *sessionState, sessionID, reason string) {
+	if state == nil || state.retired {
+		return
+	}
+	state.retired = true
+	state.retiredAt = s.now()
+	state.body = nil
+	state.headers = nil
+	state.timer = nil
+	state.nextProbeAt = time.Time{}
+	if reason != "" {
+		if s.counters.SkippedByReason == nil {
+			s.counters.SkippedByReason = make(map[string]uint64)
+		}
+		s.counters.SkippedByReason[reason]++
+		if state.lastProbe == nil || state.lastProbe.SkippedReason != reason {
+			state.lastProbe = &ProbeOutcome{At: state.retiredAt, Status: ProbeStatusSkipped, SkippedReason: reason}
+		}
+	}
+	s.pruneRetiredLocked()
+	_ = sessionID
+}
+
+// pruneRetiredLocked bounds the retired history to the newest maxRetiredSessions.
+func (s *Scheduler) pruneRetiredLocked() {
+	retired := make([]string, 0, len(s.sessions))
+	for key, state := range s.sessions {
+		if state.retired {
+			retired = append(retired, key)
+		}
+	}
+	if len(retired) <= maxRetiredSessions {
+		return
+	}
+	sort.Slice(retired, func(i, j int) bool {
+		return s.sessions[retired[i]].retiredAt.Before(s.sessions[retired[j]].retiredAt)
+	})
+	for _, key := range retired[:len(retired)-maxRetiredSessions] {
+		delete(s.sessions, key)
+	}
+}
+
+// Snapshot returns the read-only view the management endpoint serves.
+func (s *Scheduler) Snapshot() Snapshot {
+	if s == nil {
+		return Snapshot{Sessions: []SessionSnapshot{}, Counters: Counters{SkippedByReason: map[string]uint64{}}}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := Snapshot{
+		Enabled:              s.cfg.Enabled && !s.stopped,
+		BeforeExpiry:         s.cfg.BeforeExpiry.String(),
+		OnlyWhenAgentsActive: s.cfg.OnlyWhenAgentsActive,
+		MaxProbes:            s.cfg.MaxProbes,
+		MaxTokens:            s.cfg.MaxTokens,
+		Sessions:             make([]SessionSnapshot, 0, len(s.sessions)),
+		Counters: Counters{
+			Scheduled:       s.counters.Scheduled,
+			Fired:           s.counters.Fired,
+			Hits:            s.counters.Hits,
+			Misses:          s.counters.Misses,
+			Errors:          s.counters.Errors,
+			SkippedByReason: make(map[string]uint64, len(s.counters.SkippedByReason)),
+		},
+	}
+	for reason, count := range s.counters.SkippedByReason {
+		out.Counters.SkippedByReason[reason] = count
+	}
+	for sessionID, state := range s.sessions {
+		out.Sessions = append(out.Sessions, sessionSnapshot(sessionID, state))
+	}
+	sort.Slice(out.Sessions, func(i, j int) bool {
+		return out.Sessions[i].SessionID < out.Sessions[j].SessionID
+	})
+	return out
+}
+
+func sessionSnapshot(sessionID string, state *sessionState) SessionSnapshot {
+	snapshot := SessionSnapshot{
+		SessionID:         sessionID,
+		AuthID:            state.authID,
+		Provider:          state.provider,
+		Model:             state.model,
+		TTL:               state.ttl.String(),
+		TTLSeconds:        state.ttl.Seconds(),
+		ProbesSent:        state.probesSent,
+		ConsecutiveProbes: state.probes,
+		Active:            !state.retired,
+	}
+	if !state.lastRequestAt.IsZero() {
+		at := state.lastRequestAt
+		snapshot.LastRequestAt = &at
+	}
+	if !state.nextProbeAt.IsZero() {
+		at := state.nextProbeAt
+		snapshot.NextProbeAt = &at
+	}
+	if !state.retiredAt.IsZero() {
+		at := state.retiredAt
+		snapshot.RetiredAt = &at
+	}
+	if state.lastProbe != nil {
+		probe := *state.lastProbe
+		snapshot.LastProbe = &probe
+	}
+	return snapshot
 }
 
 // ProbeBody derives the minimal refresh request from an observed client body.

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -57,18 +57,46 @@ type Timer interface {
 type Config struct {
 	// Enabled turns scheduling on. A disabled scheduler ignores every observation.
 	Enabled bool
-	// BeforeExpiry fires a probe at t_start + ttl - BeforeExpiry.
+	// BeforeExpiry fires a probe at t_start + ttl - BeforeExpiry on the 1h pool.
 	BeforeExpiry time.Duration
+	// BeforeExpiry5m is the same lead time for the 5m pool. Zero falls back to
+	// BeforeExpiry, which on a 5m TTL leaves no window and drops the session.
+	BeforeExpiry5m time.Duration
+	// Probe5m selects when a 5m session is probed: Probe5mAuto, Probe5mAlways
+	// or Probe5mNever. An empty value is treated as auto.
+	Probe5m string
+	// Probe5mModels overrides the built-in cheap-cache-read list Probe5mAuto
+	// matches the request model against. Empty means CheapCacheReadModels.
+	Probe5mModels []string
 	// OnlyWhenAgentsActive gates every probe on the liveness check.
 	OnlyWhenAgentsActive bool
 	// AgentIdleWindow is how long an agent may be silent and still count as
 	// running. It is deliberately not the cache TTL: an agent that has written
 	// nothing for an hour is finished, not busy.
 	AgentIdleWindow time.Duration
-	// MaxProbes caps consecutive probes without an intervening real request.
+	// MaxProbes caps consecutive probes without an intervening real request on
+	// the 1h pool.
 	MaxProbes int
+	// MaxProbes5m is the same cap for the 5m pool. Zero falls back to MaxProbes.
+	MaxProbes5m int
 	// MaxTokens is the max_tokens value the probe body carries.
 	MaxTokens int
+}
+
+// beforeExpiryFor is the lead time the tier is scheduled with.
+func (c Config) beforeExpiryFor(tier string) time.Duration {
+	if tier == TTLTier5m && c.BeforeExpiry5m > 0 {
+		return c.BeforeExpiry5m
+	}
+	return c.BeforeExpiry
+}
+
+// maxProbesFor is the consecutive-probe budget the tier is allowed.
+func (c Config) maxProbesFor(tier string) int {
+	if tier == TTLTier5m && c.MaxProbes5m > 0 {
+		return c.MaxProbes5m
+	}
+	return c.MaxProbes
 }
 
 // ProbeRequest describes one keepalive probe to send upstream.
@@ -175,6 +203,8 @@ type sessionState struct {
 	body             []byte
 	headers          http.Header
 	ttl              time.Duration
+	tier             string
+	probe5m          string
 	probes           int
 	timer            Timer
 
@@ -229,6 +259,8 @@ type SessionSnapshot struct {
 	Model             string        `json:"model"`
 	TTL               string        `json:"ttl"`
 	TTLSeconds        float64       `json:"ttl_seconds"`
+	TTLTier           string        `json:"ttl_tier"`
+	Probe5mDecision   string        `json:"probe_5m_decision"`
 	LastRequestAt     *time.Time    `json:"last_request_at"`
 	NextProbeAt       *time.Time    `json:"next_probe_at"`
 	ProbesSent        int           `json:"probes_sent"`
@@ -253,9 +285,13 @@ type Counters struct {
 type Snapshot struct {
 	Enabled              bool              `json:"enabled"`
 	BeforeExpiry         string            `json:"before_expiry"`
+	BeforeExpiry5m       string            `json:"before_expiry_5m"`
+	Probe5m              string            `json:"probe_5m"`
+	Probe5mModels        []string          `json:"probe_5m_models"`
 	OnlyWhenAgentsActive bool              `json:"only_when_agents_active"`
 	AgentIdleWindow      string            `json:"agent_idle_window"`
 	MaxProbes            int               `json:"max_probes"`
+	MaxProbes5m          int               `json:"max_probes_5m"`
 	MaxTokens            int               `json:"max_tokens"`
 	Sessions             []SessionSnapshot `json:"sessions"`
 	Counters             Counters          `json:"counters"`
@@ -416,9 +452,11 @@ func stopTimer(state *sessionState) {
 
 // Observe records a completed real request and reschedules that session's probe.
 //
-// Callers must only pass requests that carried an explicit 1h cache_control TTL.
-// Scheduling a probe for the 5m pool loses money: thirteen reads an hour cost
-// more than the single write they avoid.
+// Callers pass any request that selected a cache pool at all; the tier policy
+// lives here so the log line and the counters see every decision. A session on
+// the 5m pool is scheduled only when Probe5m allows it: probing there is worth
+// it exactly when the model's cache reads are cheap relative to the write they
+// avoid, which is what CheapCacheReadModels records.
 func (s *Scheduler) Observe(in ObserveInput) {
 	if s == nil {
 		return
@@ -433,10 +471,23 @@ func (s *Scheduler) Observe(in ObserveInput) {
 	if in.SessionID == "" || in.AuthID == "" || in.TTL <= 0 || len(in.Body) == 0 {
 		return
 	}
-	delay := in.TTL - cfg.BeforeExpiry
+	tier := TTLTier(in.TTL)
+	decision := Probe5mDecisionNotApplicable
+	if tier == TTLTier5m {
+		var allowed bool
+		allowed, decision = probe5mDecision(cfg.Probe5m, cfg.Probe5mModels, in.Model)
+		if !allowed {
+			s.countSkip(decision)
+			log.Debugf("cache-keepalive: skipped scheduling | session=%s ttl_tier=5m model=%s reason=%s",
+				truncateSession(in.SessionID), in.Model, decision)
+			return
+		}
+	}
+	beforeExpiry := cfg.beforeExpiryFor(tier)
+	delay := in.TTL - beforeExpiry
 	if delay <= 0 {
-		log.Debugf("cache-keepalive: skipped scheduling | session=%s reason=before-expiry-exceeds-ttl ttl=%s before-expiry=%s",
-			truncateSession(in.SessionID), in.TTL, cfg.BeforeExpiry)
+		log.Debugf("cache-keepalive: skipped scheduling | session=%s ttl_tier=%s reason=before-expiry-exceeds-ttl ttl=%s before-expiry=%s",
+			truncateSession(in.SessionID), tier, in.TTL, beforeExpiry)
 		return
 	}
 	if !in.StartedAt.IsZero() {
@@ -475,6 +526,8 @@ func (s *Scheduler) Observe(in ObserveInput) {
 		body:             body,
 		headers:          headers,
 		ttl:              in.TTL,
+		tier:             tier,
+		probe5m:          decision,
 		// A real request resets the consecutive-probe budget.
 		probes: 0,
 	}
@@ -499,8 +552,22 @@ func (s *Scheduler) Observe(in ObserveInput) {
 	s.mu.Unlock()
 
 	stopTimer(previous)
-	log.Infof("cache-keepalive: scheduled | session=%s auth=%s model=%s ttl=%s fires_in=%s next_probe_at=%s",
-		truncateSession(sessionID), in.AuthID, in.Model, in.TTL, delay.Round(time.Second), state.nextProbeAt.Format(time.RFC3339))
+	log.Infof("cache-keepalive: scheduled | session=%s auth=%s model=%s ttl=%s ttl_tier=%s probe_5m=%s fires_in=%s next_probe_at=%s",
+		truncateSession(sessionID), in.AuthID, in.Model, in.TTL, tier, decision, delay.Round(time.Second), state.nextProbeAt.Format(time.RFC3339))
+}
+
+// countSkip records a decision that stopped a session before it was tracked, so
+// a policy that silently drops every 5m session is still visible in the counters.
+func (s *Scheduler) countSkip(reason string) {
+	if reason == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.counters.SkippedByReason == nil {
+		s.counters.SkippedByReason = make(map[string]uint64)
+	}
+	s.counters.SkippedByReason[reason]++
 }
 
 func (s *Scheduler) fire(sessionID string, generation uint64) {
@@ -514,10 +581,14 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		}
 		return
 	}
-	if state.probes >= cfg.MaxProbes {
+	tier := state.tier
+	if tier == "" {
+		tier = TTLTier(state.ttl)
+	}
+	if state.probes >= cfg.maxProbesFor(tier) {
 		s.mu.Unlock()
 		s.retire(sessionID, generation, "max-probes")
-		log.Infof("cache-keepalive: skipped | session=%s reason=max-probes consecutive_probes=%d", truncateSession(sessionID), state.probes)
+		log.Infof("cache-keepalive: skipped | session=%s ttl_tier=%s reason=max-probes consecutive_probes=%d", truncateSession(sessionID), tier, state.probes)
 		return
 	}
 	liveness := s.liveness
@@ -528,6 +599,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	provider := state.provider
 	model := state.model
 	ttl := state.ttl
+	probe5m := state.probe5m
 	baselineRead := state.baselineRead
 	body := state.body
 	headers := state.headers
@@ -540,7 +612,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		}
 		if liveness == nil || !liveness.Live(sessionID, idleWindow) {
 			s.retire(sessionID, generation, "no-live-agents")
-			log.Infof("cache-keepalive: skipped | session=%s auth=%s model=%s reason=no-live-agents", truncateSession(sessionID), authID, model)
+			log.Infof("cache-keepalive: skipped | session=%s auth=%s model=%s ttl_tier=%s reason=no-live-agents", truncateSession(sessionID), authID, model, tier)
 			return
 		}
 	}
@@ -604,12 +676,12 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 
 	// Reschedule from the probe's own start time so the next window is measured
 	// against the entry the probe just refreshed.
-	next := ttl - cfg.BeforeExpiry - elapsed
+	next := ttl - cfg.beforeExpiryFor(tier) - elapsed
 	s.mu.Lock()
 	current := s.sessions[sessionID]
 	if s.stopped || !s.cfg.Enabled || current == nil || current.generation != generation {
 		s.mu.Unlock()
-		s.logProbe(sessionID, authID, model, outcome, elapsed, 0, 0, false, time.Time{})
+		s.logProbe(sessionID, authID, model, tier, probe5m, outcome, elapsed, 0, 0, false, time.Time{})
 		return
 	}
 	current.probes++
@@ -618,7 +690,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	total := current.probesSent
 	rescheduled := false
 	var nextProbeAt time.Time
-	if consecutive < s.cfg.MaxProbes && next > 0 {
+	if consecutive < s.cfg.maxProbesFor(tier) && next > 0 {
 		current.timer = s.newTimer(next, func() { s.fire(sessionID, generation) })
 		nextProbeAt = s.now().Add(next)
 		current.nextProbeAt = nextProbeAt
@@ -628,7 +700,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	}
 	s.mu.Unlock()
 
-	s.logProbe(sessionID, authID, model, outcome, elapsed, total, consecutive, rescheduled, nextProbeAt)
+	s.logProbe(sessionID, authID, model, tier, probe5m, outcome, elapsed, total, consecutive, rescheduled, nextProbeAt)
 }
 
 // probeMissed reports whether a probe failed to refresh the entry it was sent for.
@@ -650,14 +722,14 @@ func probeMissed(read, baseline int64) bool {
 //
 // A probe that found nothing cached is the malfunction signal: the entry it was
 // meant to refresh had already expired, so it is logged at warning level.
-func (s *Scheduler) logProbe(sessionID, authID, model string, outcome ProbeOutcome, elapsed time.Duration, total, consecutive int, rescheduled bool, nextProbeAt time.Time) {
+func (s *Scheduler) logProbe(sessionID, authID, model, tier, probe5m string, outcome ProbeOutcome, elapsed time.Duration, total, consecutive int, rescheduled bool, nextProbeAt time.Time) {
 	next := "none"
 	if !nextProbeAt.IsZero() {
 		next = nextProbeAt.Format(time.RFC3339)
 	}
-	fields := "session=%s auth=%s model=%s status=%s cache_read_input_tokens=%d cache_creation_input_tokens=%d baseline_read_input_tokens=%d duration=%s probes_sent=%d consecutive_probes=%d rescheduled=%t next_probe_at=%s"
+	fields := "session=%s auth=%s model=%s ttl_tier=%s probe_5m=%s status=%s cache_read_input_tokens=%d cache_creation_input_tokens=%d baseline_read_input_tokens=%d duration=%s probes_sent=%d consecutive_probes=%d rescheduled=%t next_probe_at=%s"
 	args := []any{
-		truncateSession(sessionID), authID, model, outcome.Status,
+		truncateSession(sessionID), authID, model, tier, probe5m, outcome.Status,
 		outcome.CacheReadInputTokens, outcome.CacheCreationInputTokens, outcome.BaselineReadInputTokens,
 		elapsed.Round(time.Millisecond), total, consecutive, rescheduled, next,
 	}
@@ -762,9 +834,13 @@ func (s *Scheduler) Snapshot() Snapshot {
 	out := Snapshot{
 		Enabled:              s.cfg.Enabled && !s.stopped,
 		BeforeExpiry:         s.cfg.BeforeExpiry.String(),
+		BeforeExpiry5m:       s.cfg.BeforeExpiry5m.String(),
+		Probe5m:              s.cfg.Probe5m,
+		Probe5mModels:        probe5mModels(s.cfg.Probe5mModels),
 		OnlyWhenAgentsActive: s.cfg.OnlyWhenAgentsActive,
 		AgentIdleWindow:      s.cfg.AgentIdleWindow.String(),
 		MaxProbes:            s.cfg.MaxProbes,
+		MaxProbes5m:          s.cfg.MaxProbes5m,
 		MaxTokens:            s.cfg.MaxTokens,
 		Sessions:             make([]SessionSnapshot, 0, len(s.sessions)),
 		Counters: Counters{
@@ -788,7 +864,23 @@ func (s *Scheduler) Snapshot() Snapshot {
 	return out
 }
 
+// probe5mModels reports the list "auto" is matching against, so the endpoint
+// answers "which models does this build consider cheap" without a rebuild.
+func probe5mModels(configured []string) []string {
+	source := configured
+	if len(source) == 0 {
+		source = CheapCacheReadModels
+	}
+	out := make([]string, len(source))
+	copy(out, source)
+	return out
+}
+
 func sessionSnapshot(sessionID string, state *sessionState) SessionSnapshot {
+	tier := state.tier
+	if tier == "" {
+		tier = TTLTier(state.ttl)
+	}
 	snapshot := SessionSnapshot{
 		SessionID:         sessionID,
 		AuthID:            state.authID,
@@ -796,6 +888,8 @@ func sessionSnapshot(sessionID string, state *sessionState) SessionSnapshot {
 		Model:             state.model,
 		TTL:               state.ttl.String(),
 		TTLSeconds:        state.ttl.Seconds(),
+		TTLTier:           tier,
+		Probe5mDecision:   state.probe5m,
 		ProbesSent:        state.probesSent,
 		ConsecutiveProbes: state.probes,
 		Active:            !state.retired,

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -174,6 +174,7 @@ type sessionState struct {
 	lastProbe     *ProbeOutcome
 	retired       bool
 	retiredAt     time.Time
+	retiredReason string
 }
 
 // ProbeOutcome records what happened on one probe attempt.
@@ -216,6 +217,7 @@ type SessionSnapshot struct {
 	ConsecutiveProbes int           `json:"consecutive_probes"`
 	Active            bool          `json:"active"`
 	RetiredAt         *time.Time    `json:"retired_at,omitempty"`
+	RetiredReason     string        `json:"retired_reason,omitempty"`
 	LastProbe         *ProbeOutcome `json:"last_probe"`
 }
 
@@ -653,6 +655,7 @@ func (s *Scheduler) retireLocked(state *sessionState, sessionID, reason string) 
 	}
 	state.retired = true
 	state.retiredAt = s.now()
+	state.retiredReason = reason
 	state.body = nil
 	state.headers = nil
 	state.timer = nil
@@ -662,7 +665,10 @@ func (s *Scheduler) retireLocked(state *sessionState, sessionID, reason string) 
 			s.counters.SkippedByReason = make(map[string]uint64)
 		}
 		s.counters.SkippedByReason[reason]++
-		if state.lastProbe == nil || state.lastProbe.SkippedReason != reason {
+		// A skip that happened instead of a probe is the session's last outcome.
+		// A skip that ends a session which did probe must not erase the result of
+		// that probe: the reason is reported separately.
+		if state.lastProbe == nil {
 			state.lastProbe = &ProbeOutcome{At: state.retiredAt, Status: ProbeStatusSkipped, SkippedReason: reason}
 		}
 	}
@@ -747,6 +753,7 @@ func sessionSnapshot(sessionID string, state *sessionState) SessionSnapshot {
 	if !state.retiredAt.IsZero() {
 		at := state.retiredAt
 		snapshot.RetiredAt = &at
+		snapshot.RetiredReason = state.retiredReason
 	}
 	if state.lastProbe != nil {
 		probe := *state.lastProbe

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -60,6 +60,10 @@ type Config struct {
 	BeforeExpiry time.Duration
 	// OnlyWhenAgentsActive gates every probe on the liveness check.
 	OnlyWhenAgentsActive bool
+	// AgentIdleWindow is how long an agent may be silent and still count as
+	// running. It is deliberately not the cache TTL: an agent that has written
+	// nothing for an hour is finished, not busy.
+	AgentIdleWindow time.Duration
 	// MaxProbes caps consecutive probes without an intervening real request.
 	MaxProbes int
 	// MaxTokens is the max_tokens value the probe body carries.
@@ -103,8 +107,9 @@ type Prober interface {
 
 // Liveness reports whether a session still has work in flight.
 type Liveness interface {
-	// Live reports whether any task of the session is still running. Window
-	// bounds how stale a filesystem signal may be and still count as live.
+	// Live reports whether any agent of the session is still running. Window is
+	// the agent idle window: how stale the newest filesystem signal may be and
+	// still count as running.
 	Live(sessionID string, window time.Duration) bool
 }
 
@@ -236,11 +241,15 @@ type Snapshot struct {
 	Enabled              bool              `json:"enabled"`
 	BeforeExpiry         string            `json:"before_expiry"`
 	OnlyWhenAgentsActive bool              `json:"only_when_agents_active"`
+	AgentIdleWindow      string            `json:"agent_idle_window"`
 	MaxProbes            int               `json:"max_probes"`
 	MaxTokens            int               `json:"max_tokens"`
 	Sessions             []SessionSnapshot `json:"sessions"`
 	Counters             Counters          `json:"counters"`
 }
+
+// defaultAgentIdleWindow is the fallback when no idle window is configured.
+const defaultAgentIdleWindow = 10 * time.Minute
 
 // maxRetiredSessions bounds the retired-session history the snapshot exposes.
 // Retired records hold no request body, only counters and the last outcome.
@@ -497,7 +506,11 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	s.mu.Unlock()
 
 	if cfg.OnlyWhenAgentsActive {
-		if liveness == nil || !liveness.Live(sessionID, ttl) {
+		idleWindow := cfg.AgentIdleWindow
+		if idleWindow <= 0 {
+			idleWindow = defaultAgentIdleWindow
+		}
+		if liveness == nil || !liveness.Live(sessionID, idleWindow) {
 			s.retire(sessionID, generation, "no-live-agents")
 			log.Infof("cache-keepalive: skipped | session=%s auth=%s model=%s reason=no-live-agents", truncateSession(sessionID), authID, model)
 			return
@@ -706,6 +719,7 @@ func (s *Scheduler) Snapshot() Snapshot {
 		Enabled:              s.cfg.Enabled && !s.stopped,
 		BeforeExpiry:         s.cfg.BeforeExpiry.String(),
 		OnlyWhenAgentsActive: s.cfg.OnlyWhenAgentsActive,
+		AgentIdleWindow:      s.cfg.AgentIdleWindow.String(),
 		MaxProbes:            s.cfg.MaxProbes,
 		MaxTokens:            s.cfg.MaxTokens,
 		Sessions:             make([]SessionSnapshot, 0, len(s.sessions)),

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -28,6 +28,23 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+// ProbeMetadataKey marks an execution as a keepalive probe.
+//
+// A probe travels the ordinary request path, so without this marker the
+// observation hook would record the probe as a real request: that would reset
+// the consecutive-probe budget on every probe and let an idle session probe
+// forever, defeating max-probes.
+const ProbeMetadataKey = "cache_keepalive_probe"
+
+// IsProbeExecution reports whether execution metadata belongs to a keepalive probe.
+func IsProbeExecution(metadata map[string]any) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	marker, ok := metadata[ProbeMetadataKey].(bool)
+	return ok && marker
+}
+
 // Timer is the subset of time.Timer the scheduler needs. Tests substitute a
 // deterministic implementation.
 type Timer interface {

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -1,0 +1,511 @@
+// Package keepalive implements agent-aware prompt-cache keepalive for Claude
+// Code sessions.
+//
+// An orchestrator session that blocks on a subagent for longer than the prompt
+// cache TTL pays a full cache write on the return turn instead of a read. On the
+// 1h pool that write costs roughly ten times the read it replaces, so refreshing
+// the entry with one minimal request per TTL window is close to free.
+//
+// The proxy is the right place for that refresh because it holds the last request
+// body, the credential, and the session-to-account binding, so the probe warms the
+// same per-account cache the next real request will hit.
+//
+// The scheduler probes only while a task belonging to the session is still
+// running. A session idling on human input is never probed: that wait is
+// unbounded, and the guarantee that another turn is coming is what makes the
+// probe pay for itself.
+package keepalive
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Timer is the subset of time.Timer the scheduler needs. Tests substitute a
+// deterministic implementation.
+type Timer interface {
+	Stop() bool
+}
+
+// Config holds the resolved runtime settings for the scheduler.
+type Config struct {
+	// Enabled turns scheduling on. A disabled scheduler ignores every observation.
+	Enabled bool
+	// BeforeExpiry fires a probe at t_start + ttl - BeforeExpiry.
+	BeforeExpiry time.Duration
+	// OnlyWhenAgentsActive gates every probe on the liveness check.
+	OnlyWhenAgentsActive bool
+	// MaxProbes caps consecutive probes without an intervening real request.
+	MaxProbes int
+	// MaxTokens is the max_tokens value the probe body carries.
+	MaxTokens int
+}
+
+// ProbeRequest describes one keepalive probe to send upstream.
+type ProbeRequest struct {
+	// SessionID is the Claude Code session the probe warms.
+	SessionID string
+	// AuthID is the credential the session is bound to. The probe must not run
+	// on any other credential: a probe on a different account warms nothing.
+	AuthID string
+	// Provider is the auth provider namespace, normally "claude".
+	Provider string
+	// Model is the model the observed request used.
+	Model string
+	// Body is the probe-shaped request body.
+	Body []byte
+	// Headers are the observed request headers, including Anthropic-Beta.
+	Headers http.Header
+}
+
+// ProbeResult reports what the upstream said about the refreshed entry.
+type ProbeResult struct {
+	// CacheReadInputTokens is cache_read_input_tokens from the probe response.
+	// A value greater than zero means the probe hit the cached prefix.
+	CacheReadInputTokens int64
+}
+
+// Prober sends a probe through the same execution path a real request uses.
+type Prober interface {
+	Probe(ctx context.Context, req ProbeRequest) (ProbeResult, error)
+}
+
+// Liveness reports whether a session still has work in flight.
+type Liveness interface {
+	// Live reports whether any task of the session is still running. Window
+	// bounds how stale a filesystem signal may be and still count as live.
+	Live(sessionID string, window time.Duration) bool
+}
+
+// Binding reports the credential a session is currently bound to.
+type Binding interface {
+	BoundAuthID(provider, sessionID, model string) (string, bool)
+}
+
+// ObserveInput describes one completed real request.
+type ObserveInput struct {
+	SessionID string
+	AuthID    string
+	Provider  string
+	Model     string
+	// Body is the inbound client body, stored verbatim so the probe reproduces
+	// the same prefix the next real request will send.
+	Body []byte
+	// Headers are the inbound client headers.
+	Headers http.Header
+	// TTL is the cache TTL the request asked for.
+	TTL time.Duration
+	// StartedAt is when the observed request began.
+	StartedAt time.Time
+}
+
+type sessionState struct {
+	generation uint64
+	authID     string
+	provider   string
+	model      string
+	body       []byte
+	headers    http.Header
+	ttl        time.Duration
+	probes     int
+	timer      Timer
+}
+
+// Scheduler keeps one pending keepalive probe per Claude Code session.
+//
+// Stored bodies live in memory only, are replaced on every real request, and are
+// dropped when the session stops qualifying or exhausts its probe budget. They
+// are never persisted.
+type Scheduler struct {
+	mu       sync.Mutex
+	cfg      Config
+	sessions map[string]*sessionState
+	stopped  bool
+
+	prober   Prober
+	liveness Liveness
+	binding  Binding
+
+	newTimer func(time.Duration, func()) Timer
+	now      func() time.Time
+}
+
+// New creates a scheduler with the given configuration.
+func New(cfg Config) *Scheduler {
+	return &Scheduler{
+		cfg:      cfg,
+		sessions: make(map[string]*sessionState),
+		newTimer: func(d time.Duration, f func()) Timer { return time.AfterFunc(d, f) },
+		now:      time.Now,
+	}
+}
+
+// SetProber installs the upstream probe sender.
+func (s *Scheduler) SetProber(prober Prober) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.prober = prober
+}
+
+// SetLiveness installs the liveness strategy.
+func (s *Scheduler) SetLiveness(liveness Liveness) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.liveness = liveness
+}
+
+// SetBinding installs the session-to-credential binding lookup.
+func (s *Scheduler) SetBinding(binding Binding) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.binding = binding
+}
+
+// ApplyConfig swaps the runtime configuration. Disabling the feature cancels
+// every pending probe so a hot config reload takes effect immediately.
+func (s *Scheduler) ApplyConfig(cfg Config) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.cfg = cfg
+	if cfg.Enabled {
+		s.mu.Unlock()
+		return
+	}
+	states := s.takeAllLocked()
+	s.mu.Unlock()
+	for _, state := range states {
+		stopTimer(state)
+	}
+}
+
+// Enabled reports whether scheduling is currently on.
+func (s *Scheduler) Enabled() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cfg.Enabled && !s.stopped
+}
+
+// Stop cancels every pending probe. The scheduler stays usable but inert.
+func (s *Scheduler) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.stopped = true
+	states := s.takeAllLocked()
+	s.mu.Unlock()
+	for _, state := range states {
+		stopTimer(state)
+	}
+}
+
+func (s *Scheduler) takeAllLocked() []*sessionState {
+	states := make([]*sessionState, 0, len(s.sessions))
+	for key, state := range s.sessions {
+		states = append(states, state)
+		delete(s.sessions, key)
+	}
+	return states
+}
+
+func stopTimer(state *sessionState) {
+	if state != nil && state.timer != nil {
+		state.timer.Stop()
+	}
+}
+
+// Observe records a completed real request and reschedules that session's probe.
+//
+// Callers must only pass requests that carried an explicit 1h cache_control TTL.
+// Scheduling a probe for the 5m pool loses money: thirteen reads an hour cost
+// more than the single write they avoid.
+func (s *Scheduler) Observe(in ObserveInput) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	cfg := s.cfg
+	stopped := s.stopped
+	s.mu.Unlock()
+	if stopped || !cfg.Enabled {
+		return
+	}
+	if in.SessionID == "" || in.AuthID == "" || in.TTL <= 0 || len(in.Body) == 0 {
+		return
+	}
+	delay := in.TTL - cfg.BeforeExpiry
+	if delay <= 0 {
+		log.Debugf("cache-keepalive: skipped scheduling | session=%s reason=before-expiry-exceeds-ttl ttl=%s before-expiry=%s",
+			truncateSession(in.SessionID), in.TTL, cfg.BeforeExpiry)
+		return
+	}
+	if !in.StartedAt.IsZero() {
+		if elapsed := s.now().Sub(in.StartedAt); elapsed > 0 {
+			delay -= elapsed
+		}
+		if delay <= 0 {
+			log.Debugf("cache-keepalive: skipped scheduling | session=%s reason=window-already-elapsed", truncateSession(in.SessionID))
+			return
+		}
+	}
+
+	headers := in.Headers.Clone()
+	if headers == nil {
+		headers = http.Header{}
+	}
+	body := make([]byte, len(in.Body))
+	copy(body, in.Body)
+
+	s.mu.Lock()
+	if s.stopped || !s.cfg.Enabled {
+		s.mu.Unlock()
+		return
+	}
+	previous := s.sessions[in.SessionID]
+	generation := uint64(1)
+	if previous != nil {
+		generation = previous.generation + 1
+	}
+	state := &sessionState{
+		generation: generation,
+		authID:     in.AuthID,
+		provider:   in.Provider,
+		model:      in.Model,
+		body:       body,
+		headers:    headers,
+		ttl:        in.TTL,
+		// A real request resets the consecutive-probe budget.
+		probes: 0,
+	}
+	s.sessions[in.SessionID] = state
+	sessionID := in.SessionID
+	state.timer = s.newTimer(delay, func() { s.fire(sessionID, generation) })
+	s.mu.Unlock()
+
+	stopTimer(previous)
+	log.Infof("cache-keepalive: scheduled | session=%s auth=%s model=%s ttl=%s fires_in=%s",
+		truncateSession(sessionID), in.AuthID, in.Model, in.TTL, delay.Round(time.Second))
+}
+
+func (s *Scheduler) fire(sessionID string, generation uint64) {
+	s.mu.Lock()
+	cfg := s.cfg
+	state := s.sessions[sessionID]
+	if s.stopped || !cfg.Enabled || state == nil || state.generation != generation {
+		s.mu.Unlock()
+		if state != nil && state.generation != generation {
+			log.Debugf("cache-keepalive: skipped | session=%s reason=superseded", truncateSession(sessionID))
+		}
+		return
+	}
+	if state.probes >= cfg.MaxProbes {
+		delete(s.sessions, sessionID)
+		s.mu.Unlock()
+		log.Infof("cache-keepalive: skipped | session=%s reason=max-probes probes=%d", truncateSession(sessionID), state.probes)
+		return
+	}
+	liveness := s.liveness
+	binding := s.binding
+	prober := s.prober
+	authID := state.authID
+	provider := state.provider
+	model := state.model
+	ttl := state.ttl
+	body := state.body
+	headers := state.headers
+	s.mu.Unlock()
+
+	if cfg.OnlyWhenAgentsActive {
+		if liveness == nil || !liveness.Live(sessionID, ttl) {
+			s.drop(sessionID, generation)
+			log.Infof("cache-keepalive: skipped | session=%s reason=no-live-agents", truncateSession(sessionID))
+			return
+		}
+	}
+	if binding != nil {
+		boundAuthID, ok := binding.BoundAuthID(provider, sessionID, model)
+		if !ok || boundAuthID != authID {
+			s.drop(sessionID, generation)
+			log.Infof("cache-keepalive: skipped | session=%s reason=auth-binding-lost want_auth=%s bound_auth=%s",
+				truncateSession(sessionID), authID, boundAuthID)
+			return
+		}
+	}
+	if prober == nil {
+		s.drop(sessionID, generation)
+		log.Warnf("cache-keepalive: skipped | session=%s reason=no-prober", truncateSession(sessionID))
+		return
+	}
+
+	probeBody, errBody := ProbeBody(body, cfg.MaxTokens)
+	if errBody != nil {
+		s.drop(sessionID, generation)
+		log.Warnf("cache-keepalive: skipped | session=%s reason=probe-body-build-failed error=%v", truncateSession(sessionID), errBody)
+		return
+	}
+
+	probeStart := s.now()
+	result, errProbe := prober.Probe(context.Background(), ProbeRequest{
+		SessionID: sessionID,
+		AuthID:    authID,
+		Provider:  provider,
+		Model:     model,
+		Body:      probeBody,
+		Headers:   headers.Clone(),
+	})
+	if errProbe != nil {
+		s.drop(sessionID, generation)
+		log.Warnf("cache-keepalive: probe failed | session=%s auth=%s model=%s error=%v",
+			truncateSession(sessionID), authID, model, errProbe)
+		return
+	}
+
+	// Reschedule from the probe's own start time so the next window is measured
+	// against the entry the probe just refreshed.
+	next := ttl - cfg.BeforeExpiry - s.now().Sub(probeStart)
+	s.mu.Lock()
+	current := s.sessions[sessionID]
+	if s.stopped || !s.cfg.Enabled || current == nil || current.generation != generation {
+		s.mu.Unlock()
+		log.Infof("cache-keepalive: fired | session=%s auth=%s model=%s cache_read_input_tokens=%d rescheduled=false",
+			truncateSession(sessionID), authID, model, result.CacheReadInputTokens)
+		return
+	}
+	current.probes++
+	probes := current.probes
+	rescheduled := false
+	if probes < s.cfg.MaxProbes && next > 0 {
+		current.timer = s.newTimer(next, func() { s.fire(sessionID, generation) })
+		rescheduled = true
+	} else {
+		delete(s.sessions, sessionID)
+	}
+	s.mu.Unlock()
+
+	log.Infof("cache-keepalive: fired | session=%s auth=%s model=%s cache_read_input_tokens=%d probes=%d rescheduled=%t",
+		truncateSession(sessionID), authID, model, result.CacheReadInputTokens, probes, rescheduled)
+}
+
+func (s *Scheduler) drop(sessionID string, generation uint64) {
+	s.mu.Lock()
+	state := s.sessions[sessionID]
+	if state != nil && state.generation == generation {
+		delete(s.sessions, sessionID)
+	} else {
+		state = nil
+	}
+	s.mu.Unlock()
+	stopTimer(state)
+}
+
+// ProbeBody derives the minimal refresh request from an observed client body.
+//
+// Everything that participates in the cache prefix — tools, system, messages and
+// every cache_control marker — is left byte-identical. Only the fields that
+// decide how much the probe generates are rewritten.
+func ProbeBody(body []byte, maxTokens int) ([]byte, error) {
+	if maxTokens <= 0 {
+		maxTokens = 1
+	}
+	out, err := sjson.SetBytes(body, "max_tokens", maxTokens)
+	if err != nil {
+		return nil, err
+	}
+	out, err = sjson.SetBytes(out, "stream", false)
+	if err != nil {
+		return nil, err
+	}
+	// Extended thinking forces a minimum max_tokens well above the probe budget,
+	// so the probe drops it. It is not part of the cached prefix.
+	out, err = sjson.DeleteBytes(out, "thinking")
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ExtendedCacheTTL returns the longest explicit cache_control TTL in the body,
+// or zero when the body carries no explicit TTL.
+//
+// A bare {"type":"ephemeral"} marker is the 5m wire default and returns zero:
+// only a TTL the client wrote out is treated as an opt-in to the long pool.
+func ExtendedCacheTTL(body []byte) time.Duration {
+	if len(body) == 0 || !json.Valid(body) {
+		return 0
+	}
+	var longest time.Duration
+	walkCacheControlTTLs(gjson.ParseBytes(body), func(ttl time.Duration) {
+		if ttl > longest {
+			longest = ttl
+		}
+	})
+	return longest
+}
+
+func walkCacheControlTTLs(value gjson.Result, visit func(time.Duration)) {
+	switch {
+	case value.IsObject():
+		value.ForEach(func(key, child gjson.Result) bool {
+			if key.String() == "cache_control" && child.IsObject() {
+				if ttl := parseCacheTTL(child.Get("ttl").String()); ttl > 0 {
+					visit(ttl)
+				}
+				return true
+			}
+			walkCacheControlTTLs(child, visit)
+			return true
+		})
+	case value.IsArray():
+		value.ForEach(func(_, child gjson.Result) bool {
+			walkCacheControlTTLs(child, visit)
+			return true
+		})
+	}
+}
+
+func parseCacheTTL(raw string) time.Duration {
+	if raw == "" {
+		return 0
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		return 0
+	}
+	return ttl
+}
+
+func truncateSession(sessionID string) string {
+	if len(sessionID) <= 8 {
+		return sessionID
+	}
+	return sessionID[:8] + "..."
+}
+
+// IsExtendedCacheTTL reports whether a TTL selects the long cache pool.
+//
+// Keepalive is only economical there. On the 5m pool a probe every window costs
+// thirteen reads an hour, which is more than the single write it avoids.
+func IsExtendedCacheTTL(ttl time.Duration) bool {
+	return ttl >= time.Hour
+}

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -824,7 +825,36 @@ func ProbeBody(body []byte, maxTokens int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	// Dropping thinking invalidates any context-management strategy that requires
+	// it: Claude Code sends clear_thinking_20251015, and the upstream rejects the
+	// request outright when thinking is absent. Neither the strategy nor thinking
+	// participates in the cached prefix, so the probe drops both together.
+	return removeThinkingDependentContextManagement(out)
+}
+
+// contextManagementThinkingPrefix marks the strategies that require thinking.
+const contextManagementThinkingPrefix = "clear_thinking"
+
+func removeThinkingDependentContextManagement(body []byte) ([]byte, error) {
+	edits := gjson.GetBytes(body, "context_management.edits")
+	if !edits.IsArray() {
+		return body, nil
+	}
+	kept := make([]json.RawMessage, 0, len(edits.Array()))
+	for _, edit := range edits.Array() {
+		if strings.HasPrefix(edit.Get("type").String(), contextManagementThinkingPrefix) {
+			continue
+		}
+		kept = append(kept, json.RawMessage(edit.Raw))
+	}
+	if len(kept) == len(edits.Array()) {
+		return body, nil
+	}
+	if len(kept) == 0 {
+		// An empty edits array is not a valid context_management block.
+		return sjson.DeleteBytes(body, "context_management")
+	}
+	return sjson.SetBytes(body, "context_management.edits", kept)
 }
 
 // ExtendedCacheTTL returns the longest explicit cache_control TTL in the body,

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -154,6 +154,10 @@ type ObserveInput struct {
 	Headers http.Header
 	// TTL is the cache TTL the request asked for.
 	TTL time.Duration
+	// CacheReadInputTokens is what the observed real request read from the
+	// cache. It is the baseline a later probe is judged against. Zero means
+	// unknown, which disables the proportional check.
+	CacheReadInputTokens int64
 	// StartedAt is when the observed request began.
 	StartedAt time.Time
 }
@@ -174,6 +178,7 @@ type sessionState struct {
 	// history so the management endpoint can explain what happened, but drops
 	// the body and headers immediately.
 	lastRequestAt time.Time
+	baselineRead  int64
 	nextProbeAt   time.Time
 	probesSent    int
 	lastProbe     *ProbeOutcome
@@ -189,8 +194,11 @@ type ProbeOutcome struct {
 	CacheReadInputTokens     int64     `json:"cache_read_input_tokens"`
 	CacheCreationInputTokens int64     `json:"cache_creation_input_tokens"`
 	SkippedReason            string    `json:"skipped_reason,omitempty"`
-	Error                    string    `json:"error,omitempty"`
-	Diagnosis                string    `json:"diagnosis,omitempty"`
+	// BaselineReadInputTokens is what the observed real request read. A probe
+	// that reads far less than this refreshed only part of the prefix.
+	BaselineReadInputTokens int64  `json:"baseline_read_input_tokens,omitempty"`
+	Error                   string `json:"error,omitempty"`
+	Diagnosis               string `json:"diagnosis,omitempty"`
 }
 
 // Probe outcome statuses.
@@ -458,6 +466,7 @@ func (s *Scheduler) Observe(in ObserveInput) {
 		state.lastRequestAt = now
 	}
 	state.nextProbeAt = now.Add(delay)
+	state.baselineRead = in.CacheReadInputTokens
 	// A session that had already probed keeps its lifetime probe count; only the
 	// consecutive budget resets on a real request.
 	if previous != nil {
@@ -501,6 +510,7 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	provider := state.provider
 	model := state.model
 	ttl := state.ttl
+	baselineRead := state.baselineRead
 	body := state.body
 	headers := state.headers
 	s.mu.Unlock()
@@ -565,9 +575,10 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		Status:                   ProbeStatusHit,
 		CacheReadInputTokens:     result.CacheReadInputTokens,
 		CacheCreationInputTokens: result.CacheCreationInputTokens,
+		BaselineReadInputTokens:  baselineRead,
 		Diagnosis:                result.Diagnosis,
 	}
-	if result.CacheReadInputTokens <= 0 {
+	if probeMissed(result.CacheReadInputTokens, baselineRead) {
 		outcome.Status = ProbeStatusMiss
 	}
 	s.recordProbe(sessionID, generation, outcome)
@@ -601,6 +612,20 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 	s.logProbe(sessionID, authID, model, outcome, elapsed, total, consecutive, rescheduled, nextProbeAt)
 }
 
+// probeMissed reports whether a probe failed to refresh the entry it was sent for.
+//
+// Reading nothing is an outright miss. Reading less than half the baseline is
+// also a miss: the probe found only a fragment of the prefix cached, so most of
+// the context it was meant to keep warm had already expired. A zero baseline
+// means the observed request's usage was unavailable, which leaves only the
+// outright check.
+func probeMissed(read, baseline int64) bool {
+	if read <= 0 {
+		return true
+	}
+	return baseline > 0 && read*2 < baseline
+}
+
 // logProbe emits the single line that tells the whole story of one probe, so
 // `grep cache-keepalive` needs no other source.
 //
@@ -611,16 +636,16 @@ func (s *Scheduler) logProbe(sessionID, authID, model string, outcome ProbeOutco
 	if !nextProbeAt.IsZero() {
 		next = nextProbeAt.Format(time.RFC3339)
 	}
-	fields := "session=%s auth=%s model=%s status=%s cache_read_input_tokens=%d cache_creation_input_tokens=%d duration=%s probes_sent=%d consecutive_probes=%d rescheduled=%t next_probe_at=%s"
+	fields := "session=%s auth=%s model=%s status=%s cache_read_input_tokens=%d cache_creation_input_tokens=%d baseline_read_input_tokens=%d duration=%s probes_sent=%d consecutive_probes=%d rescheduled=%t next_probe_at=%s"
 	args := []any{
 		truncateSession(sessionID), authID, model, outcome.Status,
-		outcome.CacheReadInputTokens, outcome.CacheCreationInputTokens,
+		outcome.CacheReadInputTokens, outcome.CacheCreationInputTokens, outcome.BaselineReadInputTokens,
 		elapsed.Round(time.Millisecond), total, consecutive, rescheduled, next,
 	}
 	if outcome.Status == ProbeStatusMiss {
-		fields += " diagnosis=%q"
+		fields += " cache_miss_reason=%q"
 		args = append(args, outcome.Diagnosis)
-		log.Warnf("cache-keepalive: probe missed, the cached prefix was already gone | "+fields, args...)
+		log.Warnf("cache-keepalive: probe MISSED | "+fields, args...)
 		return
 	}
 	log.Infof("cache-keepalive: probe | "+fields, args...)

--- a/internal/runtime/keepalive/keepalive.go
+++ b/internal/runtime/keepalive/keepalive.go
@@ -84,9 +84,23 @@ type Liveness interface {
 	Live(sessionID string, window time.Duration) bool
 }
 
+// BindingState describes what the proxy knows about a session's credential binding.
+type BindingState int
+
+const (
+	// BindingUnknown means routing is not session-sticky, so there is no binding
+	// to check. The scheduler proceeds: with no affinity there is no binding to lose.
+	BindingUnknown BindingState = iota
+	// BindingBound means the session is bound to the reported credential.
+	BindingBound
+	// BindingLost means the session had a binding and no longer has one, normally
+	// because the credential entered cooldown or rotated out.
+	BindingLost
+)
+
 // Binding reports the credential a session is currently bound to.
 type Binding interface {
-	BoundAuthID(provider, sessionID, model string) (string, bool)
+	SessionBinding(provider, sessionID, model string) (authID string, state BindingState)
 }
 
 // ObserveInput describes one completed real request.
@@ -145,6 +159,19 @@ func New(cfg Config) *Scheduler {
 		newTimer: func(d time.Duration, f func()) Timer { return time.AfterFunc(d, f) },
 		now:      time.Now,
 	}
+}
+
+// SetTimerFactory replaces the timer constructor.
+//
+// Tests use it to drive scheduling deterministically; the repository forbids
+// wall-clock sleeps in TTL and ordering tests for exactly this reason.
+func (s *Scheduler) SetTimerFactory(factory func(time.Duration, func()) Timer) {
+	if s == nil || factory == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.newTimer = factory
 }
 
 // SetProber installs the upstream probe sender.
@@ -344,8 +371,8 @@ func (s *Scheduler) fire(sessionID string, generation uint64) {
 		}
 	}
 	if binding != nil {
-		boundAuthID, ok := binding.BoundAuthID(provider, sessionID, model)
-		if !ok || boundAuthID != authID {
+		boundAuthID, state := binding.SessionBinding(provider, sessionID, model)
+		if state == BindingLost || (state == BindingBound && boundAuthID != authID) {
 			s.drop(sessionID, generation)
 			log.Infof("cache-keepalive: skipped | session=%s reason=auth-binding-lost want_auth=%s bound_auth=%s",
 				truncateSession(sessionID), authID, boundAuthID)

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -475,6 +475,46 @@ func TestCacheControlTTL(t *testing.T) {
 	}
 }
 
+func TestRequestCacheTTLResolvesTheWireDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want time.Duration
+	}{
+		{name: "explicit one hour", body: oneHourBody, want: time.Hour},
+		{name: "explicit five minutes", body: fiveMinuteBody, want: 5 * time.Minute},
+		{name: "bare ephemeral is the 5m default", body: `{"system":[{"type":"text","cache_control":{"type":"ephemeral"}}]}`, want: 5 * time.Minute},
+		{name: "bare ephemeral nested in messages", body: `{"messages":[{"content":[{"cache_control":{"type":"ephemeral"}}]}]}`, want: 5 * time.Minute},
+		{name: "longest marker wins over a bare one", body: `{"tools":[{"cache_control":{"type":"ephemeral"}}],"system":[{"cache_control":{"type":"ephemeral","ttl":"1h"}}]}`, want: time.Hour},
+		{name: "no cache control caches nothing", body: `{"messages":[{"role":"user","content":"hi"}]}`, want: 0},
+		{name: "invalid json", body: `not json`, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequestCacheTTL([]byte(tt.body)); got != tt.want {
+				t.Fatalf("RequestCacheTTL() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTTLTier(t *testing.T) {
+	tests := []struct {
+		ttl  time.Duration
+		want string
+	}{
+		{ttl: 5 * time.Minute, want: TTLTier5m},
+		{ttl: 59 * time.Minute, want: TTLTier5m},
+		{ttl: time.Hour, want: TTLTier1h},
+		{ttl: 2 * time.Hour, want: TTLTier1h},
+	}
+	for _, tt := range tests {
+		if got := TTLTier(tt.ttl); got != tt.want {
+			t.Fatalf("TTLTier(%s) = %q, want %q", tt.ttl, got, tt.want)
+		}
+	}
+}
+
 func TestIsExtendedCacheTTL(t *testing.T) {
 	if IsExtendedCacheTTL(ExtendedCacheTTL([]byte(fiveMinuteBody))) {
 		t.Fatalf("a 5m-only body must not qualify for keepalive")

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -743,3 +743,54 @@ func TestFullReadAgainstABaselineCountsAsAHit(t *testing.T) {
 		t.Fatalf("counters = %+v", counters)
 	}
 }
+
+func TestProbeBodyDropsThinkingDependentContextManagement(t *testing.T) {
+	body := []byte(`{"model":"m","max_tokens":32000,"thinking":{"type":"adaptive"},` +
+		`"context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]},` +
+		`"messages":[{"role":"user","content":"hi"}]}`)
+
+	probe, err := ProbeBody(body, 1)
+	if err != nil {
+		t.Fatalf("ProbeBody() error = %v", err)
+	}
+	if gjson.GetBytes(probe, "thinking").Exists() {
+		t.Fatalf("thinking survived into the probe body")
+	}
+	// The upstream rejects clear_thinking_20251015 outright when thinking is
+	// absent, so the strategy must go with it.
+	if gjson.GetBytes(probe, "context_management").Exists() {
+		t.Fatalf("context_management survived with only a thinking-dependent edit: %s", probe)
+	}
+}
+
+func TestProbeBodyKeepsOtherContextManagementEdits(t *testing.T) {
+	body := []byte(`{"model":"m","max_tokens":32000,"thinking":{"type":"adaptive"},` +
+		`"context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"},{"type":"clear_tool_uses_20250919","keep":3}]},` +
+		`"messages":[{"role":"user","content":"hi"}]}`)
+
+	probe, err := ProbeBody(body, 1)
+	if err != nil {
+		t.Fatalf("ProbeBody() error = %v", err)
+	}
+	edits := gjson.GetBytes(probe, "context_management.edits")
+	if !edits.IsArray() || len(edits.Array()) != 1 {
+		t.Fatalf("edits = %s, want only the non-thinking edit", edits.Raw)
+	}
+	if got := edits.Get("0.type").String(); got != "clear_tool_uses_20250919" {
+		t.Fatalf("kept edit = %q", got)
+	}
+}
+
+func TestProbeBodyLeavesContextManagementAloneWhenNoThinkingEdit(t *testing.T) {
+	body := []byte(`{"model":"m","max_tokens":32000,` +
+		`"context_management":{"edits":[{"type":"clear_tool_uses_20250919","keep":3}]},` +
+		`"messages":[{"role":"user","content":"hi"}]}`)
+
+	probe, err := ProbeBody(body, 1)
+	if err != nil {
+		t.Fatalf("ProbeBody() error = %v", err)
+	}
+	if got := gjson.GetBytes(probe, "context_management.edits.0.type").String(); got != "clear_tool_uses_20250919" {
+		t.Fatalf("context_management was rewritten: %s", probe)
+	}
+}

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -675,7 +675,9 @@ func TestProbeMissed(t *testing.T) {
 		{name: "read nothing with no baseline is still a miss", read: 0, baseline: 0, want: true},
 		{name: "full read is a hit", read: 100000, baseline: 100000, want: false},
 		{name: "just above half is a hit", read: 50001, baseline: 100000, want: false},
-		{name: "exactly half is a miss", read: 50000, baseline: 100000, want: true},
+		// The rule is "below half", so exactly half still counts as a hit.
+		{name: "exactly half is a hit", read: 50000, baseline: 100000, want: false},
+		{name: "one token below half is a miss", read: 49999, baseline: 100000, want: true},
 		{name: "far below half is a miss", read: 12000, baseline: 100000, want: true},
 		{name: "unknown baseline cannot judge proportion", read: 12000, baseline: 0, want: false},
 		{name: "reading more than the baseline is a hit", read: 120000, baseline: 100000, want: false},

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -104,11 +104,11 @@ func (l staticLiveness) Live(string, time.Duration) bool { return l.live }
 
 type staticBinding struct {
 	authID string
-	ok     bool
+	state  BindingState
 }
 
-func (b staticBinding) BoundAuthID(string, string, string) (string, bool) {
-	return b.authID, b.ok
+func (b staticBinding) SessionBinding(string, string, string) (string, BindingState) {
+	return b.authID, b.state
 }
 
 const oneHourBody = `{
@@ -145,7 +145,7 @@ func testScheduler(t *testing.T, clock *fakeClock, prober Prober, liveness Liven
 	scheduler.SetProber(prober)
 	scheduler.SetLiveness(liveness)
 	scheduler.SetBinding(binding)
-	scheduler.newTimer = clock.after
+	scheduler.SetTimerFactory(clock.after)
 	return scheduler
 }
 
@@ -165,7 +165,7 @@ func observeOneHour(scheduler *Scheduler, session string) {
 func TestObserveSchedulesAtTTLMinusBeforeExpiry(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 
@@ -182,7 +182,7 @@ func TestObserveSchedulesAtTTLMinusBeforeExpiry(t *testing.T) {
 func TestObserveSupersedesEarlierTimer(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	observeOneHour(scheduler, "sess-1")
@@ -210,7 +210,7 @@ func TestObserveSupersedesEarlierTimer(t *testing.T) {
 func TestFireSkipsWhenNoAgentsLive(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	clock.fireLatest(t)
@@ -226,7 +226,7 @@ func TestFireSkipsWhenNoAgentsLive(t *testing.T) {
 func TestFireProbesWhenLivenessIsAlwaysEvenWithNoAgents(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
 		cfg.OnlyWhenAgentsActive = false
 	})
 
@@ -238,10 +238,23 @@ func TestFireProbesWhenLivenessIsAlwaysEvenWithNoAgents(t *testing.T) {
 	}
 }
 
+func TestFireProbesWhenBindingIsUnknown(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{state: BindingUnknown}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 1 {
+		t.Fatalf("probed %d times, want 1: without session-sticky routing there is no binding to lose", len(calls))
+	}
+}
+
 func TestFireSkipsWhenAuthBindingLost(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "", ok: false}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{state: BindingLost}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	clock.fireLatest(t)
@@ -254,7 +267,7 @@ func TestFireSkipsWhenAuthBindingLost(t *testing.T) {
 func TestFireSkipsWhenAuthBindingMovedToAnotherCredential(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-b", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-b", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	clock.fireLatest(t)
@@ -267,7 +280,7 @@ func TestFireSkipsWhenAuthBindingMovedToAnotherCredential(t *testing.T) {
 func TestConsecutiveProbesStopAtMaxProbes(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
 		cfg.MaxProbes = 3
 	})
 
@@ -299,7 +312,7 @@ func TestConsecutiveProbesStopAtMaxProbes(t *testing.T) {
 func TestRealRequestResetsProbeBudget(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
 		cfg.MaxProbes = 1
 	})
 
@@ -316,7 +329,7 @@ func TestRealRequestResetsProbeBudget(t *testing.T) {
 func TestProbeBodyPreservesCacheControlBetasAndPrefix(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	clock.fireLatest(t)
@@ -369,7 +382,7 @@ func TestProbeBodyPreservesCacheControlBetasAndPrefix(t *testing.T) {
 func TestDisabledSchedulerNeverSchedules(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
 		cfg.Enabled = false
 	})
 
@@ -388,7 +401,7 @@ func TestNilSchedulerObserveIsSafe(t *testing.T) {
 func TestObserveIgnoredWithoutSessionOrTTL(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	scheduler.Observe(ObserveInput{AuthID: "auth-a", Body: []byte(oneHourBody), TTL: time.Hour})
 	scheduler.Observe(ObserveInput{SessionID: "sess-1", AuthID: "auth-a", Body: []byte(oneHourBody)})
@@ -402,7 +415,7 @@ func TestObserveIgnoredWithoutSessionOrTTL(t *testing.T) {
 func TestObserveIgnoredWhenBeforeExpiryExceedsTTL(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
 		cfg.BeforeExpiry = 2 * time.Hour
 	})
 
@@ -450,7 +463,7 @@ func TestIsExtendedCacheTTL(t *testing.T) {
 func TestStopClearsScheduledTimers(t *testing.T) {
 	clock := &fakeClock{}
 	prober := &recordingProber{}
-	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
 
 	observeOneHour(scheduler, "sess-1")
 	scheduler.Stop()

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -138,8 +138,11 @@ func testScheduler(t *testing.T, clock *fakeClock, prober Prober, liveness Liven
 	cfg := Config{
 		Enabled:              true,
 		BeforeExpiry:         5 * time.Minute,
+		BeforeExpiry5m:       45 * time.Second,
+		Probe5m:              Probe5mAuto,
 		OnlyWhenAgentsActive: true,
 		MaxProbes:            6,
+		MaxProbes5m:          30,
 		MaxTokens:            1,
 	}
 	if mutate != nil {
@@ -163,6 +166,20 @@ func observeOneHour(scheduler *Scheduler, session string) {
 		Body:             []byte(oneHourBody),
 		Headers:          http.Header{"Anthropic-Beta": []string{"claude-code-20250219,extended-cache-ttl-2025-04-11"}},
 		TTL:              time.Hour,
+		StartedAt:        time.Now(),
+	})
+}
+
+func observeFiveMinutes(scheduler *Scheduler, session, model string) {
+	scheduler.Observe(ObserveInput{
+		SessionID:        session,
+		BindingSessionID: "claude:" + session + ":agent:main",
+		AuthID:           "auth-a",
+		Provider:         "claude",
+		Model:            model,
+		Body:             []byte(fiveMinuteBody),
+		Headers:          http.Header{"Anthropic-Beta": []string{"claude-code-20250219"}},
+		TTL:              5 * time.Minute,
 		StartedAt:        time.Now(),
 	})
 }
@@ -832,5 +849,191 @@ func TestProbeBodyLeavesContextManagementAloneWhenNoThinkingEdit(t *testing.T) {
 	}
 	if got := gjson.GetBytes(probe, "context_management.edits.0.type").String(); got != "clear_tool_uses_20250919" {
 		t.Fatalf("context_management was rewritten: %s", probe)
+	}
+}
+
+func TestProbe5mDecision(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		models  []string
+		model   string
+		wantOK  bool
+		wantWhy string
+	}{
+		{name: "auto matches fable", mode: Probe5mAuto, model: "claude-fable-5-1", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "auto matches mythos", mode: Probe5mAuto, model: "claude-mythos-5-1", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "auto matches a suffixed spelling", mode: Probe5mAuto, model: "claude-fable-5-1[1m]", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "auto matches a provider-prefixed spelling", mode: Probe5mAuto, model: "us.anthropic.CLAUDE-FABLE-5-1-v1:0", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "auto skips opus", mode: Probe5mAuto, model: "claude-opus-5", wantOK: false, wantWhy: Probe5mDecisionSkippedModel},
+		{name: "auto skips an empty model", mode: Probe5mAuto, model: "", wantOK: false, wantWhy: Probe5mDecisionSkippedModel},
+		{name: "an empty mode behaves as auto", mode: "", model: "claude-fable-5-1", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "always takes any model", mode: Probe5mAlways, model: "claude-opus-5", wantOK: true, wantWhy: Probe5mDecisionAlways},
+		{name: "never refuses fable too", mode: Probe5mNever, model: "claude-fable-5-1", wantOK: false, wantWhy: Probe5mDecisionSkippedNever},
+		{name: "an override list replaces the built-in one", mode: Probe5mAuto, models: []string{"claude-opus-5"}, model: "claude-opus-5", wantOK: true, wantWhy: Probe5mDecisionModelAuto},
+		{name: "an override list excludes the built-in entries", mode: Probe5mAuto, models: []string{"claude-opus-5"}, model: "claude-fable-5-1", wantOK: false, wantWhy: Probe5mDecisionSkippedModel},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, why := probe5mDecision(tt.mode, tt.models, tt.model)
+			if ok != tt.wantOK || why != tt.wantWhy {
+				t.Fatalf("probe5mDecision(%q, %v, %q) = (%t, %q), want (%t, %q)", tt.mode, tt.models, tt.model, ok, why, tt.wantOK, tt.wantWhy)
+			}
+		})
+	}
+}
+
+func TestObserveSchedulesA5mSessionAtTTLMinusBeforeExpiry5m(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-fable-5-1")
+
+	if clock.count() != 1 {
+		t.Fatalf("scheduled %d timers, want 1", clock.count())
+	}
+	// 5m minus the 45s lead time, measured from the observed request's start.
+	if got := clock.timers[0].delay; got > 4*time.Minute+15*time.Second || got < 4*time.Minute+10*time.Second {
+		t.Fatalf("delay = %s, want ~4m15s", got)
+	}
+}
+
+func TestObserveAutoSkipsA5mSessionOnAnExpensiveCacheReadModel(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-opus-5")
+
+	if clock.count() != 0 {
+		t.Fatalf("scheduled %d timers for an expensive-cache-read model, want 0", clock.count())
+	}
+	if got := scheduler.Snapshot().Counters.SkippedByReason[Probe5mDecisionSkippedModel]; got != 1 {
+		t.Fatalf("skipped_by_reason[%s] = %d, want 1", Probe5mDecisionSkippedModel, got)
+	}
+}
+
+func TestObserveAutoStillSchedulesA1hSessionOnAnyModel(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	// oneHourBody's model is a haiku, which is not on the cheap-cache-read list.
+	observeOneHour(scheduler, "sess-1h")
+
+	if clock.count() != 1 {
+		t.Fatalf("scheduled %d timers for a 1h session, want 1: probe-5m must not gate the 1h pool", clock.count())
+	}
+}
+
+func TestObserveAlwaysProbesA5mSessionOnAnyModel(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound},
+		func(cfg *Config) { cfg.Probe5m = Probe5mAlways })
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-opus-5")
+
+	if clock.count() != 1 {
+		t.Fatalf("scheduled %d timers under probe-5m=always, want 1", clock.count())
+	}
+	if got := scheduler.Snapshot().Sessions[0].Probe5mDecision; got != Probe5mDecisionAlways {
+		t.Fatalf("probe_5m_decision = %q, want %q", got, Probe5mDecisionAlways)
+	}
+}
+
+func TestObserveNeverSkipsEvery5mSessionButKeepsThe1hPool(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound},
+		func(cfg *Config) { cfg.Probe5m = Probe5mNever })
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-fable-5-1")
+	if clock.count() != 0 {
+		t.Fatalf("scheduled %d timers under probe-5m=never, want 0", clock.count())
+	}
+	if got := scheduler.Snapshot().Counters.SkippedByReason[Probe5mDecisionSkippedNever]; got != 1 {
+		t.Fatalf("skipped_by_reason[%s] = %d, want 1", Probe5mDecisionSkippedNever, got)
+	}
+
+	observeOneHour(scheduler, "sess-1h")
+	if clock.count() != 1 {
+		t.Fatalf("probe-5m=never must leave the 1h pool alone; timers = %d, want 1", clock.count())
+	}
+}
+
+func TestFiveMinuteSessionsUseTheirOwnProbeBudget(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 4096}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound},
+		func(cfg *Config) {
+			cfg.MaxProbes = 6
+			cfg.MaxProbes5m = 2
+		})
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-fable-5-1")
+	clock.fireLatest(t)
+	clock.fireLatest(t)
+	if calls := prober.calls(); len(calls) != 2 {
+		t.Fatalf("probed %d times, want 2 from max-probes-5m", len(calls))
+	}
+	// The second probe exhausts the 5m budget, so nothing is rearmed.
+	if clock.count() != 2 {
+		t.Fatalf("timers = %d, want 2: the budget must stop the rescheduling", clock.count())
+	}
+	session := scheduler.Snapshot().Sessions[0]
+	if session.Active || session.RetiredReason != "max-probes" {
+		t.Fatalf("session = %+v, want retired for max-probes", session)
+	}
+}
+
+func TestFiveMinuteRescheduleUsesThe5mLeadTime(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 4096}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-fable-5-1")
+	clock.fireLatest(t)
+
+	if clock.count() != 2 {
+		t.Fatalf("timers = %d, want 2: the probe must rearm", clock.count())
+	}
+	if got := clock.timers[1].delay; got > 4*time.Minute+15*time.Second || got < 4*time.Minute+10*time.Second {
+		t.Fatalf("reschedule delay = %s, want ~4m15s", got)
+	}
+}
+
+func TestSnapshotReportsTheTierAndTheProbe5mSettings(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeFiveMinutes(scheduler, "sess-5m", "claude-fable-5-1")
+	observeOneHour(scheduler, "sess-1h")
+
+	snapshot := scheduler.Snapshot()
+	if snapshot.BeforeExpiry5m != "45s" {
+		t.Fatalf("before_expiry_5m = %q, want 45s", snapshot.BeforeExpiry5m)
+	}
+	if snapshot.Probe5m != Probe5mAuto {
+		t.Fatalf("probe_5m = %q, want %q", snapshot.Probe5m, Probe5mAuto)
+	}
+	if snapshot.MaxProbes5m != 30 {
+		t.Fatalf("max_probes_5m = %d, want 30", snapshot.MaxProbes5m)
+	}
+	if len(snapshot.Probe5mModels) != len(CheapCacheReadModels) {
+		t.Fatalf("probe_5m_models = %v, want the built-in list %v", snapshot.Probe5mModels, CheapCacheReadModels)
+	}
+
+	byID := map[string]SessionSnapshot{}
+	for _, session := range snapshot.Sessions {
+		byID[session.SessionID] = session
+	}
+	if got := byID["sess-5m"]; got.TTLTier != TTLTier5m || got.Probe5mDecision != Probe5mDecisionModelAuto {
+		t.Fatalf("5m session = (tier %q, decision %q), want (%q, %q)", got.TTLTier, got.Probe5mDecision, TTLTier5m, Probe5mDecisionModelAuto)
+	}
+	if got := byID["sess-1h"]; got.TTLTier != TTLTier1h || got.Probe5mDecision != Probe5mDecisionNotApplicable {
+		t.Fatalf("1h session = (tier %q, decision %q), want (%q, %q)", got.TTLTier, got.Probe5mDecision, TTLTier1h, Probe5mDecisionNotApplicable)
 	}
 }

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -151,14 +151,15 @@ func testScheduler(t *testing.T, clock *fakeClock, prober Prober, liveness Liven
 
 func observeOneHour(scheduler *Scheduler, session string) {
 	scheduler.Observe(ObserveInput{
-		SessionID: session,
-		AuthID:    "auth-a",
-		Provider:  "claude",
-		Model:     "claude-haiku-4-5-20251001",
-		Body:      []byte(oneHourBody),
-		Headers:   http.Header{"Anthropic-Beta": []string{"claude-code-20250219,extended-cache-ttl-2025-04-11"}},
-		TTL:       time.Hour,
-		StartedAt: time.Now(),
+		SessionID:        session,
+		BindingSessionID: "claude:" + session + ":agent:main",
+		AuthID:           "auth-a",
+		Provider:         "claude",
+		Model:            "claude-haiku-4-5-20251001",
+		Body:             []byte(oneHourBody),
+		Headers:          http.Header{"Anthropic-Beta": []string{"claude-code-20250219,extended-cache-ttl-2025-04-11"}},
+		TTL:              time.Hour,
+		StartedAt:        time.Now(),
 	})
 }
 
@@ -235,6 +236,28 @@ func TestFireProbesWhenLivenessIsAlwaysEvenWithNoAgents(t *testing.T) {
 
 	if calls := prober.calls(); len(calls) != 1 {
 		t.Fatalf("probed %d times, want 1", len(calls))
+	}
+}
+
+func TestFireSkipsBindingCheckWithoutBindingSessionID(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{state: BindingLost}, nil)
+
+	scheduler.Observe(ObserveInput{
+		SessionID: "sess-1",
+		AuthID:    "auth-a",
+		Provider:  "claude",
+		Model:     "claude-haiku-4-5-20251001",
+		Body:      []byte(oneHourBody),
+		Headers:   http.Header{},
+		TTL:       time.Hour,
+		StartedAt: time.Now(),
+	})
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 1 {
+		t.Fatalf("probed %d times, want 1: with no binding identity there is nothing to check", len(calls))
 	}
 }
 

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -663,3 +663,81 @@ func TestRetiredSessionHistoryIsBounded(t *testing.T) {
 		t.Fatalf("retained %d retired sessions, want at most %d", got, maxRetiredSessions)
 	}
 }
+
+func TestProbeMissed(t *testing.T) {
+	tests := []struct {
+		name     string
+		read     int64
+		baseline int64
+		want     bool
+	}{
+		{name: "read nothing is a miss", read: 0, baseline: 100000, want: true},
+		{name: "read nothing with no baseline is still a miss", read: 0, baseline: 0, want: true},
+		{name: "full read is a hit", read: 100000, baseline: 100000, want: false},
+		{name: "just above half is a hit", read: 50001, baseline: 100000, want: false},
+		{name: "exactly half is a miss", read: 50000, baseline: 100000, want: true},
+		{name: "far below half is a miss", read: 12000, baseline: 100000, want: true},
+		{name: "unknown baseline cannot judge proportion", read: 12000, baseline: 0, want: false},
+		{name: "reading more than the baseline is a hit", read: 120000, baseline: 100000, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := probeMissed(tt.read, tt.baseline); got != tt.want {
+				t.Fatalf("probeMissed(%d, %d) = %t, want %t", tt.read, tt.baseline, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartialReadCountsAsAMiss(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 4000, Diagnosis: "messages_changed"}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	scheduler.Observe(ObserveInput{
+		SessionID:            "sess-1",
+		BindingSessionID:     "claude:sess-1:agent:main",
+		AuthID:               "auth-a",
+		Provider:             "claude",
+		Model:                "claude-haiku-4-5-20251001",
+		Body:                 []byte(oneHourBody),
+		Headers:              http.Header{},
+		TTL:                  time.Hour,
+		StartedAt:            time.Now(),
+		CacheReadInputTokens: 100000,
+	})
+	clock.fireLatest(t)
+
+	snapshot := scheduler.Snapshot()
+	if snapshot.Counters.Misses != 1 || snapshot.Counters.Hits != 0 {
+		t.Fatalf("a probe reading 4%% of the baseline must count as a miss: %+v", snapshot.Counters)
+	}
+	probe := snapshot.Sessions[0].LastProbe
+	if probe == nil || probe.Status != ProbeStatusMiss || probe.BaselineReadInputTokens != 100000 {
+		t.Fatalf("last probe = %+v", probe)
+	}
+}
+
+func TestFullReadAgainstABaselineCountsAsAHit(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 99000}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	scheduler.Observe(ObserveInput{
+		SessionID:            "sess-1",
+		BindingSessionID:     "claude:sess-1:agent:main",
+		AuthID:               "auth-a",
+		Provider:             "claude",
+		Model:                "claude-haiku-4-5-20251001",
+		Body:                 []byte(oneHourBody),
+		Headers:              http.Header{},
+		TTL:                  time.Hour,
+		StartedAt:            time.Now(),
+		CacheReadInputTokens: 100000,
+	})
+	clock.fireLatest(t)
+
+	if counters := scheduler.Snapshot().Counters; counters.Hits != 1 || counters.Misses != 0 {
+		t.Fatalf("counters = %+v", counters)
+	}
+}

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -602,6 +602,9 @@ func TestSnapshotKeepsRetiredSessionsWithoutTheirBodies(t *testing.T) {
 	if session.LastProbe == nil || session.LastProbe.SkippedReason != "no-live-agents" {
 		t.Fatalf("retired session last probe = %+v", session.LastProbe)
 	}
+	if session.RetiredReason != "no-live-agents" {
+		t.Fatalf("retired reason = %q", session.RetiredReason)
+	}
 	if snapshot.Counters.SkippedByReason["no-live-agents"] != 1 {
 		t.Fatalf("skipped_by_reason = %+v", snapshot.Counters.SkippedByReason)
 	}
@@ -612,6 +615,28 @@ func TestSnapshotKeepsRetiredSessionsWithoutTheirBodies(t *testing.T) {
 	scheduler.mu.Unlock()
 	if body != nil || headers != nil {
 		t.Fatalf("retired session kept its request body in memory")
+	}
+}
+
+func TestRetiringDoesNotEraseTheLastProbeResult(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 4242}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, func(cfg *Config) {
+		cfg.MaxProbes = 1
+	})
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	session := scheduler.Snapshot().Sessions[0]
+	if session.Active {
+		t.Fatalf("session should be retired after reaching max-probes")
+	}
+	if session.RetiredReason != "max-probes" {
+		t.Fatalf("retired reason = %q, want max-probes", session.RetiredReason)
+	}
+	if session.LastProbe == nil || session.LastProbe.Status != ProbeStatusHit || session.LastProbe.CacheReadInputTokens != 4242 {
+		t.Fatalf("retiring erased the probe result: %+v", session.LastProbe)
 	}
 }
 

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -2,13 +2,17 @@ package keepalive
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/tidwall/gjson"
 )
+
+var errProbeTest = errors.New("upstream refused the probe")
 
 // fakeTimer records the requested delay and fires only when the test says so.
 type fakeTimer struct {
@@ -497,5 +501,140 @@ func TestStopClearsScheduledTimers(t *testing.T) {
 	clock.fireAt(t, 0)
 	if calls := prober.calls(); len(calls) != 0 {
 		t.Fatalf("probed after Stop(), want 0 probes")
+	}
+}
+
+func TestSnapshotTracksSessionAndCounters(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 12468, CacheCreationInputTokens: 3}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	snapshot := scheduler.Snapshot()
+	if !snapshot.Enabled || len(snapshot.Sessions) != 1 {
+		t.Fatalf("snapshot after Observe = %+v", snapshot)
+	}
+	session := snapshot.Sessions[0]
+	if session.SessionID != "sess-1" || session.AuthID != "auth-a" || !session.Active {
+		t.Fatalf("session snapshot = %+v", session)
+	}
+	if session.LastRequestAt == nil || session.NextProbeAt == nil {
+		t.Fatalf("session snapshot is missing timestamps: %+v", session)
+	}
+	if session.TTL != "1h0m0s" || session.ProbesSent != 0 {
+		t.Fatalf("session snapshot = %+v", session)
+	}
+	if snapshot.Counters.Scheduled != 1 || snapshot.Counters.Fired != 0 {
+		t.Fatalf("counters after Observe = %+v", snapshot.Counters)
+	}
+
+	clock.fireLatest(t)
+	snapshot = scheduler.Snapshot()
+	if snapshot.Counters.Fired != 1 || snapshot.Counters.Hits != 1 || snapshot.Counters.Misses != 0 {
+		t.Fatalf("counters after a hit = %+v", snapshot.Counters)
+	}
+	session = snapshot.Sessions[0]
+	if session.ProbesSent != 1 || session.ConsecutiveProbes != 1 {
+		t.Fatalf("probe counts = %+v", session)
+	}
+	if session.LastProbe == nil || session.LastProbe.Status != ProbeStatusHit {
+		t.Fatalf("last probe = %+v", session.LastProbe)
+	}
+	if session.LastProbe.CacheReadInputTokens != 12468 || session.LastProbe.CacheCreationInputTokens != 3 {
+		t.Fatalf("last probe tokens = %+v", session.LastProbe)
+	}
+}
+
+func TestSnapshotRecordsAProbeThatMissed(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{result: ProbeResult{CacheReadInputTokens: 0, Diagnosis: "messages_changed"}}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	snapshot := scheduler.Snapshot()
+	if snapshot.Counters.Misses != 1 || snapshot.Counters.Hits != 0 {
+		t.Fatalf("counters after a miss = %+v", snapshot.Counters)
+	}
+	probe := snapshot.Sessions[0].LastProbe
+	if probe == nil || probe.Status != ProbeStatusMiss || probe.Diagnosis != "messages_changed" {
+		t.Fatalf("last probe = %+v", probe)
+	}
+}
+
+func TestSnapshotRecordsProbeErrors(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{err: errProbeTest}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	snapshot := scheduler.Snapshot()
+	if snapshot.Counters.Errors != 1 {
+		t.Fatalf("counters after an error = %+v", snapshot.Counters)
+	}
+	if snapshot.Counters.SkippedByReason["probe-error"] != 1 {
+		t.Fatalf("skipped_by_reason = %+v", snapshot.Counters.SkippedByReason)
+	}
+}
+
+func TestSnapshotKeepsRetiredSessionsWithoutTheirBodies(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	snapshot := scheduler.Snapshot()
+	if len(snapshot.Sessions) != 1 {
+		t.Fatalf("retired session was dropped from the snapshot: %+v", snapshot.Sessions)
+	}
+	session := snapshot.Sessions[0]
+	if session.Active {
+		t.Fatalf("retired session still reports active")
+	}
+	if session.RetiredAt == nil || session.NextProbeAt != nil {
+		t.Fatalf("retired session = %+v", session)
+	}
+	if session.LastProbe == nil || session.LastProbe.SkippedReason != "no-live-agents" {
+		t.Fatalf("retired session last probe = %+v", session.LastProbe)
+	}
+	if snapshot.Counters.SkippedByReason["no-live-agents"] != 1 {
+		t.Fatalf("skipped_by_reason = %+v", snapshot.Counters.SkippedByReason)
+	}
+
+	scheduler.mu.Lock()
+	body := scheduler.sessions["sess-1"].body
+	headers := scheduler.sessions["sess-1"].headers
+	scheduler.mu.Unlock()
+	if body != nil || headers != nil {
+		t.Fatalf("retired session kept its request body in memory")
+	}
+}
+
+func TestSnapshotOnNilScheduler(t *testing.T) {
+	var scheduler *Scheduler
+	snapshot := scheduler.Snapshot()
+	if snapshot.Enabled || snapshot.Sessions == nil || snapshot.Counters.SkippedByReason == nil {
+		t.Fatalf("nil scheduler snapshot must be empty but well formed: %+v", snapshot)
+	}
+}
+
+func TestRetiredSessionHistoryIsBounded(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", state: BindingBound}, nil)
+
+	for index := range maxRetiredSessions + 20 {
+		session := "sess-" + strconv.Itoa(index)
+		observeOneHour(scheduler, session)
+		clock.fireLatest(t)
+	}
+
+	if got := len(scheduler.Snapshot().Sessions); got > maxRetiredSessions {
+		t.Fatalf("retained %d retired sessions, want at most %d", got, maxRetiredSessions)
 	}
 }

--- a/internal/runtime/keepalive/keepalive_test.go
+++ b/internal/runtime/keepalive/keepalive_test.go
@@ -1,0 +1,465 @@
+package keepalive
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// fakeTimer records the requested delay and fires only when the test says so.
+type fakeTimer struct {
+	clock   *fakeClock
+	delay   time.Duration
+	fire    func()
+	stopped bool
+}
+
+func (t *fakeTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	already := t.stopped
+	t.stopped = true
+	return !already
+}
+
+type fakeClock struct {
+	mu     sync.Mutex
+	timers []*fakeTimer
+}
+
+func (c *fakeClock) after(delay time.Duration, fire func()) Timer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	timer := &fakeTimer{clock: c, delay: delay, fire: fire}
+	c.timers = append(c.timers, timer)
+	return timer
+}
+
+// fireLatest runs the most recently scheduled timer that is still armed.
+func (c *fakeClock) fireLatest(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	var target *fakeTimer
+	for index := len(c.timers) - 1; index >= 0; index-- {
+		if !c.timers[index].stopped {
+			target = c.timers[index]
+			break
+		}
+	}
+	c.mu.Unlock()
+	if target == nil {
+		t.Fatalf("no armed timer to fire")
+	}
+	target.fire()
+}
+
+// fireAt runs the timer scheduled at the given index regardless of supersession.
+func (c *fakeClock) fireAt(t *testing.T, index int) {
+	t.Helper()
+	c.mu.Lock()
+	if index >= len(c.timers) {
+		c.mu.Unlock()
+		t.Fatalf("timer %d not scheduled (have %d)", index, len(c.timers))
+	}
+	target := c.timers[index]
+	c.mu.Unlock()
+	target.fire()
+}
+
+func (c *fakeClock) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.timers)
+}
+
+type recordingProber struct {
+	mu       sync.Mutex
+	requests []ProbeRequest
+	result   ProbeResult
+	err      error
+}
+
+func (p *recordingProber) Probe(_ context.Context, req ProbeRequest) (ProbeResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = append(p.requests, req)
+	return p.result, p.err
+}
+
+func (p *recordingProber) calls() []ProbeRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]ProbeRequest, len(p.requests))
+	copy(out, p.requests)
+	return out
+}
+
+type staticLiveness struct{ live bool }
+
+func (l staticLiveness) Live(string, time.Duration) bool { return l.live }
+
+type staticBinding struct {
+	authID string
+	ok     bool
+}
+
+func (b staticBinding) BoundAuthID(string, string, string) (string, bool) {
+	return b.authID, b.ok
+}
+
+const oneHourBody = `{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 32000,
+  "stream": true,
+  "thinking": {"type": "enabled", "budget_tokens": 4000},
+  "system": [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral", "ttl": "1h"}}],
+  "tools": [{"name": "Bash", "cache_control": {"type": "ephemeral", "ttl": "1h"}}],
+  "messages": [{"role": "user", "content": [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]}],
+  "metadata": {"user_id": "{\"session_id\":\"sess-1\"}"}
+}`
+
+const fiveMinuteBody = `{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 100,
+  "system": [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral", "ttl": "5m"}}],
+  "messages": [{"role": "user", "content": "hi"}]
+}`
+
+func testScheduler(t *testing.T, clock *fakeClock, prober Prober, liveness Liveness, binding Binding, mutate func(*Config)) *Scheduler {
+	t.Helper()
+	cfg := Config{
+		Enabled:              true,
+		BeforeExpiry:         5 * time.Minute,
+		OnlyWhenAgentsActive: true,
+		MaxProbes:            6,
+		MaxTokens:            1,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	scheduler := New(cfg)
+	scheduler.SetProber(prober)
+	scheduler.SetLiveness(liveness)
+	scheduler.SetBinding(binding)
+	scheduler.newTimer = clock.after
+	return scheduler
+}
+
+func observeOneHour(scheduler *Scheduler, session string) {
+	scheduler.Observe(ObserveInput{
+		SessionID: session,
+		AuthID:    "auth-a",
+		Provider:  "claude",
+		Model:     "claude-haiku-4-5-20251001",
+		Body:      []byte(oneHourBody),
+		Headers:   http.Header{"Anthropic-Beta": []string{"claude-code-20250219,extended-cache-ttl-2025-04-11"}},
+		TTL:       time.Hour,
+		StartedAt: time.Now(),
+	})
+}
+
+func TestObserveSchedulesAtTTLMinusBeforeExpiry(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+
+	if clock.count() != 1 {
+		t.Fatalf("scheduled %d timers, want 1", clock.count())
+	}
+	// The delay is measured from the observed request's start, so it lands just
+	// under the nominal window.
+	if got := clock.timers[0].delay; got > 55*time.Minute || got < 54*time.Minute {
+		t.Fatalf("delay = %s, want ~55m", got)
+	}
+}
+
+func TestObserveSupersedesEarlierTimer(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	observeOneHour(scheduler, "sess-1")
+
+	if clock.count() != 2 {
+		t.Fatalf("scheduled %d timers, want 2", clock.count())
+	}
+	if !clock.timers[0].stopped {
+		t.Fatalf("first timer was not stopped by the superseding Observe")
+	}
+
+	// Firing the stale timer must not probe.
+	clock.fireAt(t, 0)
+	if calls := prober.calls(); len(calls) != 0 {
+		t.Fatalf("superseded timer probed %d times, want 0", len(calls))
+	}
+
+	// The live timer still probes.
+	clock.fireAt(t, 1)
+	if calls := prober.calls(); len(calls) != 1 {
+		t.Fatalf("live timer probed %d times, want 1", len(calls))
+	}
+}
+
+func TestFireSkipsWhenNoAgentsLive(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 0 {
+		t.Fatalf("probed %d times with no live agents, want 0", len(calls))
+	}
+	if clock.count() != 1 {
+		t.Fatalf("rescheduled after a liveness skip; timers = %d, want 1", clock.count())
+	}
+}
+
+func TestFireProbesWhenLivenessIsAlwaysEvenWithNoAgents(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: false}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+		cfg.OnlyWhenAgentsActive = false
+	})
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 1 {
+		t.Fatalf("probed %d times, want 1", len(calls))
+	}
+}
+
+func TestFireSkipsWhenAuthBindingLost(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "", ok: false}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 0 {
+		t.Fatalf("probed %d times with no binding, want 0", len(calls))
+	}
+}
+
+func TestFireSkipsWhenAuthBindingMovedToAnotherCredential(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-b", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 0 {
+		t.Fatalf("probed %d times after the session rebound to another auth, want 0", len(calls))
+	}
+}
+
+func TestConsecutiveProbesStopAtMaxProbes(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+		cfg.MaxProbes = 3
+	})
+
+	observeOneHour(scheduler, "sess-1")
+	for range 6 {
+		if clock.count() == 0 {
+			break
+		}
+		armed := false
+		clock.mu.Lock()
+		for index := len(clock.timers) - 1; index >= 0; index-- {
+			if !clock.timers[index].stopped {
+				armed = true
+				break
+			}
+		}
+		clock.mu.Unlock()
+		if !armed {
+			break
+		}
+		clock.fireLatest(t)
+	}
+
+	if calls := prober.calls(); len(calls) != 3 {
+		t.Fatalf("probed %d times, want max-probes = 3", len(calls))
+	}
+}
+
+func TestRealRequestResetsProbeBudget(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+		cfg.MaxProbes = 1
+	})
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	if calls := prober.calls(); len(calls) != 2 {
+		t.Fatalf("probed %d times, want 2 (the real request resets the budget)", len(calls))
+	}
+}
+
+func TestProbeBodyPreservesCacheControlBetasAndPrefix(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	clock.fireLatest(t)
+
+	calls := prober.calls()
+	if len(calls) != 1 {
+		t.Fatalf("probed %d times, want 1", len(calls))
+	}
+	probe := calls[0]
+	body := probe.Body
+
+	if got := gjson.GetBytes(body, "max_tokens").Int(); got != 1 {
+		t.Fatalf("max_tokens = %d, want 1", got)
+	}
+	if got := gjson.GetBytes(body, "stream"); !got.Exists() || got.Bool() {
+		t.Fatalf("stream = %v, want false", got.Raw)
+	}
+	if gjson.GetBytes(body, "thinking").Exists() {
+		t.Fatalf("thinking survived into the probe body")
+	}
+	for _, path := range []string{
+		"system.0.cache_control.ttl",
+		"tools.0.cache_control.ttl",
+		"messages.0.content.0.cache_control.ttl",
+	} {
+		if got := gjson.GetBytes(body, path).String(); got != "1h" {
+			t.Fatalf("%s = %q, want 1h", path, got)
+		}
+	}
+	if got := gjson.GetBytes(body, "system.0.text").String(); got != "sys" {
+		t.Fatalf("system text rewritten: %q", got)
+	}
+	if got := gjson.GetBytes(body, "messages.0.content.0.text").String(); got != "hi" {
+		t.Fatalf("message text rewritten: %q", got)
+	}
+	if got := gjson.GetBytes(body, "metadata.user_id").String(); got == "" {
+		t.Fatalf("metadata.user_id dropped from the probe body")
+	}
+	if got := probe.Headers.Get("Anthropic-Beta"); got != "claude-code-20250219,extended-cache-ttl-2025-04-11" {
+		t.Fatalf("Anthropic-Beta = %q, want the observed betas verbatim", got)
+	}
+	if probe.AuthID != "auth-a" {
+		t.Fatalf("AuthID = %q, want auth-a", probe.AuthID)
+	}
+	if probe.Model != "claude-haiku-4-5-20251001" {
+		t.Fatalf("Model = %q", probe.Model)
+	}
+}
+
+func TestDisabledSchedulerNeverSchedules(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+		cfg.Enabled = false
+	})
+
+	observeOneHour(scheduler, "sess-1")
+
+	if clock.count() != 0 {
+		t.Fatalf("scheduled %d timers while disabled, want 0", clock.count())
+	}
+}
+
+func TestNilSchedulerObserveIsSafe(t *testing.T) {
+	var scheduler *Scheduler
+	scheduler.Observe(ObserveInput{SessionID: "sess-1", TTL: time.Hour})
+}
+
+func TestObserveIgnoredWithoutSessionOrTTL(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	scheduler.Observe(ObserveInput{AuthID: "auth-a", Body: []byte(oneHourBody), TTL: time.Hour})
+	scheduler.Observe(ObserveInput{SessionID: "sess-1", AuthID: "auth-a", Body: []byte(oneHourBody)})
+	scheduler.Observe(ObserveInput{SessionID: "sess-1", Body: []byte(oneHourBody), TTL: time.Hour})
+
+	if clock.count() != 0 {
+		t.Fatalf("scheduled %d timers for incomplete observations, want 0", clock.count())
+	}
+}
+
+func TestObserveIgnoredWhenBeforeExpiryExceedsTTL(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, func(cfg *Config) {
+		cfg.BeforeExpiry = 2 * time.Hour
+	})
+
+	observeOneHour(scheduler, "sess-1")
+
+	if clock.count() != 0 {
+		t.Fatalf("scheduled %d timers with before-expiry > ttl, want 0", clock.count())
+	}
+}
+
+func TestCacheControlTTL(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want time.Duration
+	}{
+		{name: "one hour", body: oneHourBody, want: time.Hour},
+		{name: "five minutes only", body: fiveMinuteBody, want: 5 * time.Minute},
+		{name: "bare ephemeral has no explicit ttl", body: `{"system":[{"type":"text","cache_control":{"type":"ephemeral"}}]}`, want: 0},
+		{name: "no cache control", body: `{"messages":[{"role":"user","content":"hi"}]}`, want: 0},
+		{name: "nested one hour", body: `{"messages":[{"content":[{"cache_control":{"ttl":"1h"}}]}]}`, want: time.Hour},
+		{name: "invalid json", body: `not json`, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtendedCacheTTL([]byte(tt.body)); got != tt.want {
+				t.Fatalf("ExtendedCacheTTL() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExtendedCacheTTL(t *testing.T) {
+	if IsExtendedCacheTTL(ExtendedCacheTTL([]byte(fiveMinuteBody))) {
+		t.Fatalf("a 5m-only body must not qualify for keepalive")
+	}
+	if !IsExtendedCacheTTL(ExtendedCacheTTL([]byte(oneHourBody))) {
+		t.Fatalf("a 1h body must qualify for keepalive")
+	}
+	if IsExtendedCacheTTL(ExtendedCacheTTL([]byte(`{"messages":[]}`))) {
+		t.Fatalf("a body with no cache_control must not qualify for keepalive")
+	}
+}
+
+func TestStopClearsScheduledTimers(t *testing.T) {
+	clock := &fakeClock{}
+	prober := &recordingProber{}
+	scheduler := testScheduler(t, clock, prober, staticLiveness{live: true}, staticBinding{authID: "auth-a", ok: true}, nil)
+
+	observeOneHour(scheduler, "sess-1")
+	scheduler.Stop()
+
+	if !clock.timers[0].stopped {
+		t.Fatalf("Stop() left a timer armed")
+	}
+	clock.fireAt(t, 0)
+	if calls := prober.calls(); len(calls) != 0 {
+		t.Fatalf("probed after Stop(), want 0 probes")
+	}
+}

--- a/internal/runtime/keepalive/liveness_claude_code.go
+++ b/internal/runtime/keepalive/liveness_claude_code.go
@@ -11,17 +11,27 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// DefaultTaskStateDirs is where Claude Code writes per-session task state JSON.
-var DefaultTaskStateDirs = []string{"~/.claude/tasks"}
-
-// DefaultTaskOutputDirs is where Claude Code writes per-task output files. The
-// <uid> placeholder expands to the current process user id.
+// DefaultTaskOutputDirs is where Claude Code records one file per background
+// agent or shell. The <uid> placeholder expands to the current process user id.
+//
+// The layout is <root>/<project-slug>/<session-uuid>/tasks/*.output, where the
+// project slug is the working directory with every "/" replaced by "-", for
+// example /Users/me/src becomes -Users-me-src. The slug is matched with a
+// wildcard rather than derived, because the proxy does not know the client's
+// working directory.
 var DefaultTaskOutputDirs = []string{"/private/tmp/claude-<uid>"}
 
-// terminalTaskStatuses are the task states that mean no further turn is coming
-// from that task. Anything else — pending, in_progress, or a status this build
-// has not seen — counts as live, because a false negative silently disables the
-// feature while a false positive costs one cheap cache read.
+// DefaultTaskStateDirs is where Claude Code writes per-session TodoWrite state.
+//
+// This is the secondary signal only. These files are the user-facing todo list,
+// not subagent state: a session with a running subagent frequently has no todo
+// file at all, and a stale todo left at in_progress would keep a finished
+// session looking alive. The task output files above are the authority.
+var DefaultTaskStateDirs = []string{"~/.claude/tasks"}
+
+// terminalTaskStatuses are the todo states that mean no further turn is coming
+// from that item. Anything else counts as live, because a false negative
+// silently disables the feature while a false positive costs one cheap read.
 var terminalTaskStatuses = map[string]struct{}{
 	"completed": {},
 	"complete":  {},
@@ -35,32 +45,41 @@ var terminalTaskStatuses = map[string]struct{}{
 
 // AlwaysLive is the "always" liveness strategy: it never blocks a probe.
 //
-// It exists for clients whose agent state the proxy cannot observe. Combined with
-// a session that is genuinely idle it will keep probing until max-probes, which
-// is the documented cost ceiling for that choice.
+// It exists for clients whose agent state the proxy cannot observe. Combined
+// with a session that is genuinely idle it will keep probing until max-probes,
+// which is the documented cost ceiling for that choice.
 type AlwaysLive struct{}
 
 // Live always reports true.
 func (AlwaysLive) Live(string, time.Duration) bool { return true }
 
 // ClaudeCodeTasksLiveness reports session liveness from Claude Code's on-disk
-// task state.
+// agent state.
 //
-// Two independent signals are consulted, and either one is enough:
+// The primary and authoritative signal is the per-agent task output file:
 //
-//   - a task state file under <state dir>/<session>/*.json whose status is not
-//     terminal;
-//   - a task output file under <output dir>/<project>/<session>/tasks/*.output
-//     modified within the TTL window.
+//	<output dir>/<project-slug>/<session-uuid>/tasks/*.output
 //
-// Claude Code names a session's state directory either by the full session UUID
-// or by a "session-" prefix plus the first eight characters of the UUID, so both
-// spellings are searched.
+// Every background agent and shell of a session has one. A running agent keeps
+// writing to it, so its modification time advances. Some of these files are
+// symlinks into ~/.claude/projects/<slug>/<session>/subagents/agent-*.jsonl,
+// where the real writes land; the symlink's own timestamp lags the target's, so
+// liveness follows the link and reads the target.
+//
+// A file counts as live only while it was written inside the idle window. The
+// window is not the cache TTL: an agent that has produced nothing for an hour is
+// finished, not busy. Its flip side is that a genuinely silent agent, one doing
+// long work that emits nothing, looks idle once the window passes, so the window
+// should exceed the longest silence worth paying a probe for.
+//
+// The TodoWrite state files are consulted only as a secondary fallback.
 type ClaudeCodeTasksLiveness struct {
-	// StateDirs are the roots holding per-session task state directories.
-	StateDirs []string
 	// OutputDirs are the roots holding <project>/<session>/tasks/*.output files.
+	// This is the primary signal.
 	OutputDirs []string
+	// StateDirs are the roots holding per-session TodoWrite state directories.
+	// Secondary signal only; see DefaultTaskStateDirs.
+	StateDirs []string
 
 	now func() time.Time
 }
@@ -81,15 +100,52 @@ func NewClaudeCodeTasksLiveness(stateDirs, outputDirs []string) *ClaudeCodeTasks
 	}
 }
 
-// Live reports whether the session still has a task in flight.
+// Live reports whether the session still has an agent running. The window is the
+// configured agent idle window.
 func (l *ClaudeCodeTasksLiveness) Live(sessionID string, window time.Duration) bool {
 	if l == nil || strings.TrimSpace(sessionID) == "" {
 		return false
 	}
-	if l.hasRunningTaskState(sessionID) {
+	// Primary: a task output file written inside the idle window.
+	if l.hasRecentTaskOutput(sessionID, window) {
 		return true
 	}
-	return l.hasRecentTaskOutput(sessionID, window)
+	// Secondary: a TodoWrite item that never reached a terminal status.
+	return l.hasRunningTaskState(sessionID)
+}
+
+func (l *ClaudeCodeTasksLiveness) hasRecentTaskOutput(sessionID string, window time.Duration) bool {
+	if window <= 0 {
+		window = 10 * time.Minute
+	}
+	now := time.Now
+	if l.now != nil {
+		now = l.now
+	}
+	cutoff := now().Add(-window)
+	for _, root := range l.OutputDirs {
+		for _, dirName := range sessionDirNames(sessionID) {
+			entries, errGlob := filepath.Glob(filepath.Join(root, "*", dirName, "tasks", "*.output"))
+			if errGlob != nil {
+				continue
+			}
+			for _, entry := range entries {
+				// os.Stat follows symlinks, which is required: these entries are
+				// often links to the agent transcript, and only the target's
+				// timestamp advances as the agent writes.
+				info, errStat := os.Stat(entry)
+				if errStat != nil {
+					continue
+				}
+				if info.ModTime().After(cutoff) {
+					log.Debugf("cache-keepalive: liveness hit | session=%s source=task-output file=%s modified=%s",
+						truncateSession(sessionID), entry, info.ModTime().Format(time.RFC3339))
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (l *ClaudeCodeTasksLiveness) hasRunningTaskState(sessionID string) bool {
@@ -109,37 +165,8 @@ func (l *ClaudeCodeTasksLiveness) hasRunningTaskState(sessionID string) bool {
 					continue
 				}
 				if _, terminal := terminalTaskStatuses[status]; !terminal {
-					log.Debugf("cache-keepalive: liveness hit | session=%s file=%s status=%s", truncateSession(sessionID), entry, status)
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-func (l *ClaudeCodeTasksLiveness) hasRecentTaskOutput(sessionID string, window time.Duration) bool {
-	if window <= 0 {
-		window = time.Hour
-	}
-	now := time.Now
-	if l.now != nil {
-		now = l.now
-	}
-	cutoff := now().Add(-window)
-	for _, root := range l.OutputDirs {
-		for _, dirName := range sessionDirNames(sessionID) {
-			entries, errGlob := filepath.Glob(filepath.Join(root, "*", dirName, "tasks", "*.output"))
-			if errGlob != nil {
-				continue
-			}
-			for _, entry := range entries {
-				info, errStat := os.Stat(entry)
-				if errStat != nil {
-					continue
-				}
-				if info.ModTime().After(cutoff) {
-					log.Debugf("cache-keepalive: liveness hit | session=%s file=%s modified=%s", truncateSession(sessionID), entry, info.ModTime())
+					log.Debugf("cache-keepalive: liveness hit | session=%s source=todo-state file=%s status=%s",
+						truncateSession(sessionID), entry, status)
 					return true
 				}
 			}
@@ -149,6 +176,8 @@ func (l *ClaudeCodeTasksLiveness) hasRecentTaskOutput(sessionID string, window t
 }
 
 // sessionDirNames returns the directory spellings Claude Code uses for a session.
+// Task output directories use the full session UUID; the secondary TodoWrite
+// directories are also seen as "session-" plus the first eight characters.
 func sessionDirNames(sessionID string) []string {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {

--- a/internal/runtime/keepalive/liveness_claude_code.go
+++ b/internal/runtime/keepalive/liveness_claude_code.go
@@ -1,0 +1,192 @@
+package keepalive
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+// DefaultTaskStateDirs is where Claude Code writes per-session task state JSON.
+var DefaultTaskStateDirs = []string{"~/.claude/tasks"}
+
+// DefaultTaskOutputDirs is where Claude Code writes per-task output files. The
+// <uid> placeholder expands to the current process user id.
+var DefaultTaskOutputDirs = []string{"/private/tmp/claude-<uid>"}
+
+// terminalTaskStatuses are the task states that mean no further turn is coming
+// from that task. Anything else — pending, in_progress, or a status this build
+// has not seen — counts as live, because a false negative silently disables the
+// feature while a false positive costs one cheap cache read.
+var terminalTaskStatuses = map[string]struct{}{
+	"completed": {},
+	"complete":  {},
+	"failed":    {},
+	"cancelled": {},
+	"canceled":  {},
+	"killed":    {},
+	"aborted":   {},
+	"error":     {},
+}
+
+// AlwaysLive is the "always" liveness strategy: it never blocks a probe.
+//
+// It exists for clients whose agent state the proxy cannot observe. Combined with
+// a session that is genuinely idle it will keep probing until max-probes, which
+// is the documented cost ceiling for that choice.
+type AlwaysLive struct{}
+
+// Live always reports true.
+func (AlwaysLive) Live(string, time.Duration) bool { return true }
+
+// ClaudeCodeTasksLiveness reports session liveness from Claude Code's on-disk
+// task state.
+//
+// Two independent signals are consulted, and either one is enough:
+//
+//   - a task state file under <state dir>/<session>/*.json whose status is not
+//     terminal;
+//   - a task output file under <output dir>/<project>/<session>/tasks/*.output
+//     modified within the TTL window.
+//
+// Claude Code names a session's state directory either by the full session UUID
+// or by a "session-" prefix plus the first eight characters of the UUID, so both
+// spellings are searched.
+type ClaudeCodeTasksLiveness struct {
+	// StateDirs are the roots holding per-session task state directories.
+	StateDirs []string
+	// OutputDirs are the roots holding <project>/<session>/tasks/*.output files.
+	OutputDirs []string
+
+	now func() time.Time
+}
+
+// NewClaudeCodeTasksLiveness builds a liveness checker, falling back to the
+// built-in paths when the operator configured none.
+func NewClaudeCodeTasksLiveness(stateDirs, outputDirs []string) *ClaudeCodeTasksLiveness {
+	if len(stateDirs) == 0 {
+		stateDirs = DefaultTaskStateDirs
+	}
+	if len(outputDirs) == 0 {
+		outputDirs = DefaultTaskOutputDirs
+	}
+	return &ClaudeCodeTasksLiveness{
+		StateDirs:  expandPaths(stateDirs),
+		OutputDirs: expandPaths(outputDirs),
+		now:        time.Now,
+	}
+}
+
+// Live reports whether the session still has a task in flight.
+func (l *ClaudeCodeTasksLiveness) Live(sessionID string, window time.Duration) bool {
+	if l == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	if l.hasRunningTaskState(sessionID) {
+		return true
+	}
+	return l.hasRecentTaskOutput(sessionID, window)
+}
+
+func (l *ClaudeCodeTasksLiveness) hasRunningTaskState(sessionID string) bool {
+	for _, root := range l.StateDirs {
+		for _, dirName := range sessionDirNames(sessionID) {
+			entries, errGlob := filepath.Glob(filepath.Join(root, dirName, "*.json"))
+			if errGlob != nil {
+				continue
+			}
+			for _, entry := range entries {
+				data, errRead := os.ReadFile(entry)
+				if errRead != nil {
+					continue
+				}
+				status := strings.ToLower(strings.TrimSpace(gjson.GetBytes(data, "status").String()))
+				if status == "" {
+					continue
+				}
+				if _, terminal := terminalTaskStatuses[status]; !terminal {
+					log.Debugf("cache-keepalive: liveness hit | session=%s file=%s status=%s", truncateSession(sessionID), entry, status)
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (l *ClaudeCodeTasksLiveness) hasRecentTaskOutput(sessionID string, window time.Duration) bool {
+	if window <= 0 {
+		window = time.Hour
+	}
+	now := time.Now
+	if l.now != nil {
+		now = l.now
+	}
+	cutoff := now().Add(-window)
+	for _, root := range l.OutputDirs {
+		for _, dirName := range sessionDirNames(sessionID) {
+			entries, errGlob := filepath.Glob(filepath.Join(root, "*", dirName, "tasks", "*.output"))
+			if errGlob != nil {
+				continue
+			}
+			for _, entry := range entries {
+				info, errStat := os.Stat(entry)
+				if errStat != nil {
+					continue
+				}
+				if info.ModTime().After(cutoff) {
+					log.Debugf("cache-keepalive: liveness hit | session=%s file=%s modified=%s", truncateSession(sessionID), entry, info.ModTime())
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// sessionDirNames returns the directory spellings Claude Code uses for a session.
+func sessionDirNames(sessionID string) []string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	names := []string{sessionID}
+	if len(sessionID) > 8 {
+		names = append(names, "session-"+sessionID[:8])
+	}
+	return names
+}
+
+func expandPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if expanded := expandPath(path); expanded != "" {
+			out = append(out, expanded)
+		}
+	}
+	return out
+}
+
+// expandPath resolves a leading ~ and the <uid> placeholder.
+func expandPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = strings.ReplaceAll(path, "<uid>", strconv.Itoa(os.Getuid()))
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, errHome := os.UserHomeDir()
+		if errHome != nil {
+			return path
+		}
+		if path == "~" {
+			return home
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/internal/runtime/keepalive/liveness_claude_code_symlink_test.go
+++ b/internal/runtime/keepalive/liveness_claude_code_symlink_test.go
@@ -1,0 +1,71 @@
+//go:build darwin || linux
+
+package keepalive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// writeSymlinkedTaskOutput mirrors the real layout, where a subagent's output
+// file is a symlink into the project transcript directory and only the target's
+// timestamp advances as the agent writes.
+func writeSymlinkedTaskOutput(t *testing.T, root, project, sessionDir, name string, targetModTime, linkModTime time.Time) {
+	t.Helper()
+	targetDir := filepath.Join(root, "transcripts")
+	if errMkdir := os.MkdirAll(targetDir, 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	target := filepath.Join(targetDir, "agent-"+name+".jsonl")
+	if errWrite := os.WriteFile(target, []byte("{}\n"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+	if errChtimes := os.Chtimes(target, targetModTime, targetModTime); errChtimes != nil {
+		t.Fatalf("Chtimes: %v", errChtimes)
+	}
+
+	linkDir := filepath.Join(root, project, sessionDir, "tasks")
+	if errMkdir := os.MkdirAll(linkDir, 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	link := filepath.Join(linkDir, name+".output")
+	if errLink := os.Symlink(target, link); errLink != nil {
+		t.Fatalf("Symlink: %v", errLink)
+	}
+	// The link's own timestamp must be set without following it. os.Chtimes
+	// follows symlinks and would rewrite the target, defeating the fixture.
+	stamp := unix.NsecToTimespec(linkModTime.UnixNano())
+	if errUtimes := unix.UtimesNanoAt(unix.AT_FDCWD, link, []unix.Timespec{stamp, stamp}, unix.AT_SYMLINK_NOFOLLOW); errUtimes != nil {
+		t.Skipf("cannot set symlink timestamps on this platform: %v", errUtimes)
+	}
+}
+
+func TestClaudeCodeTasksLivenessFollowsSymlinkToTheAgentTranscript(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	// The link is stale, the transcript it points at is fresh. Following the link
+	// is the difference between "agent running" and "agent gone".
+	writeSymlinkedTaskOutput(t, outputRoot, "-Users-me-src", testSession, "a320d50c23cf12b0a",
+		now.Add(-30*time.Second), now.Add(-40*time.Minute))
+
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+	if !liveness.Live(testSession, 10*time.Minute) {
+		t.Fatalf("Live() = false, want true: the symlink target was written 30s ago")
+	}
+}
+
+func TestClaudeCodeTasksLivenessStaleSymlinkTargetIsNotLive(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	writeSymlinkedTaskOutput(t, outputRoot, "-Users-me-src", testSession, "a320d50c23cf12b0a",
+		now.Add(-30*time.Minute), now.Add(-30*time.Minute))
+
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+	if liveness.Live(testSession, 10*time.Minute) {
+		t.Fatalf("Live() = true, want false: the agent has written nothing for 30 minutes")
+	}
+}

--- a/internal/runtime/keepalive/liveness_claude_code_test.go
+++ b/internal/runtime/keepalive/liveness_claude_code_test.go
@@ -1,0 +1,172 @@
+package keepalive
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTaskState(t *testing.T, root, sessionDir, name, status string) {
+	t.Helper()
+	dir := filepath.Join(root, sessionDir)
+	if errMkdir := os.MkdirAll(dir, 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	body := `{"id":"1","subject":"probe","status":"` + status + `"}`
+	if errWrite := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+}
+
+func writeTaskOutput(t *testing.T, root, project, sessionDir, name string, modTime time.Time) {
+	t.Helper()
+	dir := filepath.Join(root, project, sessionDir, "tasks")
+	if errMkdir := os.MkdirAll(dir, 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll: %v", errMkdir)
+	}
+	path := filepath.Join(dir, name)
+	if errWrite := os.WriteFile(path, []byte("output"), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile: %v", errWrite)
+	}
+	if errChtimes := os.Chtimes(path, modTime, modTime); errChtimes != nil {
+		t.Fatalf("Chtimes: %v", errChtimes)
+	}
+}
+
+const testSession = "4463ede6-1111-2222-3333-444455556666"
+
+func TestClaudeCodeTasksLivenessRunningTask(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeTaskState(t, stateRoot, testSession, "1.json", "in_progress")
+
+	liveness := &ClaudeCodeTasksLiveness{StateDirs: []string{stateRoot}}
+	if !liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = false, want true for an in_progress task")
+	}
+}
+
+func TestClaudeCodeTasksLivenessPendingTaskCountsAsLive(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeTaskState(t, stateRoot, testSession, "1.json", "pending")
+
+	liveness := &ClaudeCodeTasksLiveness{StateDirs: []string{stateRoot}}
+	if !liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = false, want true for a pending task")
+	}
+}
+
+func TestClaudeCodeTasksLivenessAllTerminal(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeTaskState(t, stateRoot, testSession, "1.json", "completed")
+	writeTaskState(t, stateRoot, testSession, "2.json", "failed")
+	writeTaskState(t, stateRoot, testSession, "3.json", "cancelled")
+	writeTaskState(t, stateRoot, testSession, "4.json", "killed")
+
+	liveness := &ClaudeCodeTasksLiveness{StateDirs: []string{stateRoot}}
+	if liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = true, want false when every task reached a terminal status")
+	}
+}
+
+func TestClaudeCodeTasksLivenessPrefixedSessionDirectory(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeTaskState(t, stateRoot, "session-"+testSession[:8], "1.json", "in_progress")
+
+	liveness := &ClaudeCodeTasksLiveness{StateDirs: []string{stateRoot}}
+	if !liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = false, want true for the session-<prefix> directory spelling")
+	}
+}
+
+func TestClaudeCodeTasksLivenessOtherSessionIgnored(t *testing.T) {
+	stateRoot := t.TempDir()
+	writeTaskState(t, stateRoot, "99999999-0000-0000-0000-000000000000", "1.json", "in_progress")
+
+	liveness := &ClaudeCodeTasksLiveness{StateDirs: []string{stateRoot}}
+	if liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = true, want false when only another session has running tasks")
+	}
+}
+
+func TestClaudeCodeTasksLivenessRecentOutput(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	writeTaskOutput(t, outputRoot, "-Users-someone-project", testSession, "abc.output", now.Add(-10*time.Minute))
+
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+	if !liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = false, want true for an output file modified inside the window")
+	}
+}
+
+func TestClaudeCodeTasksLivenessStaleOutput(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	writeTaskOutput(t, outputRoot, "-Users-someone-project", testSession, "abc.output", now.Add(-3*time.Hour))
+
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+	if liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = true, want false for an output file older than the window")
+	}
+}
+
+func TestClaudeCodeTasksLivenessNoSignal(t *testing.T) {
+	liveness := NewClaudeCodeTasksLiveness([]string{t.TempDir()}, []string{t.TempDir()})
+	if liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = true, want false with no task state at all")
+	}
+	if liveness.Live("", time.Hour) {
+		t.Fatalf("Live() = true for an empty session id")
+	}
+}
+
+func TestAlwaysLive(t *testing.T) {
+	if !(AlwaysLive{}).Live("anything", time.Hour) {
+		t.Fatalf("AlwaysLive must never block a probe")
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	home, errHome := os.UserHomeDir()
+	if errHome != nil {
+		t.Skipf("no home directory: %v", errHome)
+	}
+	if got := expandPath("~/.claude/tasks"); got != filepath.Join(home, ".claude/tasks") {
+		t.Fatalf("expandPath(~) = %q", got)
+	}
+	uid := os.Getuid()
+	want := "/private/tmp/claude-" + itoa(uid)
+	if got := expandPath("/private/tmp/claude-<uid>"); got != want {
+		t.Fatalf("expandPath(<uid>) = %q, want %q", got, want)
+	}
+}
+
+func itoa(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	negative := value < 0
+	if negative {
+		value = -value
+	}
+	digits := make([]byte, 0, 12)
+	for value > 0 {
+		digits = append([]byte{byte('0' + value%10)}, digits...)
+		value /= 10
+	}
+	if negative {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+func TestNewClaudeCodeTasksLivenessDefaults(t *testing.T) {
+	liveness := NewClaudeCodeTasksLiveness(nil, nil)
+	if len(liveness.StateDirs) != 1 || liveness.StateDirs[0] == DefaultTaskStateDirs[0] {
+		t.Fatalf("StateDirs = %v, want the expanded default", liveness.StateDirs)
+	}
+	if len(liveness.OutputDirs) != 1 || liveness.OutputDirs[0] == DefaultTaskOutputDirs[0] {
+		t.Fatalf("OutputDirs = %v, want the expanded default", liveness.OutputDirs)
+	}
+}

--- a/internal/runtime/keepalive/liveness_claude_code_test.go
+++ b/internal/runtime/keepalive/liveness_claude_code_test.go
@@ -36,6 +36,7 @@ func writeTaskOutput(t *testing.T, root, project, sessionDir, name string, modTi
 
 const testSession = "4463ede6-1111-2222-3333-444455556666"
 
+// The TodoWrite files are the secondary signal; these tests pin that fallback.
 func TestClaudeCodeTasksLivenessRunningTask(t *testing.T) {
 	stateRoot := t.TempDir()
 	writeTaskState(t, stateRoot, testSession, "1.json", "in_progress")
@@ -168,5 +169,49 @@ func TestNewClaudeCodeTasksLivenessDefaults(t *testing.T) {
 	}
 	if len(liveness.OutputDirs) != 1 || liveness.OutputDirs[0] == DefaultTaskOutputDirs[0] {
 		t.Fatalf("OutputDirs = %v, want the expanded default", liveness.OutputDirs)
+	}
+}
+
+func TestClaudeCodeTasksLivenessUsesTheIdleWindowNotTheTTL(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	// Twenty minutes of silence: inside a 1h cache TTL, outside a 10m idle window.
+	writeTaskOutput(t, outputRoot, "-Users-me-src", testSession, "abc.output", now.Add(-20*time.Minute))
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+
+	if liveness.Live(testSession, 10*time.Minute) {
+		t.Fatalf("Live() = true for a 10m idle window, want false")
+	}
+	if !liveness.Live(testSession, time.Hour) {
+		t.Fatalf("Live() = false for a 1h window; the test fixture is wrong")
+	}
+}
+
+func TestClaudeCodeTasksLivenessOutputWinsWithNoTodoState(t *testing.T) {
+	outputRoot := t.TempDir()
+	stateRoot := t.TempDir()
+	now := time.Now()
+	writeTaskOutput(t, outputRoot, "-Users-me-src", testSession, "abc.output", now.Add(-1*time.Minute))
+
+	// The real failure this replaced: a session with a running subagent has no
+	// TodoWrite file at all, so the todo check alone reported it dead.
+	liveness := &ClaudeCodeTasksLiveness{
+		OutputDirs: []string{outputRoot},
+		StateDirs:  []string{stateRoot},
+		now:        func() time.Time { return now },
+	}
+	if !liveness.Live(testSession, 10*time.Minute) {
+		t.Fatalf("Live() = false, want true: a fresh task output must not need a todo file")
+	}
+}
+
+func TestClaudeCodeTasksLivenessIgnoresAnotherSessionsOutput(t *testing.T) {
+	outputRoot := t.TempDir()
+	now := time.Now()
+	writeTaskOutput(t, outputRoot, "-Users-me-src", "99999999-0000-0000-0000-000000000000", "abc.output", now)
+
+	liveness := &ClaudeCodeTasksLiveness{OutputDirs: []string{outputRoot}, now: func() time.Time { return now }}
+	if liveness.Live(testSession, 10*time.Minute) {
+		t.Fatalf("Live() = true, want false when only another session has fresh output")
 	}
 }

--- a/internal/runtime/keepalive/probe_5m.go
+++ b/internal/runtime/keepalive/probe_5m.go
@@ -1,0 +1,97 @@
+package keepalive
+
+import "strings"
+
+// Probe-5m modes. They select when a session on the 5m cache pool is probed.
+const (
+	// Probe5mAuto probes a 5m session only when the model's cache reads are
+	// cheap enough for the arithmetic to work out. It is the default.
+	Probe5mAuto = "auto"
+	// Probe5mAlways probes every confirmed session regardless of tier or model.
+	Probe5mAlways = "always"
+	// Probe5mNever restores the original behaviour: only 1h sessions are probed.
+	Probe5mNever = "never"
+)
+
+// Probe-5m decisions. They appear in the `cache-keepalive:` log lines, in the
+// management snapshot, and, for the two skips, as keys in
+// counters.skipped_by_reason.
+const (
+	// Probe5mDecisionNotApplicable marks a session on the 1h pool, where the
+	// 5m policy never applies.
+	Probe5mDecisionNotApplicable = "n/a"
+	// Probe5mDecisionModelAuto means auto matched the request model against the
+	// cheap-cache-read list.
+	Probe5mDecisionModelAuto = "model-auto"
+	// Probe5mDecisionAlways means the operator opted every session in.
+	Probe5mDecisionAlways = "always"
+	// Probe5mDecisionSkippedNever means 5m probing is turned off.
+	Probe5mDecisionSkippedNever = "skipped-never"
+	// Probe5mDecisionSkippedModel means auto found no cheap-cache-read match.
+	Probe5mDecisionSkippedModel = "skipped-model"
+)
+
+// CheapCacheReadModels lists the models whose cache reads are cheap enough that
+// holding a 5m entry open with probes beats letting it expire.
+//
+// The break-even is the cache-read multiple of base input. Most Claude models
+// read at 0.1x base and write at 1.25x, so the twelve or thirteen reads a 5m
+// window needs per hour cost ~1.2x the context against the 1.25x write they
+// avoid: a wash at best, which is why 5m probing was originally refused
+// outright. claude-fable-5-1 and claude-mythos-5-1 read at 0.025x base
+// ($0.25/MTok against $10/MTok input), so the same twelve reads cost ~0.3x
+// against that same 1.25x write, roughly four times cheaper than letting the
+// entry expire. Anthropic's prompt-caching guidance makes the same point from
+// the other side: on these models prefer a keepalive on the 5m tier over paying
+// the 1h TTL premium, unless pauses regularly approach an hour.
+//
+// Entries match case-insensitively as substrings so a provider-prefixed or
+// suffixed spelling still resolves, for example
+// "us.anthropic.claude-fable-5-1-v1:0" or "claude-fable-5-1[1m]". Operators
+// replace the list with claude-code.cache-keepalive.probe-5m-models when a new
+// model lands before this build does.
+var CheapCacheReadModels = []string{
+	"claude-fable-5-1",
+	"claude-mythos-5-1",
+}
+
+// probe5mDecision reports whether a 5m session may be probed, and why.
+//
+// An unrecognised mode is treated as auto: configuration validation rejects
+// those before they reach the scheduler, so the fallback only ever covers an
+// SDK caller that built the Config by hand.
+func probe5mDecision(mode string, models []string, model string) (bool, string) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case Probe5mNever:
+		return false, Probe5mDecisionSkippedNever
+	case Probe5mAlways:
+		return true, Probe5mDecisionAlways
+	default:
+		if matchesCheapCacheReadModel(models, model) {
+			return true, Probe5mDecisionModelAuto
+		}
+		return false, Probe5mDecisionSkippedModel
+	}
+}
+
+// matchesCheapCacheReadModel reports whether the model is on the cheap-cache-read
+// list. An empty override list falls back to the built-in one.
+func matchesCheapCacheReadModel(models []string, model string) bool {
+	name := strings.ToLower(strings.TrimSpace(model))
+	if name == "" {
+		return false
+	}
+	if len(models) == 0 {
+		models = CheapCacheReadModels
+	}
+	for _, candidate := range models {
+		candidate = strings.ToLower(strings.TrimSpace(candidate))
+		if candidate == "" {
+			continue
+		}
+		if strings.Contains(name, candidate) {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/cliproxy/auth/selector_session_binding.go
+++ b/sdk/cliproxy/auth/selector_session_binding.go
@@ -1,0 +1,41 @@
+package auth
+
+import "strings"
+
+// SessionBindingLookup reports the credential a session is currently bound to.
+type SessionBindingLookup interface {
+	BoundAuthID(provider, sessionID, model string) (string, bool)
+}
+
+// BoundAuthID reports the auth a session is currently bound to without
+// refreshing the binding's TTL.
+//
+// A read that refreshed the entry would let a background caller keep a stale
+// binding alive, so this deliberately uses the non-refreshing lookup.
+func (s *SessionAffinitySelector) BoundAuthID(provider, sessionID, model string) (string, bool) {
+	if s == nil || s.cache == nil {
+		return "", false
+	}
+	provider = strings.TrimSpace(provider)
+	sessionID = strings.TrimSpace(sessionID)
+	if provider == "" || sessionID == "" {
+		return "", false
+	}
+	return s.cache.Get(provider + "::" + sessionID + "::" + canonicalModelKey(model))
+}
+
+// SessionBindingLookup returns the active session-to-credential binding lookup.
+//
+// It reports false when routing is not session-sticky, which callers must treat
+// as "binding unknown" rather than "session unbound": with no affinity selector
+// there is no binding to lose.
+func (m *Manager) SessionBindingLookup() (SessionBindingLookup, bool) {
+	if m == nil {
+		return nil, false
+	}
+	lookup, ok := m.Selector().(SessionBindingLookup)
+	if !ok || lookup == nil {
+		return nil, false
+	}
+	return lookup, true
+}

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 
@@ -162,10 +163,14 @@ func announceCacheKeepalive(settings internalconfig.ClaudeCodeCacheKeepaliveConf
 	}
 	return previous.Enabled != settings.Enabled ||
 		previous.BeforeExpiry != settings.BeforeExpiry ||
+		previous.BeforeExpiry5m != settings.BeforeExpiry5m ||
+		previous.Probe5m != settings.Probe5m ||
+		!slices.Equal(previous.Probe5mModels, settings.Probe5mModels) ||
 		previous.OnlyWhenAgentsActive != settings.OnlyWhenAgentsActive ||
 		previous.Liveness != settings.Liveness ||
 		previous.AgentIdleWindow != settings.AgentIdleWindow ||
 		previous.MaxProbes != settings.MaxProbes ||
+		previous.MaxProbes5m != settings.MaxProbes5m ||
 		previous.MaxTokens != settings.MaxTokens
 }
 
@@ -198,9 +203,13 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 	runtimeCfg := keepalive.Config{
 		Enabled:              true,
 		BeforeExpiry:         settings.BeforeExpiry,
+		BeforeExpiry5m:       settings.BeforeExpiry5m,
+		Probe5m:              settings.Probe5m,
+		Probe5mModels:        settings.Probe5mModels,
 		OnlyWhenAgentsActive: settings.OnlyWhenAgentsActive,
 		AgentIdleWindow:      settings.AgentIdleWindow,
 		MaxProbes:            settings.MaxProbes,
+		MaxProbes5m:          settings.MaxProbes5m,
 		MaxTokens:            settings.MaxTokens,
 	}
 
@@ -226,7 +235,8 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 		scheduler.ApplyConfig(runtimeCfg)
 	}
 	if changed {
-		log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s agent-idle-window=%s max-probes=%d max-tokens=%d",
-			settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.AgentIdleWindow, settings.MaxProbes, settings.MaxTokens)
+		log.Infof("cache-keepalive: enabled | before-expiry=%s before-expiry-5m=%s probe-5m=%s only-when-agents-active=%t liveness=%s agent-idle-window=%s max-probes=%d max-probes-5m=%d max-tokens=%d",
+			settings.BeforeExpiry, settings.BeforeExpiry5m, settings.Probe5m, settings.OnlyWhenAgentsActive, settings.Liveness,
+			settings.AgentIdleWindow, settings.MaxProbes, settings.MaxProbes5m, settings.MaxTokens)
 	}
 }

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -1,0 +1,137 @@
+package cliproxy
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+// cacheKeepaliveProbeProvider is the auth provider a Claude Code keepalive probe
+// routes through when the observation recorded none.
+const cacheKeepaliveProbeProvider = "claude"
+
+// cacheKeepaliveProber sends a probe through the ordinary execution path so it
+// receives the same translation, cloaking, header and cache_control handling a
+// real request gets. The credential is pinned to the one the session is bound to.
+type cacheKeepaliveProber struct {
+	manager *coreauth.Manager
+}
+
+func (p cacheKeepaliveProber) Probe(ctx context.Context, probe keepalive.ProbeRequest) (keepalive.ProbeResult, error) {
+	if p.manager == nil {
+		return keepalive.ProbeResult{}, errors.New("cache keepalive: no auth manager")
+	}
+	provider := strings.TrimSpace(probe.Provider)
+	if provider == "" || strings.EqualFold(provider, "mixed") {
+		provider = cacheKeepaliveProbeProvider
+	}
+	claudeFormat := sdktranslator.FromString("claude")
+	req := coreexecutor.Request{Model: probe.Model, Payload: probe.Body}
+	opts := coreexecutor.Options{
+		Stream:          false,
+		OriginalRequest: probe.Body,
+		SourceFormat:    claudeFormat,
+		ResponseFormat:  claudeFormat,
+		Headers:         probe.Headers,
+		Metadata: map[string]any{
+			coreexecutor.PinnedAuthMetadataKey:     probe.AuthID,
+			coreexecutor.RequestedModelMetadataKey: probe.Model,
+		},
+	}
+	resp, err := p.manager.Execute(ctx, []string{provider}, req, opts)
+	if err != nil {
+		return keepalive.ProbeResult{}, err
+	}
+	return keepalive.ProbeResult{
+		CacheReadInputTokens: gjson.GetBytes(resp.Payload, "usage.cache_read_input_tokens").Int(),
+	}, nil
+}
+
+// cacheKeepaliveBinding answers whether the session is still bound to the
+// credential the probe was recorded against.
+type cacheKeepaliveBinding struct {
+	manager *coreauth.Manager
+}
+
+func (b cacheKeepaliveBinding) SessionBinding(provider, sessionID, model string) (string, keepalive.BindingState) {
+	if b.manager == nil {
+		return "", keepalive.BindingUnknown
+	}
+	lookup, ok := b.manager.SessionBindingLookup()
+	if !ok {
+		// Routing is not session-sticky, so there is no binding to lose.
+		return "", keepalive.BindingUnknown
+	}
+	authID, bound := lookup.BoundAuthID(provider, sessionID, model)
+	if !bound {
+		return "", keepalive.BindingLost
+	}
+	return authID, keepalive.BindingBound
+}
+
+// applyCacheKeepaliveConfig installs or reconfigures the prompt-cache keepalive
+// scheduler. It is safe to call on every config reload.
+func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
+	if s == nil {
+		return
+	}
+	settings := internalconfig.ClaudeCodeCacheKeepaliveConfig{}
+	if cfg != nil {
+		settings = cfg.ClaudeCode.CacheKeepalive
+	}
+	settings = settings.WithDefaults()
+
+	if !settings.Enabled {
+		if keepalive.Default() != nil {
+			log.Info("cache-keepalive: disabled")
+		}
+		keepalive.SetDefault(nil)
+		return
+	}
+	if s.coreManager == nil {
+		log.Warn("cache-keepalive: enabled but no auth manager is available; keepalive stays off")
+		keepalive.SetDefault(nil)
+		return
+	}
+
+	runtimeCfg := keepalive.Config{
+		Enabled:              true,
+		BeforeExpiry:         settings.BeforeExpiry,
+		OnlyWhenAgentsActive: settings.OnlyWhenAgentsActive,
+		MaxProbes:            settings.MaxProbes,
+		MaxTokens:            settings.MaxTokens,
+	}
+
+	var liveness keepalive.Liveness
+	switch settings.Liveness {
+	case internalconfig.ClaudeCodeKeepaliveLivenessAlways:
+		liveness = keepalive.AlwaysLive{}
+	default:
+		liveness = keepalive.NewClaudeCodeTasksLiveness(settings.TaskStateDirs, settings.TaskOutputDirs)
+	}
+
+	scheduler := keepalive.Default()
+	if scheduler == nil {
+		scheduler = keepalive.New(runtimeCfg)
+		scheduler.SetProber(cacheKeepaliveProber{manager: s.coreManager})
+		scheduler.SetBinding(cacheKeepaliveBinding{manager: s.coreManager})
+		scheduler.SetLiveness(liveness)
+		keepalive.SetDefault(scheduler)
+	} else {
+		scheduler.SetProber(cacheKeepaliveProber{manager: s.coreManager})
+		scheduler.SetBinding(cacheKeepaliveBinding{manager: s.coreManager})
+		scheduler.SetLiveness(liveness)
+		scheduler.ApplyConfig(runtimeCfg)
+	}
+	log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s max-probes=%d max-tokens=%d",
+		settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.MaxProbes, settings.MaxTokens)
+}

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
@@ -78,6 +79,31 @@ func (b cacheKeepaliveBinding) SessionBinding(provider, sessionID, model string)
 	return authID, keepalive.BindingBound
 }
 
+// cacheKeepaliveLastApplied guards the announcement of the keepalive settings so
+// startup and the config-runtime pass that follows it do not log the same state
+// twice. It tracks the process-wide scheduler, which is itself a package global.
+var (
+	cacheKeepaliveAnnounceMu sync.Mutex
+	cacheKeepaliveAnnounced  *internalconfig.ClaudeCodeCacheKeepaliveConfig
+)
+
+// announceCacheKeepalive reports whether the settings changed since the last call.
+func announceCacheKeepalive(settings internalconfig.ClaudeCodeCacheKeepaliveConfig) bool {
+	cacheKeepaliveAnnounceMu.Lock()
+	defer cacheKeepaliveAnnounceMu.Unlock()
+	previous := cacheKeepaliveAnnounced
+	cacheKeepaliveAnnounced = &settings
+	if previous == nil {
+		return true
+	}
+	return previous.Enabled != settings.Enabled ||
+		previous.BeforeExpiry != settings.BeforeExpiry ||
+		previous.OnlyWhenAgentsActive != settings.OnlyWhenAgentsActive ||
+		previous.Liveness != settings.Liveness ||
+		previous.MaxProbes != settings.MaxProbes ||
+		previous.MaxTokens != settings.MaxTokens
+}
+
 // applyCacheKeepaliveConfig installs or reconfigures the prompt-cache keepalive
 // scheduler. It is safe to call on every config reload.
 func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
@@ -90,6 +116,7 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 	}
 	settings = settings.WithDefaults()
 
+	changed := announceCacheKeepalive(settings)
 	if !settings.Enabled {
 		if keepalive.Default() != nil {
 			log.Info("cache-keepalive: disabled")
@@ -132,6 +159,8 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 		scheduler.SetLiveness(liveness)
 		scheduler.ApplyConfig(runtimeCfg)
 	}
-	log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s max-probes=%d max-tokens=%d",
-		settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.MaxProbes, settings.MaxTokens)
+	if changed {
+		log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s max-probes=%d max-tokens=%d",
+			settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.MaxProbes, settings.MaxTokens)
+	}
 }

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -1,6 +1,7 @@
 package cliproxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -54,41 +55,70 @@ func (p cacheKeepaliveProber) Probe(ctx context.Context, probe keepalive.ProbeRe
 		return keepalive.ProbeResult{}, err
 	}
 	usage := gjson.GetBytes(resp.Payload, "usage")
+	reason, missedTokens := claudeCacheMissReason(resp.Payload)
 	return keepalive.ProbeResult{
 		CacheReadInputTokens:     usage.Get("cache_read_input_tokens").Int(),
 		CacheCreationInputTokens: usage.Get("cache_creation_input_tokens").Int(),
-		Diagnosis:                claudeCacheDiagnosis(resp.Payload),
+		Diagnosis:                reason,
+		CacheMissedInputTokens:   missedTokens,
 	}, nil
 }
 
-// claudeCacheDiagnosis extracts the upstream cache-miss explanation when the
-// account carries the cache-diagnosis beta and the response supplied one.
+// claudeCacheMissReason reads the cache-miss diagnostics a Claude response
+// carries when the account has the cache-diagnosis beta.
 //
-// diagnostics.cache_miss_reason is the documented field. The others are shapes
-// seen on the wire; every known location is tried in order and an absent
-// diagnosis is simply empty, so a wrong guess costs an empty string, never an
-// error.
-func claudeCacheDiagnosis(payload []byte) string {
-	for _, path := range []string{
-		"diagnostics.cache_miss_reason",
-		"usage.diagnostics.cache_miss_reason",
-		"usage.cache_diagnosis.reason",
-		"usage.cache_diagnosis",
-		"cache_diagnosis.reason",
-		"cache_diagnosis",
-	} {
-		value := gjson.GetBytes(payload, path)
-		if !value.Exists() {
+// Two confirmed shapes, both captured on the wire:
+//
+//	non-streaming: {"usage":{...},"diagnostics":{"cache_miss_reason":{"type":"messages_changed","cache_missed_input_tokens":25154}}}
+//	streaming:     the identical object inside the message_start event's "message"
+//
+// This duplicates applyClaudeCacheMissReason in
+// internal/runtime/executor/helps/claude_cache_diagnostics.go on the cache-stats
+// branch. That file is not on this branch, so the two paths are read here
+// directly; fold them into the shared helper once both land.
+func claudeCacheMissReason(payload []byte) (string, int64) {
+	if len(payload) == 0 {
+		return "", 0
+	}
+	if gjson.ValidBytes(payload) {
+		root := gjson.ParseBytes(payload)
+		// Non-streaming: diagnostics sits beside usage at the top level.
+		if reason, tokens := cacheMissReasonAt(root); reason != "" || tokens != 0 {
+			return reason, tokens
+		}
+		// A whole message_start object handed over directly.
+		if reason, tokens := cacheMissReasonAt(root.Get("message")); reason != "" || tokens != 0 {
+			return reason, tokens
+		}
+		return "", 0
+	}
+	// Streaming: scan the SSE for the message_start event that carries it.
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue
 		}
-		if value.IsObject() || value.IsArray() {
-			return strings.TrimSpace(value.Raw)
+		event := bytes.TrimSpace(line[len("data:"):])
+		if len(event) == 0 || !gjson.ValidBytes(event) {
+			continue
 		}
-		if text := strings.TrimSpace(value.String()); text != "" {
-			return text
+		root := gjson.ParseBytes(event)
+		if root.Get("type").String() != "message_start" {
+			continue
+		}
+		if reason, tokens := cacheMissReasonAt(root.Get("message")); reason != "" || tokens != 0 {
+			return reason, tokens
 		}
 	}
-	return ""
+	return "", 0
+}
+
+func cacheMissReasonAt(node gjson.Result) (string, int64) {
+	reason := node.Get("diagnostics.cache_miss_reason")
+	if !reason.Exists() {
+		return "", 0
+	}
+	return strings.TrimSpace(reason.Get("type").String()), reason.Get("cache_missed_input_tokens").Int()
 }
 
 // cacheKeepaliveBinding answers whether the session is still bound to the

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -129,6 +129,7 @@ func announceCacheKeepalive(settings internalconfig.ClaudeCodeCacheKeepaliveConf
 		previous.BeforeExpiry != settings.BeforeExpiry ||
 		previous.OnlyWhenAgentsActive != settings.OnlyWhenAgentsActive ||
 		previous.Liveness != settings.Liveness ||
+		previous.AgentIdleWindow != settings.AgentIdleWindow ||
 		previous.MaxProbes != settings.MaxProbes ||
 		previous.MaxTokens != settings.MaxTokens
 }
@@ -163,6 +164,7 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 		Enabled:              true,
 		BeforeExpiry:         settings.BeforeExpiry,
 		OnlyWhenAgentsActive: settings.OnlyWhenAgentsActive,
+		AgentIdleWindow:      settings.AgentIdleWindow,
 		MaxProbes:            settings.MaxProbes,
 		MaxTokens:            settings.MaxTokens,
 	}
@@ -189,7 +191,7 @@ func (s *Service) applyCacheKeepaliveConfig(cfg *config.Config) {
 		scheduler.ApplyConfig(runtimeCfg)
 	}
 	if changed {
-		log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s max-probes=%d max-tokens=%d",
-			settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.MaxProbes, settings.MaxTokens)
+		log.Infof("cache-keepalive: enabled | before-expiry=%s only-when-agents-active=%t liveness=%s agent-idle-window=%s max-probes=%d max-tokens=%d",
+			settings.BeforeExpiry, settings.OnlyWhenAgentsActive, settings.Liveness, settings.AgentIdleWindow, settings.MaxProbes, settings.MaxTokens)
 	}
 }

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -62,11 +62,16 @@ func (p cacheKeepaliveProber) Probe(ctx context.Context, probe keepalive.ProbeRe
 }
 
 // claudeCacheDiagnosis extracts the upstream cache-miss explanation when the
-// account carries the cache-diagnosis beta and the response supplied one. The
-// field has moved between response shapes, so every known location is tried and
-// an absent diagnosis is simply empty.
+// account carries the cache-diagnosis beta and the response supplied one.
+//
+// diagnostics.cache_miss_reason is the documented field. The others are shapes
+// seen on the wire; every known location is tried in order and an absent
+// diagnosis is simply empty, so a wrong guess costs an empty string, never an
+// error.
 func claudeCacheDiagnosis(payload []byte) string {
 	for _, path := range []string{
+		"diagnostics.cache_miss_reason",
+		"usage.diagnostics.cache_miss_reason",
 		"usage.cache_diagnosis.reason",
 		"usage.cache_diagnosis",
 		"cache_diagnosis.reason",

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -46,6 +46,7 @@ func (p cacheKeepaliveProber) Probe(ctx context.Context, probe keepalive.ProbeRe
 		Metadata: map[string]any{
 			coreexecutor.PinnedAuthMetadataKey:     probe.AuthID,
 			coreexecutor.RequestedModelMetadataKey: probe.Model,
+			keepalive.ProbeMetadataKey:             true,
 		},
 	}
 	resp, err := p.manager.Execute(ctx, []string{provider}, req, opts)

--- a/sdk/cliproxy/service_cache_keepalive.go
+++ b/sdk/cliproxy/service_cache_keepalive.go
@@ -53,9 +53,37 @@ func (p cacheKeepaliveProber) Probe(ctx context.Context, probe keepalive.ProbeRe
 	if err != nil {
 		return keepalive.ProbeResult{}, err
 	}
+	usage := gjson.GetBytes(resp.Payload, "usage")
 	return keepalive.ProbeResult{
-		CacheReadInputTokens: gjson.GetBytes(resp.Payload, "usage.cache_read_input_tokens").Int(),
+		CacheReadInputTokens:     usage.Get("cache_read_input_tokens").Int(),
+		CacheCreationInputTokens: usage.Get("cache_creation_input_tokens").Int(),
+		Diagnosis:                claudeCacheDiagnosis(resp.Payload),
 	}, nil
+}
+
+// claudeCacheDiagnosis extracts the upstream cache-miss explanation when the
+// account carries the cache-diagnosis beta and the response supplied one. The
+// field has moved between response shapes, so every known location is tried and
+// an absent diagnosis is simply empty.
+func claudeCacheDiagnosis(payload []byte) string {
+	for _, path := range []string{
+		"usage.cache_diagnosis.reason",
+		"usage.cache_diagnosis",
+		"cache_diagnosis.reason",
+		"cache_diagnosis",
+	} {
+		value := gjson.GetBytes(payload, path)
+		if !value.Exists() {
+			continue
+		}
+		if value.IsObject() || value.IsArray() {
+			return strings.TrimSpace(value.Raw)
+		}
+		if text := strings.TrimSpace(value.String()); text != "" {
+			return text
+		}
+	}
+	return ""
 }
 
 // cacheKeepaliveBinding answers whether the session is still bound to the

--- a/sdk/cliproxy/service_cache_keepalive_test.go
+++ b/sdk/cliproxy/service_cache_keepalive_test.go
@@ -1,0 +1,70 @@
+package cliproxy
+
+import "testing"
+
+// The two fragments below are the confirmed wire shapes for the cache-diagnosis
+// beta: diagnostics sits beside usage in a non-streaming body, and the identical
+// object rides inside the message_start event when streaming.
+const nonStreamingDiagnosticsBody = `{
+  "id": "msg_01",
+  "type": "message",
+  "role": "assistant",
+  "content": [{"type": "text", "text": "ok"}],
+  "usage": {"input_tokens": 3, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 25154},
+  "diagnostics": {"cache_miss_reason": {"type": "messages_changed", "cache_missed_input_tokens": 25154}}
+}`
+
+const streamingDiagnosticsBody = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],` +
+	`"usage":{"input_tokens":3,"cache_read_input_tokens":0,"cache_creation_input_tokens":25154},` +
+	`"diagnostics":{"cache_miss_reason":{"type":"messages_changed","cache_missed_input_tokens":25154}}}}` + "\n\n" +
+	"event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}` + "\n\n"
+
+func TestClaudeCacheMissReasonNonStreaming(t *testing.T) {
+	reason, tokens := claudeCacheMissReason([]byte(nonStreamingDiagnosticsBody))
+	if reason != "messages_changed" {
+		t.Fatalf("reason = %q, want messages_changed", reason)
+	}
+	if tokens != 25154 {
+		t.Fatalf("cache_missed_input_tokens = %d, want 25154", tokens)
+	}
+}
+
+func TestClaudeCacheMissReasonStreaming(t *testing.T) {
+	reason, tokens := claudeCacheMissReason([]byte(streamingDiagnosticsBody))
+	if reason != "messages_changed" {
+		t.Fatalf("reason = %q, want messages_changed", reason)
+	}
+	if tokens != 25154 {
+		t.Fatalf("cache_missed_input_tokens = %d, want 25154", tokens)
+	}
+}
+
+func TestClaudeCacheMissReasonBareMessageStartObject(t *testing.T) {
+	body := `{"type":"message_start","message":{"diagnostics":{"cache_miss_reason":{"type":"tools_changed","cache_missed_input_tokens":42}}}}`
+	reason, tokens := claudeCacheMissReason([]byte(body))
+	if reason != "tools_changed" || tokens != 42 {
+		t.Fatalf("reason = %q tokens = %d", reason, tokens)
+	}
+}
+
+func TestClaudeCacheMissReasonAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "a clean hit carries no diagnostics", body: `{"usage":{"cache_read_input_tokens":161937}}`},
+		{name: "empty body", body: ``},
+		{name: "not json and not sse", body: `garbage`},
+		{name: "sse without message_start", body: "data: {\"type\":\"ping\"}\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, tokens := claudeCacheMissReason([]byte(tt.body))
+			if reason != "" || tokens != 0 {
+				t.Fatalf("reason = %q tokens = %d, want empty", reason, tokens)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -192,6 +192,7 @@ func (s *Service) applyConfigRuntime(ctx context.Context, commit configCommit, s
 		return false
 	}
 	s.syncPluginModelRuntime(registrationCtx)
+	s.applyCacheKeepaliveConfig(cfg)
 	return ctx.Err() == nil
 }
 

--- a/sdk/cliproxy/service_lifecycle.go
+++ b/sdk/cliproxy/service_lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/keepalive"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -126,6 +127,8 @@ func (s *Service) Run(ctx context.Context) error {
 		s.authManager = newDefaultAuthManager()
 	}
 
+	s.applyCacheKeepaliveConfig(s.cfg)
+
 	if homeEnabled {
 		s.startHomeSubscriber(ctx)
 	}
@@ -233,6 +236,8 @@ func (s *Service) Shutdown(ctx context.Context) error {
 		if ctx == nil {
 			ctx = context.Background()
 		}
+
+		keepalive.SetDefault(nil)
 
 		s.homeLifecycleMu.Lock()
 		if supervisor := s.homeSupervisor; supervisor != nil {


### PR DESCRIPTION

Branch: `feat/claude-code-cache-keepalive` — 13 commits off `dev` (18e01a76), HEAD `29bffbeb`.

## Summary

With `promptCacheTtl: "1h"`, an orchestrator session that blocks on a subagent for longer than the TTL pays a full cache write of its whole context on the return turn instead of a read. On the 1h pool that write costs roughly ten times the read it replaces, so refreshing the entry with one minimal request per window is close to free. A client-side hook cannot do this, because it cannot guarantee which account the refresh lands on; the proxy holds the last request body, the credential and the session-to-account binding, so its probe warms the same per-account entry the next real request will hit. The feature is opt-in and off by default, and only requests from a confirmed Claude Code client that carried an explicit `cache_control` ttl of `1h` are ever probed. A 5m session is never probed: on that pool the thirteen reads an hour cost more than the single write they avoid.

Independent of the cache-stats and version-floor branches. It reads the cache-miss diagnostics itself rather than importing the cache-stats helper; see the note below.

## Diff

26 files, +3,637 / −0.

| File | + |
| --- | --- |
| `internal/runtime/keepalive/keepalive.go` (new) | 928 |
| `internal/runtime/keepalive/keepalive_test.go` (new) | 796 |
| `docs/cache-keepalive.md` (new) | 241 |
| `sdk/cliproxy/service_cache_keepalive.go` (new) | 232 |
| `internal/runtime/keepalive/liveness_claude_code.go` (new) | 221 |
| `internal/runtime/keepalive/liveness_claude_code_test.go` (new) | 217 |
| `internal/config/claude_cache_keepalive.go` (new) | 179 |
| `internal/runtime/executor/helps/claude_cache_keepalive_test.go` (new) | 133 |
| `internal/config/claude_cache_keepalive_test.go` (new) | 122 |
| `internal/api/handlers/management/cache_keepalive_test.go` (new) | 111 |
| `internal/runtime/executor/helps/claude_cache_keepalive.go` (new) | 109 |
| `internal/runtime/keepalive/liveness_claude_code_symlink_test.go` (new) | 71 |
| `sdk/cliproxy/service_cache_keepalive_test.go` (new) | 70 |
| `config.example.yaml` | 65 |
| `sdk/cliproxy/auth/selector_session_binding.go` (new) | 41 |
| `internal/runtime/keepalive/default.go` (new) | 28 |
| `internal/api/handlers/management/cache_keepalive.go` (new) | 26 |
| `internal/runtime/executor/claude_executor_execute.go` | 15 |
| `internal/runtime/executor/claude_executor_stream.go` | 12 |
| remaining wiring (`service_lifecycle.go`, `service_config.go`, `config_load.go`, `parse.go`, `sdk_config.go`, `server_management.go`, `README.md`) | 20 |

No deletions; the two executor files gain one Observe call and a start timestamp each.

## Behaviour

- Session-keyed scheduler. On each confirmed Claude Code request carrying `cache_control.ttl: "1h"`, the body is stored and a timer is armed for `ttl − before-expiry`.
- On fire the probe is skipped if a real request superseded it, if `max-probes` consecutive probes were already sent, if no agent is live, or if the auth binding was lost or moved. Otherwise the stored body is sent with `max_tokens: 1` and with `thinking` and the thinking-dependent `context_management` edit removed, since neither is in the cached prefix and the API rejects one without the other. Tools, system, messages, `cache_control` and betas go out byte-identical.
- The probe goes through `Manager.Execute` with `pinned_auth_id`, so translation, headers, retries and token refresh are the same path a real request takes. The probe marks its own context so it cannot observe itself and rearm.
- Liveness `claude-code-tasks` looks for any `<output-dir>/<project-slug>/<session>/tasks/*.output` (symlinks resolved) modified within `agent-idle-window`. The `~/.claude/tasks` todo list is only a secondary OR, since it is not subagent state. Documented caveat: a silent process does not advance its output file, so the window must exceed the expected silence. `liveness: always` skips the check entirely, at a cost of up to `max-probes` reads per idle session.
- Observability: a `cache-keepalive:` prefix on every schedule, probe and skip, with a reason. `probe MISSED` at WARN carrying `cache_miss_reason` and `cache_missed_input_tokens` when the probe's read is zero or below half the observed baseline. `GET /v0/management/cache-keepalive` reports per-session `next_probe_at`, `probes_sent`, `last_probe` and `retired_reason` plus global counters. Retired sessions stay listed under a cap so idle and broken are distinguishable; stored bodies are dropped on retirement.
- Nothing is written to disk. Probe bodies are held in memory only.

## Config

```yaml
claude-code:
  cache-keepalive:
    # Opt-in. Default false.
    enabled: false

    # Fire the probe at (request start + ttl - before-expiry). Default 5m.
    before-expiry: 5m

    # Probe only while a task of that session is still running. Default true.
    only-when-agents-active: true

    # claude-code-tasks (default) reads Claude Code's on-disk task state.
    # always skips the liveness check.
    liveness: claude-code-tasks

    # How recently a task output file must have been touched. Default 10m.
    agent-idle-window: 10m

    # Stop after this many consecutive probes without an intervening real
    # request. Bounds an abandoned session to max-probes reads. Default 6.
    max-probes: 6

    # max_tokens the probe body carries. Default 1.
    max-tokens: 1
```

Applied on hot reload; disabling the block cancels every timer and logs `cache-keepalive: disabled`.

## Verification

```
go build ./...   ok
go vet ./...     ok
go test ./...    ok
```

123 packages: 93 with tests, all passing; 30 with no test files; 0 failures. 63 tests cover the scheduler, the liveness reader including the symlink case, the config, the management handler and the diagnostics reader.

Behaviour verified on a scratch instance against api.anthropic.com with a real `claude` session (haiku, `--strict-mcp-config`) and a ticking background task: probes fired while the task ran, reporting `status=hit` with `cache_read_input_tokens` equal to the real request's, then a `no-live-agents` skip once the task ended and the window passed. A second run took two hits and stopped at `max-probes`, with the endpoint reflecting both the live and the end state. Probing a real body is what surfaced the `context_management` rejection that the final probe shape fixes.

`config.example.yaml` documents only the `claude-code.cache-keepalive` block on this branch; no `usage-cache-stats` keys are present.

## Note for reviewers

`claudeCacheMissReason` in `sdk/cliproxy/service_cache_keepalive.go` reads `diagnostics.cache_miss_reason` from both the non-streaming body and the streaming `message_start` event. It duplicates `applyClaudeCacheMissReason` from the per-session cache-statistics branch, which is not a dependency of this one. The comment in the file points at the other implementation so the two can be folded into a shared helper once both land.

Why: see https://github.com/ArshansGithub/claude-code-fable-usage

Context: https://github.com/ArshansGithub/claude-code-fable-usage.
