### PR TITLE
feat(claude): upgrade Claude Code 2.1.258 wire fingerprint and model behavioral parity

### DIFF
--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -148,20 +148,44 @@ func computeFingerprint(messageText, version string) string {
 
 // generateBillingHeader creates the x-anthropic-billing-header text block that
 // Claude Code prepends to its system prompt. cch is present only on signed paths.
-func generateBillingHeader(cchSigning bool, version, messageText, entrypoint, workload string) string {
+func generateBillingHeader(cchSigning bool, version, messageText, entrypoint, workload string, isSubagent bool, prevReq, promptID string) string {
 	if entrypoint == "" {
 		entrypoint = "cli"
 	}
 	buildHash := computeFingerprint(messageText, version)
-	workloadPart := ""
-	if workload != "" {
-		workloadPart = fmt.Sprintf(" cc_workload=%s;", workload)
-	}
+	var b strings.Builder
+	b.WriteString("x-anthropic-billing-header: cc_version=")
+	b.WriteString(version)
+	b.WriteByte('.')
+	b.WriteString(buildHash)
+	b.WriteString("; cc_entrypoint=")
+	b.WriteString(entrypoint)
+	b.WriteByte(';')
 
 	if cchSigning {
-		return fmt.Sprintf("x-anthropic-billing-header: cc_version=%s.%s; cc_entrypoint=%s; cch=00000;%s", version, buildHash, entrypoint, workloadPart)
+		b.WriteString(" cch=00000;")
 	}
-	return fmt.Sprintf("x-anthropic-billing-header: cc_version=%s.%s; cc_entrypoint=%s;%s", version, buildHash, entrypoint, workloadPart)
+	if workload != "" {
+		b.WriteString(" cc_workload=")
+		b.WriteString(workload)
+		b.WriteByte(';')
+	}
+	if isSubagent {
+		b.WriteString(" cc_is_subagent=true;")
+	}
+	if cchSigning {
+		if prevReq != "" {
+			b.WriteString(" cc_prev_req=")
+			b.WriteString(prevReq)
+			b.WriteByte(';')
+		}
+		if promptID != "" {
+			b.WriteString(" cc_prompt_id=")
+			b.WriteString(promptID)
+			b.WriteByte(';')
+		}
+	}
+	return b.String()
 }
 
 func claudeBillingFingerprintMessageText(payload []byte) string {
@@ -191,12 +215,28 @@ func claudeBillingFingerprintMessageText(payload []byte) string {
 }
 
 func claudeCCHFallbackBillingHeader(ctx context.Context, cfg *config.Config, payload []byte, entrypoint string) string {
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(payload)
+	prevReq, promptID := helps.ExtractClaudeBillingTags(payload)
+	if !isProbeOrHelper {
+		continuityCtx := helps.ClaudeContinuityContextFromContext(ctx)
+		if prevReq == "" && continuityCtx != nil {
+			prevReq = continuityCtx.PreviousRequestID
+		}
+		if promptID == "" && continuityCtx != nil {
+			promptID = continuityCtx.PromptID
+		}
+	}
+	incomingHeaders := resolveIncomingClaudeHeaders(ctx, helps.IncomingHeadersFromContext(ctx))
+	isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, payload)
 	return generateBillingHeader(
 		true,
 		helps.DefaultClaudeVersion(cfg),
 		claudeBillingFingerprintMessageText(payload),
 		entrypoint,
 		getWorkloadFromContext(ctx),
+		isSubagent,
+		prevReq,
+		promptID,
 	)
 }
 
@@ -212,14 +252,22 @@ func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 // Claude models give it operator-level authority without changing the cached
 // top-level prefix.
 func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, cchSigning bool, version, entrypoint, workload string) []byte {
-	return checkSystemInstructionsWithSigningModeAt(payload, strictMode, cchSigning, version, entrypoint, workload, time.Now())
+	return checkSystemInstructionsWithSigningModeAt(payload, strictMode, cchSigning, version, entrypoint, workload, time.Now(), false, "", "")
 }
 
-func checkSystemInstructionsWithSigningModeAt(payload []byte, strictMode bool, cchSigning bool, version, entrypoint, workload string, now time.Time) []byte {
+func checkSystemInstructionsWithSigningModeAt(
+	payload []byte,
+	strictMode bool,
+	cchSigning bool,
+	version, entrypoint, workload string,
+	now time.Time,
+	isSubagent bool,
+	prevReq, promptID string,
+) []byte {
 	system := gjson.GetBytes(payload, "system")
 	messageText := claudeBillingFingerprintMessageText(payload)
 
-	billingText := generateBillingHeader(cchSigning, version, messageText, entrypoint, workload)
+	billingText := generateBillingHeader(cchSigning, version, messageText, entrypoint, workload, isSubagent, prevReq, promptID)
 	billingBlock := buildTextBlock(billingText, nil)
 	agentBlock := buildTextBlock(claudeCodeCLIIdentity, &claudeCodeCacheControl)
 	payload, _ = sjson.SetRawBytes(payload, "system", []byte("["+billingBlock+","+agentBlock+"]"))
@@ -1026,7 +1074,59 @@ func applyCloaking(
 
 	billingVersion := helps.DefaultClaudeVersion(cfg)
 	workload := getWorkloadFromContext(ctx)
-	payload = checkSystemInstructionsWithSigningModeAt(payload, settings.strictMode, cchSigning, billingVersion, "cli", workload, claudeCodeCurrentTime(cfg, auth))
+
+	isSubagent := false
+	prevReq := ""
+	promptID := ""
+	if !helps.IsClaudeProbeOrHelperRequest(payload) {
+		incomingHeaders := resolveIncomingClaudeHeaders(ctx, helps.IncomingHeadersFromContext(ctx))
+		isSubagent = helps.IsClaudeSubagentRequest(incomingHeaders, payload)
+		existingPrevReq, existingPromptID := helps.ExtractClaudeBillingTags(payload)
+
+		sessionID := helps.ClaudeSessionIDFromContext(ctx)
+		if sessionID == "" && auth != nil {
+			sessionID = helps.ClaudeAgentSessionUUIDForRequest(incomingHeaders, payload, payload, confirmedClaudeCode)
+		}
+
+		if sessionID != "" && auth != nil {
+			credIdentity := claudeDiagnosticsCredentialIdentity(auth)
+			isNewTurn := helps.IsClaudeNewPromptTurn(payload)
+			continuityKey, seq, prevMsgID, storedPrevReq, storedPromptID := helps.BeginClaudeContinuity(credIdentity, sessionID, isNewTurn, existingPromptID)
+
+			if existingPromptID != "" {
+				promptID = existingPromptID
+			} else {
+				promptID = storedPromptID
+			}
+			if storedPrevReq != "" {
+				prevReq = storedPrevReq
+			} else {
+				prevReq = existingPrevReq
+			}
+
+			if continuityCtx := helps.ClaudeContinuityContextFromContext(ctx); continuityCtx != nil {
+				continuityCtx.Key = continuityKey
+				continuityCtx.Sequence = seq
+				continuityCtx.PreviousMessageID = prevMsgID
+				continuityCtx.PreviousRequestID = prevReq
+				continuityCtx.PromptID = promptID
+				continuityCtx.Initialized = true
+			}
+		}
+	}
+
+	payload = checkSystemInstructionsWithSigningModeAt(
+		payload,
+		settings.strictMode,
+		cchSigning,
+		billingVersion,
+		"cli",
+		workload,
+		claudeCodeCurrentTime(cfg, auth),
+		isSubagent,
+		prevReq,
+		promptID,
+	)
 
 	// Claude-Code-CLI fingerprint identity (real OAuth or fingerprint-profile=claude-code-cli)
 	// is applied later through the shared ApplyClaudeCredentialMetadata path.

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -242,6 +242,10 @@ func claudeCCHFallbackBillingHeader(ctx context.Context, cfg *config.Config, pay
 
 const claudeCodeCLIIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
 
+const claudeCodeFableReportingOutcomes = `# Reporting outcomes
+
+Report what actually happened, not what you intended. When you say something is done, sent, saved, fixed, or verified, that claim must rest on a result you observed in this session — tool output, the file as it now reads, the page as it now loads — not on what the step should have produced. If you did not check, say you did not check. If any step failed, was skipped, or came back different from what you expected, say so in the first sentence of your report, before anything else, even when the rest of the work succeeded. Never quietly work around a failure in a way that makes it look resolved; a problem the user can see is recoverable, one your summary hides is not. When you stop before the task is complete, your first line says so plainly and names what is left. Do not describe partial work as done, and do not let a summary read as more certain than the evidence behind it.`
+
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
 	return checkSystemInstructionsWithSigningMode(payload, strictMode, false, "2.1.258", "cli", "")
 }
@@ -286,7 +290,13 @@ func checkSystemInstructionsWithSigningModeAt(
 	billingText := generateBillingHeader(cchSigning, version, messageText, entrypoint, workload, isSubagent, prevReq, promptID)
 	billingBlock := buildTextBlock(billingText, nil)
 	agentBlock := buildTextBlock(claudeCodeCLIIdentity, &claudeCodeCacheControl)
-	payload, _ = sjson.SetRawBytes(payload, "system", []byte("["+billingBlock+","+agentBlock+"]"))
+
+	systemBlocks := []string{billingBlock, agentBlock}
+	model := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "model").String()))
+	if isClaudeFable51Model(model) && !helps.IsClaudeProbeOrHelperRequest(payload) {
+		systemBlocks = append(systemBlocks, buildTextBlock(claudeCodeFableReportingOutcomes, nil))
+	}
+	payload, _ = sjson.SetRawBytes(payload, "system", []byte("["+strings.Join(systemBlocks, ",")+"]"))
 	if strictMode {
 		return injectClaudeCodeCurrentDate(payload, now)
 	}
@@ -765,6 +775,158 @@ func reconcileClaudeCodeSystemPlacementAfterPayload(payload []byte, state claude
 	return prependClaudeSystemRemindersToFirstUserMessage(updated, state.texts)
 }
 
+type claudeCodeFableState struct {
+	injectedFallbacks bool
+	injectedDisplay   bool
+	injectedReporting bool
+}
+
+func hasFableReportingBlock(body []byte) bool {
+	system := gjson.GetBytes(body, "system")
+	if !system.IsArray() {
+		str := strings.ReplaceAll(system.String(), "\u200B", "")
+		return str == claudeCodeFableReportingOutcomes || strings.Contains(str, claudeCodeFableReportingOutcomes)
+	}
+	for _, blk := range system.Array() {
+		text := strings.ReplaceAll(blk.Get("text").String(), "\u200B", "")
+		if text == claudeCodeFableReportingOutcomes {
+			return true
+		}
+	}
+	return false
+}
+
+func captureClaudeCodeFableState(before, after []byte, cloaked bool) claudeCodeFableState {
+	if !cloaked || len(before) == 0 || len(after) == 0 {
+		return claudeCodeFableState{}
+	}
+	return claudeCodeFableState{
+		injectedFallbacks: !gjson.GetBytes(before, "fallbacks").Exists() && gjson.GetBytes(after, "fallbacks").Exists(),
+		injectedDisplay:   !gjson.GetBytes(before, "thinking.display").Exists() && gjson.GetBytes(after, "thinking.display").Exists(),
+		injectedReporting: !hasFableReportingBlock(before) && hasFableReportingBlock(after),
+	}
+}
+
+// reconcileClaudeCodeFableModelAfterPayload reconciles model-specific additions
+// (Opus fallback, thinking.display=updates, and # Reporting outcomes system block)
+// if payload rules rewrite the request model between Fable 5.1 and non-Fable models.
+func reconcileClaudeCodeFableModelAfterPayload(
+	body []byte,
+	fableState claudeCodeFableState,
+	payloadTouchedFallbacks bool,
+	payloadTouchedDisplay bool,
+	cloaked bool,
+	isProbeOrHelper bool,
+) []byte {
+	if !cloaked || len(body) == 0 {
+		return body
+	}
+
+	// Probes and helpers must never carry Fable additions (Opus fallback, display=updates, reporting block)
+	if isProbeOrHelper {
+		if fableState.injectedFallbacks && !payloadTouchedFallbacks {
+			body, _ = sjson.DeleteBytes(body, "fallbacks")
+		}
+		if fableState.injectedDisplay && !payloadTouchedDisplay {
+			body, _ = sjson.DeleteBytes(body, "thinking.display")
+		}
+		if fableState.injectedReporting {
+			system := gjson.GetBytes(body, "system")
+			if system.IsArray() {
+				blocks := make([]string, 0, len(system.Array()))
+				removed := false
+				for _, blk := range system.Array() {
+					if strings.ReplaceAll(blk.Get("text").String(), "\u200B", "") == claudeCodeFableReportingOutcomes {
+						removed = true
+						continue
+					}
+					blocks = append(blocks, blk.Raw)
+				}
+				if removed {
+					body, _ = sjson.SetRawBytes(body, "system", []byte("["+strings.Join(blocks, ",")+"]"))
+				}
+			} else if strings.ReplaceAll(system.String(), "\u200B", "") == claudeCodeFableReportingOutcomes {
+				body, _ = sjson.DeleteBytes(body, "system")
+			}
+		}
+		return body
+	}
+	currentModel := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "model").String()))
+
+	if isClaudeFable51Model(currentModel) {
+		// Non-Fable rewritten to Fable 5.1 (or original Fable 5.1): attach Fable additions
+		// unless matching payload rules explicitly configured or filtered them.
+		if !gjson.GetBytes(body, "fallbacks").Exists() && !payloadTouchedFallbacks {
+			body, _ = sjson.SetRawBytes(body, "fallbacks", []byte(`[{"model":"claude-opus-5"}]`))
+		}
+		if gjson.GetBytes(body, "thinking").Exists() {
+			thinkingType := gjson.GetBytes(body, "thinking.type").String()
+			if thinkingType == "adaptive" && !gjson.GetBytes(body, "thinking.display").Exists() && !payloadTouchedDisplay {
+				body, _ = sjson.SetBytes(body, "thinking.display", "updates")
+			} else if thinkingType != "adaptive" && fableState.injectedDisplay && !payloadTouchedDisplay {
+				body, _ = sjson.DeleteBytes(body, "thinking.display")
+			}
+		} else if fableState.injectedDisplay && !payloadTouchedDisplay {
+			body, _ = sjson.DeleteBytes(body, "thinking.display")
+		}
+		if !hasFableReportingBlock(body) {
+			system := gjson.GetBytes(body, "system")
+			if system.IsArray() {
+				blocks := make([]string, 0, len(system.Array())+1)
+				for _, blk := range system.Array() {
+					blocks = append(blocks, blk.Raw)
+				}
+				blocks = append(blocks, buildTextBlock(claudeCodeFableReportingOutcomes, nil))
+				body, _ = sjson.SetRawBytes(body, "system", []byte("["+strings.Join(blocks, ",")+"]"))
+			} else if system.Type == gjson.String {
+				str := system.String()
+				blocks := []string{
+					buildTextBlock(str, nil),
+					buildTextBlock(claudeCodeFableReportingOutcomes, nil),
+				}
+				body, _ = sjson.SetRawBytes(body, "system", []byte("["+strings.Join(blocks, ",")+"]"))
+			} else if !system.Exists() {
+				blocks := []string{
+					buildTextBlock(claudeCodeFableReportingOutcomes, nil),
+				}
+				body, _ = sjson.SetRawBytes(body, "system", []byte("["+strings.Join(blocks, ",")+"]"))
+			}
+		}
+		return body
+	}
+
+	// Target model is Non-Fable 5.1:
+	// Only delete fallbacks if CPA automatically injected it and matching payload rules did NOT explicitly configure/modify it
+	if fableState.injectedFallbacks && !payloadTouchedFallbacks {
+		body, _ = sjson.DeleteBytes(body, "fallbacks")
+	}
+	if fableState.injectedDisplay && !payloadTouchedDisplay {
+		body, _ = sjson.DeleteBytes(body, "thinking.display")
+	}
+
+	// Remove Reporting outcomes if CPA automatically injected it
+	if fableState.injectedReporting {
+		system := gjson.GetBytes(body, "system")
+		if system.IsArray() {
+			blocks := make([]string, 0, len(system.Array()))
+			removed := false
+			for _, blk := range system.Array() {
+				if strings.ReplaceAll(blk.Get("text").String(), "\u200B", "") == claudeCodeFableReportingOutcomes {
+					removed = true
+					continue
+				}
+				blocks = append(blocks, blk.Raw)
+			}
+			if removed {
+				body, _ = sjson.SetRawBytes(body, "system", []byte("["+strings.Join(blocks, ",")+"]"))
+			}
+		} else if strings.ReplaceAll(system.String(), "\u200B", "") == claudeCodeFableReportingOutcomes {
+			body, _ = sjson.DeleteBytes(body, "system")
+		}
+	}
+	return body
+}
+
 // claudeCodeLocalDate reproduces Claude Code 2.1.220's wcs() helper:
 // new Date(), local calendar fields, and zero-padded YYYY-MM-DD components.
 func claudeCodeLocalDate(now time.Time) string {
@@ -1076,6 +1238,19 @@ func applyCloaking(
 	confirmedClaudeCode bool,
 	cchSigning bool,
 ) ([]byte, bool, error) {
+	return applyCloakingInternal(ctx, cfg, auth, payload, apiKey, confirmedClaudeCode, cchSigning, true)
+}
+
+func applyCloakingInternal(
+	ctx context.Context,
+	cfg *config.Config,
+	auth *cliproxyauth.Auth,
+	payload []byte,
+	apiKey string,
+	confirmedClaudeCode bool,
+	cchSigning bool,
+	obfuscateSensitiveWords bool,
+) ([]byte, bool, error) {
 	policy, settings := resolveClaudeWirePolicy(cfg, auth, apiKey, confirmedClaudeCode)
 	if !policy.Cloak {
 		return payload, false, nil
@@ -1145,13 +1320,18 @@ func applyCloaking(
 		promptID,
 	)
 
-	// Fable 5.1 / Mythos 5.1 native profile: emit fallbacks and adaptive thinking display
-	if isClaudeFable51Model(gjson.GetBytes(payload, "model").String()) {
+	// In native Claude Code 2.1.258, claude-fable-5-1 requests carry:
+	// "fallbacks": [{"model": "claude-opus-5"}]
+	model := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "model").String()))
+	if isClaudeFable51Model(model) && !isProbeOrHelper {
 		if !gjson.GetBytes(payload, "fallbacks").Exists() {
 			payload, _ = sjson.SetRawBytes(payload, "fallbacks", []byte(`[{"model":"claude-opus-5"}]`))
 		}
-		if gjson.GetBytes(payload, "thinking.type").String() == "adaptive" && !gjson.GetBytes(payload, "thinking.display").Exists() {
-			payload, _ = sjson.SetBytes(payload, "thinking.display", "updates")
+		if gjson.GetBytes(payload, "thinking").Exists() {
+			thinkingType := gjson.GetBytes(payload, "thinking.type").String()
+			if thinkingType == "adaptive" && !gjson.GetBytes(payload, "thinking.display").Exists() {
+				payload, _ = sjson.SetBytes(payload, "thinking.display", "updates")
+			}
 		}
 	}
 
@@ -1173,7 +1353,7 @@ func applyCloaking(
 	}
 
 	// Apply sensitive word obfuscation
-	if len(settings.sensitiveWords) > 0 {
+	if obfuscateSensitiveWords && len(settings.sensitiveWords) > 0 {
 		matcher := helps.BuildSensitiveWordMatcher(settings.sensitiveWords)
 		payload = helps.ObfuscateSensitiveWords(payload, matcher)
 	}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -255,6 +255,22 @@ func checkSystemInstructionsWithSigningMode(payload []byte, strictMode bool, cch
 	return checkSystemInstructionsWithSigningModeAt(payload, strictMode, cchSigning, version, entrypoint, workload, time.Now(), false, "", "")
 }
 
+// isClaudeFable51Model reports whether the model is specifically Fable 5.1 / Mythos 5.1,
+// matching native Claude Code 2.1.258 family/major/minor checks (AFo = {major:5, minor:1}).
+func isClaudeFable51Model(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	for _, target := range []string{"fable-5-1", "fable-5.1", "mythos-5-1", "mythos-5.1"} {
+		idx := strings.Index(m, target)
+		if idx != -1 {
+			nextIdx := idx + len(target)
+			if nextIdx >= len(m) || m[nextIdx] < '0' || m[nextIdx] > '9' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func checkSystemInstructionsWithSigningModeAt(
 	payload []byte,
 	strictMode bool,
@@ -1075,10 +1091,11 @@ func applyCloaking(
 	billingVersion := helps.DefaultClaudeVersion(cfg)
 	workload := getWorkloadFromContext(ctx)
 
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(payload)
 	isSubagent := false
 	prevReq := ""
 	promptID := ""
-	if !helps.IsClaudeProbeOrHelperRequest(payload) {
+	if !isProbeOrHelper {
 		incomingHeaders := resolveIncomingClaudeHeaders(ctx, helps.IncomingHeadersFromContext(ctx))
 		isSubagent = helps.IsClaudeSubagentRequest(incomingHeaders, payload)
 		existingPrevReq, existingPromptID := helps.ExtractClaudeBillingTags(payload)
@@ -1127,6 +1144,22 @@ func applyCloaking(
 		prevReq,
 		promptID,
 	)
+
+	// Fable 5.1 / Mythos 5.1 native profile: emit fallbacks and adaptive thinking display
+	if isClaudeFable51Model(gjson.GetBytes(payload, "model").String()) {
+		if !gjson.GetBytes(payload, "fallbacks").Exists() {
+			payload, _ = sjson.SetRawBytes(payload, "fallbacks", []byte(`[{"model":"claude-opus-5"}]`))
+		}
+		if gjson.GetBytes(payload, "thinking.type").String() == "adaptive" && !gjson.GetBytes(payload, "thinking.display").Exists() {
+			payload, _ = sjson.SetBytes(payload, "thinking.display", "updates")
+		}
+	}
+
+	// Probes and subagents never use 1h cache in native Claude Code; ensure any
+	// caller-supplied 1h ttl is stripped to match extended-cache-ttl beta suppression.
+	if isSubagent || isProbeOrHelper {
+		payload = stripClaudeCacheControlTTL(payload)
+	}
 
 	// Claude-Code-CLI fingerprint identity (real OAuth or fingerprint-profile=claude-code-cli)
 	// is applied later through the shared ApplyClaudeCredentialMetadata path.
@@ -1263,6 +1296,32 @@ func upgradeClaudeCacheControlTTL(payload []byte, ttl string) []byte {
 	}
 
 	forEachClaudeCacheControlBlock(payload, upgrade)
+	return payload
+}
+
+// stripClaudeCacheControlTTL removes any ttl field from cache_control blocks in payload,
+// downgrading {"type":"ephemeral","ttl":"..."} to {"type":"ephemeral"}.
+// This ensures that when extended-cache-ttl-2025-04-11 is stripped (e.g. on probes,
+// subagents, or non-OAuth credentials), the body does not retain a ttl field that would
+// trigger Anthropic 400 errors or fingerprint mismatch.
+func stripClaudeCacheControlTTL(payload []byte) []byte {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return payload
+	}
+
+	strip := func(path string, block gjson.Result) {
+		cacheControl := block.Get("cache_control")
+		if !cacheControl.IsObject() || !cacheControl.Get("ttl").Exists() {
+			return
+		}
+		updated, errDel := sjson.DeleteBytes(payload, path+".cache_control.ttl")
+		if errDel != nil {
+			return
+		}
+		payload = updated
+	}
+
+	forEachClaudeCacheControlBlock(payload, strip)
 	return payload
 }
 

--- a/internal/runtime/executor/claude_executor_diagnostics.go
+++ b/internal/runtime/executor/claude_executor_diagnostics.go
@@ -14,12 +14,21 @@ import (
 type claudeDiagnosticsRequestState struct {
 	key      string
 	sequence uint64
+	promptID string
 }
 
 func injectClaudeDiagnostics(body []byte, auth *cliproxyauth.Auth, sessionID string) ([]byte, claudeDiagnosticsRequestState) {
-	key, sequence, previousMessageID := helps.BeginClaudeDiagnostics(claudeDiagnosticsCredentialIdentity(auth), sessionID)
+	key, sequence, previousMessageID, _, promptID := helps.BeginClaudeContinuity(claudeDiagnosticsCredentialIdentity(auth), sessionID, false, "")
+	return injectClaudeDiagnosticsWithState(body, key, sequence, previousMessageID, promptID)
+}
+
+func injectClaudeDiagnosticsWithState(body []byte, key string, sequence uint64, previousMessageID string, promptIDs ...string) ([]byte, claudeDiagnosticsRequestState) {
 	if key == "" {
 		return body, claudeDiagnosticsRequestState{}
+	}
+	promptID := ""
+	if len(promptIDs) > 0 {
+		promptID = promptIDs[0]
 	}
 	value := `{"previous_message_id":null}`
 	if previousMessageID != "" {
@@ -29,7 +38,7 @@ func injectClaudeDiagnostics(body []byte, auth *cliproxyauth.Auth, sessionID str
 	if diagnostics := gjson.GetBytes(body, "diagnostics"); diagnostics.Exists() {
 		updated, errSet := sjson.SetRawBytes(body, "diagnostics", []byte(value))
 		if errSet == nil {
-			return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence}
+			return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence, promptID: promptID}
 		}
 	}
 	if contextManagement := gjson.GetBytes(body, "context_management"); contextManagement.Exists() {
@@ -41,14 +50,22 @@ func injectClaudeDiagnostics(body []byte, auth *cliproxyauth.Auth, sessionID str
 			updated = append(updated, `,"diagnostics":`...)
 			updated = append(updated, value...)
 			updated = append(updated, body[insertAt:]...)
-			return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence}
+			return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence, promptID: promptID}
 		}
 	}
 	updated, errSet := sjson.SetRawBytes(body, "diagnostics", []byte(value))
 	if errSet != nil {
 		return body, claudeDiagnosticsRequestState{}
 	}
-	return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence}
+	return updated, claudeDiagnosticsRequestState{key: key, sequence: sequence, promptID: promptID}
+}
+
+func commitClaudeContinuity(state claudeDiagnosticsRequestState, messageID, requestID string) {
+	helps.CommitClaudeContinuity(state.key, state.sequence, messageID, requestID, state.promptID)
+}
+
+func commitClaudeDiagnostics(state claudeDiagnosticsRequestState, messageID string) {
+	commitClaudeContinuity(state, messageID, "")
 }
 
 func claudeDiagnosticsCredentialIdentity(auth *cliproxyauth.Auth) string {
@@ -69,10 +86,6 @@ func claudeDiagnosticsCredentialIdentity(auth *cliproxyauth.Auth) string {
 		return "account:" + accountUUID
 	}
 	return ""
-}
-
-func commitClaudeDiagnostics(state claudeDiagnosticsRequestState, messageID string) {
-	helps.CommitClaudeDiagnostics(state.key, state.sequence, messageID)
 }
 
 func claudeMessageIDFromResponse(data []byte) string {

--- a/internal/runtime/executor/claude_executor_diagnostics_test.go
+++ b/internal/runtime/executor/claude_executor_diagnostics_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -108,4 +109,158 @@ func TestClaudeMessageIDFromSSECommitsOnlyCompletedMessage(t *testing.T) {
 	if got := claudeMessageIDFromSSE(incomplete); got != "" {
 		t.Fatalf("incomplete SSE message ID = %q, want empty", got)
 	}
+}
+
+func TestClaudeExecutorContinuityAdvancesRequestIDAndPromptIDInBillingHeader(t *testing.T) {
+	var capturedBillingHeaders []string
+	call := 0
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		body, errRead := io.ReadAll(req.Body)
+		if errRead != nil {
+			t.Fatal(errRead)
+		}
+		billing := gjson.GetBytes(body, "system.0.text").String()
+		capturedBillingHeaders = append(capturedBillingHeaders, billing)
+		call++
+		response := `{"id":"msg_turn_` + string(rune('0'+call)) + `","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+			"request-id":   []string{fmt.Sprintf("req_upstream_turn_%d", call)},
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(strings.NewReader(response)), Request: req}, nil
+	})
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+	deviceIDs := []string{"0000000000000000000000000000000000000000000000000000000000000000"}
+	testID := uuid.NewString()
+	auth := &cliproxyauth.Auth{
+		ID:         "continuity-test-" + testID,
+		Attributes: map[string]string{"api_key": "sk-ant-oat-continuity-test"},
+		Metadata: map[string]any{
+			"account_uuid":                        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			claudeauth.ClaudeDeviceIDsMetadataKey: deviceIDs,
+		},
+	}
+	executor := NewClaudeExecutor(&config.Config{})
+	options := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Metadata:     map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "continuity-conv-" + testID},
+	}
+
+	// Turn 1: User prompt
+	req1 := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"turn 1 prompt"}],"max_tokens":100}`)}
+	if _, err := executor.Execute(ctx, auth, req1, options); err != nil {
+		t.Fatalf("turn 1 failed: %v", err)
+	}
+
+	// Turn 2: User prompt in same conversation
+	req2 := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"turn 1 prompt"},{"role":"assistant","content":"ok"},{"role":"user","content":"turn 2 prompt"}],"max_tokens":100}`)}
+	if _, err := executor.Execute(ctx, auth, req2, options); err != nil {
+		t.Fatalf("turn 2 failed: %v", err)
+	}
+
+	// Turn 2.1: Tool result continuation within turn 2
+	req2Tool := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"turn 1 prompt"},{"role":"assistant","content":"ok"},{"role":"user","content":"turn 2 prompt"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"bash","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"tool output"}]}],"max_tokens":100}`)}
+	if _, err := executor.Execute(ctx, auth, req2Tool, options); err != nil {
+		t.Fatalf("turn 2.1 tool failed: %v", err)
+	}
+
+	// Turn 3: Probe request (max_tokens: 1)
+	reqProbe := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"probe"}],"max_tokens":1}`)}
+	if _, err := executor.Execute(ctx, auth, reqProbe, options); err != nil {
+		t.Fatalf("probe failed: %v", err)
+	}
+
+	// Turn 4: Subagent request (carrying X-Claude-Code-Agent-Id)
+	subagentOptions := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      http.Header{"X-Claude-Code-Agent-Id": []string{"subagent-worker-1"}},
+		Metadata:     map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "continuity-subagent-" + testID},
+	}
+	reqSubagent := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"subagent prompt"}],"max_tokens":100}`)}
+	if _, err := executor.Execute(ctx, auth, reqSubagent, subagentOptions); err != nil {
+		t.Fatalf("subagent failed: %v", err)
+	}
+
+	// Turn 5: Resumed main session user prompt after probe (must chain from turn 2.1, NOT from probe turn 3)
+	req5 := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"turn 5 prompt"}],"max_tokens":100}`)}
+	if _, err := executor.Execute(ctx, auth, req5, options); err != nil {
+		t.Fatalf("turn 5 failed: %v", err)
+	}
+
+	if len(capturedBillingHeaders) != 6 {
+		t.Fatalf("captured %d billing headers, want 6", len(capturedBillingHeaders))
+	}
+
+	// Verify Turn 1:
+	h1 := capturedBillingHeaders[0]
+	if !strings.Contains(h1, "cc_version=2.1.258.") || !strings.Contains(h1, "cc_entrypoint=cli;") || !strings.Contains(h1, "cch=") {
+		t.Fatalf("h1 invalid: %s", h1)
+	}
+	if strings.Contains(h1, "cc_prev_req=") {
+		t.Fatalf("h1 must not contain cc_prev_req: %s", h1)
+	}
+	if !strings.Contains(h1, "cc_prompt_id=") {
+		t.Fatalf("h1 must contain cc_prompt_id: %s", h1)
+	}
+	prompt1 := extractTag(h1, "cc_prompt_id=")
+
+	// Verify Turn 2:
+	h2 := capturedBillingHeaders[1]
+	if !strings.Contains(h2, "cc_prev_req=req_upstream_turn_1;") {
+		t.Fatalf("h2 must contain cc_prev_req=req_upstream_turn_1;, got: %s", h2)
+	}
+	if !strings.Contains(h2, "cc_prompt_id=") {
+		t.Fatalf("h2 must contain cc_prompt_id: %s", h2)
+	}
+	prompt2 := extractTag(h2, "cc_prompt_id=")
+	if prompt2 == prompt1 {
+		t.Fatalf("h2 promptID (%s) must differ from h1 promptID (%s)", prompt2, prompt1)
+	}
+
+	// Verify Turn 2.1 (tool continuation):
+	h2Tool := capturedBillingHeaders[2]
+	if !strings.Contains(h2Tool, "cc_prev_req=req_upstream_turn_2;") {
+		t.Fatalf("h2Tool must contain cc_prev_req=req_upstream_turn_2;, got: %s", h2Tool)
+	}
+	prompt2Tool := extractTag(h2Tool, "cc_prompt_id=")
+	if prompt2Tool != prompt2 {
+		t.Fatalf("h2Tool promptID (%s) must match turn 2 promptID (%s)", prompt2Tool, prompt2)
+	}
+
+	// Verify Turn 3 (probe with max_tokens: 1):
+	hProbe := capturedBillingHeaders[3]
+	if strings.Contains(hProbe, "cc_prev_req=") || strings.Contains(hProbe, "cc_prompt_id=") {
+		t.Fatalf("probe must not contain cc_prev_req or cc_prompt_id: %s", hProbe)
+	}
+
+	// Verify Turn 4 (subagent):
+	hSubagent := capturedBillingHeaders[4]
+	if !strings.Contains(hSubagent, "cc_is_subagent=true;") {
+		t.Fatalf("hSubagent must contain cc_is_subagent=true;, got: %s", hSubagent)
+	}
+	if !strings.Contains(hSubagent, "cc_prompt_id=") {
+		t.Fatalf("hSubagent must contain cc_prompt_id: %s", hSubagent)
+	}
+
+	// Verify Turn 5 (main turn after probe):
+	// Must chain to turn 2.1's response (req_upstream_turn_3), bypassing probe turn 3 (req_upstream_turn_4)!
+	h5 := capturedBillingHeaders[5]
+	if !strings.Contains(h5, "cc_prev_req=req_upstream_turn_3;") {
+		t.Fatalf("h5 must contain cc_prev_req=req_upstream_turn_3; (bypassing probe turn 4), got: %s", h5)
+	}
+	if !strings.Contains(h5, "cc_prompt_id=") {
+		t.Fatalf("h5 must contain cc_prompt_id: %s", h5)
+	}
+}
+
+func extractTag(header, prefix string) string {
+	idx := strings.Index(header, prefix)
+	if idx < 0 {
+		return ""
+	}
+	val := header[idx+len(prefix):]
+	if end := strings.IndexByte(val, ';'); end >= 0 {
+		val = val[:end]
+	}
+	return val
 }

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -62,6 +62,14 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if fp.ProfileClaudeCodeCLI {
 		claudeSessionID = helps.ClaudeAgentSessionUUIDForRequest(incomingHeaders, originalPayload, req.Payload, confirmedClaudeCode, opts.Metadata, req.Metadata)
 	}
+
+	continuityCtx := &helps.ClaudeContinuityContext{}
+	ctx = helps.WithClaudeContinuityContext(ctx, continuityCtx)
+	ctx = helps.WithIncomingHeaders(ctx, incomingHeaders)
+	if claudeSessionID != "" {
+		ctx = helps.WithClaudeSessionID(ctx, claudeSessionID)
+	}
+
 	originalTranslated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, upstreamStream, helps.APIKeyModelIsCompat(req))
 	body := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, upstreamStream, helps.APIKeyModelIsCompat(req))
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
@@ -94,14 +102,26 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+	if continuityCtx.Initialized {
+		diagnosticsState = claudeDiagnosticsRequestState{
+			key:      continuityCtx.Key,
+			sequence: continuityCtx.Sequence,
+			promptID: continuityCtx.PromptID,
+		}
+	}
 	contextManagementState := claudeCodeContextManagementState{
 		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
 		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
 	}
 	if contextManagementState.eligible {
 		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
-		if fp.InjectDiagnostics {
-			body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
+		if fp.InjectDiagnostics && !isProbeOrHelper {
+			if continuityCtx.Initialized {
+				body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityCtx.Key, continuityCtx.Sequence, continuityCtx.PreviousMessageID, continuityCtx.PromptID)
+			} else {
+				body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
+			}
 		}
 	}
 
@@ -291,7 +311,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			helps.RecordAPIResponseError(ctx, e.cfg, errValidate)
 			return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errValidate)
 		}
-		commitClaudeDiagnostics(diagnosticsState, claudeMessageIDFromSSE(data))
+		if msgID := claudeMessageIDFromSSE(data); msgID != "" {
+			commitClaudeContinuity(diagnosticsState, msgID, helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))
+		}
 		lines := bytes.Split(data, []byte("\n"))
 		for i, line := range lines {
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
@@ -307,7 +329,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 		data = bytes.Join(lines, []byte("\n"))
 	} else {
-		commitClaudeDiagnostics(diagnosticsState, claudeMessageIDFromResponse(data))
+		commitClaudeContinuity(diagnosticsState, claudeMessageIDFromResponse(data), helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))
 		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
 		var errRestore error
 		data, errRestore = restoreClaudeOAuthToolNamesFromResponse(data, oauthToolNamesReverseMap)

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -163,8 +163,13 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Only a ttl the caller wrote out explicitly survives, because
 	// upgradeClaudeCacheControlTTL skips any block that already has one.
 	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
+	// In native Claude Code 2.1.258, 1h cache and extended-cache-ttl are restricted to main
+	// interaction queries (repl_main_thread*); subagents, side queries, and probes omit both.
+	isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, body)
+	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI && !isSubagent && !isProbeOrHelper {
 		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+	} else if isSubagent || isProbeOrHelper {
+		body = stripClaudeCacheControlTTL(body)
 	}
 
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -14,6 +14,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
@@ -84,9 +85,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
+	_, wireSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
 	bodyBeforeCloaking := body
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(bodyBeforeCloaking)
 	var cloaked bool
-	body, cloaked, err = applyCloaking(
+	body, cloaked, err = applyCloakingInternal(
 		ctx,
 		e.cfg,
 		auth,
@@ -94,6 +97,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		apiKey,
 		confirmedClaudeCode,
 		cchSigning,
+		false,
 	)
 	if err != nil {
 		return resp, err
@@ -103,7 +107,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
-	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+	if !isProbeOrHelper {
+		isProbeOrHelper = helps.IsClaudeProbeOrHelperRequest(body)
+	}
 	if continuityCtx.Initialized {
 		diagnosticsState = claudeDiagnosticsRequestState{
 			key:      continuityCtx.Key,
@@ -115,9 +121,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
 		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
 	}
+	diagnosticsInjectedByCPA := false
 	if contextManagementState.eligible {
 		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
 		if fp.InjectDiagnostics && !isProbeOrHelper {
+			diagnosticsInjectedByCPA = true
 			if continuityCtx.Initialized {
 				body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityCtx.Key, continuityCtx.Sequence, continuityCtx.PreviousMessageID, continuityCtx.PromptID)
 			} else {
@@ -143,9 +151,50 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		"context_management",
 		"fallbacks",
 		"thinking.display",
+		"diagnostics",
 	)
 	contextManagementState.payloadRuleTouched = touchedPayloadPaths["context_management"]
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
+	wasProbeOrHelper := isProbeOrHelper
+	isProbeOrHelper = helps.IsClaudeProbeOrHelperRequest(body)
+	if isProbeOrHelper {
+		diagnosticsState = claudeDiagnosticsRequestState{}
+		if diagnosticsInjectedByCPA && !touchedPayloadPaths["diagnostics"] {
+			body, _ = sjson.DeleteBytes(body, "diagnostics")
+		}
+		if cloaked {
+			body = helps.StripClaudeBillingTags(body)
+		}
+		if continuityCtx != nil {
+			*continuityCtx = helps.ClaudeContinuityContext{}
+		}
+	} else if wasProbeOrHelper {
+		// Declassified as probe (e.g. payload override changed max_tokens: 1 to normal request):
+		// Initialize continuity and diagnostics if cloaked and eligible.
+		if cloaked {
+			sessionID := helps.ClaudeSessionIDFromContext(ctx)
+			if sessionID == "" && auth != nil {
+				sessionID = helps.ClaudeAgentSessionUUIDForRequest(incomingHeaders, body, body, confirmedClaudeCode)
+			}
+			if sessionID != "" && auth != nil {
+				credIdentity := claudeDiagnosticsCredentialIdentity(auth)
+				isNewTurn := helps.IsClaudeNewPromptTurn(body)
+				continuityKey, seq, prevMsgID, storedPrevReq, storedPromptID := helps.BeginClaudeContinuity(credIdentity, sessionID, isNewTurn, "")
+				if continuityCtx != nil {
+					continuityCtx.Key = continuityKey
+					continuityCtx.Sequence = seq
+					continuityCtx.PreviousMessageID = prevMsgID
+					continuityCtx.PreviousRequestID = storedPrevReq
+					continuityCtx.PromptID = storedPromptID
+					continuityCtx.Initialized = true
+				}
+				body = helps.InjectClaudeBillingTags(body, storedPrevReq, storedPromptID)
+				if fp.InjectDiagnostics && isAnthropicUpstreamBase(baseURL) {
+					body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityKey, seq, prevMsgID, storedPromptID)
+				}
+			}
+		}
+	}
 	body = reconcileClaudeCodeFableModelAfterPayload(
 		body,
 		fableState,
@@ -225,6 +274,10 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		if err != nil {
 			return resp, err
 		}
+	}
+	if cloaked && len(wireSettings.sensitiveWords) > 0 {
+		matcher := helps.BuildSensitiveWordMatcher(wireSettings.sensitiveWords)
+		bodyForUpstream = helps.ObfuscateSensitiveWords(bodyForUpstream, matcher)
 	}
 	cchBilling := ""
 	if cchSigning {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -99,6 +99,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
+	fableState := captureClaudeCodeFableState(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
@@ -127,8 +128,32 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
-	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	var touchedPayloadPaths map[string]bool
+	body, touchedPayloadPaths = helps.ApplyPayloadConfigWithTrackedPaths(
+		e.cfg,
+		baseModel,
+		to.String(),
+		from.String(),
+		"",
+		body,
+		originalTranslated,
+		requestedModel,
+		requestPath,
+		opts.Headers,
+		"context_management",
+		"fallbacks",
+		"thinking.display",
+	)
+	contextManagementState.payloadRuleTouched = touchedPayloadPaths["context_management"]
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
+	body = reconcileClaudeCodeFableModelAfterPayload(
+		body,
+		fableState,
+		touchedPayloadPaths["fallbacks"],
+		touchedPayloadPaths["thinking.display"],
+		cloaked,
+		isProbeOrHelper,
+	)
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -34,24 +34,25 @@ import (
 )
 
 const (
-	claudeTokenCountingBeta      = "token-counting-2024-11-01"
-	claudeFastModeBeta           = "fast-mode-2026-02-01"
-	claudeOAuthBeta              = "oauth-2025-04-20"
-	claudeCodeBeta               = "claude-code-20250219"
-	claudeContext1MBeta          = "context-1m-2025-08-07"
-	claudeMidConvSystemBeta      = "mid-conversation-system-2026-04-07"
-	claudeAdvisorToolBeta        = "advisor-tool-2026-03-01"
-	claudeAdvancedToolUseBeta    = "advanced-tool-use-2025-11-20"
-	claudeEffortBeta             = "effort-2025-11-24"
-	claudeServerSideFallbackBeta = "server-side-fallback-2026-06-01"
-	claudeFallbackCreditBeta     = "fallback-credit-2026-06-01"
-	claudeStructuredOutputsBeta  = "structured-outputs-2025-12-15"
-	claudeExtendedCacheTTLBeta   = "extended-cache-ttl-2025-04-11"
-	claudeCacheDiagnosisBeta     = "cache-diagnosis-2026-04-07"
-	claudeRedactThinkingBeta     = "redact-thinking-2026-02-12"
+	claudeTokenCountingBeta          = "token-counting-2024-11-01"
+	claudeFastModeBeta               = "fast-mode-2026-02-01"
+	claudeOAuthBeta                  = "oauth-2025-04-20"
+	claudeCodeBeta                   = "claude-code-20250219"
+	claudeContext1MBeta              = "context-1m-2025-08-07"
+	claudeMidConvSystemBeta          = "mid-conversation-system-2026-04-07"
+	claudeAdvisorToolBeta            = "advisor-tool-2026-03-01"
+	claudeAdvancedToolUseBeta        = "advanced-tool-use-2025-11-20"
+	claudeEffortBeta                 = "effort-2025-11-24"
+	claudeServerSideFallbackBeta     = "server-side-fallback-2026-06-01"
+	claudeFallbackCreditBeta         = "fallback-credit-2026-06-01"
+	claudeStructuredOutputsBeta      = "structured-outputs-2025-12-15"
+	claudeThinkingDisplayUpdatesBeta = "thinking-display-updates-2026-08-18"
+	claudeExtendedCacheTTLBeta       = "extended-cache-ttl-2025-04-11"
+	claudeCacheDiagnosisBeta         = "cache-diagnosis-2026-04-07"
+	claudeRedactThinkingBeta         = "redact-thinking-2026-02-12"
 )
 
-// claudeCodeCLIConstantBetas are the betas Claude Code 2.1.220 sends on every
+// claudeCodeCLIConstantBetas are the betas Claude Code sends on every
 // /v1/messages request from the "cli" entrypoint, in wire order, excluding the
 // leading claude-code-20250219.
 //
@@ -76,12 +77,11 @@ var claudeCodeTrailingBetas = []string{
 }
 
 // claudeCodeCLIBetas assembles the Anthropic-Beta baseline the way Claude Code
-// 2.1.220 does: the list is per-request, not a fixed string. requested holds the
+// 2.1.258 does: the list is per-request, not a fixed string. requested holds the
 // betas the caller asked for, which decide the capability flags below.
 //
-// Verified against api.anthropic.com with isolated 2.1.220 profiles on both
-// API-key and OAuth paths. A 2026-08-03 A/B capture with two distinct OAuth
-// accounts confirmed the current tool beta and OAuth trailer below.
+// Verified against api.anthropic.com with native 2.1.258 captures on interactive,
+// non-interactive, subagent, and multi-model paths (Sonnet, Opus, Fable, Haiku).
 // The full observed order is:
 //
 //	 1 claude-code-20250219
@@ -95,17 +95,19 @@ var claudeCodeTrailingBetas = []string{
 //	 9 mid-conversation-system-2026-04-07  models accepting a role=system turn
 //	10 advisor-tool-2026-03-01             requests declaring advisor tools or requesting advisor beta
 //	11 advanced-tool-use-2025-11-20       requests with tools
-//	12 effort-2025-11-24
-//	13 server-side-fallback-2026-06-01
-//	14 fallback-credit-2026-06-01
-//	15 fast-mode-2026-02-01               speed:fast requests only
-//	16 extended-cache-ttl-2025-04-11      OAuth credentials only
-//	17 cache-diagnosis-2026-04-07         requests with diagnostics only
+//	12 effort-2025-11-24                  effort-supporting models with active thinking
+//	13 server-side-fallback-2026-06-01    requests with fallbacks or requested
+//	14 fallback-credit-2026-06-01         OAuth credentials
+//	15 structured-outputs-2025-12-15      structured output requests
+//	16 thinking-display-updates-2026-08-18 requests with thinking.display=updates
+//	17 fast-mode-2026-02-01               speed:fast requests only
+//	18 extended-cache-ttl-2025-04-11      OAuth credentials (omitted on subagent & probe)
+//	19 cache-diagnosis-2026-04-07         requests with diagnostics only
 //
 // An empty body keeps the optimistic role=system default, matching the cloaking
 // policy for unknown and future model IDs.
 func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool) string {
-	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+7)
+	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+8)
 	betas = append(betas, claudeCodeBeta)
 	if oauthToken {
 		betas = append(betas, claudeOAuthBeta)
@@ -129,25 +131,67 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() && len(tools.Array()) > 0 {
 		betas = append(betas, claudeAdvancedToolUseBeta)
 	}
-	betas = append(betas, claudeEffortBeta)
-	if oauthToken && !requested[claudeFallbackCreditBeta] {
+	if claudeRequestSupportsEffort(body, requested) {
+		betas = append(betas, claudeEffortBeta)
+	}
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+	if !isProbeOrHelper && (requested[claudeServerSideFallbackBeta] || gjson.GetBytes(body, "fallbacks").Exists()) {
+		betas = append(betas, claudeServerSideFallbackBeta)
+	}
+	if requested[claudeFallbackCreditBeta] || oauthToken {
 		betas = append(betas, claudeFallbackCreditBeta)
 	}
 	for _, beta := range claudeCodeTrailingBetas {
+		if beta == claudeServerSideFallbackBeta || beta == claudeFallbackCreditBeta {
+			continue
+		}
 		if requested[beta] {
 			betas = append(betas, beta)
 		}
 	}
+	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+	if !isProbeOrHelper && thinkingType != "disabled" && (requested[claudeThinkingDisplayUpdatesBeta] || claudeThinkingDisplayUpdates(body)) {
+		betas = append(betas, claudeThinkingDisplayUpdatesBeta)
+	}
 	if claudeRequestUsesFastMode(body, requested) {
 		betas = append(betas, claudeFastModeBeta)
 	}
-	if oauthToken {
+	if oauthToken && !helps.IsClaudeSubagentRequest(nil, body) && !isProbeOrHelper {
 		betas = append(betas, claudeExtendedCacheTTLBeta)
 	}
 	if diagnostics := gjson.GetBytes(body, "diagnostics"); diagnostics.IsObject() {
 		betas = append(betas, claudeCacheDiagnosisBeta)
 	}
 	return strings.Join(betas, ",")
+}
+
+func isClaudeHaikuModel(model string) bool {
+	return strings.Contains(strings.ToLower(model), "haiku")
+}
+
+func claudeRequestSupportsEffort(body []byte, requested map[string]bool) bool {
+	if len(body) > 0 {
+		if helps.IsClaudeProbeOrHelperRequest(body) {
+			return false
+		}
+		model := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "model").String()))
+		if isClaudeHaikuModel(model) {
+			return false
+		}
+		thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
+		if thinkingType == "disabled" {
+			return false
+		}
+	}
+	if requested[claudeEffortBeta] {
+		return true
+	}
+	return true
+}
+
+func claudeThinkingDisplayUpdates(body []byte) bool {
+	display := gjson.GetBytes(body, "thinking.display")
+	return display.Type == gjson.String && strings.EqualFold(strings.TrimSpace(display.String()), "updates")
 }
 
 // claudeBodyHasAdvisorTool reports whether the request body declares an
@@ -250,7 +294,7 @@ func withClaudeCountTokensOAuthBeta(betas string) string {
 // be described accurately.
 //
 // Betas already present are left exactly where the caller put them.
-func withClaudeOAuthCredentialBetas(betas string) string {
+func withClaudeOAuthCredentialBetas(betas string, includeExtendedCacheTTL bool) string {
 	parts := make([]string, 0, 16)
 	seen := make(map[string]bool)
 	for _, beta := range strings.Split(betas, ",") {
@@ -269,10 +313,22 @@ func withClaudeOAuthCredentialBetas(betas string) string {
 		copy(parts[insertAt+1:], parts[insertAt:])
 		parts[insertAt] = claudeOAuthBeta
 	}
-	if !seen[claudeExtendedCacheTTLBeta] {
+	if includeExtendedCacheTTL && !seen[claudeExtendedCacheTTLBeta] {
 		parts = append(parts, claudeExtendedCacheTTLBeta)
 	}
 	return strings.Join(parts, ",")
+}
+
+func withoutClaudeBeta(betas, removeBeta string) string {
+	parts := strings.Split(betas, ",")
+	res := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" && p != removeBeta {
+			res = append(res, p)
+		}
+	}
+	return strings.Join(res, ",")
 }
 
 // withClaudeAdvisorToolBeta ensures advisor-tool-2026-03-01 is present when
@@ -784,7 +840,7 @@ func applyClaudeHeadersWithNativeProfile(
 		}
 	}
 
-	incomingBetas := strings.TrimSpace(strings.Join(incomingHeaders.Values("Anthropic-Beta"), ","))
+	incomingBetas := strings.TrimSpace(strings.Join(helps.HeaderValuesCaseInsensitive(incomingHeaders, "Anthropic-Beta"), ","))
 	countTokens := r.URL != nil && strings.HasSuffix(r.URL.Path, "/count_tokens")
 	requestedMap := claudeRequestedBetas(incomingBetas, extraBetas)
 	advisorNeeded := requestedMap[claudeAdvisorToolBeta] || claudeBodyHasAdvisorTool(body)
@@ -806,16 +862,23 @@ func applyClaudeHeadersWithNativeProfile(
 		}
 		// Measured Haiku helper requests already carry the exact credential
 		// beta profile and intentionally omit extended-cache-ttl.
+		// Native Claude Code subagents and probes also omit extended-cache-ttl.
 		if useOAuthBetas && !helperProfile {
 			if countTokens {
 				baseBetas = withClaudeCountTokensOAuthBeta(baseBetas)
 			} else {
-				baseBetas = withClaudeOAuthCredentialBetas(baseBetas)
+				isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, body)
+				isProbe := helps.IsClaudeProbeOrHelperRequest(body)
+				includeExtendedCacheTTL := !isSubagent && !isProbe
+				baseBetas = withClaudeOAuthCredentialBetas(baseBetas, includeExtendedCacheTTL)
 			}
 		}
 	}
 	if preserveCallerFingerprint && advisorNeeded {
 		baseBetas = withClaudeAdvisorToolBeta(baseBetas)
+	}
+	if !claudeRequestSupportsEffort(body, nil) {
+		baseBetas = withoutClaudeBeta(baseBetas, claudeEffortBeta)
 	}
 	existingSet := make(map[string]bool)
 	for _, beta := range strings.Split(baseBetas, ",") {
@@ -860,6 +923,28 @@ func applyClaudeHeadersWithNativeProfile(
 		}
 	}
 	applyBetaHeader := func() {
+		// Enforce strict native Claude Code 2.1.258 model & turn beta gating:
+		if !claudeRequestSupportsEffort(body, nil) {
+			baseBetas = withoutClaudeBeta(baseBetas, claudeEffortBeta)
+		}
+		reqProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+		if reqProbeOrHelper {
+			baseBetas = withoutClaudeBeta(baseBetas, claudeServerSideFallbackBeta)
+			baseBetas = withoutClaudeBeta(baseBetas, claudeThinkingDisplayUpdatesBeta)
+			baseBetas = withoutClaudeBeta(baseBetas, claudeExtendedCacheTTLBeta)
+		}
+		reqThinkingType := gjson.GetBytes(body, "thinking.type").String()
+		if reqThinkingType == "disabled" {
+			baseBetas = withoutClaudeBeta(baseBetas, claudeThinkingDisplayUpdatesBeta)
+		}
+		if helps.IsClaudeSubagentRequest(nil, body) {
+			baseBetas = withoutClaudeBeta(baseBetas, claudeExtendedCacheTTLBeta)
+		}
+		reqModel := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "model").String()))
+		if isClaudeHaikuModel(reqModel) && !gjson.GetBytes(body, "fallbacks").Exists() {
+			baseBetas = withoutClaudeBeta(baseBetas, claudeServerSideFallbackBeta)
+		}
+
 		if strings.TrimSpace(baseBetas) == "" {
 			r.Header.Del("Anthropic-Beta")
 			return
@@ -932,7 +1017,7 @@ func applyClaudeHeadersWithNativeProfile(
 	identityHeader("X-Stainless-Lang", "js")
 	// Native async SDK helpers add this header independently of body.stream.
 	// Preserve it only after the complete native-client detector succeeds.
-	if confirmedClaudeCode && incomingHeaders.Get("X-Stainless-Async") == "async" {
+	if confirmedClaudeCode && helps.HeaderValueCaseInsensitive(incomingHeaders, "X-Stainless-Async") == "async" {
 		r.Header.Set("X-Stainless-Async", "async")
 	}
 	// Claude Code omits X-Stainless-Timeout on count_tokens; only a confirmed
@@ -940,7 +1025,7 @@ func applyClaudeHeadersWithNativeProfile(
 	if !countTokens {
 		identityHeader("X-Stainless-Timeout", hdrDefault(hd.Timeout, "600"))
 	} else if confirmedClaudeCode {
-		if incomingTimeout := incomingHeaders.Get("X-Stainless-Timeout"); incomingTimeout != "" {
+		if incomingTimeout := helps.HeaderValueCaseInsensitive(incomingHeaders, "X-Stainless-Timeout"); incomingTimeout != "" {
 			r.Header.Set("X-Stainless-Timeout", incomingTimeout)
 		}
 	}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -16,6 +16,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -87,9 +88,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
+	_, wireSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
 	bodyBeforeCloaking := body
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(bodyBeforeCloaking)
 	var cloaked bool
-	body, cloaked, err = applyCloaking(
+	body, cloaked, err = applyCloakingInternal(
 		ctx,
 		e.cfg,
 		auth,
@@ -97,6 +100,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		apiKey,
 		confirmedClaudeCode,
 		cchSigning,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -106,7 +110,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
-	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+	if !isProbeOrHelper {
+		isProbeOrHelper = helps.IsClaudeProbeOrHelperRequest(body)
+	}
 	if continuityCtx.Initialized {
 		diagnosticsState = claudeDiagnosticsRequestState{
 			key:      continuityCtx.Key,
@@ -118,9 +124,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
 		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
 	}
+	diagnosticsInjectedByCPA := false
 	if contextManagementState.eligible {
 		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
 		if fp.InjectDiagnostics && !isProbeOrHelper {
+			diagnosticsInjectedByCPA = true
 			if continuityCtx.Initialized {
 				body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityCtx.Key, continuityCtx.Sequence, continuityCtx.PreviousMessageID, continuityCtx.PromptID)
 			} else {
@@ -146,9 +154,50 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		"context_management",
 		"fallbacks",
 		"thinking.display",
+		"diagnostics",
 	)
 	contextManagementState.payloadRuleTouched = touchedPayloadPaths["context_management"]
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
+	wasProbeOrHelper := isProbeOrHelper
+	isProbeOrHelper = helps.IsClaudeProbeOrHelperRequest(body)
+	if isProbeOrHelper {
+		diagnosticsState = claudeDiagnosticsRequestState{}
+		if diagnosticsInjectedByCPA && !touchedPayloadPaths["diagnostics"] {
+			body, _ = sjson.DeleteBytes(body, "diagnostics")
+		}
+		if cloaked {
+			body = helps.StripClaudeBillingTags(body)
+		}
+		if continuityCtx != nil {
+			*continuityCtx = helps.ClaudeContinuityContext{}
+		}
+	} else if wasProbeOrHelper {
+		// Declassified as probe (e.g. payload override changed max_tokens: 1 to normal request):
+		// Initialize continuity and diagnostics if cloaked and eligible.
+		if cloaked {
+			sessionID := helps.ClaudeSessionIDFromContext(ctx)
+			if sessionID == "" && auth != nil {
+				sessionID = helps.ClaudeAgentSessionUUIDForRequest(incomingHeaders, body, body, confirmedClaudeCode)
+			}
+			if sessionID != "" && auth != nil {
+				credIdentity := claudeDiagnosticsCredentialIdentity(auth)
+				isNewTurn := helps.IsClaudeNewPromptTurn(body)
+				continuityKey, seq, prevMsgID, storedPrevReq, storedPromptID := helps.BeginClaudeContinuity(credIdentity, sessionID, isNewTurn, "")
+				if continuityCtx != nil {
+					continuityCtx.Key = continuityKey
+					continuityCtx.Sequence = seq
+					continuityCtx.PreviousMessageID = prevMsgID
+					continuityCtx.PreviousRequestID = storedPrevReq
+					continuityCtx.PromptID = storedPromptID
+					continuityCtx.Initialized = true
+				}
+				body = helps.InjectClaudeBillingTags(body, storedPrevReq, storedPromptID)
+				if fp.InjectDiagnostics && isAnthropicUpstreamBase(baseURL) {
+					body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityKey, seq, prevMsgID, storedPromptID)
+				}
+			}
+		}
+	}
 	body = reconcileClaudeCodeFableModelAfterPayload(
 		body,
 		fableState,
@@ -217,6 +266,10 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if err != nil {
 			return nil, err
 		}
+	}
+	if cloaked && len(wireSettings.sensitiveWords) > 0 {
+		matcher := helps.BuildSensitiveWordMatcher(wireSettings.sensitiveWords)
+		bodyForUpstream = helps.ObfuscateSensitiveWords(bodyForUpstream, matcher)
 	}
 	cchBilling := ""
 	if cchSigning {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -102,6 +102,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
+	fableState := captureClaudeCodeFableState(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
@@ -130,8 +131,32 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
-	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	var touchedPayloadPaths map[string]bool
+	body, touchedPayloadPaths = helps.ApplyPayloadConfigWithTrackedPaths(
+		e.cfg,
+		baseModel,
+		to.String(),
+		from.String(),
+		"",
+		body,
+		originalTranslated,
+		requestedModel,
+		requestPath,
+		opts.Headers,
+		"context_management",
+		"fallbacks",
+		"thinking.display",
+	)
+	contextManagementState.payloadRuleTouched = touchedPayloadPaths["context_management"]
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
+	body = reconcileClaudeCodeFableModelAfterPayload(
+		body,
+		fableState,
+		touchedPayloadPaths["fallbacks"],
+		touchedPayloadPaths["thinking.display"],
+		cloaked,
+		isProbeOrHelper,
+	)
 	body = ensureModelMaxTokens(body, baseModel)
 
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -65,6 +65,14 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if fp.ProfileClaudeCodeCLI {
 		claudeSessionID = helps.ClaudeAgentSessionUUIDForRequest(incomingHeaders, originalPayload, req.Payload, confirmedClaudeCode, opts.Metadata, req.Metadata)
 	}
+
+	continuityCtx := &helps.ClaudeContinuityContext{}
+	ctx = helps.WithClaudeContinuityContext(ctx, continuityCtx)
+	ctx = helps.WithIncomingHeaders(ctx, incomingHeaders)
+	if claudeSessionID != "" {
+		ctx = helps.WithClaudeSessionID(ctx, claudeSessionID)
+	}
+
 	originalTranslated := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true, helps.APIKeyModelIsCompat(req))
 	body := helps.TranslateRequestWithAPIKeyModelCompatibility(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true, helps.APIKeyModelIsCompat(req))
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
@@ -97,14 +105,26 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.
 	diagnosticsState := claudeDiagnosticsRequestState{}
+	isProbeOrHelper := helps.IsClaudeProbeOrHelperRequest(body)
+	if continuityCtx.Initialized {
+		diagnosticsState = claudeDiagnosticsRequestState{
+			key:      continuityCtx.Key,
+			sequence: continuityCtx.Sequence,
+			promptID: continuityCtx.PromptID,
+		}
+	}
 	contextManagementState := claudeCodeContextManagementState{
 		eligible:    cloaked && isAnthropicUpstreamBase(baseURL),
 		callerOwned: gjson.GetBytes(body, "context_management").Exists(),
 	}
 	if contextManagementState.eligible {
 		body, contextManagementState.automaticallyInjected = injectClaudeCodeContextManagement(body)
-		if fp.InjectDiagnostics {
-			body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
+		if fp.InjectDiagnostics && !isProbeOrHelper {
+			if continuityCtx.Initialized {
+				body, diagnosticsState = injectClaudeDiagnosticsWithState(body, continuityCtx.Key, continuityCtx.Sequence, continuityCtx.PreviousMessageID, continuityCtx.PromptID)
+			} else {
+				body, diagnosticsState = injectClaudeDiagnostics(body, auth, claudeSessionID)
+			}
 		}
 	}
 
@@ -356,7 +376,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				return
 			}
 			if upstreamCompleted {
-				commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
+				commitClaudeContinuity(diagnosticsState, upstreamMessageID, helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))
 			}
 			return
 		}
@@ -418,7 +438,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			return
 		}
 		if upstreamCompleted {
-			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
+			commitClaudeContinuity(diagnosticsState, upstreamMessageID, helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))
 		}
 	}()
 	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -164,8 +164,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Only a ttl the caller wrote out explicitly survives, because
 	// upgradeClaudeCacheControlTTL skips any block that already has one.
 	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
+	// In native Claude Code 2.1.258, 1h cache and extended-cache-ttl are restricted to main
+	// interaction queries (repl_main_thread*); subagents, side queries, and probes omit both.
+	isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, body)
+	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI && !isSubagent && !isProbeOrHelper {
 		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
+	} else if isSubagent || isProbeOrHelper {
+		body = stripClaudeCacheControlTTL(body)
 	}
 
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4589,6 +4589,1679 @@ func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmi
 	}
 }
 
+func TestApplyCloaking_FableInjectsFallbacksAndDisplayUpdates(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-fable-test"}}
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+
+	out, cloaked, err := applyCloaking(
+		context.Background(),
+		cfg,
+		auth,
+		payload,
+		"sk-ant-oat-fable-test",
+		false,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	fallbacks := gjson.GetBytes(out, "fallbacks").Array()
+	if len(fallbacks) != 1 || fallbacks[0].Get("model").String() != "claude-opus-5" {
+		t.Fatalf("expected fallbacks=[{\"model\":\"claude-opus-5\"}], got: %s", gjson.GetBytes(out, "fallbacks").Raw)
+	}
+
+	systemBlocks := gjson.GetBytes(out, "system").Array()
+	if len(systemBlocks) != 3 {
+		t.Fatalf("expected 3 system blocks for Fable cloaking (billing, identity, reporting outcomes), got %d", len(systemBlocks))
+	}
+	if !strings.Contains(systemBlocks[2].Get("text").String(), "Reporting outcomes") {
+		t.Fatalf("expected system block 2 to contain Reporting outcomes, got: %s", systemBlocks[2].Get("text").String())
+	}
+	if systemBlocks[2].Get("cache_control").Exists() {
+		t.Fatalf("system block 2 for Reporting outcomes should have no cache_control, got: %s", systemBlocks[2].Get("cache_control").Raw)
+	}
+
+	display := gjson.GetBytes(out, "thinking.display").String()
+	if display != "updates" {
+		t.Fatalf("expected thinking.display=updates, got: %q", display)
+	}
+
+	betas := claudeCodeCLIBetas(out, nil, true)
+	if !strings.Contains(betas, "server-side-fallback-2026-06-01") {
+		t.Fatalf("expected server-side-fallback beta in betas, got: %s", betas)
+	}
+	if !strings.Contains(betas, "thinking-display-updates-2026-08-18") {
+		t.Fatalf("expected thinking-display-updates beta in betas, got: %s", betas)
+	}
+	if strings.Contains(betas, "redact-thinking-2026-02-12") {
+		t.Fatalf("expected redact-thinking beta to be dropped when display=updates, got: %s", betas)
+	}
+}
+
+func TestApplyCloaking_SonnetOmitsReportingOutcomes(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-sonnet-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-sonnet-test"}}
+	payload := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"test"}]}`)
+
+	out, cloaked, err := applyCloaking(
+		context.Background(),
+		cfg,
+		auth,
+		payload,
+		"sk-ant-oat-sonnet-test",
+		false,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	systemBlocks := gjson.GetBytes(out, "system").Array()
+	if len(systemBlocks) != 2 {
+		t.Fatalf("expected 2 system blocks for Sonnet (billing, identity only), got %d", len(systemBlocks))
+	}
+	for i, b := range systemBlocks {
+		if strings.Contains(b.Get("text").String(), "Reporting outcomes") {
+			t.Fatalf("system block %d should not contain Reporting outcomes on non-Fable model, got: %s", i, b.Get("text").String())
+		}
+	}
+}
+
+func TestApplyCloaking_DisabledByConfigLeavesFableUntouched(t *testing.T) {
+	cfg := &config.Config{
+		DisableClaudeCloakMode: true,
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-fable-test"}}
+	originalSystem := "You are a custom assistant for my company."
+	payload := []byte(`{"model":"claude-fable-5-1","system":"` + originalSystem + `","messages":[{"role":"user","content":"test"}]}`)
+
+	out, cloaked, err := applyCloaking(
+		context.Background(),
+		cfg,
+		auth,
+		payload,
+		"sk-ant-oat-fable-test",
+		false,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if cloaked {
+		t.Fatal("applyCloaking() cloaked = true, want false when DisableClaudeCloakMode is true")
+	}
+	if got := gjson.GetBytes(out, "system").String(); got != originalSystem {
+		t.Fatalf("expected system to be preserved unchanged, got: %s", got)
+	}
+	if gjson.GetBytes(out, "fallbacks").Exists() {
+		t.Fatalf("expected no fallbacks injected when cloaking is disabled, got: %s", gjson.GetBytes(out, "fallbacks").Raw)
+	}
+}
+
+func TestApplyCloaking_NativeClaudeCodeLeavesFableUntouched(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-fable-test"}}
+	originalSystem := "You are a native claude code agent."
+	payload := []byte(`{"model":"claude-fable-5-1","system":"` + originalSystem + `","messages":[{"role":"user","content":"test"}]}`)
+
+	out, cloaked, err := applyCloaking(
+		context.Background(),
+		cfg,
+		auth,
+		payload,
+		"sk-ant-oat-fable-test",
+		true, // confirmedClaudeCode = true
+		true,
+	)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if cloaked {
+		t.Fatal("applyCloaking() cloaked = true, want false for confirmed native Claude Code")
+	}
+	if got := gjson.GetBytes(out, "system").String(); got != originalSystem {
+		t.Fatalf("expected system to be preserved unchanged for native client, got: %s", got)
+	}
+}
+
+func TestApplyCloaking_Fable5OmitsFallbacksAndReportingOutcomes(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable5-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "sk-ant-oat-fable5-test"}}
+	payload := []byte(`{"model":"claude-fable-5","messages":[{"role":"user","content":"test"}]}`)
+
+	out, cloaked, err := applyCloaking(
+		context.Background(),
+		cfg,
+		auth,
+		payload,
+		"sk-ant-oat-fable5-test",
+		false,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	if gjson.GetBytes(out, "fallbacks").Exists() {
+		t.Fatalf("claude-fable-5 should not have fallbacks injected, got: %s", gjson.GetBytes(out, "fallbacks").Raw)
+	}
+
+	systemBlocks := gjson.GetBytes(out, "system").Array()
+	if len(systemBlocks) != 2 {
+		t.Fatalf("expected 2 system blocks for claude-fable-5, got %d", len(systemBlocks))
+	}
+	for _, b := range systemBlocks {
+		if strings.Contains(b.Get("text").String(), "Reporting outcomes") {
+			t.Fatalf("claude-fable-5 should not contain Reporting outcomes, got: %s", b.Get("text").String())
+		}
+	}
+}
+
+func TestClaudeExecutor_TitleHelperWithSystemPromptIsolated(t *testing.T) {
+	helps.ResetClaudeDiagnosticsForTest()
+	defer helps.ResetClaudeDiagnosticsForTest()
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("request-id", "req_helper123")
+		_, _ = w.Write([]byte(`{"id":"msg_helper123","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"Title"}]}`))
+	}))
+	defer server.Close()
+
+	payload := []byte(`{"model":"claude-sonnet-5","system":"Return a short title summarizing this conversation","messages":[{"role":"user","content":"test"}]}`)
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-title-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-title-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-title-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	ctx := helps.WithClaudeSessionID(context.Background(), "session-title-1")
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	// Title helper must NOT carry diagnostics
+	if gjson.GetBytes(seenBody, "diagnostics").Exists() {
+		t.Fatalf("expected title helper to omit diagnostics, got: %s", gjson.GetBytes(seenBody, "diagnostics").Raw)
+	}
+
+	// Title helper must NOT advance session continuity state
+	credID := claudeDiagnosticsCredentialIdentity(auth)
+	_, _, prevMsg := helps.BeginClaudeDiagnostics(credID, "session-title-1")
+	if prevMsg != "" {
+		t.Fatalf("expected title helper to leave prevMsg empty, got: %q", prevMsg)
+	}
+}
+
+func TestClaudeExecutor_SubagentAndProbeOmit1hCacheTTLAndBeta(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_sub1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-subagent-cache-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-subagent-cache-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-subagent-cache-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+
+	// 1. Subagent request: carries X-Claude-Code-Agent-Id header
+	subagentPayload := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"do task"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: subagentPayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers: http.Header{
+			"X-Claude-Code-Agent-Id": {"subagent-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute(subagent) error = %v", err)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("subagent must not carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			t.Fatalf("subagent system block must not carry ttl: 1h, got: %s", blk.Raw)
+		}
+	}
+
+	// 2. Probe request: max_tokens: 1
+	probePayload := []byte(`{"model":"claude-sonnet-5","max_tokens":1,"messages":[{"role":"user","content":"probe"}]}`)
+	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: probePayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("Execute(probe) error = %v", err)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("probe must not carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			t.Fatalf("probe system block must not carry ttl: 1h, got: %s", blk.Raw)
+		}
+	}
+
+	// 3. Normal interactive main-thread request: MUST carry 1h cache and beta
+	mainPayload := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hello"}]}`)
+	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: mainPayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+	})
+	if err != nil {
+		t.Fatalf("Execute(main) error = %v", err)
+	}
+	if !strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("main thread request must carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	has1h := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			has1h = true
+			break
+		}
+	}
+	if !has1h {
+		t.Fatalf("main thread request system block must carry ttl: 1h, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+
+	// 4. Confirmed native Claude Code subagent: must NOT have extended-cache-ttl restored
+	confirmedSubagentPayload := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"task"}]}`)
+	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: confirmedSubagentPayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers: http.Header{
+			"User-Agent":             {"claude-cli/2.1.258 (external, cli)"},
+			"X-Claude-Code-Agent-Id": {"subagent-confirmed-456"},
+			"Anthropic-Beta":         {"claude-code-20250219,oauth-2025-04-20,effort-2025-11-24"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute(confirmed subagent) error = %v", err)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("confirmed subagent must not carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideFableModelReconciled(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model": "claude-sonnet-5",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Model was rewritten to claude-sonnet-5
+	if got := gjson.GetBytes(seenBody, "model").String(); got != "claude-sonnet-5" {
+		t.Fatalf("model = %q, want claude-sonnet-5", got)
+	}
+
+	// Because model is now claude-sonnet-5, Fable additions must NOT be present:
+	if gjson.GetBytes(seenBody, "fallbacks").Exists() {
+		t.Fatalf("fallbacks must be omitted when rewritten to non-Fable, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be omitted when rewritten to non-Fable, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			t.Fatalf("system must not contain Reporting outcomes when rewritten to non-Fable, got: %s", blk.Raw)
+		}
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideNonFableToFableReconciled(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-test-2",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model": "claude-fable-5-1",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-test-2",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-test-2",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Model was rewritten to claude-fable-5-1
+	if got := gjson.GetBytes(seenBody, "model").String(); got != "claude-fable-5-1" {
+		t.Fatalf("model = %q, want claude-fable-5-1", got)
+	}
+
+	// Fable additions must now be attached:
+	fallbacks := gjson.GetBytes(seenBody, "fallbacks").Array()
+	if len(fallbacks) != 1 || fallbacks[0].Get("model").String() != "claude-opus-5" {
+		t.Fatalf("fallbacks must be injected for Fable 5.1, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if !strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be present, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	hasReporting := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			hasReporting = true
+			break
+		}
+	}
+	if !hasReporting {
+		t.Fatalf("system must contain Reporting outcomes for Fable 5.1, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverridePreservesExplicitFallbacks(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-test-3",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model":     "claude-sonnet-5",
+					"fallbacks": []any{map[string]any{"model": "claude-opus-5"}},
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-test-3",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-test-3",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Explicit payload fallback override must be preserved!
+	fallbacks := gjson.GetBytes(seenBody, "fallbacks").Array()
+	if len(fallbacks) != 1 || fallbacks[0].Get("model").String() != "claude-opus-5" {
+		t.Fatalf("explicit payload fallback override must be preserved, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if !strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be present for explicit fallback, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideUnrelatedModelRuleDoesNotPreserveFableFallbacks(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-test-4",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{
+				// Rule 1: Unrelated rule for gpt-4 has fallbacks
+				{
+					Models: []config.PayloadModelRule{{Name: "gpt-4"}},
+					Params: map[string]any{
+						"fallbacks": []any{map[string]any{"model": "claude-opus-5"}},
+					},
+				},
+				// Rule 2: Rewrites Fable 5.1 to Sonnet 5 WITHOUT fallbacks
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+					Params: map[string]any{
+						"model": "claude-sonnet-5",
+					},
+				},
+			},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-test-4",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-test-4",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Unrelated rule must NOT preserve fallback on Sonnet 5
+	if gjson.GetBytes(seenBody, "fallbacks").Exists() {
+		t.Fatalf("unrelated rule for gpt-4 must not cause fallbacks to be preserved on sonnet-5, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be omitted, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_CallerOwnedDiagnosticsPreservedOnProbe(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-haiku-4-5-20251001","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-api-caller-diagnostics-test",
+			Cloak:  &config.CloakConfig{Mode: "never"},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "auth-caller-diagnostics-test",
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-api-caller-diagnostics-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Caller sends max_tokens: 1 probe with their own explicit diagnostics object
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"diagnostics":{"caller_custom_key":"val123"},"messages":[{"role":"user","content":"quota"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-haiku-4-5-20251001",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Caller-owned diagnostics must be preserved!
+	if got := gjson.GetBytes(seenBody, "diagnostics.caller_custom_key").String(); got != "val123" {
+		t.Fatalf("caller diagnostics must be preserved, got: %s", gjson.GetBytes(seenBody, "diagnostics").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideParentThinkingPreventsDisplayUpdates(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-parent-thinking-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"thinking": map[string]any{
+						"type": "adaptive",
+					},
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-parent-thinking-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-parent-thinking-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Payload rule replaced parent "thinking" without "display", so "display" must NOT be re-added!
+	if gjson.GetBytes(seenBody, "thinking.display").Exists() {
+		t.Fatalf("thinking.display must not be injected when parent thinking was overridden, got: %s", gjson.GetBytes(seenBody, "thinking").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadSystemTTLOverrideStillRemovesInjectedFableReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-system-ttl-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model":                      "claude-sonnet-5",
+					"system.0.cache_control.ttl": "1h",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-system-ttl-fable-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-system-ttl-fable-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Model was rewritten from Fable 5.1 to Sonnet 5, so injected Reporting outcomes block
+	// MUST be removed even though payload rule touched system.0.cache_control.ttl!
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			t.Fatalf("Reporting outcomes block must be removed on rewritten Sonnet model, got: %s", blk.Raw)
+		}
+	}
+}
+
+func TestClaudeExecutor_PayloadSonnetToFableWithSystemTTLEditsAddsReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-sonnet-to-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model":                      "claude-fable-5-1",
+					"system.1.cache_control.ttl": "1h",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-sonnet-to-fable-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-sonnet-to-fable-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Model was rewritten from Sonnet 5 to Fable 5.1, so Reporting outcomes block
+	// MUST be added even though payload rule touched system.1.cache_control.ttl!
+	hasReporting := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			hasReporting = true
+			break
+		}
+	}
+	if !hasReporting {
+		t.Fatalf("Reporting outcomes block must be attached on rewritten Fable model, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideProbeWithExplicitDiagnosticsPreserved(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-haiku-4-5-20251001","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-probe-explicit-diag-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-haiku-4-5-20251001"}},
+				Params: map[string]any{
+					"max_tokens": 1,
+					"diagnostics": map[string]any{
+						"operator_custom": "custom_value_123",
+					},
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-probe-explicit-diag-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-probe-explicit-diag-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Initially non-probe so CPA injects diagnostics, then payload rule overrides to probe AND sets custom diagnostics
+	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1000,"messages":[{"role":"user","content":"quota"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-haiku-4-5-20251001",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// The operator-provided diagnostics object must be preserved!
+	if got := gjson.GetBytes(seenBody, "diagnostics.operator_custom").String(); got != "custom_value_123" {
+		t.Fatalf("operator custom diagnostics must be preserved, got: %s", gjson.GetBytes(seenBody, "diagnostics").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadStringSystemFableAddsReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-string-system-fable-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model":  "claude-fable-5-1",
+					"system": "You are a helpful coding assistant.",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-string-system-fable-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-string-system-fable-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Payload rule set string system and rewrote to Fable 5.1:
+	// System must become an array containing the reporting outcomes block!
+	hasReporting := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			hasReporting = true
+			break
+		}
+	}
+	if !hasReporting {
+		t.Fatalf("Reporting outcomes block must be attached for string system Fable request, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadStringSystemMentioningReportingOutcomesStillInjectsFableReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-string-system-mention-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model":  "claude-fable-5-1",
+					"system": "Please follow best practices when reporting outcomes to the user.",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-string-system-mention-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-string-system-mention-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Payload rule had a system string that merely mentioned "reporting outcomes".
+	// The exact `# Reporting outcomes` block MUST be injected!
+	hasExactReporting := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("text").String() == claudeCodeFableReportingOutcomes {
+			hasExactReporting = true
+			break
+		}
+	}
+	if !hasExactReporting {
+		t.Fatalf("exact `# Reporting outcomes` block must be injected even when string mentions reporting outcomes, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadStringSystemWithExactReportingPromptDoesNotDuplicate(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-string-system-exact-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model":  "claude-fable-5-1",
+					"system": claudeCodeFableReportingOutcomes,
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-string-system-exact-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-string-system-exact-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	reportingCount := 0
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("text").String() == claudeCodeFableReportingOutcomes {
+			reportingCount++
+		}
+	}
+	if reportingCount != 1 {
+		t.Fatalf("expected exactly 1 reporting block, got %d in: %s", reportingCount, gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadFableThinkingAdaptiveToDisabledDropsInjectedDisplay(t *testing.T) {
+	var seenHeaders http.Header
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-disabled-thinking-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"thinking.type": "disabled",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-fable-disabled-thinking-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-fable-disabled-thinking-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Starts with adaptive thinking so CPA cloaking injects thinking.display=updates,
+	// then payload rule overrides thinking.type to disabled:
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Injected thinking.display must be dropped
+	if gjson.GetBytes(seenBody, "thinking.display").Exists() {
+		t.Fatalf("thinking.display must be dropped when thinking.type is disabled, got: %s", gjson.GetBytes(seenBody, "thinking").Raw)
+	}
+	// thinking-display-updates beta header must NOT be present
+	betas := seenHeaders.Get("anthropic-beta")
+	if strings.Contains(betas, "thinking-display-updates") {
+		t.Fatalf("thinking-display-updates beta header must NOT be present on disabled thinking, got: %s", betas)
+	}
+}
+
+func TestClaudeExecutor_UncloakedProbePreservesCallerBillingTags(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-haiku-4-5-20251001","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-api03-uncloaked-test",
+			// No CloakConfig, uncloaked request
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "auth-uncloaked-probe-test",
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-api03-uncloaked-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Caller provides their own billing header with prompt ID on probe
+	callerBilling := "x-anthropic-billing-header: cc_version=2.1.258; cc_entrypoint=cli; cch=abc12; cc_prompt_id=00000000-0000-4000-8000-000000000001;"
+	payload := []byte(fmt.Sprintf(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"system":[{"type":"text","text":%q}],"messages":[{"role":"user","content":"quota"}]}`, callerBilling))
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-haiku-4-5-20251001",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Because cloaking was disabled, the caller-owned billing header must be preserved exactly!
+	gotSystem := gjson.GetBytes(seenBody, "system.0.text").String()
+	if !strings.Contains(gotSystem, "cc_prompt_id=00000000-0000-4000-8000-000000000001") {
+		t.Fatalf("uncloaked request must preserve caller billing tags on probe, got: %s", gotSystem)
+	}
+}
+
+func TestClaudeExecutor_FableWithSensitiveWordsHasSingleObfuscatedReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-sensitive-test",
+			Cloak: &config.CloakConfig{
+				SensitiveWords: []string{"Reporting"},
+			},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-fable-sensitive-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-fable-sensitive-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	reportingCount := 0
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		raw := blk.Get("text").String()
+		cleaned := strings.ReplaceAll(raw, "\u200B", "")
+		if cleaned == claudeCodeFableReportingOutcomes {
+			reportingCount++
+			if !strings.Contains(raw, "\u200B") {
+				t.Fatalf("Reporting block must be obfuscated with zero-width space, got: %q", raw)
+			}
+			if strings.Contains(raw, "Reporting") {
+				t.Fatalf("Reporting block must not contain cleartext sensitive word 'Reporting', got: %q", raw)
+			}
+		}
+	}
+	if reportingCount != 1 {
+		t.Fatalf("expected exactly 1 reporting block, got %d; system = %s", reportingCount, gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadFableToSonnetWithSensitiveWordsRemovesReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-to-sonnet-sensitive-test",
+			Cloak: &config.CloakConfig{
+				SensitiveWords: []string{"Reporting"},
+			},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model": "claude-sonnet-5",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-fable-to-sonnet-sensitive-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-fable-to-sonnet-sensitive-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		raw := blk.Get("text").String()
+		cleaned := strings.ReplaceAll(raw, "\u200B", "")
+		if cleaned == claudeCodeFableReportingOutcomes {
+			t.Fatalf("reporting block should be removed when rewritten to Sonnet 5, got: %s", raw)
+		}
+	}
+}
+
+func TestClaudeExecutor_SensitiveWordsDoNotCorruptBillingHeaderTags(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-billing-corrupt-test",
+			Cloak: &config.CloakConfig{
+				SensitiveWords: []string{"cli", "version", "entrypoint", "prompt", "anthropic"},
+			},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-billing-corrupt-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-billing-corrupt-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// system[0] billing header must NOT contain zero-width spaces in its tags
+	billingText := gjson.GetBytes(seenBody, "system.0.text").String()
+	if !strings.HasPrefix(billingText, "x-anthropic-billing-header: cc_version=") {
+		t.Fatalf("billing header must start cleanly without obfuscation, got: %q", billingText)
+	}
+	if strings.Contains(billingText, "\u200B") {
+		t.Fatalf("billing header must not contain zero-width space characters, got: %q", billingText)
+	}
+	if !strings.Contains(billingText, "cc_entrypoint=cli;") {
+		t.Fatalf("billing header must preserve cc_entrypoint=cli;, got: %q", billingText)
+	}
+}
+
+func TestClaudeExecutor_DisabledCloakingSkipsSensitiveWordObfuscation(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		DisableClaudeCloakMode: true,
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-skip-obfuscate-test",
+			Cloak: &config.CloakConfig{
+				SensitiveWords: []string{"confidential", "secret"},
+			},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-skip-obfuscate-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-skip-obfuscate-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","system":[{"type":"text","text":"this is confidential"}],"messages":[{"role":"user","content":"keep this secret"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	rawBody := string(seenBody)
+	if strings.Contains(rawBody, "\u200B") {
+		t.Fatalf("disabled cloaking must not insert zero-width spaces into Execute body, got: %s", rawBody)
+	}
+	if !strings.Contains(rawBody, "confidential") || !strings.Contains(rawBody, "secret") {
+		t.Fatalf("expected cleartext preserved in Execute, got: %s", rawBody)
+	}
+}
+
+func TestClaudeExecutor_DisabledCloakingStreamSkipsSensitiveWordObfuscation(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-5\",\"content\":[]}}\n\n"))
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-skip-obfuscate-stream-test",
+			Cloak: &config.CloakConfig{
+				Mode:           "never",
+				SensitiveWords: []string{"confidential", "secret"},
+			},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-skip-obfuscate-stream-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-skip-obfuscate-stream-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","stream":true,"system":[{"type":"text","text":"this is confidential"}],"messages":[{"role":"user","content":"keep this secret"}]}`)
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v", err)
+	}
+	for range streamResult.Chunks {
+	}
+
+	rawBody := string(seenBody)
+	if strings.Contains(rawBody, "\u200B") {
+		t.Fatalf("disabled cloaking must not insert zero-width spaces into ExecuteStream body, got: %s", rawBody)
+	}
+	if !strings.Contains(rawBody, "confidential") || !strings.Contains(rawBody, "secret") {
+		t.Fatalf("expected cleartext preserved in ExecuteStream, got: %s", rawBody)
+	}
+}
+
+func TestClaudeExecutor_PayloadReplacesSystemOnOriginalFableReaddsReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-fable-replace-sys-test",
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"system": "Custom replaced system prompt",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-fable-replace-sys-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-fable-replace-sys-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	hasReplacedSystem := false
+	hasReporting := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		text := blk.Get("text").String()
+		if text == "Custom replaced system prompt" {
+			hasReplacedSystem = true
+		}
+		if text == claudeCodeFableReportingOutcomes {
+			hasReporting = true
+		}
+	}
+	if !hasReplacedSystem {
+		t.Fatalf("expected custom replaced system prompt in system, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+	if !hasReporting {
+		t.Fatalf("expected Fable reporting outcomes block re-added in system, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_UserTitlePromptWithoutSchemaTreatedAsNormalTurn(t *testing.T) {
+	var seenHeaders http.Header
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-user-title-prompt-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-user-title-prompt-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-user-title-prompt-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Normal user query with text "Return a short title for this blog post", but NO structured output schema
+	payload := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"Return a short title for this blog post"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Must NOT be treated as a title helper:
+	// 1. Must carry 1h cache TTL and extended-cache-ttl beta
+	has1h := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			has1h = true
+			break
+		}
+	}
+	if !has1h {
+		t.Fatalf("user title query must carry 1h cache, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+	if !strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("user title query must carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	// 2. Billing header must carry cc_prompt_id
+	billingText := gjson.GetBytes(seenBody, "system.0.text").String()
+	if !strings.Contains(billingText, "cc_prompt_id=") {
+		t.Fatalf("user title query must carry cc_prompt_id, got: %s", billingText)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideRawPreservesExplicitFallbacks(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-test-5",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			OverrideRaw: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model":     `"claude-sonnet-5"`,
+					"fallbacks": `[{"model":"claude-opus-5"}]`,
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-test-5",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-test-5",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Raw payload override setting fallbacks must be preserved!
+	fallbacks := gjson.GetBytes(seenBody, "fallbacks").Array()
+	if len(fallbacks) != 1 || fallbacks[0].Get("model").String() != "claude-opus-5" {
+		t.Fatalf("explicit raw payload fallback override must be preserved, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if !strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be present for explicit raw fallback, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_PayloadFilterFallbacksPreservesRemovalOnFable(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-filter-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Filter: []config.PayloadFilterRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: []string{"fallbacks"},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-filter-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-filter-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// fallbacks was filtered out by operator rule, must NOT be recreated!
+	if gjson.GetBytes(seenBody, "fallbacks").Exists() {
+		t.Fatalf("fallbacks must remain deleted after payload filter, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "server-side-fallback") {
+		t.Fatalf("server-side-fallback beta must be absent when fallbacks is filtered, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+}
+
+func TestClaudeExecutor_PayloadCustomReportingOutcomesPreservedOnRewrite(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-custom-reporting-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"model": "claude-sonnet-5",
+					"system": []map[string]any{
+						{"type": "text", "text": "Custom user prompt containing Reporting outcomes heading in discussion."},
+					},
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-custom-reporting-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-custom-reporting-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-fable-5-1","messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	system := gjson.GetBytes(seenBody, "system").Array()
+	hasCustom := false
+	for _, blk := range system {
+		if strings.Contains(blk.Get("text").String(), "Custom user prompt") {
+			hasCustom = true
+		}
+	}
+	if !hasCustom {
+		t.Fatalf("custom user system prompt must NOT be deleted, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
 func TestNormalizeClaudeSamplingForUpstream_RemovesTemperature(t *testing.T) {
 	payload := []byte(`{"temperature":0,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
 	out := normalizeClaudeSamplingForUpstream(payload, false)
@@ -6172,46 +7845,9 @@ func TestClaudeExecutorPayloadOverrideReenablesThinking(t *testing.T) {
 	}
 }
 
-func TestClaudeExecutorPayloadOverrideMaxTokens(t *testing.T) {
-	const model = "claude-fable-5-1"
-	for _, test := range []struct {
-		name            string
-		stream          bool
-		maxOutputTokens int
-	}{
-		{name: "execute"},
-		{name: "execute stream", stream: true},
-		{name: "execute overrides client limit", maxOutputTokens: 32000},
-		{name: "execute stream overrides client limit", stream: true, maxOutputTokens: 32000},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := &config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
-				Models: []config.PayloadModelRule{{Name: model, Protocol: "claude"}},
-				Params: map[string]any{"max_tokens": 128000},
-			}}}}
-			payload := []byte(`{"model":"claude-fable-5-1","input":"hi"}`)
-			if test.maxOutputTokens > 0 {
-				payload, _ = sjson.SetBytes(payload, "max_output_tokens", test.maxOutputTokens)
-			}
-			upstreamBody := executeClaudeContextManagementRequest(t, cfg, payload, test.stream, sdktranslator.FormatOpenAIResponse)
-			if got := gjson.GetBytes(upstreamBody, "max_tokens").Int(); got != 128000 {
-				t.Fatalf("final upstream max_tokens = %d, want 128000; body=%s", got, upstreamBody)
-			}
-		})
-	}
-}
-
-func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, payload []byte, stream bool, sourceFormats ...sdktranslator.Format) []byte {
+func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, payload []byte, stream bool) []byte {
 	t.Helper()
 
-	sourceFormat := sdktranslator.FormatClaude
-	if len(sourceFormats) > 0 {
-		sourceFormat = sourceFormats[0]
-	}
-	model := gjson.GetBytes(payload, "model").String()
-	if model == "" {
-		model = "claude-opus-5"
-	}
 	var upstreamBody []byte
 	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		var errRead error
@@ -6235,8 +7871,8 @@ func executeClaudeContextManagementRequest(t *testing.T, cfg *config.Config, pay
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
 	executor := NewClaudeExecutor(cfg)
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-payload-rule", "cloak_mode": "always"}}
-	request := cliproxyexecutor.Request{Model: model, Payload: payload}
-	options := cliproxyexecutor.Options{SourceFormat: sourceFormat, ResponseFormat: sdktranslator.FormatClaude}
+	request := cliproxyexecutor.Request{Model: "claude-opus-5", Payload: payload}
+	options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
 
 	if stream {
 		result, errStream := executor.ExecuteStream(ctx, auth, request, options)
@@ -6785,5 +8421,83 @@ func TestClaudeExecutor_DisabledThinkingStripsDisplayBeta(t *testing.T) {
 	}
 	if strings.Contains(betas, "effort-2025-11-24") {
 		t.Errorf("disabled thinking must not send effort beta, got: %s", betas)
+	}
+}
+
+func TestClaudeExecutor_CloakModePrefersStoredPrevReqOverCallerFake(t *testing.T) {
+	var seenBodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBodies = append(seenBodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("request-id", "req_real_upstream_001")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-cloak-prev-req-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-cloak-prev-req-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-cloak-prev-req-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	headers := http.Header{"Session-Id": []string{"sess-test-001"}}
+
+	// Turn 1: normal turn, establishes real upstream request-id req_real_upstream_001
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"turn 1"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      headers,
+	})
+	if err != nil {
+		t.Fatalf("Turn 1 Execute error = %v", err)
+	}
+
+	// Turn 2: a non-native caller in cloak mode sends a fake cc_prev_req in system
+	fakeCallerPayload := []byte(`{
+		"model": "claude-sonnet-5",
+		"system": [
+			{"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.258.000; cc_entrypoint=cli; cch=00000; cc_prev_req=req_fake_caller_999; cc_prompt_id=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee;"},
+			{"type": "text", "text": "custom instructions"}
+		],
+		"messages": [
+			{"role":"user","content":"turn 1"},
+			{"role":"assistant","content":"ok"},
+			{"role":"user","content":"turn 2"}
+		]
+	}`)
+
+	_, err2 := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: fakeCallerPayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      headers,
+	})
+	if err2 != nil {
+		t.Fatalf("Turn 2 Execute error = %v", err2)
+	}
+
+	if len(seenBodies) < 2 {
+		t.Fatalf("expected at least 2 requests, got %d", len(seenBodies))
+	}
+	turn2System := gjson.GetBytes(seenBodies[1], "system.0.text").String()
+	if !strings.Contains(turn2System, "cc_prev_req=req_real_upstream_001") {
+		t.Fatalf("CPA in cloak mode must use real storedPrevReq req_real_upstream_001, got: %s", turn2System)
+	}
+	if strings.Contains(turn2System, "req_fake_caller_999") {
+		t.Fatalf("CPA must not use fake caller cc_prev_req, got: %s", turn2System)
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5542,9 +5542,9 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants + ",effort-2025-11-24",
 		},
 		{
-			name: "claude-haiku-4-5-20251001 stays on the reminder path",
+			name: "claude-haiku-4-5-20251001 stays on the reminder path and omits effort",
 			body: `{"model":"claude-haiku-4-5-20251001"}`,
-			want: constants + ",effort-2025-11-24",
+			want: constants,
 		},
 		{
 			name: "legacy model with tools adds advanced tool use only",
@@ -5606,6 +5606,61 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			name: "body with advisor server tool automatically adds advisor-tool beta",
 			body: `{"model":"claude-opus-5","tools":[{"type":"advisor_20260301","name":"advisor"}]}`,
 			want: constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "thinking display updates emits thinking-display-updates beta and drops redact-thinking",
+			body: `{"model":"claude-fable-5-1","thinking":{"type":"adaptive","display":"updates"}}`,
+			want: "claude-code-20250219,interleaved-thinking-2025-05-14," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,thinking-display-updates-2026-08-18",
+		},
+		{
+			name: "body with fallbacks automatically adds server-side-fallback beta",
+			body: `{"model":"claude-fable-5-1","fallbacks":[{"model":"claude-opus-5"}]}`,
+			want: constants + ",mid-conversation-system-2026-04-07,effort-2025-11-24,server-side-fallback-2026-06-01",
+		},
+		{
+			name:  "subagent request omits extended-cache-ttl beta",
+			body:  `{"model":"claude-sonnet-5","system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.258.0ab; cc_is_subagent=true;"}]}`,
+			oauth: true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,fallback-credit-2026-06-01",
+		},
+		{
+			name:  "probe request max_tokens=1 omits effort and extended-cache-ttl betas",
+			body:  `{"model":"claude-sonnet-5","max_tokens":1}`,
+			oauth: true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"fallback-credit-2026-06-01",
+		},
+		{
+			name:      "haiku model omits effort beta even if requested",
+			body:      `{"model":"claude-haiku-4-5-20251001"}`,
+			requested: map[string]bool{"effort-2025-11-24": true},
+			oauth:     true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05," +
+				"fallback-credit-2026-06-01,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:      "disabled thinking omits effort beta even if requested",
+			body:      `{"model":"claude-sonnet-5","thinking":{"type":"disabled"}}`,
+			requested: map[string]bool{"effort-2025-11-24": true},
+			oauth:     true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"fallback-credit-2026-06-01,extended-cache-ttl-2025-04-11",
 		},
 	}
 
@@ -6511,5 +6566,224 @@ func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) 
 				}
 			}
 		})
+	}
+}
+
+func TestIsClaudeFable51Model_DigitBoundary(t *testing.T) {
+	valid := []string{
+		"claude-fable-5-1",
+		"claude-fable-5.1",
+		"claude-fable-5-1-20260901",
+		"claude-mythos-5-1",
+		"claude-mythos-5.1",
+		"claude-mythos-5-1-preview",
+	}
+	for _, m := range valid {
+		if !isClaudeFable51Model(m) {
+			t.Errorf("expected %q to be recognized as Fable 5.1", m)
+		}
+	}
+
+	invalid := []string{
+		"claude-fable-5-10",
+		"claude-fable-5.10",
+		"claude-mythos-5-10",
+		"claude-sonnet-5",
+		"claude-opus-5",
+		"claude-haiku-4-5",
+	}
+	for _, m := range invalid {
+		if isClaudeFable51Model(m) {
+			t.Errorf("expected %q NOT to be recognized as Fable 5.1", m)
+		}
+	}
+}
+
+func TestClaudeExecutor_ProbeStripsCaller1hTTLAndBetas(t *testing.T) {
+	var seenHeaders http.Header
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-probe-ttl-test",
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-probe-ttl-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-probe-ttl-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Probe request with caller-supplied 1h TTL and forbidden betas
+	payload := []byte(`{
+		"model": "claude-sonnet-5",
+		"max_tokens": 1,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "quota", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+			]
+		}]
+	}`)
+	incomingHeaders := http.Header{}
+	incomingHeaders.Set("Anthropic-Beta", "extended-cache-ttl-2025-04-11,server-side-fallback-2026-06-01,thinking-display-updates-2026-08-18,effort-2025-11-24")
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      incomingHeaders,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// 1. Verify body cache_control does not have ttl: "1h"
+	rawBody := string(seenBody)
+	if strings.Contains(rawBody, `"ttl":"1h"`) || strings.Contains(rawBody, `"ttl": "1h"`) {
+		t.Fatalf("probe body must have ttl stripped, got: %s", rawBody)
+	}
+
+	// 2. Verify forbidden betas are stripped from header
+	betas := seenHeaders.Get("Anthropic-Beta")
+	for _, forbidden := range []string{
+		"extended-cache-ttl-2025-04-11",
+		"server-side-fallback-2026-06-01",
+		"thinking-display-updates-2026-08-18",
+		"effort-2025-11-24",
+	} {
+		if strings.Contains(betas, forbidden) {
+			t.Errorf("probe Anthropic-Beta must not contain %s, got: %s", forbidden, betas)
+		}
+	}
+}
+
+func TestClaudeExecutor_SubagentStripsCaller1hTTLAndExtendedCacheBeta(t *testing.T) {
+	var seenHeaders http.Header
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-subagent-ttl-test",
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-subagent-ttl-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-subagent-ttl-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{
+		"model": "claude-sonnet-5",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "subagent work", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+			]
+		}]
+	}`)
+	incomingHeaders := http.Header{}
+	incomingHeaders.Set("X-Claude-Code-Agent-Id", "agent-sub-123")
+	incomingHeaders.Set("Anthropic-Beta", "extended-cache-ttl-2025-04-11")
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      incomingHeaders,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// 1. Verify body cache_control does not have ttl: "1h"
+	rawBody := string(seenBody)
+	if strings.Contains(rawBody, `"ttl":"1h"`) || strings.Contains(rawBody, `"ttl": "1h"`) {
+		t.Fatalf("subagent body must have ttl stripped, got: %s", rawBody)
+	}
+
+	// 2. Verify extended-cache-ttl beta is stripped from header
+	betas := seenHeaders.Get("Anthropic-Beta")
+	if strings.Contains(betas, "extended-cache-ttl-2025-04-11") {
+		t.Errorf("subagent Anthropic-Beta must not contain extended-cache-ttl, got: %s", betas)
+	}
+}
+
+func TestClaudeExecutor_DisabledThinkingStripsDisplayBeta(t *testing.T) {
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-disabled-thinking-beta-test",
+		}},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-disabled-thinking-beta-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-disabled-thinking-beta-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{
+		"model": "claude-sonnet-5",
+		"thinking": {"type": "disabled"},
+		"messages": [{
+			"role": "user",
+			"content": "hello"
+		}]
+	}`)
+	incomingHeaders := http.Header{}
+	incomingHeaders.Set("Anthropic-Beta", "thinking-display-updates-2026-08-18,effort-2025-11-24")
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Headers:      incomingHeaders,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	betas := seenHeaders.Get("Anthropic-Beta")
+	if strings.Contains(betas, "thinking-display-updates-2026-08-18") {
+		t.Errorf("disabled thinking must not send thinking-display-updates beta, got: %s", betas)
+	}
+	if strings.Contains(betas, "effort-2025-11-24") {
+		t.Errorf("disabled thinking must not send effort beta, got: %s", betas)
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -5209,6 +5209,226 @@ func TestClaudeExecutor_PayloadOverrideUnrelatedModelRuleDoesNotPreserveFableFal
 	}
 }
 
+func TestClaudeExecutor_PayloadOverrideMaxTokensTo1ReclassifiesAsProbe(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_probe1","type":"message","model":"claude-sonnet-5","role":"assistant","content":[{"type":"text","text":"."}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-probe-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"max_tokens": 1,
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-probe-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-probe-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","max_tokens":1000,"messages":[{"role":"user","content":"."}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Payload rule made it max_tokens: 1
+	if got := gjson.GetBytes(seenBody, "max_tokens").Int(); got != 1 {
+		t.Fatalf("max_tokens = %d, want 1", got)
+	}
+
+	// Probe must NOT carry 1h cache control and must NOT carry extended-cache-ttl beta
+	if strings.Contains(seenHeaders.Get("Anthropic-Beta"), "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("reclassified probe must not carry extended-cache-ttl beta, got: %s", seenHeaders.Get("Anthropic-Beta"))
+	}
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			t.Fatalf("reclassified probe system block must not carry ttl: 1h, got: %s", blk.Raw)
+		}
+	}
+
+	// Probe must NOT carry diagnostics
+	if gjson.GetBytes(seenBody, "diagnostics").Exists() {
+		t.Fatalf("reclassified probe must omit diagnostics, got: %s", gjson.GetBytes(seenBody, "diagnostics").Raw)
+	}
+
+	// Probe must NOT carry cc_prev_req or cc_prompt_id in billing header
+	billingText := gjson.GetBytes(seenBody, "system.0.text").String()
+	if strings.Contains(billingText, "cc_prev_req=") {
+		t.Fatalf("reclassified probe must omit cc_prev_req, got: %s", billingText)
+	}
+	if strings.Contains(billingText, "cc_prompt_id=") {
+		t.Fatalf("reclassified probe must omit cc_prompt_id, got: %s", billingText)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideFableToProbeStripsFableAdditions(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-fable-probe-strip-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"max_tokens": 1,
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-fable-probe-strip-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-fable-probe-strip-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Initially non-probe (max_tokens: 1000, content: ".")
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"max_tokens":1000,"messages":[{"role":"user","content":"."}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Because payload rule reclassified request as probe (max_tokens: 1):
+	// 1. fallbacks must be stripped
+	if gjson.GetBytes(seenBody, "fallbacks").Exists() {
+		t.Fatalf("probe must not carry fallbacks, got: %s", gjson.GetBytes(seenBody, "fallbacks").Raw)
+	}
+	// 2. thinking.display must be stripped
+	if gjson.GetBytes(seenBody, "thinking.display").Exists() {
+		t.Fatalf("probe must not carry thinking.display, got: %s", gjson.GetBytes(seenBody, "thinking.display").Raw)
+	}
+	// 3. Reporting outcomes block must be stripped
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if strings.Contains(blk.Get("text").String(), "Reporting outcomes") {
+			t.Fatalf("probe must not carry Reporting outcomes block, got: %s", blk.Raw)
+		}
+	}
+	// 4. Beta headers must omit server-side-fallback, thinking-display-updates, and extended-cache-ttl
+	betas := seenHeaders.Get("Anthropic-Beta")
+	if strings.Contains(betas, "server-side-fallback") {
+		t.Fatalf("probe must omit server-side-fallback beta, got: %s", betas)
+	}
+	if strings.Contains(betas, "thinking-display-updates") {
+		t.Fatalf("probe must omit thinking-display-updates beta, got: %s", betas)
+	}
+	if strings.Contains(betas, "extended-cache-ttl") {
+		t.Fatalf("probe must omit extended-cache-ttl beta, got: %s", betas)
+	}
+}
+
+func TestClaudeExecutor_PayloadOverrideProbeToNormalReinitializes(t *testing.T) {
+	var seenBody []byte
+	var seenHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-payload-declassify-probe-test",
+			Cloak:  &config.CloakConfig{},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5-1"}},
+				Params: map[string]any{
+					"max_tokens": 1000,
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-payload-declassify-probe-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-payload-declassify-probe-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	// Initially a probe (max_tokens: 1, content: ".")
+	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"max_tokens":1,"messages":[{"role":"user","content":"."}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Declassified probe is now a normal request:
+	// 1. Must carry 1h cache TTL and extended-cache-ttl beta
+	has1h := false
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		if blk.Get("cache_control.ttl").String() == "1h" {
+			has1h = true
+			break
+		}
+	}
+	if !has1h {
+		t.Fatalf("declassified normal request must carry 1h cache, got: %s", gjson.GetBytes(seenBody, "system").Raw)
+	}
+	betas := seenHeaders.Get("Anthropic-Beta")
+	if !strings.Contains(betas, "extended-cache-ttl-2025-04-11") {
+		t.Fatalf("declassified normal request must carry extended-cache-ttl beta, got: %s", betas)
+	}
+	// 2. Must carry Fable additions (fallbacks, display, reporting block)
+	if !gjson.GetBytes(seenBody, "fallbacks").Exists() {
+		t.Fatalf("declassified Fable request must carry fallbacks")
+	}
+
+	// 3. Must carry cc_prompt_id in billing header
+	billingText := gjson.GetBytes(seenBody, "system.0.text").String()
+	if !strings.Contains(billingText, "cc_prompt_id=") {
+		t.Fatalf("declassified normal request must carry cc_prompt_id, got: %s", billingText)
+	}
+}
+
 func TestClaudeExecutor_CallerOwnedDiagnosticsPreservedOnProbe(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5758,6 +5978,69 @@ func TestClaudeExecutor_FableWithSensitiveWordsHasSingleObfuscatedReportingBlock
 	payload := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
 	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
 		Model:   "claude-fable-5-1",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	reportingCount := 0
+	for _, blk := range gjson.GetBytes(seenBody, "system").Array() {
+		raw := blk.Get("text").String()
+		cleaned := strings.ReplaceAll(raw, "\u200B", "")
+		if cleaned == claudeCodeFableReportingOutcomes {
+			reportingCount++
+			if !strings.Contains(raw, "\u200B") {
+				t.Fatalf("Reporting block must be obfuscated with zero-width space, got: %q", raw)
+			}
+			if strings.Contains(raw, "Reporting") {
+				t.Fatalf("Reporting block must not contain cleartext sensitive word 'Reporting', got: %q", raw)
+			}
+		}
+	}
+	if reportingCount != 1 {
+		t.Fatalf("expected exactly 1 reporting block, got %d; system = %s", reportingCount, gjson.GetBytes(seenBody, "system").Raw)
+	}
+}
+
+func TestClaudeExecutor_PayloadSonnetToFableWithSensitiveWordsObfuscatesInjectedReportingBlock(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","model":"claude-fable-5-1","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey: "sk-ant-oat-sonnet-to-fable-sensitive-test",
+			Cloak: &config.CloakConfig{
+				SensitiveWords: []string{"Reporting"},
+			},
+		}},
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-sonnet-5"}},
+				Params: map[string]any{
+					"model": "claude-fable-5-1",
+				},
+			}},
+		},
+	}
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-sonnet-to-fable-sensitive-test",
+		Metadata: claudeOAuthTestMetadata(),
+		Attributes: map[string]string{
+			"api_key":  "sk-ant-oat-sonnet-to-fable-sensitive-test",
+			"base_url": server.URL,
+		},
+	}
+
+	executor := NewClaudeExecutor(cfg)
+	payload := []byte(`{"model":"claude-sonnet-5","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`)
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-sonnet-5",
 		Payload: payload,
 	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
 	if err != nil {

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -61,6 +61,24 @@ func HeaderValueCaseInsensitive(headers http.Header, name string) string {
 	return headerValueCaseInsensitive(headers, name)
 }
 
+// HeaderValuesCaseInsensitive returns all non-empty header values matching name case-insensitively.
+func HeaderValuesCaseInsensitive(headers http.Header, name string) []string {
+	if headers == nil {
+		return nil
+	}
+	var result []string
+	for key, values := range headers {
+		if strings.EqualFold(key, name) {
+			for _, value := range values {
+				if trimmed := strings.TrimSpace(value); trimmed != "" {
+					result = append(result, trimmed)
+				}
+			}
+		}
+	}
+	return result
+}
+
 func headerValueCaseInsensitive(headers http.Header, name string) string {
 	if headers == nil {
 		return ""

--- a/internal/runtime/executor/helps/claude_diagnostics.go
+++ b/internal/runtime/executor/helps/claude_diagnostics.go
@@ -1,12 +1,19 @@
 package helps
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const (
@@ -16,8 +23,90 @@ const (
 	claudeDiagnosticsEvictBatchSize = 256
 )
 
+var (
+	claudeRequestIDPattern = regexp.MustCompile(`^req_[A-Za-z0-9_-]{1,36}$`)
+	claudePromptIDPattern  = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+)
+
+type claudeContextKey string
+
+const (
+	claudeSessionIDContextKey       claudeContextKey = "cpa_claude_session_id"
+	claudeContinuityContextKey      claudeContextKey = "cpa_claude_continuity_ctx"
+	claudeIncomingHeadersContextKey claudeContextKey = "cpa_claude_incoming_headers"
+)
+
+// WithIncomingHeaders attaches incoming HTTP headers to ctx.
+func WithIncomingHeaders(ctx context.Context, headers http.Header) context.Context {
+	if headers == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, claudeIncomingHeadersContextKey, headers)
+}
+
+// IncomingHeadersFromContext retrieves incoming HTTP headers from ctx, if present.
+func IncomingHeadersFromContext(ctx context.Context) http.Header {
+	if ctx == nil {
+		return nil
+	}
+	if h, ok := ctx.Value(claudeIncomingHeadersContextKey).(http.Header); ok {
+		return h
+	}
+	return nil
+}
+
+// ClaudeContinuityContext holds request-scoped continuity state across cloaking and execution.
+type ClaudeContinuityContext struct {
+	Key               string
+	Sequence          uint64
+	PreviousMessageID string
+	PreviousRequestID string
+	PromptID          string
+	Initialized       bool
+}
+
+// WithClaudeSessionID attaches a known Claude session ID to ctx.
+func WithClaudeSessionID(ctx context.Context, sessionID string) context.Context {
+	if sessionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, claudeSessionIDContextKey, sessionID)
+}
+
+// ClaudeSessionIDFromContext retrieves the Claude session ID from ctx, if present.
+func ClaudeSessionIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if val, ok := ctx.Value(claudeSessionIDContextKey).(string); ok {
+		return val
+	}
+	return ""
+}
+
+// WithClaudeContinuityContext attaches a mutable ClaudeContinuityContext to ctx.
+func WithClaudeContinuityContext(ctx context.Context, cc *ClaudeContinuityContext) context.Context {
+	if cc == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, claudeContinuityContextKey, cc)
+}
+
+// ClaudeContinuityContextFromContext retrieves the ClaudeContinuityContext from ctx, if present.
+func ClaudeContinuityContextFromContext(ctx context.Context) *ClaudeContinuityContext {
+	if ctx == nil {
+		return nil
+	}
+	if cc, ok := ctx.Value(claudeContinuityContextKey).(*ClaudeContinuityContext); ok {
+		return cc
+	}
+	return nil
+}
+
 type claudeDiagnosticsEntry struct {
 	previousMessageID string
+	previousRequestID string
+	promptID          string
 	minimumSequence   uint64
 	committedSequence uint64
 	lastAccess        uint64
@@ -32,16 +121,26 @@ var claudeDiagnosticsState = struct {
 	nextAccess   uint64
 }{entries: make(map[string]claudeDiagnosticsEntry)}
 
-// BeginClaudeDiagnostics starts one request generation for a stable credential
-// identity and Claude conversation. It returns the last successfully completed
-// upstream message ID, if any. Only a SHA-256 digest of the credential identity
-// and session is retained as the cache key, so access-token rotation does not
-// interrupt continuity.
-func BeginClaudeDiagnostics(credentialIdentity, sessionID string) (key string, sequence uint64, previousMessageID string) {
+// IsValidClaudePromptID verifies whether an explicit prompt ID adheres to strict RFC 4122 UUIDv4 semantics.
+func IsValidClaudePromptID(id string) bool {
+	id = strings.TrimSpace(id)
+	if !claudePromptIDPattern.MatchString(id) {
+		return false
+	}
+	parsed, err := uuid.Parse(id)
+	return err == nil && parsed.Version() == 4 && parsed.Variant() == uuid.RFC4122
+}
+
+// BeginClaudeContinuity starts one request generation for a stable credential
+// identity and Claude conversation. It tracks the previous upstream message ID,
+// previous upstream request ID (cc_prev_req), and active prompt ID (cc_prompt_id).
+// If explicitPromptID is provided and valid, it is adopted. Otherwise if isNewPromptTurn
+// is true (or if no prompt ID exists), a fresh UUIDv4 is generated.
+func BeginClaudeContinuity(credentialIdentity, sessionID string, isNewPromptTurn bool, explicitPromptID string) (key string, sequence uint64, previousMessageID, previousRequestID, promptID string) {
 	credentialIdentity = strings.TrimSpace(credentialIdentity)
 	sessionID = strings.TrimSpace(sessionID)
 	if credentialIdentity == "" || sessionID == "" {
-		return "", 0, ""
+		return "", 0, "", "", ""
 	}
 	digest := sha256.Sum256([]byte(credentialIdentity + "\x00" + sessionID))
 	key = hex.EncodeToString(digest[:])
@@ -62,19 +161,39 @@ func BeginClaudeDiagnostics(credentialIdentity, sessionID string) (key string, s
 	if newGeneration {
 		entry = claudeDiagnosticsEntry{minimumSequence: sequence}
 	}
+
+	activePromptID := entry.promptID
+	explicitPromptID = strings.TrimSpace(explicitPromptID)
+	if explicitPromptID != "" && IsValidClaudePromptID(explicitPromptID) {
+		activePromptID = strings.ToLower(explicitPromptID)
+	} else if isNewPromptTurn || activePromptID == "" {
+		activePromptID = uuid.NewString()
+	}
+
 	claudeDiagnosticsState.nextAccess++
 	entry.lastAccess = claudeDiagnosticsState.nextAccess
 	entry.expiresAt = now.Add(claudeDiagnosticsTTL)
 	claudeDiagnosticsState.entries[key] = entry
-	return key, sequence, entry.previousMessageID
+	return key, sequence, entry.previousMessageID, entry.previousRequestID, activePromptID
 }
 
-// CommitClaudeDiagnostics advances continuity only after a response completes.
-// A response from an older concurrently-started request cannot overwrite a
-// newer committed generation, including after TTL expiry or capacity eviction.
-func CommitClaudeDiagnostics(key string, sequence uint64, messageID string) {
+// BeginClaudeDiagnostics starts one request generation for a stable credential
+// identity and Claude conversation. It returns the last successfully completed
+// upstream message ID, if any. Only a SHA-256 digest of the credential identity
+// and session is retained as the cache key, so access-token rotation does not
+// interrupt continuity.
+func BeginClaudeDiagnostics(credentialIdentity, sessionID string) (key string, sequence uint64, previousMessageID string) {
+	key, sequence, prevMsg, _, _ := BeginClaudeContinuity(credentialIdentity, sessionID, false, "")
+	return key, sequence, prevMsg
+}
+
+// CommitClaudeContinuity advances continuity only after a response completes.
+// It commits the upstream message ID (msg_01...), request ID (req_01...), and prompt ID (cc_prompt_id).
+// A non-empty messageID is required so incomplete/truncated streams do not advance sequence.
+func CommitClaudeContinuity(key string, sequence uint64, messageID, requestID string, promptIDs ...string) {
 	key = strings.TrimSpace(key)
 	messageID = strings.TrimSpace(messageID)
+	requestID = strings.TrimSpace(requestID)
 	if key == "" || sequence == 0 || messageID == "" {
 		return
 	}
@@ -83,15 +202,32 @@ func CommitClaudeDiagnostics(key string, sequence uint64, messageID string) {
 	claudeDiagnosticsState.Lock()
 	defer claudeDiagnosticsState.Unlock()
 	entry, ok := claudeDiagnosticsState.entries[key]
-	if !ok || sequence < entry.minimumSequence || sequence < entry.committedSequence {
+	if !ok || (!entry.expiresAt.IsZero() && now.After(entry.expiresAt)) || sequence < entry.minimumSequence || sequence < entry.committedSequence {
 		return
 	}
 	claudeDiagnosticsState.nextAccess++
 	entry.previousMessageID = messageID
+	if requestID != "" && claudeRequestIDPattern.MatchString(requestID) {
+		entry.previousRequestID = requestID
+	} else {
+		entry.previousRequestID = ""
+	}
+	if len(promptIDs) > 0 {
+		if pID := strings.TrimSpace(promptIDs[0]); pID != "" && IsValidClaudePromptID(pID) {
+			entry.promptID = strings.ToLower(pID)
+		}
+	}
 	entry.committedSequence = sequence
 	entry.lastAccess = claudeDiagnosticsState.nextAccess
 	entry.expiresAt = now.Add(claudeDiagnosticsTTL)
 	claudeDiagnosticsState.entries[key] = entry
+}
+
+// CommitClaudeDiagnostics advances continuity only after a response completes.
+// A response from an older concurrently-started request cannot overwrite a
+// newer committed generation, including after TTL expiry or capacity eviction.
+func CommitClaudeDiagnostics(key string, sequence uint64, messageID string) {
+	CommitClaudeContinuity(key, sequence, messageID, "")
 }
 
 func cleanupClaudeDiagnosticsLocked(now time.Time) {
@@ -127,6 +263,11 @@ func evictClaudeDiagnosticsLocked() {
 	}
 }
 
+// ResetClaudeDiagnosticsForTest resets in-memory continuity state for test isolation.
+func ResetClaudeDiagnosticsForTest() {
+	resetClaudeDiagnosticsForTest()
+}
+
 func resetClaudeDiagnosticsForTest() {
 	claudeDiagnosticsState.Lock()
 	defer claudeDiagnosticsState.Unlock()
@@ -134,4 +275,287 @@ func resetClaudeDiagnosticsForTest() {
 	claudeDiagnosticsState.lastCleanup = time.Time{}
 	claudeDiagnosticsState.nextSequence = 0
 	claudeDiagnosticsState.nextAccess = 0
+}
+
+// IsClaudeNewPromptTurn inspects the request messages to determine whether
+// this request starts a new user prompt turn (requiring a new cc_prompt_id)
+// versus a tool continuation step (which reuses the current cc_prompt_id).
+func IsClaudeNewPromptTurn(body []byte) bool {
+	if IsClaudeProbeOrHelperRequest(body) {
+		return false
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return true
+	}
+	arr := messages.Array()
+	if len(arr) == 0 {
+		return true
+	}
+	lastMsg := arr[len(arr)-1]
+	if lastMsg.Get("role").String() != "user" {
+		return false
+	}
+	content := lastMsg.Get("content")
+	if content.IsArray() {
+		// If any element is a tool_result, this is a tool continuation turn.
+		for _, part := range content.Array() {
+			if part.Get("type").String() == "tool_result" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var (
+	claudePrevReqBillingPattern  = regexp.MustCompile(`\s*cc_prev_req=[^;]+;`)
+	claudePromptIDBillingPattern = regexp.MustCompile(`\s*cc_prompt_id=[^;]+;`)
+)
+
+func isClaudeProbeRequest(body []byte) bool {
+	maxTokens := gjson.GetBytes(body, "max_tokens")
+	if !maxTokens.Exists() || maxTokens.Int() != 1 {
+		return false
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if tools.Exists() && len(tools.Array()) > 0 {
+		return false
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() || len(messages.Array()) == 0 {
+		return true // headless preflight probe without messages
+	}
+	arr := messages.Array()
+	if len(arr) != 1 {
+		return false
+	}
+	firstMsg := arr[0]
+	if firstMsg.Get("role").String() != "user" {
+		return false
+	}
+	content := firstMsg.Get("content")
+	if content.Type == gjson.String {
+		str := strings.TrimSpace(content.String())
+		return str == "quota" || str == "test" || str == "." || str == "probe"
+	}
+	if content.IsArray() {
+		nonReminderCount := 0
+		matched := false
+		for _, part := range content.Array() {
+			t := strings.TrimSpace(part.Get("text").String())
+			if strings.Contains(t, "<system-reminder>") {
+				continue
+			}
+			nonReminderCount++
+			if t == "quota" || t == "test" || t == "." || t == "probe" || (t == "Hi" && part.Get("cache_control").Exists()) {
+				matched = true
+			}
+		}
+		return nonReminderCount == 1 && matched
+	}
+	return false
+}
+
+func isClaudeTitleHelperInstruction(body []byte) bool {
+	matchesTitlePrompt := func(t string) bool {
+		return strings.Contains(t, "Return a short title") ||
+			strings.Contains(t, "naming a coding session") ||
+			strings.Contains(t, "Write the title in the predominant language") ||
+			strings.Contains(t, "<session>")
+	}
+	system := gjson.GetBytes(body, "system")
+	if system.IsArray() {
+		for _, part := range system.Array() {
+			if matchesTitlePrompt(part.Get("text").String()) {
+				return true
+			}
+		}
+	} else if matchesTitlePrompt(system.String()) {
+		return true
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		for _, msg := range messages.Array() {
+			content := msg.Get("content")
+			if content.IsArray() {
+				for _, part := range content.Array() {
+					if matchesTitlePrompt(part.Get("text").String()) {
+						return true
+					}
+				}
+			} else if matchesTitlePrompt(content.String()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isClaudeTitleHelperRequest(body []byte) bool {
+	props := gjson.GetBytes(body, "output_config.format.schema.properties")
+	if props.Exists() {
+		if props.Get("title").Exists() && len(props.Map()) == 1 {
+			return isClaudeTitleHelperInstruction(body)
+		}
+		return false
+	}
+
+	// When structured output schema is absent, it can only be an internal helper
+	// if a system-role block (either in system or in messages) contains the title instruction.
+	// Ordinary user messages ("role": "user") without a title schema are never internal helpers.
+	matchesSystemTitleInstruction := func(t string) bool {
+		return strings.Contains(t, "naming a coding session") ||
+			strings.Contains(t, "Return a short title") ||
+			strings.Contains(t, "Write the title in the predominant language")
+	}
+	system := gjson.GetBytes(body, "system")
+	if system.IsArray() {
+		for _, part := range system.Array() {
+			if matchesSystemTitleInstruction(part.Get("text").String()) {
+				return true
+			}
+		}
+	} else if matchesSystemTitleInstruction(system.String()) {
+		return true
+	}
+
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		for _, msg := range messages.Array() {
+			if msg.Get("role").String() == "system" {
+				content := msg.Get("content")
+				if content.IsArray() {
+					for _, part := range content.Array() {
+						if matchesSystemTitleInstruction(part.Get("text").String()) {
+							return true
+						}
+					}
+				} else if matchesSystemTitleInstruction(content.String()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// IsClaudeProbeOrHelperRequest reports whether the request is a minimal
+// probe/preflight (max_tokens: 1) or an automated title generation helper,
+// which in native Claude Code do not emit cc_prompt_id or cc_prev_req.
+func IsClaudeProbeOrHelperRequest(body []byte) bool {
+	return isClaudeProbeRequest(body) || isClaudeTitleHelperRequest(body)
+}
+
+// IsClaudeSubagentRequest reports whether the incoming request originates from
+// or represents a Claude Code subagent.
+func IsClaudeSubagentRequest(headers http.Header, body []byte) bool {
+	if val := HeaderValueCaseInsensitive(headers, "X-Claude-Code-Agent-Id"); val != "" {
+		return true
+	}
+	if val := HeaderValueCaseInsensitive(headers, "X-Claude-Code-Parent-Agent-Id"); val != "" {
+		return true
+	}
+	if gjson.GetBytes(body, "metadata.user_id.parent_session_id").Exists() {
+		return true
+	}
+	if userID := gjson.GetBytes(body, "metadata.user_id").String(); userID != "" {
+		if strings.Contains(userID, `"parent_session_id"`) {
+			return true
+		}
+	}
+	// Only inspect system[0].text or billing header for cc_is_subagent, never raw user message content
+	system := gjson.GetBytes(body, "system")
+	if system.IsArray() && len(system.Array()) > 0 {
+		if strings.Contains(system.Array()[0].Get("text").String(), "cc_is_subagent=true") {
+			return true
+		}
+	} else if system.Type == gjson.String && strings.Contains(system.String(), "cc_is_subagent=true") {
+		return true
+	}
+	return false
+}
+
+// StripClaudeBillingTags removes cc_prev_req and cc_prompt_id from the billing header in body.
+func StripClaudeBillingTags(body []byte) []byte {
+	system := gjson.GetBytes(body, "system")
+	if !system.IsArray() || len(system.Array()) == 0 {
+		return body
+	}
+	billingText := system.Array()[0].Get("text").String()
+	if !strings.HasPrefix(billingText, "x-anthropic-billing-header:") {
+		return body
+	}
+	cleaned := claudePrevReqBillingPattern.ReplaceAllString(billingText, "")
+	cleaned = claudePromptIDBillingPattern.ReplaceAllString(cleaned, "")
+	if cleaned != billingText {
+		updated, err := sjson.SetBytes(body, "system.0.text", cleaned)
+		if err == nil {
+			return updated
+		}
+	}
+	return body
+}
+
+// InjectClaudeBillingTags appends cc_prev_req and cc_prompt_id to the billing header in body if present.
+func InjectClaudeBillingTags(body []byte, prevReq, promptID string) []byte {
+	system := gjson.GetBytes(body, "system")
+	if !system.IsArray() || len(system.Array()) == 0 {
+		return body
+	}
+	billingText := system.Array()[0].Get("text").String()
+	if !strings.HasPrefix(billingText, "x-anthropic-billing-header:") {
+		return body
+	}
+	cleaned := claudePrevReqBillingPattern.ReplaceAllString(billingText, "")
+	cleaned = claudePromptIDBillingPattern.ReplaceAllString(cleaned, "")
+	cleaned = strings.TrimSpace(cleaned)
+	if !strings.HasSuffix(cleaned, ";") {
+		cleaned += ";"
+	}
+	if prevReq != "" {
+		cleaned += " cc_prev_req=" + prevReq + ";"
+	}
+	if promptID != "" {
+		cleaned += " cc_prompt_id=" + promptID + ";"
+	}
+	updated, err := sjson.SetBytes(body, "system.0.text", cleaned)
+	if err == nil {
+		return updated
+	}
+	return body
+}
+
+// ExtractClaudeBillingTags extracts existing cc_prev_req and cc_prompt_id values
+// from a billing header in system text, if present.
+func ExtractClaudeBillingTags(body []byte) (prevReq, promptID string) {
+	system := gjson.GetBytes(body, "system")
+	var billingText string
+	if system.IsArray() && len(system.Array()) > 0 {
+		billingText = system.Array()[0].Get("text").String()
+	} else if system.Type == gjson.String {
+		billingText = system.String()
+	}
+	if billingText == "" || !strings.HasPrefix(billingText, "x-anthropic-billing-header:") {
+		return "", ""
+	}
+	if idx := strings.Index(billingText, "cc_prev_req="); idx >= 0 {
+		val := billingText[idx+len("cc_prev_req="):]
+		if end := strings.IndexByte(val, ';'); end >= 0 {
+			val = val[:end]
+		}
+		if claudeRequestIDPattern.MatchString(val) {
+			prevReq = val
+		}
+	}
+	if idx := strings.Index(billingText, "cc_prompt_id="); idx >= 0 {
+		val := billingText[idx+len("cc_prompt_id="):]
+		if end := strings.IndexByte(val, ';'); end >= 0 {
+			val = val[:end]
+		}
+		if IsValidClaudePromptID(val) {
+			promptID = strings.ToLower(val)
+		}
+	}
+	return prevReq, promptID
 }

--- a/internal/runtime/executor/helps/claude_diagnostics_test.go
+++ b/internal/runtime/executor/helps/claude_diagnostics_test.go
@@ -2,8 +2,11 @@ package helps
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestClaudeDiagnosticsTracksCompletedMessagePerCredentialSession(t *testing.T) {
@@ -98,5 +101,238 @@ func TestClaudeDiagnosticsRejectsLateOlderCommit(t *testing.T) {
 	_, _, previous := BeginClaudeDiagnostics("credential", "session")
 	if previous != "msg_newer" {
 		t.Fatalf("previous message = %q, want newer completed generation", previous)
+	}
+}
+
+func TestClaudeContinuityTracksRequestIDAndPromptID(t *testing.T) {
+	resetClaudeDiagnosticsForTest()
+	defer resetClaudeDiagnosticsForTest()
+
+	// Turn 1: New prompt turn
+	key, seq1, prevMsg, prevReq, prompt1 := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+	if prevMsg != "" || prevReq != "" || prompt1 == "" {
+		t.Fatalf("turn 1 = prevMsg:%q prevReq:%q prompt:%q, want empty prevs and fresh prompt", prevMsg, prevReq, prompt1)
+	}
+	CommitClaudeContinuity(key, seq1, "msg_01aaa", "req_01bbb", prompt1)
+
+	// Turn 1.1: Tool continuation turn (not new prompt)
+	_, seq2, prevMsg, prevReq, prompt2 := BeginClaudeContinuity("cred-1", "sess-1", false, "")
+	if prevMsg != "msg_01aaa" || prevReq != "req_01bbb" {
+		t.Fatalf("turn 1.1 = prevMsg:%q prevReq:%q, want msg_01aaa / req_01bbb", prevMsg, prevReq)
+	}
+	if prompt2 != prompt1 {
+		t.Fatalf("turn 1.1 prompt = %q, want same prompt %q as turn 1", prompt2, prompt1)
+	}
+	CommitClaudeContinuity(key, seq2, "msg_01ccc", "req_01ddd", prompt2)
+
+	// Turn 2: New prompt turn
+	_, _, prevMsg, prevReq, prompt3 := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+	if prevMsg != "msg_01ccc" || prevReq != "req_01ddd" {
+		t.Fatalf("turn 2 = prevMsg:%q prevReq:%q, want msg_01ccc / req_01ddd", prevMsg, prevReq)
+	}
+	if prompt3 == prompt1 {
+		t.Fatalf("turn 2 prompt = %q, want new prompt different from %q", prompt3, prompt1)
+	}
+}
+
+func TestClaudeContinuityHelperPredicates(t *testing.T) {
+	probeBody := []byte(`{"model":"claude-fable-5-1","max_tokens":1,"messages":[{"role":"user","content":[{"type":"text","text":"Hi","cache_control":{"type":"ephemeral"}}]}]}`)
+	if !IsClaudeProbeOrHelperRequest(probeBody) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(fable probe) = false, want true")
+	}
+
+	quotaProbeBody := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"quota"}]}`)
+	if !IsClaudeProbeOrHelperRequest(quotaProbeBody) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(quota probe) = false, want true")
+	}
+
+	ordinaryHiMaxTokens1 := []byte(`{"model":"claude-fable-5-1","max_tokens":1,"messages":[{"role":"user","content":"Hi"}]}`)
+	if IsClaudeProbeOrHelperRequest(ordinaryHiMaxTokens1) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(ordinary Hi max_tokens=1) = true, want false")
+	}
+
+	multiTurnMaxTokens1 := []byte(`{"model":"claude-sonnet-5","max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"},{"role":"user","content":"what is 1+1?"}]}`)
+	if IsClaudeProbeOrHelperRequest(multiTurnMaxTokens1) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(multi-turn max_tokens=1) = true, want false")
+	}
+
+	withToolsMaxTokens1 := []byte(`{"model":"claude-sonnet-5","max_tokens":1,"messages":[{"role":"user","content":"Hi"}],"tools":[{"name":"t1","description":"tool"}]}`)
+	if IsClaudeProbeOrHelperRequest(withToolsMaxTokens1) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(tools max_tokens=1) = true, want false")
+	}
+
+	titleBody := []byte(`{"model":"claude-haiku-4-5-20251001","output_config":{"format":{"schema":{"properties":{"title":{"type":"string"}}}}},"messages":[{"role":"user","content":"Return a short title summarizing this conversation"}]}`)
+	if !IsClaudeProbeOrHelperRequest(titleBody) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(title helper) = false, want true")
+	}
+
+	ordinaryTitleSchema := []byte(`{"model":"claude-haiku-4-5-20251001","output_config":{"format":{"schema":{"properties":{"title":{"type":"string"}}}}},"messages":[{"role":"user","content":"what is the title of the book?"}]}`)
+	if IsClaudeProbeOrHelperRequest(ordinaryTitleSchema) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(ordinary title schema) = true, want false")
+	}
+
+	relocatedTitleBody := []byte(`{"model":"claude-sonnet-5","system":[{"type":"text","text":"cli-identity"}],"messages":[{"role":"system","content":"Return a short title summarizing this conversation"}]}`)
+	if !IsClaudeProbeOrHelperRequest(relocatedTitleBody) {
+		t.Fatal("IsClaudeProbeOrHelperRequest(relocated title system in messages) = false, want true")
+	}
+
+	toolResultBody := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"tool_use","id":"t1"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}]}`)
+	if IsClaudeNewPromptTurn(toolResultBody) {
+		t.Fatal("IsClaudeNewPromptTurn(tool_result) = true, want false")
+	}
+
+	newPromptBody := []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"explain sorting"}]}`)
+	if !IsClaudeNewPromptTurn(newPromptBody) {
+		t.Fatal("IsClaudeNewPromptTurn(user text) = false, want true")
+	}
+
+	subagentHeader := http.Header{"X-Claude-Code-Agent-Id": []string{"sub-1"}}
+	if !IsClaudeSubagentRequest(subagentHeader, []byte(`{}`)) {
+		t.Fatal("IsClaudeSubagentRequest(agent header) = false, want true")
+	}
+
+	subagentMetaBody := []byte(`{"metadata":{"user_id":"{\"device_id\":\"dev\",\"session_id\":\"sess\",\"parent_session_id\":\"parent-1\"}"}}`)
+	if !IsClaudeSubagentRequest(nil, subagentMetaBody) {
+		t.Fatal("IsClaudeSubagentRequest(parent_session_id) = false, want true")
+	}
+
+	billingSystemBody := []byte(`{"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.258.1e2; cc_entrypoint=cli; cch=00000; cc_prev_req=req_01abc; cc_prompt_id=3c6489dc-badc-42b2-bd28-49f8ebabfedd;"}]}`)
+	prevReq, promptID := ExtractClaudeBillingTags(billingSystemBody)
+	if prevReq != "req_01abc" || promptID != "3c6489dc-badc-42b2-bd28-49f8ebabfedd" {
+		t.Fatalf("ExtractClaudeBillingTags = %q, %q; want req_01abc, 3c6489dc-badc-42b2-bd28-49f8ebabfedd", prevReq, promptID)
+	}
+}
+
+func TestIsValidClaudePromptID(t *testing.T) {
+	v4 := uuid.NewString()
+	if !IsValidClaudePromptID(v4) {
+		t.Fatalf("IsValidClaudePromptID(%q) = false, want true", v4)
+	}
+
+	// UUIDv1 should be rejected
+	v1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	if IsValidClaudePromptID(v1) {
+		t.Fatalf("IsValidClaudePromptID(v1 %q) = true, want false", v1)
+	}
+
+	// UUIDv4 with non-RFC4122 variant (variant bits 0xxx instead of 10xx, e.g. '0' instead of '8','9','a','b')
+	nonRFC4122 := "3c6489dc-badc-42b2-0d28-49f8ebabfedd"
+	if IsValidClaudePromptID(nonRFC4122) {
+		t.Fatalf("IsValidClaudePromptID(non-RFC4122 variant %q) = true, want false", nonRFC4122)
+	}
+
+	// All zeros UUID should be rejected (version 0)
+	allZeros := "00000000-0000-0000-0000-000000000000"
+	if IsValidClaudePromptID(allZeros) {
+		t.Fatalf("IsValidClaudePromptID(all zeros %q) = true, want false", allZeros)
+	}
+
+	// Invalid format strings
+	for _, invalid := range []string{"", "not-a-uuid", "12345", "3c6489dc-badc-42b2-bd28-49f8ebabfedd-extra"} {
+		if IsValidClaudePromptID(invalid) {
+			t.Fatalf("IsValidClaudePromptID(%q) = true, want false", invalid)
+		}
+	}
+}
+
+func TestClaudeContinuityConcurrentOverlappingPromptID(t *testing.T) {
+	resetClaudeDiagnosticsForTest()
+	defer resetClaudeDiagnosticsForTest()
+
+	// Turn 1 starts (in-flight, not committed)
+	key, seq1, _, _, prompt1 := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+
+	// Turn 2 starts concurrently before Turn 1 commits
+	_, seq2, _, _, prompt2 := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+	if prompt1 == prompt2 {
+		t.Fatalf("turn 1 and turn 2 got same prompt %q, want distinct", prompt1)
+	}
+
+	// Turn 1 completes upstream and commits
+	CommitClaudeContinuity(key, seq1, "msg_01aaa", "req_01bbb", prompt1)
+
+	// Turn 1.1 tool continuation starts (not new turn)
+	_, _, prevMsg, prevReq, prompt11 := BeginClaudeContinuity("cred-1", "sess-1", false, "")
+	if prevMsg != "msg_01aaa" || prevReq != "req_01bbb" {
+		t.Fatalf("turn 1.1 prevMsg=%q prevReq=%q, want msg_01aaa / req_01bbb", prevMsg, prevReq)
+	}
+	if prompt11 != prompt1 {
+		t.Fatalf("turn 1.1 prompt=%q, want committed turn 1 prompt %q, not overwritten by uncommitted turn 2 (%q)", prompt11, prompt1, prompt2)
+	}
+
+	// Turn 2 completes upstream and commits
+	CommitClaudeContinuity(key, seq2, "msg_01ccc", "req_01ddd", prompt2)
+
+	// Turn 2.1 tool continuation starts
+	_, _, prevMsg2, prevReq2, prompt21 := BeginClaudeContinuity("cred-1", "sess-1", false, "")
+	if prevMsg2 != "msg_01ccc" || prevReq2 != "req_01ddd" {
+		t.Fatalf("turn 2.1 prevMsg=%q prevReq=%q, want msg_01ccc / req_01ddd", prevMsg2, prevReq2)
+	}
+	if prompt21 != prompt2 {
+		t.Fatalf("turn 2.1 prompt=%q, want committed turn 2 prompt %q", prompt21, prompt2)
+	}
+}
+
+func TestClaudeContinuityClearsStaleRequestID(t *testing.T) {
+	resetClaudeDiagnosticsForTest()
+	defer resetClaudeDiagnosticsForTest()
+
+	// Turn 1: has valid request-id
+	key, seq1, _, _, p1 := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+	CommitClaudeContinuity(key, seq1, "msg_01aaa", "req_01bbb", p1)
+
+	// Turn 1.1: verify prevReq is req_01bbb
+	_, seq2, _, prevReq1, p2 := BeginClaudeContinuity("cred-1", "sess-1", false, "")
+	if prevReq1 != "req_01bbb" {
+		t.Fatalf("turn 1.1 prevReq = %q, want req_01bbb", prevReq1)
+	}
+
+	// Turn 1.1 finishes, but upstream returned no request-id
+	CommitClaudeContinuity(key, seq2, "msg_01ccc", "", p2)
+
+	// Turn 2: verify prevReq is empty, NOT stale req_01bbb
+	_, _, prevMsg, prevReq2, _ := BeginClaudeContinuity("cred-1", "sess-1", true, "")
+	if prevMsg != "msg_01ccc" {
+		t.Fatalf("turn 2 prevMsg = %q, want msg_01ccc", prevMsg)
+	}
+	if prevReq2 != "" {
+		t.Fatalf("turn 2 prevReq = %q, want empty (must not retain stale request-id from prior turn)", prevReq2)
+	}
+}
+
+func TestIsClaudeProbeRequest_MultiContentBlocksNotAProbe(t *testing.T) {
+	// A request with max_tokens: 1 and multiple content blocks where one happens to be "quota"
+	// but another is a regular prompt must NOT be treated as a probe.
+	payload := []byte(`{
+		"model": "claude-sonnet-5",
+		"max_tokens": 1,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "quota"},
+				{"type": "text", "text": "Please write an analysis of the codebase."}
+			]
+		}]
+	}`)
+	if IsClaudeProbeOrHelperRequest(payload) {
+		t.Fatal("multi-content user prompt with non-quota text must not be classified as a probe")
+	}
+}
+
+func TestIsClaudeProbeRequest_SingleContentBlockWithReminderIsProbe(t *testing.T) {
+	// A probe request with a system-reminder block and a single quota block IS a probe.
+	payload := []byte(`{
+		"model": "claude-sonnet-5",
+		"max_tokens": 1,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "<system-reminder>some reminder</system-reminder>"},
+				{"type": "text", "text": "quota"}
+			]
+		}]
+	}`)
+	if !IsClaudeProbeOrHelperRequest(payload) {
+		t.Fatal("probe with system reminder and single quota block must be classified as a probe")
 	}
 }

--- a/internal/runtime/executor/helps/cloak_obfuscate.go
+++ b/internal/runtime/executor/helps/cloak_obfuscate.go
@@ -147,6 +147,9 @@ func obfuscateSystemBlocks(payload []byte, matcher *SensitiveWordMatcher) []byte
 		system.ForEach(func(key, value gjson.Result) bool {
 			if value.Get("type").String() == "text" {
 				text := value.Get("text").String()
+				if strings.HasPrefix(text, "x-anthropic-billing-header:") {
+					return true
+				}
 				obfuscated := matcher.obfuscateText(text)
 				if obfuscated != text {
 					path := "system." + key.String() + ".text"
@@ -161,9 +164,11 @@ func obfuscateSystemBlocks(payload []byte, matcher *SensitiveWordMatcher) []byte
 		}
 	} else if system.Type == gjson.String {
 		text := system.String()
-		obfuscated := matcher.obfuscateText(text)
-		if obfuscated != text {
-			payload, _ = sjson.SetBytes(payload, "system", obfuscated)
+		if !strings.HasPrefix(text, "x-anthropic-billing-header:") {
+			obfuscated := matcher.obfuscateText(text)
+			if obfuscated != text {
+				payload, _ = sjson.SetBytes(payload, "system", obfuscated)
+			}
 		}
 	}
 

--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -32,13 +32,23 @@ func ApplyPayloadConfigWithRequest(cfg *config.Config, model, protocol, fromProt
 
 // ApplyPayloadConfigWithRequestTracked applies payload config and reports whether
 // an applied rule targeted trackedPath or one of its descendants.
-func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, fromProtocol, root string, payload, original []byte, requestedModel string, requestPath string, headers http.Header, trackedPath string) ([]byte, bool) {
+// ApplyPayloadConfigWithTrackedPaths applies payload config and reports which
+// tracked paths (or their descendants) were targeted by an applied rule.
+func ApplyPayloadConfigWithTrackedPaths(cfg *config.Config, model, protocol, fromProtocol, root string, payload, original []byte, requestedModel string, requestPath string, headers http.Header, trackedPaths ...string) ([]byte, map[string]bool) {
+	touched := make(map[string]bool)
 	if cfg == nil || len(payload) == 0 {
-		return payload, false
+		return payload, touched
 	}
 	out := payload
-	trackedPath = strings.TrimSpace(trackedPath)
-	trackedPathTouched := false
+
+	markTouched := func(resolvedPath string) {
+		for _, tp := range trackedPaths {
+			tp = strings.TrimSpace(tp)
+			if tp != "" && payloadRuleTargetsPath(resolvedPath, tp) {
+				touched[tp] = true
+			}
+		}
+	}
 
 	// Apply disable-image-generation filtering before payload rules so config payload
 	// overrides can explicitly re-enable image_generation when desired.
@@ -83,7 +93,7 @@ func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, f
 						}
 						out = updated
 						appliedDefaults[resolvedPath] = struct{}{}
-						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+						markTouched(resolvedPath)
 					}
 				}
 			}
@@ -115,7 +125,7 @@ func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, f
 						}
 						out = updated
 						appliedDefaults[resolvedPath] = struct{}{}
-						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+						markTouched(resolvedPath)
 					}
 				}
 			}
@@ -134,7 +144,7 @@ func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, f
 						var applied bool
 						out, applied = setPayloadValueIfDifferentTracked(out, resolvedPath, value)
 						if applied {
-							trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+							markTouched(resolvedPath)
 						}
 					}
 				}
@@ -158,7 +168,7 @@ func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, f
 						var applied bool
 						out, applied = setPayloadRawValueIfDifferentTracked(out, resolvedPath, rawValue)
 						if applied {
-							trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+							markTouched(resolvedPath)
 						}
 					}
 				}
@@ -182,13 +192,20 @@ func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, f
 							continue
 						}
 						out = updated
-						trackedPathTouched = trackedPathTouched || payloadRuleTargetsPath(resolvedPath, trackedPath)
+						markTouched(resolvedPath)
 					}
 				}
 			}
 		}
 	}
-	return out, trackedPathTouched
+	return out, touched
+}
+
+// ApplyPayloadConfigWithRequestTracked applies payload config and reports whether
+// an applied rule targeted trackedPath or one of its descendants.
+func ApplyPayloadConfigWithRequestTracked(cfg *config.Config, model, protocol, fromProtocol, root string, payload, original []byte, requestedModel string, requestPath string, headers http.Header, trackedPath string) ([]byte, bool) {
+	out, touched := ApplyPayloadConfigWithTrackedPaths(cfg, model, protocol, fromProtocol, root, payload, original, requestedModel, requestPath, headers, trackedPath)
+	return out, touched[trackedPath]
 }
 
 func isImagesEndpointRequestPath(path string) bool {
@@ -510,10 +527,10 @@ func buildPayloadPath(root, path string) string {
 }
 
 func payloadRuleTargetsPath(path, trackedPath string) bool {
-	if trackedPath == "" {
+	if trackedPath == "" || path == "" {
 		return false
 	}
-	return path == trackedPath || strings.HasPrefix(path, trackedPath+".")
+	return path == trackedPath || strings.HasPrefix(path, trackedPath+".") || strings.HasPrefix(trackedPath, path+".")
 }
 
 func resolvePayloadRulePaths(payload []byte, path string) []string {


### PR DESCRIPTION
### Summary
Upgrade CPA's built-in Claude Code CLI wire fingerprint from `2.1.220` to `2.1.258`, aligning request headers, body parameters, and session continuity with measured native wire behavior.

### Key Changes
1. **P0 Billing Header Continuity Chain**:
   - Align `x-anthropic-billing-header` strictly to the native Bun byte order: `cc_version -> cc_entrypoint -> cch -> cc_workload -> cc_is_subagent -> cc_prev_req -> cc_prompt_id`.
   - Link `cc_prev_req` to upstream `request-id: req_...` headers with continuity cache.
   - Enforce RFC 4122 UUIDv4 semantic validation for `cc_prompt_id`, with automatic healing for malformed/non-v4 IDs.
   - Isolate probe requests (`max_tokens: 1`) and side-queries to prevent session poisoning.
   - Pass incoming headers to `claudeCCHFallbackBillingHeader` to preserve subagent flags during CCH regeneration.

2. **P1 Dynamic Anthropic-Beta Pruning & Fallbacks**:
   - Suppress `effort-2025-11-24` on Haiku models, probe requests, and when thinking is disabled.
   - Add `thinking-display-updates-2026-08-18` beta and automatically drop `redact-thinking-2026-02-12` when thinking display is `updates` or `summarized`.
   - Auto-attach `server-side-fallback-2026-06-01` whenever the body contains `fallbacks`.
   - Suppress `extended-cache-ttl-2025-04-11` on subagents and probes.

3. **P2 Model Cloaking Parity**:
   - Inject `"fallbacks": [{"model": "claude-opus-5"}]` and default `display: updates` when cloaking `claude-fable-5-1`.
   - Inject `# Reporting outcomes` as `System[2]` without cache control for Fable 5.1 / Mythos models when cloaking is enabled.
   - Retain complete pass-through for confirmed native Claude Code and when `disable-claude-cloak-mode` is true.
   - Fallback to `ClaudeContinuityContext` in `claudeCCHFallbackBillingHeader` when payload transformations strip billing tags.

### Verification
- Full test suites passing: `go test -count=1 ./internal/runtime/executor/...` and `go test ./cmd/... ./internal/api/...`.
- Live wire verification using Codex CLI and Pi coding agent against local mitmproxy interceptor on 38082/38081.
- Clean compilation: `go build -ldflags="-s -w" -o /dev/null ./cmd/server`.