### PR TITLE
test(openai): cover glm-5.3-flash large tool images

### DIFF
--- a/internal/runtime/executor/openai_compat_executor_tool_results_test.go
+++ b/internal/runtime/executor/openai_compat_executor_tool_results_test.go
@@ -2,9 +2,11 @@ package executor
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -96,5 +98,45 @@ func TestOpenAICompatExecutorToolResultContentByInputModalities(t *testing.T) {
 				t.Fatalf("tool content type = %s, want array; body=%s", toolContent.Type, string(gotBody))
 			}
 		})
+	}
+}
+
+func TestOpenAICompatExecutorGLM53FlashLargeToolImage(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3295,"completion_tokens":1,"total_tokens":3296}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatible-zai", &config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"base_url": server.URL + "/v1",
+			"api_key":  "test",
+		},
+	}
+	dataURL := "data:image/png;base64," + strings.Repeat("A", base64.StdEncoding.EncodedLen(1_790_000))
+	payload := []byte(`{"model":"glm-5.3-flash","input":[{"type":"function_call","call_id":"call_image","name":"view_image","arguments":"{}"},{"type":"function_call_output","call_id":"call_image","output":[{"type":"input_image","image_url":"` + dataURL + `","detail":"high"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"Describe the tool image."}]}]}`)
+	req := cliproxyexecutor.Request{Model: "glm-5.3-flash", Payload: payload}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAIResponse,
+		ResponseFormat: sdktranslator.FormatOpenAIResponse,
+	}
+
+	if _, errExecute := executor.Execute(context.Background(), auth, req, opts); errExecute != nil {
+		t.Fatalf("Execute error: %v", errExecute)
+	}
+	toolContent := gjson.GetBytes(gotBody, "messages.1.content")
+	if !toolContent.IsArray() {
+		t.Fatalf("tool content type = %s, want multimodal array", toolContent.Type)
+	}
+	if got := gjson.GetBytes(gotBody, "messages.1.tool_call_id").String(); got != "call_image" {
+		t.Fatalf("tool_call_id = %q, want call_image", got)
+	}
+	if got := toolContent.Get("0.image_url.url").String(); got != dataURL {
+		t.Fatalf("tool image URL length = %d, want %d", len(got), len(dataURL))
 	}
 }


### PR DESCRIPTION
## Summary

- add an executor-level regression for the new `glm-5.3-flash` multimodal model
- cover a 1.79 MB `function_call_output` image through the complete Responses -> OpenAI-compatible execution path
- verify that the image remains a native multimodal `image_url` array and that `call_id` is preserved

## Why

`glm-5.3-flash` accepts a large image when it is supplied in a user message. On gateways that serialize the same image from `function_call_output.output` as tool-result text, the Base64 payload is counted as prompt text and GLM returns `1261 Prompt exceeds max length`.

The correct upstream payload is native visual content:

```json
{
  "type": "image_url",
  "image_url": {
    "url": "data:image/png;base64,...",
    "detail": "high"
  }
}
```

The generic structured tool-output conversion was fixed by #4699 and is already present on `dev`. This PR intentionally does not duplicate that translator logic or add provider-specific runtime behavior. It adds the missing regression at the OpenAI-compatible executor boundary so future changes cannot silently turn a large GLM tool image back into prompt text.

## Verification

- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- real Z.AI Coding Plan call using `glm-5.3-flash` and the same 1888x1334 PNG:
  - user `input_image`: success, 3285 input tokens
  - `function_call_output` image: success, 3295 input tokens
  - API key and Base64 data were not written to the repository or PR

The 10-token (0.30%) difference confirms that the tool result is handled as native visual input rather than Base64 prompt text.

### Minimal reproduction

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${GATEWAY_BASE_URL:?Set GATEWAY_BASE_URL, for example http://127.0.0.1:8317/v1}"
: "${GATEWAY_API_KEY:?Set GATEWAY_API_KEY}"
: "${IMAGE_PATH:?Set IMAGE_PATH to a PNG file}"

MODEL="${MODEL:-glm-5.3-flash}"
data_url_file="$(mktemp)"
user_payload="$(mktemp)"
tool_payload="$(mktemp)"
trap 'rm -f "$data_url_file" "$user_payload" "$tool_payload"' EXIT

printf 'data:image/png;base64,' >"$data_url_file"
base64 <"$IMAGE_PATH" | tr -d '\n' >>"$data_url_file"

jq -n --arg model "$MODEL" --rawfile image "$data_url_file" '{
  model: $model,
  input: [{
    type: "message",
    role: "user",
    content: [
      {type: "input_text", text: "Briefly describe this image."},
      {type: "input_image", image_url: $image, detail: "high"}
    ]
  }]
}' >"$user_payload"

jq -n --arg model "$MODEL" --rawfile image "$data_url_file" '{
  model: $model,
  input: [
    {type: "function_call", call_id: "call_image", name: "view_image", arguments: "{}"},
    {type: "function_call_output", call_id: "call_image", output: [
      {type: "input_image", image_url: $image, detail: "high"}
    ]},
    {type: "message", role: "user", content: [
      {type: "input_text", text: "Briefly describe the tool image."}
    ]}
  ]
}' >"$tool_payload"

for scenario in user tool; do
  payload_var="${scenario}_payload"
  curl -fsS "${GATEWAY_BASE_URL%/}/responses" \
    -H "Authorization: Bearer $GATEWAY_API_KEY" \
    -H 'Content-Type: application/json' \
    --data-binary "@${!payload_var}" \
    | jq --arg scenario "$scenario" '{scenario: $scenario, status, usage}'
done
```

Expected result: both requests complete successfully and report comparable `usage.input_tokens`. A broken adapter returns GLM error `1261 Prompt exceeds max length` for the tool scenario.

### Observed result

```json
{
  "model": "glm-5.3-flash",
  "fixture": {
    "mime_type": "image/png",
    "bytes": 3448711,
    "width": 1888,
    "height": 1334
  },
  "user_input_image": {
    "status": "success",
    "input_tokens": 3285
  },
  "function_call_output_image": {
    "status": "success",
    "input_tokens": 3295
  },
  "token_delta": {
    "tokens": 10,
    "percent": 0.30
  },
  "api_key_included": false,
  "base64_included": false
}
```
