### PR TITLE
feat: GET /v1/models/:model endpoint (from #5190)

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -66,7 +66,7 @@ func (s *Server) setupRoutes() {
 		// :model is a wildcard so prefixed IDs containing slashes (e.g.
 		// "teamA/gemini-3-pro-preview" exposed by force-model-prefix) reach
 		// the handler; it strips the leading "models/" itself.
-		v1.GET("/models/*model", openaiHandlers.OpenAIModel)
+		v1.GET("/models/*model", s.unifiedModelDetailHandler(openaiHandlers))
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
 		v1.POST("/completions", openaiHandlers.Completions)
 		v1.POST("/images/generations", openaiHandlers.ImagesGenerations)
@@ -583,6 +583,43 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 		} else {
 			openaiHandler.OpenAIModels(c)
 		}
+	}
+}
+
+// unifiedModelDetailHandler dispatches GET /v1/models/*model the same way
+// unifiedModelsHandler dispatches the collection: when Home is enabled the
+// per-request catalog from the control center is authoritative (a model
+// advertised by Home but absent from the local registry must still resolve),
+// otherwise it falls back to the local-registry lookup.
+func (s *Server) unifiedModelDetailHandler(openaiHandler *openai.OpenAIAPIHandler) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if s != nil && s.cfg != nil && s.cfg.Home.Enabled {
+			entries, ok := s.loadHomeModelEntries(c)
+			if !ok {
+				return
+			}
+			want := strings.TrimPrefix(c.Param("model"), "/")
+			for _, entry := range entries {
+				if entry.id != want {
+					continue
+				}
+				model := map[string]any{
+					"id":     entry.id,
+					"object": "model",
+				}
+				if entry.created > 0 {
+					model["created"] = entry.created
+				}
+				if entry.ownedBy != "" {
+					model["owned_by"] = entry.ownedBy
+				}
+				c.JSON(http.StatusOK, model)
+				return
+			}
+			c.JSON(http.StatusNotFound, gin.H{"error": "model not found"})
+			return
+		}
+		openaiHandler.OpenAIModel(c)
 	}
 }
 

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -63,6 +63,10 @@ func (s *Server) setupRoutes() {
 	v1.Use(AuthMiddleware(s.accessManager))
 	{
 		v1.GET("/models", s.unifiedModelsHandler(openaiHandlers, claudeCodeHandlers))
+		// :model is a wildcard so prefixed IDs containing slashes (e.g.
+		// "teamA/gemini-3-pro-preview" exposed by force-model-prefix) reach
+		// the handler; it strips the leading "models/" itself.
+		v1.GET("/models/*model", openaiHandlers.OpenAIModel)
 		v1.POST("/chat/completions", openaiHandlers.ChatCompletions)
 		v1.POST("/completions", openaiHandlers.Completions)
 		v1.POST("/images/generations", openaiHandlers.ImagesGenerations)

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -93,6 +94,30 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 		"object": "list",
 		"data":   filteredModels,
 	})
+}
+
+// OpenAIModel handles the GET /v1/models/:model endpoint.
+// OpenAI SDK clients (including Hermes) validate a model by fetching its
+// individual record before use; without this route they get 404 and fall
+// back to another provider.
+func (h *OpenAIAPIHandler) OpenAIModel(c *gin.Context) {
+	// Wildcard param: strip the leading slash Gin keeps ("/teamA/gemini-x").
+	modelID := strings.TrimPrefix(c.Param("model"), "/")
+	if modelID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing model id"})
+		return
+	}
+	// The Codex client list payload is only valid on the collection endpoint
+	// (/v1/models?client_version=...). On the detail route always perform the
+	// normal single-record lookup so unknown IDs return 404 and model
+	// validation stays meaningful.
+	for _, model := range h.Models() {
+		if id, _ := model["id"].(string); id == modelID {
+			c.JSON(http.StatusOK, model)
+			return
+		}
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "model not found"})
 }
 
 // ChatCompletions handles the /v1/chat/completions endpoint.


### PR DESCRIPTION
Single-model endpoint so OpenAI SDK clients validate models via detail route instead of 404 + provider fallback.

Item 3 of #5190. Split from #5022. Zero translator changes: 2 files, +29.