### PR TITLE
docs: add Infinitus to "Who is with us?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ Run multiple native-feeling Claude Code commands, each powered by a different mo
 
 Browser agent that can connect to CLIProxyAPI's local OpenAI-compatible endpoint as a model provider. See WebBrain's independent [setup, security, and account-risk guide](https://webbrain.one/docs/easy-cli-proxy/) for using CLIProxyAPI through EasyCLIProxyAPI.
 
+### [Infinitus](https://github.com/deathemperor/infinitus)
+
+Native macOS menu bar app that runs a fleet of Claude accounts through CLIProxyAPI's Management API (claude-swap and 9Router too): 5h / 7d / per-model quota gauges, switch / hold / star from the popup, a run-rate forecast of when each window runs out, and an iPhone companion that mirrors it all - no API keys needed.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -264,6 +264,10 @@ VS Code 扩展，可将你的 Claude、ChatGPT/Codex、Antigravity、Grok 和 Ki
 
 可将 CLIProxyAPI 的本地 OpenAI 兼容端点用作模型提供商的浏览器智能体。通过 EasyCLIProxyAPI 使用 CLIProxyAPI 时，请参阅 WebBrain 提供的独立[设置、安全与账号风险指南](https://webbrain.one/docs/zh/easy-cli-proxy/)。
 
+### [Infinitus](https://github.com/deathemperor/infinitus)
+
+原生 macOS 菜单栏应用，通过 CLIProxyAPI 的管理 API 管理多个 Claude 账号（也支持 claude-swap 与 9Router）：5 小时 / 7 天 / 按模型的配额仪表，弹窗内切换 / 暂停 / 星标账号，按当前消耗速度预测各窗口何时耗尽，并可在 iPhone 上同步查看。
+
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -263,6 +263,10 @@ macOSネイティブのSwiftUI製AIサブスクリプションダッシュボー
 
 CLIProxyAPI のローカル OpenAI 互換エンドポイントをモデルプロバイダーとして利用できるブラウザーエージェントです。EasyCLIProxyAPI を通じて CLIProxyAPI を使用する場合は、WebBrain の独立した[セットアップ、セキュリティ、アカウントリスクのガイド](https://webbrain.one/docs/easy-cli-proxy/)をご覧ください。
 
+### [Infinitus](https://github.com/deathemperor/infinitus)
+
+CLIProxyAPI の Management API 経由で複数の Claude アカウントを管理するネイティブ macOS メニューバーアプリ（claude-swap と 9Router にも対応）。5 時間 / 7 日 / モデル別のクォータゲージ、ポップアップからの切り替え / 保留 / スター、現在のペースから各ウィンドウが尽きる時刻を予測する機能に加え、iPhone からも同じ状態を確認できます。
+
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。
 


### PR DESCRIPTION
Adds [Infinitus](https://github.com/deathemperor/infinitus) to the "Who is with us?" list in README.md, README_CN.md and README_JA.md, after WebBrain.

Infinitus is a native macOS menu bar app (MIT) that manages a fleet of Claude accounts through CLIProxyAPI's Management API — auth-file listing, per-credential quota gauges (5h / 7d / per-model), switch / hold / star via priority, routing strategy and session-affinity settings — alongside claude-swap and 9Router, with a run-rate forecast and an iPhone companion.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)