### PR TITLE
feat(claude): per-credential fold of mid-conversation system turns for upstreams that only cache up to the last user text block (MiniMax)

### DIFF
--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -373,6 +373,11 @@ type ClaudeKey struct {
 	// RebuildMidSystemMessage moves Claude messages with role "system" into the top-level system field.
 	RebuildMidSystemMessage bool `yaml:"rebuild-mid-system-message,omitempty" json:"rebuild-mid-system-message,omitempty"`
 
+	// FoldMidSystemMessage folds Claude messages with role "system" into the preceding user turn as text blocks and
+	// anchors tool_result-ending user turns with a text block, for upstreams that only cache up to the last user text
+	// block (e.g. MiniMax). Ignored when RebuildMidSystemMessage is also set (rebuild wins, a warning is logged).
+	FoldMidSystemMessage bool `yaml:"fold-mid-system-message,omitempty" json:"fold-mid-system-message,omitempty"`
+
 	// DisableCooling overrides the global cooling policy for this credential when set.
 	// True disables auth/model cooldowns; false explicitly enables them.
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -122,6 +122,17 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// first-user marker cannot suppress system/latest-user breakpoints.
 	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
 	// forces Cloak off for a confirmed native client.
+	// Fold mid-conversation system turns for upstreams that only cache up to the last user text block (MiniMax).
+	// Runs after cloaking and payload rules so nothing re-introduces a role=system turn, and before the marker
+	// steps below so the moved marker is what enforceCacheControlLimit/normalizeCacheControlTTL see.
+	if foldMidSystemMessageEnabled(e.cfg, auth) {
+		if rebuildMidSystemMessageEnabled(e.cfg, auth) {
+			log.Warnf("[fold-mid-system] rebuild-mid-system-message and fold-mid-system-message are both set for this credential; rebuild wins, fold skipped")
+		} else if folded, applied := foldMidSystemMessagesIntoUserTurns(body); applied {
+			body = folded
+			logFoldApplied(body, apiKey)
+		}
+	}
 	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
 	if cpaOwnsCacheControl {
 		body = ensureCacheControl(body)

--- a/internal/runtime/executor/claude_executor_fold.go
+++ b/internal/runtime/executor/claude_executor_fold.go
@@ -1,0 +1,251 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// claudeFoldAnchorText is appended after a trailing tool_result when a user
+// turn would otherwise end in a tool_result block. Some Anthropic-compatible
+// upstreams (MiniMax) extend the prompt cache only up to the last TEXT block
+// of the last user message and ignore cache_control on tool_result blocks and
+// on mid-conversation role=system turns. The anchor is deterministic on every
+// such user turn so the prefix stays byte-stable across turns. It is
+// deliberately short and non-instructional.
+const claudeFoldAnchorText = "."
+
+// foldMidSystemMessagesIntoUserTurns rewrites a Claude Messages payload for
+// upstreams that drop mid-conversation {"role":"system"} turns:
+//
+//  1. every role=system turn's text blocks are appended, in order, to the
+//     immediately preceding user turn (string content is promoted to a text
+//     block); when the preceding turn is not a user turn, a user turn holding
+//     the text is inserted in place;
+//  2. afterwards, every user turn whose last content block is still a
+//     tool_result gets the anchor text block appended; a cache_control carried
+//     by that tool_result moves onto the anchor.
+//
+// Moved text blocks keep their own cache_control, so a marker the caller put on
+// the trailing system turn ends up on the last text block of the last user
+// message — the position these upstreams honor.
+//
+// The fold fails closed (original payload, false) when the payload is not
+// valid JSON, messages is not an array, a system turn carries anything but
+// non-empty text (tool_addition / tool_removal / output_config / empty), a
+// system turn directly follows an assistant turn that issued a tool_use (a
+// synthetic user turn there would break the tool_result protocol), or any JSON
+// edit fails. Payloads with nothing to fold are returned unchanged with false.
+func foldMidSystemMessagesIntoUserTurns(payload []byte) ([]byte, bool) {
+	if !gjson.ValidBytes(payload) {
+		return payload, false
+	}
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload, false
+	}
+	type outMsg struct {
+		raw        string
+		isUser     bool
+		hasToolUse bool
+	}
+	var out []outMsg
+	foldable, changed := true, false
+	messages.ForEach(func(_, message gjson.Result) bool {
+		role := strings.ToLower(strings.TrimSpace(message.Get("role").String()))
+		switch role {
+		case "system":
+			parts, ok := claudeFoldSystemTextParts(message.Get("content"))
+			if !ok {
+				foldable = false
+				return false
+			}
+			if n := len(out); n > 0 && out[n-1].isUser {
+				merged, okAppend := appendTextBlocksToUserMessage(out[n-1].raw, parts)
+				if !okAppend {
+					foldable = false
+					return false
+				}
+				out[n-1].raw = merged
+			} else {
+				if n := len(out); n > 0 && out[n-1].hasToolUse {
+					foldable = false
+					return false
+				}
+				out = append(out, outMsg{raw: `{"role":"user","content":` + string(rawJSONArray(parts)) + `}`, isUser: true})
+			}
+			changed = true
+		case "user":
+			out = append(out, outMsg{raw: message.Raw, isUser: true})
+		default:
+			out = append(out, outMsg{raw: message.Raw, hasToolUse: messageHasBlockType(message, "tool_use")})
+		}
+		return true
+	})
+	if !foldable {
+		return payload, false
+	}
+	raws := make([]string, 0, len(out))
+	for _, m := range out {
+		raw := m.raw
+		if m.isUser {
+			anchored, did, ok := anchorTrailingToolResult(raw)
+			if !ok {
+				return payload, false
+			}
+			if did {
+				raw, changed = anchored, true
+			}
+		}
+		raws = append(raws, raw)
+	}
+	if !changed {
+		return payload, false
+	}
+	updated, err := sjson.SetRawBytes(payload, "messages", rawJSONArray(raws))
+	if err != nil {
+		return payload, false
+	}
+	return updated, true
+}
+
+// claudeFoldSystemTextParts returns the text blocks of a system turn, or
+// ok=false when the content is empty or holds anything other than non-empty
+// strings / text blocks (message-level controls must not be folded away).
+func claudeFoldSystemTextParts(content gjson.Result) ([]string, bool) {
+	if !content.Exists() {
+		return nil, false
+	}
+	if content.Type == gjson.String {
+		if strings.TrimSpace(content.String()) == "" {
+			return nil, false
+		}
+		block := []byte(`{"type":"text","text":""}`)
+		block, _ = sjson.SetBytes(block, "text", content.String())
+		return []string{string(block)}, true
+	}
+	if !content.IsArray() {
+		return nil, false
+	}
+	var parts []string
+	ok := true
+	content.ForEach(func(_, item gjson.Result) bool {
+		switch {
+		case item.Type == gjson.String && strings.TrimSpace(item.String()) != "":
+			block := []byte(`{"type":"text","text":""}`)
+			block, _ = sjson.SetBytes(block, "text", item.String())
+			parts = append(parts, string(block))
+		case item.IsObject() && item.Get("type").String() == "text" && strings.TrimSpace(item.Get("text").String()) != "":
+			parts = append(parts, item.Raw)
+		default:
+			ok = false
+			return false
+		}
+		return true
+	})
+	if !ok || len(parts) == 0 {
+		return nil, false
+	}
+	return parts, true
+}
+
+func messageHasBlockType(message gjson.Result, blockType string) bool {
+	found := false
+	content := message.Get("content")
+	if !content.IsArray() {
+		return false
+	}
+	content.ForEach(func(_, item gjson.Result) bool {
+		if item.Get("type").String() == blockType {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// appendTextBlocksToUserMessage appends raw text blocks to a user message's
+// content, promoting string content to a single text block first. ok=false
+// when the content has an unsupported shape or the edit fails.
+func appendTextBlocksToUserMessage(rawMessage string, parts []string) (string, bool) {
+	content := gjson.Get(rawMessage, "content")
+	var blocks []string
+	switch {
+	case content.IsArray():
+		content.ForEach(func(_, item gjson.Result) bool {
+			blocks = append(blocks, item.Raw)
+			return true
+		})
+	case content.Type == gjson.String:
+		block := []byte(`{"type":"text","text":""}`)
+		block, _ = sjson.SetBytes(block, "text", content.String())
+		blocks = append(blocks, string(block))
+	default:
+		return rawMessage, false
+	}
+	blocks = append(blocks, parts...)
+	updated, err := sjson.SetRaw(rawMessage, "content", string(rawJSONArray(blocks)))
+	if err != nil {
+		return rawMessage, false
+	}
+	return updated, true
+}
+
+// anchorTrailingToolResult appends the anchor text block when the user message
+// ends in a tool_result block, moving that block's cache_control (if any) onto
+// the anchor. Returns (message, changed, ok); ok=false means an edit failed and
+// the caller must abandon the fold.
+func anchorTrailingToolResult(rawMessage string) (string, bool, bool) {
+	content := gjson.Get(rawMessage, "content")
+	if !content.IsArray() {
+		return rawMessage, false, true
+	}
+	items := content.Array()
+	if len(items) == 0 {
+		return rawMessage, false, true
+	}
+	last := items[len(items)-1]
+	if last.Get("type").String() != "tool_result" {
+		return rawMessage, false, true
+	}
+	anchor := []byte(`{"type":"text","text":""}`)
+	anchor, _ = sjson.SetBytes(anchor, "text", claudeFoldAnchorText)
+	updated := rawMessage
+	if cc := last.Get("cache_control"); cc.Exists() {
+		var err error
+		anchor, err = sjson.SetRawBytes(anchor, "cache_control", []byte(cc.Raw))
+		if err != nil {
+			return rawMessage, false, false
+		}
+		updated, err = sjson.Delete(updated, "content."+strconv.Itoa(len(items)-1)+".cache_control")
+		if err != nil {
+			return rawMessage, false, false
+		}
+	}
+	appended, err := sjson.SetRaw(updated, "content.-1", string(anchor))
+	if err != nil {
+		return rawMessage, false, false
+	}
+	return appended, true, true
+}
+
+// logFoldApplied emits one line per folded request so worker transcripts
+// (session id) can be joined to the credential cohort (hashed key) during a
+// staged rollout.
+func logFoldApplied(payload []byte, apiKey string) {
+	userID := gjson.GetBytes(payload, "metadata.user_id").String()
+	sessionID := userID
+	if parsed := gjson.Parse(userID); parsed.IsObject() {
+		sessionID = parsed.Get("session_id").String()
+	} else if idx := strings.LastIndex(userID, "_session_"); idx >= 0 {
+		sessionID = userID[idx+len("_session_"):]
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(apiKey)))
+	log.Infof("[fold-mid-system] applied session=%s auth=%s", sessionID, hex.EncodeToString(sum[:])[:8])
+}

--- a/internal/runtime/executor/claude_executor_fold_test.go
+++ b/internal/runtime/executor/claude_executor_fold_test.go
@@ -1,0 +1,147 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func foldOrFail(t *testing.T, in string) ([]byte, bool) {
+	t.Helper()
+	out, applied := foldMidSystemMessagesIntoUserTurns([]byte(in))
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("fold produced invalid JSON: %s", out)
+	}
+	return out, applied
+}
+
+func TestFoldMidSystemMessagesIntoUserTurns(t *testing.T) {
+	t.Run("trailing system turn folds into last user message with its marker and no extra anchor", func(t *testing.T) {
+		out, applied := foldOrFail(t, `{"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]},
+			{"role":"system","content":[{"type":"text","text":"reminder","cache_control":{"type":"ephemeral","ttl":"1h"}}]}
+		]}`)
+		if !applied {
+			t.Fatal("expected applied")
+		}
+		msgs := gjson.GetBytes(out, "messages").Array()
+		if len(msgs) != 3 || msgs[2].Get("role").String() != "user" {
+			t.Fatalf("unexpected messages: %s", out)
+		}
+		blocks := msgs[2].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("type").String() != "tool_result" || blocks[1].Get("text").String() != "reminder" || blocks[1].Get("cache_control.ttl").String() != "1h" {
+			t.Fatalf("unexpected blocks: %s", msgs[2].Raw)
+		}
+		if strings.Contains(string(out), `"text":"`+claudeFoldAnchorText+`"`) {
+			t.Fatalf("anchor must not be added when a reminder was folded: %s", out)
+		}
+	})
+
+	t.Run("mid-history system turn folds into the preceding user message; string content promoted", func(t *testing.T) {
+		out, applied := foldOrFail(t, `{"messages":[
+			{"role":"user","content":"hello"},
+			{"role":"system","content":[{"type":"text","text":"r1"}]},
+			{"role":"assistant","content":[{"type":"text","text":"hey"}]},
+			{"role":"user","content":[{"type":"text","text":"next","cache_control":{"type":"ephemeral"}}]}
+		]}`)
+		if !applied {
+			t.Fatal("expected applied")
+		}
+		msgs := gjson.GetBytes(out, "messages").Array()
+		first := msgs[0].Get("content").Array()
+		if len(msgs) != 3 || len(first) != 2 || first[0].Get("text").String() != "hello" || first[1].Get("text").String() != "r1" || first[1].Get("cache_control").Exists() {
+			t.Fatalf("unexpected: %s", out)
+		}
+		if msgs[2].Get("content.0.cache_control.type").String() != "ephemeral" {
+			t.Fatalf("existing user marker lost: %s", msgs[2].Raw)
+		}
+	})
+
+	t.Run("tool_result-ending user turn gets the anchor and inherits the marker", func(t *testing.T) {
+		out, applied := foldOrFail(t, `{"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"ok"}],"cache_control":{"type":"ephemeral"}}]}
+		]}`)
+		if !applied {
+			t.Fatal("expected applied")
+		}
+		last := gjson.GetBytes(out, "messages.2.content").Array()
+		if len(last) != 2 || last[1].Get("type").String() != "text" || last[1].Get("text").String() != claudeFoldAnchorText {
+			t.Fatalf("anchor missing: %s", out)
+		}
+		if last[0].Get("cache_control").Exists() || last[1].Get("cache_control.type").String() != "ephemeral" {
+			t.Fatalf("marker not moved to anchor: %s", out)
+		}
+		if last[0].Get("content.0.text").String() != "ok" {
+			t.Fatalf("tool_result content altered: %s", last[0].Raw)
+		}
+	})
+
+	t.Run("every tool_result-ending user turn is anchored deterministically", func(t *testing.T) {
+		out, _ := foldOrFail(t, `{"messages":[
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"a"}]},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Read","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"b"}]}
+		]}`)
+		if n := strings.Count(string(out), `"text":"`+claudeFoldAnchorText+`"`); n != 2 {
+			t.Fatalf("expected 2 anchors, got %d: %s", n, out)
+		}
+	})
+
+	t.Run("system turn first becomes a user turn in place", func(t *testing.T) {
+		out, applied := foldOrFail(t, `{"messages":[{"role":"system","content":"lead"},{"role":"user","content":"hi"}]}`)
+		msgs := gjson.GetBytes(out, "messages").Array()
+		if !applied || len(msgs) != 2 || msgs[0].Get("role").String() != "user" || msgs[0].Get("content.0.text").String() != "lead" || msgs[1].Get("content").String() != "hi" {
+			t.Fatalf("unexpected: %s", out)
+		}
+	})
+
+	t.Run("system turn after an assistant tool_use fails closed", func(t *testing.T) {
+		in := `{"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]},
+			{"role":"system","content":"note"},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"a"}]}
+		]}`
+		out, applied := foldOrFail(t, in)
+		if applied || string(out) != in {
+			t.Fatalf("expected untouched payload: %s", out)
+		}
+	})
+
+	t.Run("system turn after a plain assistant turn is inserted in place as a user turn", func(t *testing.T) {
+		out, applied := foldOrFail(t, `{"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[{"type":"text","text":"yo"}]},
+			{"role":"system","content":"note"},
+			{"role":"user","content":"more"}
+		]}`)
+		msgs := gjson.GetBytes(out, "messages").Array()
+		if !applied || len(msgs) != 4 || msgs[2].Get("role").String() != "user" || msgs[2].Get("content.0.text").String() != "note" {
+			t.Fatalf("unexpected: %s", out)
+		}
+	})
+
+	for name, in := range map[string]string{
+		"empty system array":         `{"messages":[{"role":"user","content":"hi"},{"role":"system","content":[]}]}`,
+		"whitespace system string":   `{"messages":[{"role":"user","content":"hi"},{"role":"system","content":"   "}]}`,
+		"tool_addition system block": `{"messages":[{"role":"user","content":"hi"},{"role":"system","content":[{"type":"tool_addition","tools":[]}]}]}`,
+		"mixed system blocks":        `{"messages":[{"role":"user","content":"hi"},{"role":"system","content":[{"type":"text","text":"t"},{"type":"output_config","effort":"low"}]}]}`,
+		"no system no tool_result":   `{"model":"x","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"yo"},{"role":"user","content":[{"type":"text","text":"more","cache_control":{"type":"ephemeral"}}]}]}`,
+		"messages not an array":      `{"messages":"nope"}`,
+		"invalid json":               `{"messages":[`,
+	} {
+		t.Run("fails closed / no-op: "+name, func(t *testing.T) {
+			out, applied := foldMidSystemMessagesIntoUserTurns([]byte(in))
+			if applied || string(out) != in {
+				t.Fatalf("expected untouched payload, got applied=%v: %s", applied, out)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -125,6 +125,17 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// first-user marker cannot suppress system/latest-user breakpoints.
 	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
 	// forces Cloak off for a confirmed native client.
+	// Fold mid-conversation system turns for upstreams that only cache up to the last user text block (MiniMax).
+	// Runs after cloaking and payload rules so nothing re-introduces a role=system turn, and before the marker
+	// steps below so the moved marker is what enforceCacheControlLimit/normalizeCacheControlTTL see.
+	if foldMidSystemMessageEnabled(e.cfg, auth) {
+		if rebuildMidSystemMessageEnabled(e.cfg, auth) {
+			log.Warnf("[fold-mid-system] rebuild-mid-system-message and fold-mid-system-message are both set for this credential; rebuild wins, fold skipped")
+		} else if folded, applied := foldMidSystemMessagesIntoUserTurns(body); applied {
+			body = folded
+			logFoldApplied(body, apiKey)
+		}
+	}
 	cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
 	if cpaOwnsCacheControl {
 		body = ensureCacheControl(body)

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -46,6 +46,10 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
+	} else if foldMidSystemMessageEnabled(e.cfg, auth) {
+		if folded, applied := foldMidSystemMessagesIntoUserTurns(body); applied {
+			body = folded
+		}
 	}
 	body = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, baseModel, helps.APIKeyModelIsCompat(req))
 	if errValidate := validateClaudeTokenCountRequest(body); errValidate != nil {
@@ -152,6 +156,10 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
+	} else if foldMidSystemMessageEnabled(e.cfg, auth) {
+		if folded, applied := foldMidSystemMessagesIntoUserTurns(body); applied {
+			body = folded
+		}
 	}
 
 	directAnthropic := isAnthropicUpstreamBase(baseURL)

--- a/internal/runtime/executor/claude_signing.go
+++ b/internal/runtime/executor/claude_signing.go
@@ -542,6 +542,14 @@ func resolveClaudeKeyCloakConfig(cfg *config.Config, auth *cliproxyauth.Auth) *c
 	return entry.Cloak
 }
 
+func foldMidSystemMessageEnabled(cfg *config.Config, auth *cliproxyauth.Auth) bool {
+	if auth != nil && auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes["fold_mid_system_message"]), "true") {
+		return true
+	}
+	entry := resolveClaudeKeyConfig(cfg, auth)
+	return entry != nil && entry.FoldMidSystemMessage
+}
+
 func rebuildMidSystemMessageEnabled(cfg *config.Config, auth *cliproxyauth.Auth) bool {
 	if auth != nil && auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes["rebuild_mid_system_message"]), "true") {
 		return true


### PR DESCRIPTION
## Problem

Some Anthropic-compatible upstreams — measured on **MiniMax** (`api.minimax.io/anthropic`) — extend the prompt cache only up to the **last text block of the last user message**. They ignore `cache_control` on `tool_result` blocks and drop mid-conversation `{"role":"system"}` turns entirely.

Claude Code (2.1.240+) places its rolling cache marker on exactly those two spots: on a trailing `role: system` turn (hook / system-reminder text) when one exists, otherwise on the last `tool_result`. Result on a production fleet through CLIProxyAPI: `cache_read_input_tokens` frozen at tools+system for every turn, **32% hit rate, ~75% of turns re-read at full price**.

Neither `rebuild-mid-system-message` (moves the reminder into top-level `system`, which changes the system prefix every turn) nor `payload.filter` (runs before `ensureCacheControl`) can express the needed shape, and there is no client-side switch in Claude Code.

## Change

New per-credential option on `claude-api-key` entries: `fold-mid-system-message: true` (or auth attribute `fold_mid_system_message: "true"`).

When enabled, `foldMidSystemMessagesIntoUserTurns` rewrites the Claude Messages payload:

1. every `role: system` turn's text blocks are appended, in order, to the **immediately preceding user turn** (string content promoted to a text block); with no preceding user turn, a user turn is inserted in place. Moved blocks keep their own `cache_control`, so the caller's rolling marker lands on the last text block of the last user message.
2. afterwards, every user turn that still ends in a `tool_result` gets a short `"."` text block appended (deterministic on every such turn, so the prefix stays byte-stable across turns); a `cache_control` on that `tool_result` moves onto the anchor.

Fails closed (payload untouched) on invalid JSON, `messages` not an array, non-text / empty system content (`tool_addition`, `tool_removal`, `output_config`, …), or a system turn directly after an assistant `tool_use` (a synthetic user turn there would break the tool-result protocol).

Wired in `Execute`, `ExecuteStream` and both `CountTokens` paths, **after** cloaking and payload rules and **before** `ensureCacheControl` / `enforceCacheControlLimit` / `normalizeCacheControlTTL`. Mutually exclusive with `rebuild-mid-system-message` (rebuild wins, a warning is logged). One info log line per folded request (`[fold-mid-system] applied session=… auth=<sha256[:8]>`) for cohort attribution during staged rollouts. Default off: with the flag unset the request bytes are unchanged.

## Verification

- Unit tests (`claude_executor_fold_test.go`, 14 cases): marker preservation, string promotion, anchor + marker move, deterministic anchors, in-place synthetic user turn, all fail-closed cases, byte-identical no-op.
- Isolated CLIProxyAPI copy with one MiniMax key, real Claude Agent SDK 0.3.240 sessions: cache hit **32% → 80%**, frozen turns **75% → ~0**, cache reads growing every turn with only the delta written; flag off = identical to today's behaviour.
- Production (3 workers, ~20k requests/3 h on 21 credentials, 10 h): hit 78.5–80.6%, zero MiniMax 400s, job success rate unchanged.
