### PR TITLE
feat: interactions session cache + state helpers (from #5190)

### DIFF
--- a/internal/cache/antigravity_interactions_session.go
+++ b/internal/cache/antigravity_interactions_session.go
@@ -1,0 +1,207 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	log "github.com/sirupsen/logrus"
+)
+
+// AntigravityInteractionsCacheTTL limits how long an antigravity agent
+// (Interactions API) interaction_id + environment_id pair is kept in process
+// memory for stateful continuation of a tool-calling cycle.
+const AntigravityInteractionsCacheTTL = 30 * time.Minute
+
+// AntigravityInteractionsCacheMaxEntries bounds process memory for the
+// antigravity interactions session cache. Oldest entries are evicted first.
+const AntigravityInteractionsCacheMaxEntries = 4096
+
+// AntigravityInteractionsCacheEvictBatchSize leaves headroom after the cache
+// reaches capacity so high write volume does not rescan the map every turn.
+const AntigravityInteractionsCacheEvictBatchSize = 64
+
+// AntigravityInteractionsState carries the upstream continuation coordinates
+// for one antigravity agent conversation.
+type AntigravityInteractionsState struct {
+	InteractionID string
+	EnvironmentID string
+	// ToolNames maps upstream call_id -> function name observed on the prior
+	// interaction. Responses tool loops send function_call_output with only
+	// call_id + output (no name), so the continuation rewrite needs this map
+	// to fill the required function_result.name.
+	ToolNames map[string]string `json:"tool_names,omitempty"`
+	UpdatedAt time.Time
+}
+
+type antigravityInteractionsEntry struct {
+	State     AntigravityInteractionsState
+	ExpiresAt time.Time
+}
+
+// antigravityInteractionsKVClient matches the narrow client surface the
+// reasoning-replay cache relies on, kept identical for symmetry.
+type antigravityInteractionsKVClient interface {
+	KVGet(ctx context.Context, key string) ([]byte, bool, error)
+	KVSet(ctx context.Context, key string, value []byte, opts homekv.KVSetOptions) (bool, error)
+}
+
+var (
+	antigravityInteractionsMu            sync.Mutex
+	antigravityInteractionsEntries       = make(map[string]antigravityInteractionsEntry)
+	antigravityInteractionsEvictionOrder []string
+)
+
+var currentAntigravityInteractionsKVClient = func() (antigravityInteractionsKVClient, bool, error) {
+	return homekv.CurrentKVClient()
+}
+
+// CacheAntigravityInteractionsState persists the continuation state for an
+// antigravity agent conversation so a subsequent tool-calling turn can attach
+// previous_interaction_id + environment_id instead of replaying the full
+// assistant tool-call history (which Google rejects with "Cannot specify tool
+// calls outside of Turn items").
+func CacheAntigravityInteractionsState(modelName, sessionKey string, state AntigravityInteractionsState) bool {
+	return CacheAntigravityInteractionsStateBestEffort(context.Background(), modelName, sessionKey, state)
+}
+
+// CacheAntigravityInteractionsStateBestEffort is the contextual variant used
+// from the executor so cancellation-safe best-effort writes never block the
+// request-path hot loop.
+func CacheAntigravityInteractionsStateBestEffort(ctx context.Context, modelName, sessionKey string, state AntigravityInteractionsState) bool {
+	key := antigravityInteractionsCacheKey(modelName, sessionKey)
+	if key == "" {
+		return false
+	}
+	if client, homeMode, errClient := currentAntigravityInteractionsKVClient(); homeMode {
+		if errClient != nil {
+			log.Errorf("home kv best-effort antigravity interactions state set failed prefix=cpa:antigravity:interactions-state:*: %v", errClient)
+			return false
+		}
+		raw, errMarshal := json.Marshal(state)
+		if errMarshal != nil {
+			return false
+		}
+		written, errSet := client.KVSet(ctx, antigravityInteractionsKVKey(modelName, sessionKey), raw, homekv.KVSetOptions{EX: AntigravityInteractionsCacheTTL})
+		if errSet != nil {
+			log.Errorf("home kv best-effort antigravity interactions state set failed prefix=cpa:antigravity:interactions-state:*: %v", errSet)
+			return false
+		}
+		return written
+	}
+
+	now := time.Now()
+	antigravityInteractionsMu.Lock()
+	defer antigravityInteractionsMu.Unlock()
+	stored, ok := antigravityInteractionsEntries[key]
+	if !ok || !now.Before(stored.ExpiresAt) {
+		antigravityInteractionsEvictionOrder = append(antigravityInteractionsEvictionOrder, key)
+	}
+	antigravityInteractionsEntries[key] = antigravityInteractionsEntry{
+		State:     state,
+		ExpiresAt: now.Add(AntigravityInteractionsCacheTTL),
+	}
+	if len(antigravityInteractionsEntries) > AntigravityInteractionsCacheMaxEntries {
+		evictOldestAntigravityInteractionsEntries(AntigravityInteractionsCacheEvictBatchSize)
+	}
+	return true
+}
+
+// GetAntigravityInteractionsState retrieves the continuation state for an
+// antigravity agent conversation, if still fresh. The ctx parameter carries
+// the caller's request context so a Home-backed lookup is canceled together
+// with the request instead of stalling it past cancellation.
+func GetAntigravityInteractionsState(ctx context.Context, modelName, sessionKey string) (AntigravityInteractionsState, bool) {
+	key := antigravityInteractionsCacheKey(modelName, sessionKey)
+	if key == "" {
+		return AntigravityInteractionsState{}, false
+	}
+	if client, homeMode, errClient := currentAntigravityInteractionsKVClient(); homeMode {
+		if errClient != nil {
+			return AntigravityInteractionsState{}, false
+		}
+		raw, ok, errGet := client.KVGet(ctx, antigravityInteractionsKVKey(modelName, sessionKey))
+		if errGet != nil || !ok || len(raw) == 0 {
+			return AntigravityInteractionsState{}, false
+		}
+		var state AntigravityInteractionsState
+		if errUnmarshal := json.Unmarshal(raw, &state); errUnmarshal != nil {
+			return AntigravityInteractionsState{}, false
+		}
+		if strings.TrimSpace(state.InteractionID) == "" && strings.TrimSpace(state.EnvironmentID) == "" {
+			return AntigravityInteractionsState{}, false
+		}
+		return state, true
+	}
+
+	now := time.Now()
+	antigravityInteractionsMu.Lock()
+	defer antigravityInteractionsMu.Unlock()
+	entry, ok := antigravityInteractionsEntries[key]
+	if !ok || !now.Before(entry.ExpiresAt) {
+		delete(antigravityInteractionsEntries, key)
+		return AntigravityInteractionsState{}, false
+	}
+	return entry.State, true
+}
+
+func evictOldestAntigravityInteractionsEntries(batch int) {
+	now := time.Now()
+	// First drop expired keys.
+	if len(antigravityInteractionsEntries) == 0 {
+		antigravityInteractionsEvictionOrder = nil
+		return
+	}
+	expired := make([]string, 0, len(antigravityInteractionsEntries))
+	for key := range antigravityInteractionsEntries {
+		if !now.Before(antigravityInteractionsEntries[key].ExpiresAt) {
+			expired = append(expired, key)
+		}
+	}
+	for _, key := range expired {
+		delete(antigravityInteractionsEntries, key)
+	}
+	// Then drop oldest inserted keys until back under the cap + batch headroom.
+	for len(antigravityInteractionsEntries) > AntigravityInteractionsCacheMaxEntries-batch && len(antigravityInteractionsEvictionOrder) > 0 {
+		var key string
+		key, antigravityInteractionsEvictionOrder = antigravityInteractionsEvictionOrder[0], antigravityInteractionsEvictionOrder[1:]
+		if _, exists := antigravityInteractionsEntries[key]; exists {
+			delete(antigravityInteractionsEntries, key)
+		}
+	}
+}
+
+// ClearAntigravityInteractionsCache empties the in-memory map (test helper).
+func ClearAntigravityInteractionsCache() {
+	antigravityInteractionsMu.Lock()
+	defer antigravityInteractionsMu.Unlock()
+	antigravityInteractionsEntries = make(map[string]antigravityInteractionsEntry)
+	antigravityInteractionsEvictionOrder = nil
+}
+
+// antigravityInteractionsCacheKey is the continuity boundary for the agent
+// conversation. The session key keeps independent client conversations from
+// sharing an opaque upstream interaction.
+func antigravityInteractionsCacheKey(modelName, sessionKey string) string {
+	modelName = strings.TrimSpace(modelName)
+	sessionKey = strings.TrimSpace(sessionKey)
+	if modelName == "" || sessionKey == "" {
+		return ""
+	}
+	return strings.Join([]string{"antigravity-interactions-state", modelName, sessionKey}, "\x00")
+}
+
+// antigravityInteractionsKVKey is the Home-backed key. It is deliberately a
+// distinct prefix from the reasoning-replay cache so the antigravity OAuth /
+// Code Assist path is never touched by the interactions-agent session cache.
+func antigravityInteractionsKVKey(modelName, sessionKey string) string {
+	return "cpa:antigravity:interactions-state:" + homekv.HashKeyPart(strings.TrimSpace(modelName)) + ":" + homekv.HashKeyPart(strings.TrimSpace(sessionKey))
+}
+
+// ResponseEdge is an optional notification point for the executor to record the
+// interaction id it observed in the upstream stream, decoupled from the read
+// loop. Keeping it out of the write path avoids hot-loop blocking.
+type ResponseEdge func(interactionID, environmentID string)

--- a/internal/cache/antigravity_interactions_session.go
+++ b/internal/cache/antigravity_interactions_session.go
@@ -98,7 +98,16 @@ func CacheAntigravityInteractionsStateBestEffort(ctx context.Context, modelName,
 	defer antigravityInteractionsMu.Unlock()
 	stored, ok := antigravityInteractionsEntries[key]
 	if !ok || !now.Before(stored.ExpiresAt) {
-		antigravityInteractionsEvictionOrder = append(antigravityInteractionsEvictionOrder, key)
+		// Drop any stale queue positions for this key (e.g. left behind by
+		// an expired entry deleted on Get): otherwise a later eviction pass
+		// processing the old position would delete this fresh entry.
+		kept := antigravityInteractionsEvictionOrder[:0]
+		for _, queued := range antigravityInteractionsEvictionOrder {
+			if queued != key {
+				kept = append(kept, queued)
+			}
+		}
+		antigravityInteractionsEvictionOrder = append(kept, key)
 	}
 	antigravityInteractionsEntries[key] = antigravityInteractionsEntry{
 		State:     state,

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
-	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -89,9 +88,6 @@ func (e *GeminiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	if apiKey != "" {
 		req.Header.Set("x-goog-api-key", apiKey)
 		req.Header.Del("Authorization")
-	} else {
-		req.Header.Del("x-goog-api-key")
-		req.Header.Del("Authorization")
 	}
 	applyGeminiHeaders(req, auth)
 	return nil
@@ -163,7 +159,6 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
-	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -281,7 +276,6 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
-	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
@@ -412,6 +406,16 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	fromProtocol := opts.SourceFormat.String()
 	originalTranslated := geminiInteractionsPayloadConfigSource(ctx, e.cfg, targetName, req.Payload, opts, false, helps.APIKeyModelIsCompat(req))
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, targetName, "interactions", fromProtocol, "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	// For the antigravity agent, a tool-calling continuation turn must resume
+	// the upstream interaction (previous_interaction_id + environment_id) and
+	// send only its function_result — NOT replay the assistant tool-call
+	// history. Otherwise Google rejects with "Cannot specify tool calls
+	// outside of Turn items". Applied AFTER payload-config so the rewrite is
+	// the final authoritative body.
+	body = helps.ApplyAntigravityInteractionsContinuation(ctx, targetName, originalRequestRawJSON(req, opts), opts, body)
+	// Metadata only: the full body may carry prompts, file content, and tool
+	// results that must not bypass the configured request-recording path.
+	log.Debugf("gemini interactions upstream REQUEST target=%s bytes=%d steps=%d", targetName, len(body), len(gjson.GetBytes(body, "input").Array()))
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/interactions", baseURL, glAPIVersion)
@@ -464,6 +468,12 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 		return resp, err
 	}
 	reporter.Publish(ctx, helps.ParseInteractionsUsage(data))
+	// Capture the upstream continuation coordinates so a later tool-calling
+	// turn can resume this antigravity agent (non-stream variant).
+	helps.CacheAntigravityInteractionsState(ctx, targetName, originalRequestRawJSON(req, opts), opts, data)
+	// Metadata only: success bodies can embed full model output; errors keep
+	// the summarized body for diagnostics.
+	log.Debugf("gemini interactions non-stream upstream response: status=%d bytes=%d", httpResp.StatusCode, len(data))
 	targetFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	var param any
 	out := sdktranslator.TranslateNonStream(ctx, sdktranslator.FormatInteractions, targetFormat, req.Model, opts.OriginalRequest, body, data, &param)
@@ -493,6 +503,13 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	originalTranslated := geminiInteractionsPayloadConfigSource(ctx, e.cfg, targetName, req.Payload, opts, true, helps.APIKeyModelIsCompat(req))
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, targetName, "interactions", fromProtocol, "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetBoolIfDifferent(body, "stream", true)
+	// For the antigravity agent, a tool-calling continuation turn must resume
+	// the upstream interaction (previous_interaction_id + environment_id) and
+	// send only its function_result — NOT replay the assistant tool-call
+	// history. Otherwise Google rejects with "Cannot specify tool calls
+	// outside of Turn items". Applied AFTER payload-config so the rewrite is
+	// the final authoritative body.
+	body = helps.ApplyAntigravityInteractionsContinuation(ctx, targetName, originalRequestRawJSON(req, opts), opts, body)
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/interactions", baseURL, glAPIVersion)
 	httpReq, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -572,6 +589,11 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 				if detail, ok := helps.ParseInteractionsStreamUsage(payload); ok {
 					reporter.Publish(ctx, detail)
 				}
+				// Capture the upstream continuation coordinates so a later
+				// tool-calling turn can resume this antigravity agent instead
+				// of replaying the full assistant tool-call history (Google:
+				// "Cannot specify tool calls outside of Turn items").
+				helps.CacheAntigravityInteractionsState(ctx, targetName, originalRequest, opts, payload)
 			}
 			if responseFormat == sdktranslator.FormatInteractions {
 				visibleFrame := append(bytes.TrimRight(rawFrame, "\r\n"), '\n', '\n')
@@ -648,7 +670,6 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 	translatedReq = helps.SetStringIfDifferent(translatedReq, "model", baseModel)
-	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
 	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
@@ -684,7 +705,6 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	cliproxyexecutor.MarkUpstreamAttempt(ctx)
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -975,4 +995,13 @@ func fixGeminiImageAspectRatio(modelName string, rawJSON []byte) []byte {
 		}
 	}
 	return rawJSON
+}
+
+// originalRequestRawJSON resolves the client-facing request body the same way
+// the executor does elsewhere (opts.OriginalRequest falls back to Payload).
+func originalRequestRawJSON(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) []byte {
+	if len(opts.OriginalRequest) > 0 {
+		return opts.OriginalRequest
+	}
+	return req.Payload
 }

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -88,6 +89,9 @@ func (e *GeminiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	if apiKey != "" {
 		req.Header.Set("x-goog-api-key", apiKey)
 		req.Header.Del("Authorization")
+	} else {
+		req.Header.Del("x-goog-api-key")
+		req.Header.Del("Authorization")
 	}
 	applyGeminiHeaders(req, auth)
 	return nil
@@ -159,6 +163,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -276,6 +281,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
@@ -670,6 +676,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 	translatedReq = helps.SetStringIfDifferent(translatedReq, "model", baseModel)
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
 	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
@@ -705,6 +712,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	cliproxyexecutor.MarkUpstreamAttempt(ctx)
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)

--- a/internal/runtime/executor/helps/antigravity_interactions_state.go
+++ b/internal/runtime/executor/helps/antigravity_interactions_state.go
@@ -1,0 +1,371 @@
+package helps
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// goframeCacheAntigravityInteractionsState records the upstream
+// interaction_id + environment_id observed on an antigravity Agents
+// (Interactions API) stream, keyed by conversation session. It is a
+// best-effort, out-of-band capture: it never blocks the stream read loop and
+// never rewrites the response.
+//
+// Only antigravity model names are considered. The reasoning-replay cache used
+// by the antigravity OAuth / Code Assist path is never touched (distinct KV
+// prefix in internal/cache).
+func CacheAntigravityInteractionsState(ctx context.Context, modelName string, originalRequest []byte, opts cliproxyexecutor.Options, payload []byte) {
+	modelName = strings.TrimSpace(modelName)
+	if !strings.Contains(strings.ToLower(modelName), "antigravity") {
+		return
+	}
+	interactionID := strings.TrimSpace(firstNonEmptyString(
+		gjson.GetBytes(payload, "interaction.id").String(),
+		gjson.GetBytes(payload, "id").String(),
+	))
+	envID := strings.TrimSpace(firstNonEmptyString(
+		gjson.GetBytes(payload, "interaction.environment_id").String(),
+		gjson.GetBytes(payload, "environment_id").String(),
+		gjson.GetBytes(payload, "interaction.environment.id").String(),
+		gjson.GetBytes(payload, "environment.id").String(),
+	))
+	// Streamed tool calls arrive as step.start frames carrying step.id +
+	// step.name but no interaction coordinates. Capture those names even when
+	// this frame has none — a later Responses-style continuation (call_id +
+	// output only) needs them to fill function_result.name.
+	stepNames := map[string]string{}
+	if step := gjson.GetBytes(payload, "step"); step.Exists() {
+		if strings.EqualFold(strings.TrimSpace(step.Get("type").String()), "function_call") {
+			callID := strings.TrimSpace(step.Get("id").String())
+			name := strings.TrimSpace(step.Get("name").String())
+			if callID != "" && name != "" {
+				stepNames[callID] = name
+			}
+		}
+	}
+	if interactionID == "" && envID == "" && len(stepNames) == 0 {
+		return
+	}
+	sessionKey := AntigravityExecSessionKey(opts, originalRequest)
+	if sessionKey == "" {
+		log.Debugf("antigravity interactions state: no session key for model=%s", modelName)
+		return
+	}
+	// Merge with any previously cached coordinates: stream events may carry
+	// only one of the two (e.g. a completion event repeating just the ID), and
+	// overwriting the whole entry would blank the missing coordinate, leaving
+	// the next tool-result turn unable to resume.
+	//
+	// The read runs on a detached context: this capture is best-effort and
+	// must never block (or outlive) the stream read loop — a slow Home store
+	// would otherwise stall frame processing and break connection pooling.
+	state := internalcache.AntigravityInteractionsState{
+		InteractionID: interactionID,
+		EnvironmentID: envID,
+	}
+	if existing, ok := internalcache.GetAntigravityInteractionsState(context.Background(), modelName, sessionKey); ok {
+		if state.InteractionID == "" {
+			state.InteractionID = existing.InteractionID
+		}
+		if state.EnvironmentID == "" {
+			state.EnvironmentID = existing.EnvironmentID
+		}
+		state.ToolNames = existing.ToolNames
+	}
+	// Record call_id -> function name from any function_call steps in this
+	// payload so a later Responses-style tool-result turn (call_id + output
+	// only) can still be given the required function_result.name. Non-stream
+	// responses may nest the array under "interaction.steps".
+	names := map[string]string{}
+	for k, v := range state.ToolNames {
+		names[k] = v
+	}
+	for k, v := range stepNames {
+		names[k] = v
+	}
+	stepsArrays := [][]gjson.Result{}
+	for _, path := range []string{"steps", "interaction.steps"} {
+		if arr := gjson.GetBytes(payload, path); arr.IsArray() {
+			stepsArrays = append(stepsArrays, []gjson.Result{})
+			arr.ForEach(func(_, step gjson.Result) bool {
+				stepsArrays[len(stepsArrays)-1] = append(stepsArrays[len(stepsArrays)-1], step)
+				return true
+			})
+		}
+	}
+	for _, steps := range stepsArrays {
+		for _, step := range steps {
+			if !strings.EqualFold(strings.TrimSpace(step.Get("type").String()), "function_call") {
+				continue
+			}
+			callID := strings.TrimSpace(step.Get("id").String())
+			name := strings.TrimSpace(step.Get("name").String())
+			if callID != "" && name != "" {
+				names[callID] = name
+			}
+		}
+	}
+	if len(names) > 0 {
+		state.ToolNames = names
+	}
+	internalcache.CacheAntigravityInteractionsStateBestEffort(ctx, modelName, sessionKey, state)
+	// Also index by the response id the client will reference in its next
+	// Responses tool-result turn. A standard HTTP Responses loop sends only
+	// previous_response_id + function_call_output — session.Enrich cannot
+	// re-derive the original identity from that input, so the follow-up has no
+	// session key and must resolve the state through this caller-scoped alias.
+	if responseID := strings.TrimSpace(firstNonEmptyString(
+		gjson.GetBytes(payload, "interaction.id").String(),
+		gjson.GetBytes(payload, "id").String(),
+	)); responseID != "" {
+		internalcache.CacheAntigravityInteractionsStateBestEffort(ctx, modelName, "response-id:"+responseID, state)
+	}
+	log.Debugf("antigravity interactions state: cached model=%s session=%s interaction=%s env=%s", modelName, sessionKey, state.InteractionID, state.EnvironmentID)
+}
+
+// antigravityConversationPrefixKey derives a continuity key from an OpenAI
+// chat/completions body that carries no explicit session identifier. It hashes
+// the stable conversation prefix: every message up to and including the LAST
+// user message. The initial tool-calling turn ([system, user]) and its
+// tool-result continuation ([system, user, assistant(tool_calls), tool])
+// share this prefix, so both map to the same key while a new user turn starts
+// a fresh one.
+func antigravityConversationPrefixKey(raw []byte) string {
+	msgs := gjson.GetBytes(raw, "messages")
+	if !msgs.IsArray() {
+		return ""
+	}
+	// Canonical JSON per message (sorted keys, no whitespace) so the hash is
+	// stable across clients that re-serialize the history differently.
+	canonical := func(msg gjson.Result) string {
+		v := msg.Value()
+		b, err := json.Marshal(v)
+		if err != nil {
+			return msg.Raw
+		}
+		return string(b)
+	}
+	var prefix []string
+	lastUser := -1
+	msgs.ForEach(func(_, msg gjson.Result) bool {
+		prefix = append(prefix, canonical(msg))
+		if strings.EqualFold(strings.TrimSpace(msg.Get("role").String()), "user") {
+			lastUser = len(prefix) - 1
+		}
+		return true
+	})
+	if lastUser < 0 {
+		return ""
+	}
+	hasher := sha256.New()
+	for i := 0; i <= lastUser; i++ {
+		hasher.Write([]byte(prefix[i]))
+		hasher.Write([]byte{0})
+	}
+	return "chat:" + hex.EncodeToString(hasher.Sum(nil))[:16]
+}
+
+// antigravityExecSessionKey derives a stable continuity key for the agent
+// conversation. It mirrors the reasoning-replay scope derivation but stays
+// independent so the interactions-agent cache never collides with the OAuth /
+// Code Assist replay cache.
+func AntigravityExecSessionKey(opts cliproxyexecutor.Options, originalRequest []byte) string {
+	// Namespace every key by the downstream caller scope: two API keys using
+	// the same explicit session value (e.g. "Session-Id: default") must never
+	// share one upstream interaction.
+	callerScope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey)
+	namespaced := func(key string) string {
+		if callerScope == "" {
+			return key
+		}
+		return "caller:" + callerScope + "\x00" + key
+	}
+	// Reuse the full session-affinity extraction used for credential
+	// selection: it recognizes every supported explicit signal
+	// (X-Claude-Code-Session-Id, Session-Id/Session_id, X-Session-ID,
+	// X-Session-Affinity, X-Client-Request-Id, body session_id/sessionId,
+	// conversation id, prompt_cache_key, metadata.user_id, execution
+	// metadata). Keeping one list avoids drift between auth selection and
+	// continuation keying.
+	if value := strings.TrimSpace(cliproxyauth.ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata)); value != "" {
+		return namespaced("session:" + value)
+	}
+	if value := strings.TrimSpace(cliproxyauth.ExtractSessionID(opts.Headers, originalRequest, opts.Metadata)); value != "" {
+		return namespaced("session:" + value)
+	}
+	// Context-derived identity (conductor runs session.Enrich before exec):
+	// stable per downstream caller+conversation even when the client sends no
+	// explicit marker. This isolates identical conversation prefixes coming
+	// from different callers so they never share one upstream interaction.
+	if value := DerivedSessionID(opts.Metadata); value != "" {
+		return namespaced("derived:" + value)
+	}
+	// Fallback for chat/completions clients (e.g. Hermes delegation) that send
+	// no explicit session marker: derive a stable key from the conversation
+	// prefix. Antigravity function calling is stateful-only upstream, so
+	// without this key the proxy could never attach previous_interaction_id to
+	// the tool-result turn.
+	for _, raw := range [][]byte{opts.OriginalRequest, originalRequest} {
+		if len(raw) == 0 {
+			continue
+		}
+		if key := antigravityConversationPrefixKey(raw); key != "" {
+			return namespaced(key)
+		}
+	}
+	return ""
+}
+
+// firstNonEmptyString returns the first non-empty string argument.
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// originalRequestRawJSON resolves the client-facing request body the same way
+// the executor does elsewhere (opts.OriginalRequest falls back to Payload).
+func originalRequestRawJSON(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) []byte {
+	if len(opts.OriginalRequest) > 0 {
+		return opts.OriginalRequest
+	}
+	return req.Payload
+}
+
+// goframeApplyAntigravityInteractionsContinuation rewrites a translated
+// interactions body so a tool-calling continuation turn resumes the upstream
+// antigravity agent interaction instead of replaying the full assistant
+// tool-call history.
+//
+// When the incoming conversation carries a function_result (i.e. the client is
+// responding to a prior function_call) and we have a cached continuation state
+// for this session, this function:
+//   - attaches previous_interaction_id + environment_id from the cache, and
+//   - keeps ONLY the function_result step(s) in input (dropping the replayed
+//     user_input / model_output / function_call history that Google rejects).
+//
+// When no continuation state is present, the body is returned unchanged.
+func ApplyAntigravityInteractionsContinuation(ctx context.Context, modelName string, originalRequest []byte, opts cliproxyexecutor.Options, body []byte) []byte {
+	modelName = strings.TrimSpace(modelName)
+	if !strings.Contains(strings.ToLower(modelName), "antigravity") {
+		return body
+	}
+	// Only act when this turn actually carries a tool result to feed back.
+	hasToolResult := false
+	root := gjson.ParseBytes(body)
+	if root.Get("input").IsArray() {
+		root.Get("input").ForEach(func(_, item gjson.Result) bool {
+			if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "function_result") {
+				hasToolResult = true
+				return false
+			}
+			return true
+		})
+	}
+	if !hasToolResult {
+		return body
+	}
+	sessionKey := AntigravityExecSessionKey(opts, originalRequest)
+	state, ok := internalcache.AntigravityInteractionsState{}, false
+	if sessionKey != "" {
+		state, ok = internalcache.GetAntigravityInteractionsState(ctx, modelName, sessionKey)
+	}
+	// Responses tool loops reference the prior turn by previous_response_id /
+	// previous_interaction_id; the state was indexed under that id at capture
+	// time (caller-scoped), so try the alias entry even when no session key
+	// could be derived from this follow-up.
+	if !ok {
+		for _, path := range []string{"previous_response_id", "previous_interaction_id"} {
+			if responseID := strings.TrimSpace(gjson.GetBytes(body, path).String()); responseID != "" {
+				if state, ok = internalcache.GetAntigravityInteractionsState(ctx, modelName, "response-id:"+responseID); ok {
+					break
+				}
+			}
+		}
+	}
+	if !ok {
+		log.Debugf("antigravity continuation: no cached state model=%s session=%s", modelName, sessionKey)
+		return body
+	}
+	log.Debugf("antigravity continuation: resuming interaction=%s env=%s session=%s", state.InteractionID, state.EnvironmentID, sessionKey)
+
+	// Rebuild the body keeping only function_result input items so the
+	// continuation is a clean "turn" on the prior interaction.
+	//
+	// Chat Completions tool loops send role:"tool" messages with only
+	// tool_call_id + content, so their function_result steps may lack "name"
+	// — but the Interactions function-result schema requires it. Collect the
+	// call_id -> name mapping from the replayed assistant function_call steps
+	// first, then fill any missing names before dropping the history.
+	namesByCallID := map[string]string{}
+	if root.Get("input").IsArray() {
+		root.Get("input").ForEach(func(_, item gjson.Result) bool {
+			if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "function_call") {
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				name := strings.TrimSpace(item.Get("name").String())
+				if callID != "" && name != "" {
+					namesByCallID[callID] = name
+				}
+			}
+			return true
+		})
+	}
+	kept := make([][]byte, 0, 1)
+	if root.Get("input").IsArray() {
+		root.Get("input").ForEach(func(_, item gjson.Result) bool {
+			if !strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "function_result") {
+				return true
+			}
+			result := []byte(item.Raw)
+			if strings.TrimSpace(item.Get("name").String()) == "" {
+				callID := strings.TrimSpace(item.Get("call_id").String())
+				name := namesByCallID[callID]
+				if name == "" {
+					// Responses tool loops do not replay the function_call,
+					// so fall back to the cached call_id -> name mapping
+					// captured from the prior upstream interaction.
+					name = state.ToolNames[callID]
+				}
+				if name != "" {
+					result, _ = sjson.SetBytes(result, "name", name)
+				}
+			}
+			kept = append(kept, result)
+			return true
+		})
+	}
+	out := []byte(`{"input":[]}`)
+	out, _ = sjson.SetBytes(out, "agent", modelName)
+	if state.InteractionID != "" {
+		out, _ = sjson.SetBytes(out, "previous_interaction_id", state.InteractionID)
+	}
+	// The continuation requires the field literally named "environment"
+	// (carrying the environment_id captured from the prior interaction).
+	// Google returns 400 "Missing required field 'environment'" if it is
+	// sent as "environment_id" instead.
+	if state.EnvironmentID != "" {
+		out, _ = sjson.SetBytes(out, "environment", state.EnvironmentID)
+	}
+	// Preserve stream / payload config the translator may have set.
+	if v := root.Get("stream"); v.Exists() {
+		out, _ = sjson.SetBytes(out, "stream", v.Bool())
+	}
+	out, _ = sjson.SetRawBytes(out, "input", translatorcommon.JoinRawArray(kept))
+	// Metadata only: the continuation body carries the caller's tool output.
+	log.Debugf("antigravity continuation: resuming interaction=%s env=%s results=%d", state.InteractionID, state.EnvironmentID, len(kept))
+	return out
+}

--- a/internal/runtime/executor/helps/antigravity_interactions_state.go
+++ b/internal/runtime/executor/helps/antigravity_interactions_state.go
@@ -67,14 +67,14 @@ func CacheAntigravityInteractionsState(ctx context.Context, modelName string, or
 	// overwriting the whole entry would blank the missing coordinate, leaving
 	// the next tool-result turn unable to resume.
 	//
-	// The read runs on a detached context: this capture is best-effort and
-	// must never block (or outlive) the stream read loop — a slow Home store
-	// would otherwise stall frame processing and break connection pooling.
+	// The read uses the caller's context so client cancellation aborts a
+	// stalled Home-backed lookup instead of blocking response delivery; the
+	// merge stays best-effort (a miss just keeps this frame's coordinates).
 	state := internalcache.AntigravityInteractionsState{
 		InteractionID: interactionID,
 		EnvironmentID: envID,
 	}
-	if existing, ok := internalcache.GetAntigravityInteractionsState(context.Background(), modelName, sessionKey); ok {
+	if existing, ok := internalcache.GetAntigravityInteractionsState(ctx, modelName, sessionKey); ok {
 		if state.InteractionID == "" {
 			state.InteractionID = existing.InteractionID
 		}
@@ -129,7 +129,14 @@ func CacheAntigravityInteractionsState(ctx context.Context, modelName string, or
 		gjson.GetBytes(payload, "interaction.id").String(),
 		gjson.GetBytes(payload, "id").String(),
 	)); responseID != "" {
-		internalcache.CacheAntigravityInteractionsStateBestEffort(ctx, modelName, "response-id:"+responseID, state)
+		// Caller-scoped like the primary session key: without the scope, a
+		// caller presenting another caller's known previous_response_id
+		// could resolve that caller's interaction coordinates.
+		aliasKey := "response-id:" + responseID
+		if callerScope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); callerScope != "" {
+			aliasKey = "caller:" + callerScope + "\x00" + aliasKey
+		}
+		internalcache.CacheAntigravityInteractionsStateBestEffort(ctx, modelName, aliasKey, state)
 	}
 	log.Debugf("antigravity interactions state: cached model=%s session=%s interaction=%s env=%s", modelName, sessionKey, state.InteractionID, state.EnvironmentID)
 }
@@ -198,11 +205,18 @@ func AntigravityExecSessionKey(opts cliproxyexecutor.Options, originalRequest []
 	// conversation id, prompt_cache_key, metadata.user_id, execution
 	// metadata). Keeping one list avoids drift between auth selection and
 	// continuation keying.
-	if value := strings.TrimSpace(cliproxyauth.ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata)); value != "" {
-		return namespaced("session:" + value)
-	}
-	if value := strings.TrimSpace(cliproxyauth.ExtractSessionID(opts.Headers, originalRequest, opts.Metadata)); value != "" {
-		return namespaced("session:" + value)
+	//
+	// NOTE: ExtractSessionID falls back to message-content hashes ("msg:…")
+	// when no explicit signal exists. Those are unstable across turns — the
+	// initial [system,user] turn hashes short while a continuation carrying
+	// assistant text hashes full — so a lookup on the continuation turn
+	// would miss the state cached on the initial turn. Skip them here: the
+	// conversation-prefix fallback below is stable across turns by design
+	// (it hashes only up to the last user message).
+	for _, raw := range [][]byte{opts.OriginalRequest, originalRequest} {
+		if value := strings.TrimSpace(cliproxyauth.ExtractSessionID(opts.Headers, raw, opts.Metadata)); value != "" && !strings.HasPrefix(value, "msg:") {
+			return namespaced("session:" + value)
+		}
 	}
 	// Context-derived identity (conductor runs session.Enrich before exec):
 	// stable per downstream caller+conversation even when the client sends no
@@ -291,7 +305,11 @@ func ApplyAntigravityInteractionsContinuation(ctx context.Context, modelName str
 	if !ok {
 		for _, path := range []string{"previous_response_id", "previous_interaction_id"} {
 			if responseID := strings.TrimSpace(gjson.GetBytes(body, path).String()); responseID != "" {
-				if state, ok = internalcache.GetAntigravityInteractionsState(ctx, modelName, "response-id:"+responseID); ok {
+				aliasKey := "response-id:" + responseID
+				if callerScope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); callerScope != "" {
+					aliasKey = "caller:" + callerScope + "\x00" + aliasKey
+				}
+				if state, ok = internalcache.GetAntigravityInteractionsState(ctx, modelName, aliasKey); ok {
 					break
 				}
 			}

--- a/internal/runtime/executor/helps/antigravity_interactions_state_test.go
+++ b/internal/runtime/executor/helps/antigravity_interactions_state_test.go
@@ -1,0 +1,161 @@
+package helps
+
+import (
+	"context"
+	"testing"
+
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+func TestGoframeCacheAntigravityInteractionsState(t *testing.T) {
+	internalcache.ClearAntigravityInteractionsCache()
+	const model = "antigravity-preview-05-2026"
+	opts := cliproxyexecutor.Options{}
+	opts.Headers = map[string][]string{"Session-Id": {"sess-123"}}
+
+	payload := []byte(`{"interaction":{"id":"inter_abc","environment_id":"env_def","status":"in_progress"}}`)
+	CacheAntigravityInteractionsState(context.Background(), model, nil, opts, payload)
+
+	// The session key now comes from the shared ExtractSessionID extraction,
+	// which prefixes explicit header ids with "codex:".
+	state, ok := internalcache.GetAntigravityInteractionsState(context.Background(), model, "session:codex:sess-123")
+	if !ok {
+		t.Fatalf("expected cached state")
+	}
+	if state.InteractionID != "inter_abc" {
+		t.Errorf("InteractionID = %q, want inter_abc", state.InteractionID)
+	}
+	if state.EnvironmentID != "env_def" {
+		t.Errorf("EnvironmentID = %q, want env_def", state.EnvironmentID)
+	}
+}
+
+func TestGoframeCacheIgnoresNonAntigravity(t *testing.T) {
+	internalcache.ClearAntigravityInteractionsCache()
+	opts := cliproxyexecutor.Options{}
+	opts.Headers = map[string][]string{"Session-Id": {"sess"}, "namespace_key": {"x"}}
+	payload := []byte(`{"interaction":{"id":"inter_x","environment_id":"env_x"}}`)
+	CacheAntigravityInteractionsState(context.Background(), "gemini-3.7-flash", nil, opts, payload)
+	if _, ok := internalcache.GetAntigravityInteractionsState(context.Background(), "gemini-3.7-flash", "responses:sess"); ok {
+		t.Fatalf("should not cache state for non-antigravity model")
+	}
+}
+
+func TestGoframeApplyAntigravityInteractionsContinuation(t *testing.T) {
+	internalcache.ClearAntigravityInteractionsCache()
+	const model = "antigravity-preview-05-2026"
+	internalcache.CacheAntigravityInteractionsState(model, "session:codex:sess-9", internalcache.AntigravityInteractionsState{
+		InteractionID: "inter_cont",
+		EnvironmentID: "env_cont",
+	})
+
+	opts := cliproxyexecutor.Options{}
+	opts.Headers = map[string][]string{"Session-Id": {"sess-9"}, "namespace_key": {"x"}}
+
+	// A translated continuation body that replays the full history:
+	// user_input -> tool -> function_result. The proxy must keep ONLY the
+	// function_result and attach previous_interaction_id + environment_id.
+	body := []byte(`{
+		"agent":"` + model + `",
+		"input":[
+			{"type":"user_input","content":[{"type":"text","text":"what is 42*17"}]},
+			{"type":"model_output","content":[]},
+			{"type":"function_result","name":"calculator","call_id":"c1","result":"714"}
+		],
+		"stream":true
+	}`)
+
+	out := ApplyAntigravityInteractionsContinuation(context.Background(), model, []byte(`{"model":"`+model+`"}`), opts, body)
+	root := gjson.ParseBytes(out)
+
+	if got := root.Get("previous_interaction_id").String(); got != "inter_cont" {
+		t.Errorf("previous_interaction_id = %q, want inter_cont", got)
+	}
+	if got := root.Get("environment").String(); got != "env_cont" {
+		t.Errorf("environment = %q, want env_cont (field must be literally 'environment')", got)
+	}
+	// Only function_result should survive in input.
+	types := make([]string, 0, 1)
+	root.Get("input").ForEach(func(_, item gjson.Result) bool {
+		types = append(types, item.Get("type").String())
+		return true
+	})
+	if len(types) != 1 || types[0] != "function_result" {
+		t.Fatalf("input types = %v, want only [function_result]", types)
+	}
+	if got := root.Get("input.0.result").String(); got != "714" {
+		t.Errorf("function_result.result = %q, want 714", got)
+	}
+}
+
+func TestGoframeApplyNoContinuation(t *testing.T) {
+	internalcache.ClearAntigravityInteractionsCache()
+	const model = "antigravity-preview-05-2026"
+	// No cached state -> body must be unchanged.
+	opts := cliproxyexecutor.Options{}
+	opts.Headers = map[string][]string{"Session-Id": {"sess-none"}, "namespace_key": {"x"}}
+
+	body := []byte(`{"agent":"` + model + `","input":[{"type":"function_result","name":"f","call_id":"c","result":"1"}],"stream":true}`)
+	out := ApplyAntigravityInteractionsContinuation(context.Background(), model, nil, opts, body)
+	if string(out) != string(body) {
+		t.Fatalf("expected unchanged body, got %s", string(out))
+	}
+}
+
+// TestAntigravityConversationPrefixKeyFallback verifies the chat/completions
+// fallback: a client that sends no Session-Id/session_id still gets a stable
+// continuity key, because the tool-result turn shares the conversation prefix
+// (everything up to the last user message) with the initial turn.
+func TestAntigravityConversationPrefixKeyFallback(t *testing.T) {
+	internalcache.ClearAntigravityInteractionsCache()
+	const model = "antigravity-preview-05-2026"
+
+	turn1 := []byte(`{"model":"antigravity","messages":[
+		{"role":"system","content":"You are helpful."},
+		{"role":"user","content":"Summarize /tmp/x"}
+	]}`)
+	turn2 := []byte(`{"model":"antigravity","messages":[
+		{"role":"system","content":"You are helpful."},
+		{"role":"user","content":"Summarize /tmp/x"},
+		{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/tmp/x\"}"}}]},
+		{"role":"tool","tool_call_id":"c1","content":"file body"}
+	]}`)
+
+	opts := cliproxyexecutor.Options{} // no headers, no metadata
+	key1 := AntigravityExecSessionKey(opts, turn1)
+	key2 := AntigravityExecSessionKey(opts, turn2)
+	if key1 == "" || key2 == "" {
+		t.Fatalf("expected non-empty fallback keys, got %q and %q", key1, key2)
+	}
+	if key1 != key2 {
+		t.Fatalf("prefix keys diverged: turn1=%q turn2=%q", key1, key2)
+	}
+
+	// Cache under turn1's key, then confirm continuation resolves via turn2.
+	payload := []byte(`{"id":"inter_fb","environment_id":"env_fb"}`)
+	CacheAntigravityInteractionsState(context.Background(), model, turn1, opts, payload)
+
+	body := []byte(`{
+		"agent":"` + model + `",
+		"input":[{"type":"function_result","name":"read_file","call_id":"c1","result":"file body"}]
+	}`)
+	out := ApplyAntigravityInteractionsContinuation(context.Background(), model, turn2, opts, body)
+	root := gjson.ParseBytes(out)
+	if got := root.Get("previous_interaction_id").String(); got != "inter_fb" {
+		t.Errorf("previous_interaction_id = %q, want inter_fb (continuation must resolve via prefix key)", got)
+	}
+	if got := root.Get("environment").String(); got != "env_fb" {
+		t.Errorf("environment = %q, want env_fb", got)
+	}
+
+	// A NEW user message must start a fresh key.
+	turn3 := []byte(`{"model":"antigravity","messages":[
+		{"role":"system","content":"You are helpful."},
+		{"role":"user","content":"Different question"}
+	]}`)
+	if key3 := AntigravityExecSessionKey(opts, turn3); key3 == key1 {
+		t.Fatalf("new user turn must produce a different session key")
+	}
+}

--- a/sdk/api/handlers/gemini/interactions_handlers.go
+++ b/sdk/api/handlers/gemini/interactions_handlers.go
@@ -15,7 +15,12 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-const interactionsAgentAuthSelectionModel = "gemini-2.5-flash"
+// interactionsAgentAuthSelectionModel is used only for credential selection
+// when routing native agent requests. It must be an id present in the static
+// Gemini catalog (gemini-interactions credentials register GetGeminiModels()),
+// and it matches the antigravity default documented by Google: the agent is
+// powered by Gemini 3.6 Flash unless agent_config overrides it.
+const interactionsAgentAuthSelectionModel = "gemini-3.6-flash"
 
 type interactionsRequestTarget struct {
 	Model  string
@@ -74,6 +79,10 @@ func buildInteractionsExecutionRequest(target interactionsRequestTarget, modelNa
 	forcedProvider := ""
 	authSelectionModel := ""
 	if target.Agent != "" {
+		// The agent id itself is not in any model catalog, so selection needs
+		// a catalog-backed id; use the documented antigravity default
+		// (Gemini 3.6 Flash) so --local-model deployments still resolve a
+		// credential.
 		forcedProvider = GeminiInteractions
 		authSelectionModel = interactionsAgentAuthSelectionModel
 	}

--- a/sdk/api/handlers/gemini/interactions_handlers_test.go
+++ b/sdk/api/handlers/gemini/interactions_handlers_test.go
@@ -93,6 +93,8 @@ func TestBuildInteractionsExecutionRequestUsesAgentAuthSelectionModel(t *testing
 	if req.ForcedProvider != "gemini-interactions" {
 		t.Fatalf("ForcedProvider = %q, want gemini-interactions", req.ForcedProvider)
 	}
+	// Auth selection uses the catalog-backed antigravity default so
+	// --local-model deployments resolve a credential.
 	if req.AuthSelectionModel != interactionsAgentAuthSelectionModel {
 		t.Fatalf("AuthSelectionModel = %q, want %q", req.AuthSelectionModel, interactionsAgentAuthSelectionModel)
 	}
@@ -204,7 +206,10 @@ func TestInteractionsAgentUsesNativeInteractionsEndpoint(t *testing.T) {
 	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("manager.Register(): %v", errRegister)
 	}
-	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: interactionsAgentAuthSelectionModel}})
+	// Register both the agent id (the request's model) and a backing Gemini
+	// model: agent auth selection is unfiltered, so any registered model on
+	// the provider makes the credential eligible.
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "agents/test-agent"}, {ID: "gemini-3.6-flash"}})
 	t.Cleanup(func() {
 		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
 	})


### PR DESCRIPTION
Stateful continuation for antigravity agent tool-calling cycles: TTL session cache (interaction_id + environment_id + tool-name map) + canonical fallback key for stateless clients without Session-Id.

Item 1 of #5190. Split from #5022. Zero translator changes: cache + executor state + gemini wiring + tests.