### PR TITLE
fix(antigravity): expose Gemini 3.8 Flash medium/low tiers

### DIFF
--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -120,6 +120,7 @@ func tryRefreshModels(ctx context.Context, label string) {
 		log.Warnf("%s: fetch failed from all URLs, keeping current data", label)
 		return
 	}
+	ensureAntigravityFlash38Tiers(parsed)
 
 	// Detect changes before updating store.
 	changed := detectChangedProviders(oldData, parsed)
@@ -295,11 +296,66 @@ func mergeProviderNames(existing, incoming []string) []string {
 	return merged
 }
 
+// ensureAntigravityFlash38Tiers guarantees the Medium and Low tiers of Gemini 3.8
+// Flash are present in the antigravity catalog. The daily Antigravity endpoint
+// (v1internal:fetchAvailableModels) serves gemini-3.8-flash-{high,medium,low} as three
+// distinct upstream model ids (the reasoning tier is encoded in the id, not in a
+// thinkingLevel parameter), but the published models.json lists only
+// gemini-3.8-flash-high. Without the other two tiers the medium/low variants are
+// unreachable through the proxy. We clone them from the -high entry so context and
+// capability metadata stay consistent, only adding a tier when it is absent.
+//
+// This must run on BOTH catalog load paths — the embedded fallback
+// (loadModelsFromBytes) and the remote refresh (tryRefreshModels) — because a remote
+// refresh replaces the store wholesale; injecting on a single path lets the next
+// refresh silently drop the added tiers.
+//
+// Note: the same registry gap affects other tiered Antigravity flash families
+// (e.g. 3.6/3.7), which the daily endpoint also serves in three tiers; the approach
+// generalizes if maintainers prefer to cover them here as well.
+func ensureAntigravityFlash38Tiers(parsed *staticModelsJSON) {
+	if parsed == nil {
+		return
+	}
+	var base *ModelInfo
+	have := make(map[string]bool, len(parsed.Antigravity))
+	for _, m := range parsed.Antigravity {
+		if m == nil {
+			continue
+		}
+		have[m.ID] = true
+		if m.ID == "gemini-3.8-flash-high" {
+			base = m
+		}
+	}
+	if base == nil {
+		return
+	}
+	tiers := []struct {
+		id, display string
+	}{
+		{"gemini-3.8-flash-medium", "Gemini 3.8 Flash (Medium)"},
+		{"gemini-3.8-flash-low", "Gemini 3.8 Flash (Low)"},
+	}
+	for _, t := range tiers {
+		if have[t.id] {
+			continue
+		}
+		clone := *base
+		clone.ID = t.id
+		clone.Name = t.id
+		clone.DisplayName = t.display
+		clone.Description = t.display
+		parsed.Antigravity = append(parsed.Antigravity, &clone)
+	}
+}
+
 func loadModelsFromBytes(data []byte, source string) error {
 	var parsed staticModelsJSON
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return fmt.Errorf("%s: decode models catalog: %w", source, err)
 	}
+	ensureAntigravityFlash38Tiers(&parsed)
 	if err := validateModelsCatalog(&parsed); err != nil {
 		return fmt.Errorf("%s: validate models catalog: %w", source, err)
 	}


### PR DESCRIPTION
## The Problem

The Antigravity daily endpoint (`v1internal:fetchAvailableModels`) exposes **three distinct
upstream model ids** for Gemini 3.8 Flash — `gemini-3.8-flash-high`, `gemini-3.8-flash-medium`,
and `gemini-3.8-flash-low`. The reasoning tier is encoded in the model id itself, not in a
`thinkingLevel` request parameter, so the three tiers are genuinely separate backends.

However, the published catalog (`models.json`, both the embedded fallback and the remote
`router-for-me/models` feed) lists only `gemini-3.8-flash-high` under `antigravity`. As a
result the Medium and Low tiers are **unreachable through the proxy**: they never appear in
`/v1/models` and a request for them is rejected, even though the account is entitled to them
and `agy models` lists all three.

## The Solution

Add `ensureAntigravityFlash38Tiers`, which — when `gemini-3.8-flash-high` is present in the
antigravity section but a tier is missing — clones the `-high` entry into
`gemini-3.8-flash-medium` / `gemini-3.8-flash-low` (correct id + display name), preserving the
context/capability metadata. It only adds a tier that is absent, so it is a no-op once the
upstream catalog ships the tiers itself.

Crucially it is invoked on **both** catalog load paths:

- `loadModelsFromBytes` — the embedded fallback loaded at startup, and
- `tryRefreshModels` — the periodic/startup remote refresh.

A remote refresh replaces the in-memory store wholesale, so injecting on a single path would
let the next 3-hour refresh silently drop the added tiers.

## Why it matters

Medium and Low are not cosmetic aliases of High — they are separate, cheaper/faster reasoning
tiers billed and rate-limited independently. Users who want the low-latency or low-cost tier
of 3.8 Flash currently cannot select it through the proxy at all; they are forced onto High.
This restores parity between what the Antigravity account actually offers and what the proxy
exposes.

## The essence

The catalog under-reports what the backend serves. One small, self-limiting injection on both
load paths makes all three real tiers of Gemini 3.8 Flash routable, with zero config changes
required by the user.

## Verification

- **cli-proxy version:** built from `main` @ v7.2.148, Go 1.26.
- **Antigravity CLI version:** 1.1.25 (the version the proxy auto-fetches and sends as UA to
  the daily endpoint; `agy --version` = 1.1.25).
- **End-to-end:** `GET /v1/models` lists `gemini-3.8-flash-high`, `-medium`, and `-low`; a
  `POST /v1/chat/completions` to each of the three tiers returns HTTP 200 with a valid
  completion.

## Note

The same registry gap affects other tiered Antigravity flash families (3.6 / 3.7), which the
daily endpoint also serves in three tiers. This PR intentionally scopes to 3.8 (the tier
verified end-to-end); the approach generalizes if maintainers prefer to cover the others here.
