### PR TITLE
Treat transient upstream 404 as short retry, not 12h credential cooldown

### DIFF
--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -22,6 +22,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: upstreamModel}
 
 	apiKey, baseURL := claudeCreds(auth)
 	if baseURL == "" {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -188,6 +188,11 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 	}
 	bodyForUpstream = stripDefaultKimiClaudeCodeAttribution(auth, url, fp.ProfileClaudeCodeCLI, bodyForUpstream)
+	// Payload rules (ApplyPayloadConfigWithRequestTracked) can rewrite model
+	// long after upstreamModel was computed, so re-derive the wire model from
+	// the finished body: a structured error naming an overridden model must
+	// classify against what was actually sent, not the pre-override value.
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(bodyForUpstream, upstreamModel)}
 	// Runs on the finished body: payload rules can rewrite model and messages
 	// long after translation, so an earlier check would not describe the request
 	// that is about to be sent.

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -179,6 +179,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 	}
 	bodyForUpstream = stripDefaultKimiClaudeCodeAttribution(auth, url, fp.ProfileClaudeCodeCLI, bodyForUpstream)
+	// Payload rules (ApplyPayloadConfigWithRequestTracked) can rewrite model
+	// long after upstreamModel was computed, so re-derive the wire model from
+	// the finished body: a structured error naming an overridden model must
+	// classify against what was actually sent, not the pre-override value.
+	wireModel := finalWireModel(bodyForUpstream, upstreamModel)
 	// Runs on the finished body: payload rules can rewrite model and messages
 	// long after translation, so an earlier check would not describe the request
 	// that is about to be sent.
@@ -244,7 +249,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				// RequestScopedError elsewhere expect this exact type.
 				return nil, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errClassified)
 			}
-			return nil, withWireModel(errClassified, upstreamModel)
+			return nil, withWireModel(errClassified, wireModel)
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -261,7 +266,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if fastRequest {
 			return nil, newClaudeFastDirectResponseError(httpResp, b)
 		}
-		return nil, withWireModel(classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b), upstreamModel)
+		return nil, withWireModel(classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b), wireModel)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, claudeResponseContentEncoding(httpResp.Header))
 	if err != nil {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -430,7 +430,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
 		}
 	}()
-	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}
+	result := &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wireModel},
+	}
 	if replayScope.valid() {
 		result = wrapClaudeThinkingReplayStream(ctx, result, replayScope)
 	}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -238,9 +238,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			helps.LogWithRequestID(ctx).Warn(msg)
 			errClassified := classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, []byte(msg))
 			if fastRequest {
+				// Fast-path errors are request-scoped and bypass cooldown
+				// classification entirely (see isRequestScopedError), so they
+				// keep their existing wrapping unchanged; type assertions on
+				// RequestScopedError elsewhere expect this exact type.
 				return nil, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errClassified)
 			}
-			return nil, errClassified
+			return nil, withWireModel(errClassified, upstreamModel)
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -257,7 +261,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if fastRequest {
 			return nil, newClaudeFastDirectResponseError(httpResp, b)
 		}
-		return nil, classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b)
+		return nil, withWireModel(classifyClaudeUpstreamError(httpResp.StatusCode, httpResp.Header, b), upstreamModel)
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, claudeResponseContentEncoding(httpResp.Header))
 	if err != nil {

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -300,5 +300,11 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	count := gjson.GetBytes(data, "input_tokens").Int()
 	out := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, data)
-	return cliproxyexecutor.Response{Payload: out, Headers: resp.Header.Clone()}, nil
+	return cliproxyexecutor.Response{
+		Payload: out,
+		Headers: resp.Header.Clone(),
+		Metadata: map[string]any{
+			cliproxyexecutor.WireModelMetadataKey: wireModel,
+		},
+	}, nil
 }

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -217,6 +217,12 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	if errMidSystem := validateClaudeMidSystemMessageModel(body, confirmedClaudeCode, directAnthropic); errMidSystem != nil {
 		return cliproxyexecutor.Response{}, errMidSystem
 	}
+	// count_tokens has no payload-rule pass of its own, but read the finished
+	// body anyway so this stays symmetric with Execute/ExecuteStream and keeps
+	// working if one is ever added. CountTokens returns a zero Response on
+	// every error path, so the wire model must ride on the error like the
+	// stream path does.
+	wireModel := finalWireModel(body, upstreamModel)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
@@ -258,7 +264,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 			helps.RecordAPIResponseError(ctx, e.cfg, decErr)
 			msg := fmt.Sprintf("failed to decode error response body: %v", decErr)
 			helps.LogWithRequestID(ctx).Warn(msg)
-			return cliproxyexecutor.Response{}, classifyClaudeUpstreamError(resp.StatusCode, resp.Header, []byte(msg))
+			return cliproxyexecutor.Response{}, withWireModel(classifyClaudeUpstreamError(resp.StatusCode, resp.Header, []byte(msg)), wireModel)
 		}
 		b, readErr := io.ReadAll(errBody)
 		if readErr != nil {
@@ -271,7 +277,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, classifyClaudeUpstreamError(resp.StatusCode, resp.Header, b)
+		return cliproxyexecutor.Response{}, withWireModel(classifyClaudeUpstreamError(resp.StatusCode, resp.Header, b), wireModel)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, claudeResponseContentEncoding(resp.Header))
 	if err != nil {

--- a/internal/runtime/executor/claude_wire_model_payload_override_test.go
+++ b/internal/runtime/executor/claude_wire_model_payload_override_test.go
@@ -1,0 +1,125 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+func gjsonModel(body []byte) string {
+	return gjson.GetBytes(body, "model").String()
+}
+
+// claudeOverridePayloadConfig builds a config that rewrites the outbound
+// model field for the given requested model, exercising the real
+// ApplyPayloadConfigWithRequestTracked path (not a mock), so these tests
+// prove finalWireModel actually reads the finished body rather than the
+// pre-override upstreamModel variable.
+func claudeOverridePayloadConfig(requestedModel, overrideModel string) *config.Config {
+	return &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: requestedModel, Protocol: "claude"}},
+				Params: map[string]any{"model": overrideModel},
+			}},
+		},
+	}
+}
+
+func claudeStructuredNotFoundBody(model string) string {
+	return `{"type":"error","error":{"type":"not_found_error","message":"model ` + model + ` was not found"}}`
+}
+
+// TestClaudeExecutor_ExecutePayloadOverrideWireModelReflectsFinalBody drives
+// the real Claude Execute path against an httptest upstream: a payload
+// override rule rewrites the outbound model long after upstreamModel was
+// computed, and the upstream's structured 404 names the override target. The
+// wire model reported on the error's Response.Metadata must be the override
+// target, not the pre-override upstreamModel.
+func TestClaudeExecutor_ExecutePayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "claude-3-5-sonnet-20241022"
+	const overrideModel = "claude-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(claudeStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(claudeOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("Execute() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+	wire, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != overrideModel {
+		t.Fatalf("Response.Metadata[%s] = %v, want %q (finalWireModel must read the finished body, not the pre-override upstreamModel)", cliproxyexecutor.WireModelMetadataKey, resp.Metadata[cliproxyexecutor.WireModelMetadataKey], overrideModel)
+	}
+}
+
+// TestClaudeExecutor_ExecuteStreamPayloadOverrideWireModelReflectsFinalBody
+// is the ExecuteStream counterpart: StreamResult carries no Metadata, so the
+// wire model must ride on the returned error via WireModel().
+func TestClaudeExecutor_ExecuteStreamPayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "claude-3-5-sonnet-20241022"
+	const overrideModel = "claude-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(claudeStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(claudeOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("ExecuteStream() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	wmp, ok := err.(wireModelProvider)
+	if !ok {
+		t.Fatalf("ExecuteStream() error = %v (%T), want a WireModel()-carrying error", err, err)
+	}
+	if got := wmp.WireModel(); got != overrideModel {
+		t.Fatalf("WireModel() = %q, want %q (finalWireModel must read the finished body, not the pre-override upstreamModel)", got, overrideModel)
+	}
+}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -412,6 +412,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	fromProtocol := opts.SourceFormat.String()
 	originalTranslated := geminiInteractionsPayloadConfigSource(ctx, e.cfg, targetName, req.Payload, opts, false, helps.APIKeyModelIsCompat(req))
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, targetName, "interactions", fromProtocol, "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(body, targetName)}
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/interactions", baseURL, glAPIVersion)
@@ -460,7 +461,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		err = statusErr{code: httpResp.StatusCode, msg: string(data)}
+		err = withWireModelIfNotFound(statusErr{code: httpResp.StatusCode, msg: string(data)}, httpResp.StatusCode, finalWireModel(body, targetName))
 		return resp, err
 	}
 	reporter.Publish(ctx, helps.ParseInteractionsUsage(data))
@@ -470,7 +471,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	if targetFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
-	return cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}, nil
+	return cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone(), Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(body, targetName)}}, nil
 }
 
 func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -533,7 +534,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 			log.Errorf("gemini executor: close interactions error response body error: %v", errClose)
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(data)}
+		return nil, withWireModelIfNotFound(statusErr{code: httpResp.StatusCode, msg: string(data)}, httpResp.StatusCode, finalWireModel(body, targetName))
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -624,7 +624,11 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 			}
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	return &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(body, targetName)},
+	}, nil
 }
 
 // CountTokens counts tokens for the given request using the Gemini API.

--- a/internal/runtime/executor/gemini_interactions_wire_model_test.go
+++ b/internal/runtime/executor/gemini_interactions_wire_model_test.go
@@ -1,0 +1,159 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// geminiInteractionsOverridePayloadConfig builds a config that rewrites the
+// outbound model for the given requested model on the interactions protocol.
+// Unlike GeminiExecutor.Execute's main (non-interactions) path,
+// executeInteractions/executeInteractionsStream call SetStringIfDifferent
+// BEFORE ApplyPayloadConfigWithRequest, so a payload rule genuinely changes
+// what's sent — this is the gap Codex flagged that the blanket Gemini N/A
+// claim missed.
+func geminiInteractionsOverridePayloadConfig(requestedModel, overrideModel string) *config.Config {
+	return &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: requestedModel, Protocol: "interactions"}},
+				Params: map[string]any{"model": overrideModel},
+			}},
+		},
+	}
+}
+
+func geminiInteractionsStructuredNotFoundBody(model string) string {
+	return `{"error":{"type":"not_found_error","message":"model ` + model + ` does not exist"}}`
+}
+
+func TestGeminiExecutor_ExecuteInteractionsPayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "gemini-3-flash"
+	const overrideModel = "gemini-interactions-override-target"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(geminiInteractionsStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(geminiInteractionsOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Provider: "gemini-interactions", Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err == nil {
+		t.Fatal("Execute() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire, or did not route through executeInteractions; test setup is wrong)", got, overrideModel)
+	}
+	wire, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != overrideModel {
+		t.Fatalf("Response.Metadata[%s] = %v, want %q (finalWireModel must read the finished body)", cliproxyexecutor.WireModelMetadataKey, resp.Metadata[cliproxyexecutor.WireModelMetadataKey], overrideModel)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	wmp, ok := err.(wireModelProvider)
+	if !ok {
+		t.Fatalf("Execute() error = %v (%T), want a WireModel()-carrying error", err, err)
+	}
+	if got := wmp.WireModel(); got != overrideModel {
+		t.Fatalf("err.WireModel() = %q, want %q", got, overrideModel)
+	}
+}
+
+func TestGeminiExecutor_ExecuteInteractionsStreamPayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "gemini-3-flash"
+	const overrideModel = "gemini-interactions-override-target"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(geminiInteractionsStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(geminiInteractionsOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Provider: "gemini-interactions", Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err == nil {
+		t.Fatal("ExecuteStream() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire, or did not route through executeInteractionsStream; test setup is wrong)", got, overrideModel)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	wmp, ok := err.(wireModelProvider)
+	if !ok {
+		t.Fatalf("ExecuteStream() error = %v (%T), want a WireModel()-carrying error", err, err)
+	}
+	if got := wmp.WireModel(); got != overrideModel {
+		t.Fatalf("WireModel() = %q, want %q", got, overrideModel)
+	}
+}
+
+// TestOpenAICompatExecutor_NonNotFoundErrorKeepsConcreteStatusErrType proves
+// the withWireModelIfNotFound gate: any non-404 status must return exactly
+// the origin/dev statusErr value (not wrapped in wireModelErr), so a direct
+// type assertion elsewhere on statusErr keeps working unchanged.
+func TestOpenAICompatExecutor_NonNotFoundErrorKeepsConcreteStatusErrType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("compat-test", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-4o-mini",
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("Execute() unexpectedly succeeded")
+	}
+	se, ok := err.(statusErr)
+	if !ok {
+		t.Fatalf("Execute() error = %v (%T), want the exact statusErr concrete type for a non-404 response (got a wrapped type instead)", err, err)
+	}
+	if se.code != http.StatusTooManyRequests {
+		t.Fatalf("statusErr.code = %d, want %d", se.code, http.StatusTooManyRequests)
+	}
+}

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -372,7 +372,11 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	return &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wireModel},
+	}, nil
 }
 
 // CountTokens estimates token count for Kimi requests.

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -127,6 +127,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 
 	// Strip kimi- prefix and any [1m] suffix for upstream API
 	upstreamModel := normalizeKimiUpstreamModel(baseModel)
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: upstreamModel}
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
 		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -147,6 +147,10 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	}
 	body = normalizeKimiTools(body)
 	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+	// Payload rules (ApplyPayloadConfigWithRequest) can rewrite model long
+	// after upstreamModel was computed, so re-derive the wire model from the
+	// finished body about to be sent.
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(body, upstreamModel)}
 
 	url := kimiauth.KimiAPIBaseURL + "/v1/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -272,6 +276,10 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	}
 	body = normalizeKimiTools(body)
 	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+	// Payload rules (ApplyPayloadConfigWithRequest) can rewrite model long
+	// after upstreamModel was computed, so re-derive the wire model from the
+	// finished body about to be sent.
+	wireModel := finalWireModel(body, upstreamModel)
 
 	url := kimiauth.KimiAPIBaseURL + "/v1/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -317,7 +325,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("kimi executor: close response body error: %v", errClose)
 		}
-		err = withWireModel(statusErr{code: httpResp.StatusCode, msg: string(b)}, upstreamModel)
+		err = withWireModel(statusErr{code: httpResp.StatusCode, msg: string(b)}, wireModel)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -317,7 +317,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("kimi executor: close response body error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = withWireModel(statusErr{code: httpResp.StatusCode, msg: string(b)}, upstreamModel)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -211,6 +211,42 @@ func TestKimiExecutorCountTokensUsesCanonicalUpstreamModel(t *testing.T) {
 	}
 }
 
+// TestKimiExecutorCountTokensReportsWireModelOnSuccess covers Codex's finding
+// at conductor_execution.go:743 / claude_executor_tokens.go:303: a successful
+// CountTokens call for a normalized model (Kimi's suffix stripping, shared by
+// Claude via countTokensUpstream) must report the actually-sent wire model in
+// Response.Metadata[WireModelMetadataKey], mirroring the wire_model contract
+// Execute/ExecuteStream already honor on success. Without it, the conductor's
+// wireModelOrSent falls back to the pre-normalization sent model and
+// Result.UpstreamModel is wrong for every successful count.
+func TestKimiExecutorCountTokensReportsWireModelOnSuccess(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"input_tokens":42}`)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := []byte(`{"model":"kimi-k3[1m](high)","messages":[{"role":"user","content":"hello"}]}`)
+	resp, err := executor.CountTokens(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3[1m](high)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	got, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || got != "k3" {
+		t.Fatalf("Response.Metadata[WireModelMetadataKey] = %v (ok=%v), want %q", resp.Metadata[cliproxyexecutor.WireModelMetadataKey], ok, "k3")
+	}
+}
+
 func TestKimiExecutorCountTokensInvalidGzipErrorBodyReturnsDecodeMessage(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -476,7 +476,7 @@ func wrapThinkingReplayStream(ctx context.Context, result *cliproxyexecutor.Stre
 			clearContent(ctx, scope)
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: result.Headers.Clone(), Chunks: out}
+	return &cliproxyexecutor.StreamResult{Headers: result.Headers.Clone(), Chunks: out, Metadata: result.Metadata}
 }
 
 func wrapKimiThinkingReplayStream(ctx context.Context, result *cliproxyexecutor.StreamResult, scope kimiThinkingReplayScope) *cliproxyexecutor.StreamResult {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -1109,3 +1109,15 @@ func withWireModel(err error, model string) error {
 	}
 	return wireModelErr{error: err, model: model}
 }
+
+// finalWireModel reads the model actually present in the finished outbound
+// payload, falling back when the field is absent or empty. Payload rules
+// (ApplyPayloadConfigWithRequest/Tracked) can rewrite the top-level model
+// long after the pre-call normalization that computes upstreamModel, so only
+// a read of the body about to be sent describes what the provider will see.
+func finalWireModel(body []byte, fallback string) string {
+	if v := strings.TrimSpace(gjson.GetBytes(body, "model").String()); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -194,7 +194,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), finalWireModel(translated, baseModel))
+		err = withWireModelIfNotFound(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), httpResp.StatusCode, finalWireModel(translated, baseModel))
 		return resp, err
 	}
 	body, err := io.ReadAll(httpResp.Body)
@@ -295,7 +295,7 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
-		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, body), finalWireModel(payload, baseModel))
+		err = withWireModelIfNotFound(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, body), httpResp.StatusCode, finalWireModel(payload, baseModel))
 		return resp, err
 	}
 
@@ -406,7 +406,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
-		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), finalWireModel(translated, baseModel))
+		err = withWireModelIfNotFound(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), httpResp.StatusCode, finalWireModel(translated, baseModel))
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -648,7 +648,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
-		return nil, withWireModel(statusErr{code: httpResp.StatusCode, msg: string(body)}, finalWireModel(payload, baseModel))
+		return nil, withWireModelIfNotFound(statusErr{code: httpResp.StatusCode, msg: string(body)}, httpResp.StatusCode, finalWireModel(payload, baseModel))
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -1109,6 +1109,19 @@ func withWireModel(err error, model string) error {
 		return err
 	}
 	return wireModelErr{error: err, model: model}
+}
+
+// withWireModelIfNotFound wraps err with the wire model only when statusCode
+// is 404. Only the not-found classification (explicit-model vs
+// endpoint-neutral) depends on knowing the model actually sent; every other
+// status code must keep returning the exact statusErr value origin/dev
+// returns, since callers elsewhere type-assert on that concrete type
+// directly rather than via errors.As.
+func withWireModelIfNotFound(err error, statusCode int, model string) error {
+	if statusCode != http.StatusNotFound {
+		return err
+	}
+	return withWireModel(err, model)
 }
 
 // finalWireModel reads the model actually present in the finished outbound

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -142,6 +142,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
 	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
+	resp.Metadata = map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(translated, baseModel)}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
@@ -193,7 +194,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b)
+		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), finalWireModel(translated, baseModel))
 		return resp, err
 	}
 	body, err := io.ReadAll(httpResp.Body)
@@ -211,7 +212,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if responseFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
-	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone(), Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(translated, baseModel)}}
 	return resp, nil
 }
 
@@ -294,13 +295,13 @@ func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxy
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
-		err = newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, body)
+		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, body), finalWireModel(payload, baseModel))
 		return resp, err
 	}
 
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
 	reporter.EnsurePublished(ctx)
-	resp = cliproxyexecutor.Response{Payload: body, Headers: httpResp.Header.Clone()}
+	resp = cliproxyexecutor.Response{Payload: body, Headers: httpResp.Header.Clone(), Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(payload, baseModel)}}
 	return resp, nil
 }
 
@@ -405,7 +406,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
-		err = newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b)
+		err = withWireModel(newOpenAICompatStatusError(httpResp.StatusCode, httpResp.Header, b), finalWireModel(translated, baseModel))
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -647,7 +648,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, body)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), body))
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(body)}
+		return nil, withWireModel(statusErr{code: httpResp.StatusCode, msg: string(body)}, finalWireModel(payload, baseModel))
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -573,7 +573,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		streamUsage.Publish(ctx, reporter)
 		reporter.EnsurePublished(ctx)
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	return &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(translated, baseModel)},
+	}, nil
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -690,7 +694,11 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 			}
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	return &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: finalWireModel(payload, baseModel)},
+	}, nil
 }
 
 func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -1066,3 +1066,46 @@ func openAICompatRetryAfter(status int, headers http.Header, body []byte, now ti
 	}
 	return nil
 }
+
+// wireModelErr decorates an error with the exact model an executor placed on
+// the outbound upstream request. Execute/CountTokens report this via
+// Response.Metadata (see cliproxyexecutor.WireModelMetadataKey), but
+// ExecuteStream returns no Response on failure, so this is the only channel
+// available for a structured stream-path error to carry the wire model back
+// to the conductor for classification.
+type wireModelErr struct {
+	error
+	model string
+}
+
+func (e wireModelErr) WireModel() string { return e.model }
+func (e wireModelErr) Unwrap() error     { return e.error }
+
+// StatusCode/RetryAfter forward to the wrapped error when present, so code
+// that type-asserts these interfaces directly (rather than via errors.As)
+// keeps working unchanged through the wrapper.
+func (e wireModelErr) StatusCode() int {
+	type statusCoder interface{ StatusCode() int }
+	if sc, ok := e.error.(statusCoder); ok {
+		return sc.StatusCode()
+	}
+	return 0
+}
+func (e wireModelErr) RetryAfter() *time.Duration {
+	type retryAfterProvider interface{ RetryAfter() *time.Duration }
+	if rap, ok := e.error.(retryAfterProvider); ok {
+		return rap.RetryAfter()
+	}
+	return nil
+}
+
+// withWireModel wraps err with the wire model an executor placed on the
+// outbound request, if err is non-nil and model is non-empty. Wrapping
+// preserves StatusCode()/RetryAfter()/etc. via Unwrap, so callers using
+// errors.As for those still find them.
+func withWireModel(err error, model string) error {
+	if err == nil || model == "" {
+		return err
+	}
+	return wireModelErr{error: err, model: model}
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -436,8 +436,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			}
 			helps.RecordAPIResponseError(ctx, e.cfg, loggedErr)
 			reporter.PublishFailure(ctx, loggedErr)
+			// A structured error arriving mid-stream (after a 200) still needs the
+			// wire model attached when it is a 404, so a not-found classification
+			// after the SSE has started reads the same as one caught on the
+			// initial response status check.
+			chunkErr := withWireModelIfNotFound(error(streamErr), streamErr.code, finalWireModel(translated, baseModel))
 			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case out <- cliproxyexecutor.StreamChunk{Err: chunkErr}:
 			case <-ctx.Done():
 			}
 			streamFailed = true

--- a/internal/runtime/executor/openai_compat_wire_model_payload_override_test.go
+++ b/internal/runtime/executor/openai_compat_wire_model_payload_override_test.go
@@ -119,3 +119,78 @@ func TestOpenAICompatExecutor_ExecuteStreamPayloadOverrideWireModelReflectsFinal
 		t.Fatalf("WireModel() = %q, want %q", got, overrideModel)
 	}
 }
+
+// TestOpenAICompatExecutor_MidStreamStructuredNotFoundChunkErrorCarriesWireModel
+// covers the SSE mid-stream case: the initial HTTP response is 200, so
+// ExecuteStream's status check never runs, but the first data frame embeds a
+// structured 404 naming the payload-override model. The conductor only ever
+// sees this via StreamChunk.Err (see wrapStreamResult in
+// sdk/cliproxy/auth/conductor_stream.go), so the executor must attach the
+// wire model to that chunk error the same way it does for a status-line 404.
+func TestOpenAICompatExecutor_MidStreamStructuredNotFoundChunkErrorCarriesWireModel(t *testing.T) {
+	const requestedModel = "gpt-4o-mini"
+	const overrideModel = "compat-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: " + openaiCompatStreamStructuredNotFoundFrame(overrideModel) + "\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("compat-test", openaiCompatOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed before streaming began: %v", err)
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+
+	var chunkErr error
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			chunkErr = chunk.Err
+			break
+		}
+	}
+	if chunkErr == nil {
+		t.Fatal("no StreamChunk carried an error; the mid-stream structured 404 was not detected")
+	}
+	type statusCodeProvider interface {
+		StatusCode() int
+	}
+	if sc, ok := chunkErr.(statusCodeProvider); !ok || sc.StatusCode() != http.StatusNotFound {
+		t.Fatalf("chunk error = %v (%T), want a 404 StatusCode()", chunkErr, chunkErr)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	wmp, ok := chunkErr.(wireModelProvider)
+	if !ok {
+		t.Fatalf("chunk error = %v (%T), want a WireModel()-carrying error", chunkErr, chunkErr)
+	}
+	if got := wmp.WireModel(); got != overrideModel {
+		t.Fatalf("WireModel() = %q, want %q", got, overrideModel)
+	}
+}
+
+func openaiCompatStreamStructuredNotFoundFrame(model string) string {
+	return `{"error":{"type":"invalid_request_error","code":"model_not_found","message":"The model ` + model + ` does not exist","status":404}}`
+}

--- a/internal/runtime/executor/openai_compat_wire_model_payload_override_test.go
+++ b/internal/runtime/executor/openai_compat_wire_model_payload_override_test.go
@@ -1,0 +1,121 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// openaiCompatOverridePayloadConfig builds a config that rewrites the
+// outbound model field for the given requested model, exercising the real
+// ApplyPayloadConfigWithRequest path. Unlike Claude/Kimi, OpenAICompatExecutor
+// never overwrites the model field again after applying payload rules, so
+// this is the executor Codex flagged as never reporting a wire model at all.
+func openaiCompatOverridePayloadConfig(requestedModel, overrideModel string) *config.Config {
+	return &config.Config{
+		Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: requestedModel, Protocol: "openai"}},
+				Params: map[string]any{"model": overrideModel},
+			}},
+		},
+	}
+}
+
+func openaiCompatStructuredNotFoundBody(model string) string {
+	return `{"error":{"type":"invalid_request_error","code":"model_not_found","message":"The model ` + model + ` does not exist"}}`
+}
+
+func TestOpenAICompatExecutor_ExecutePayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "gpt-4o-mini"
+	const overrideModel = "compat-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(openaiCompatStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("compat-test", openaiCompatOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("Execute() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+	wire, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != overrideModel {
+		t.Fatalf("Response.Metadata[%s] = %v, want %q (finalWireModel must read the finished body)", cliproxyexecutor.WireModelMetadataKey, resp.Metadata[cliproxyexecutor.WireModelMetadataKey], overrideModel)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	if wmp, ok := err.(wireModelProvider); ok {
+		if got := wmp.WireModel(); got != overrideModel {
+			t.Fatalf("err.WireModel() = %q, want %q", got, overrideModel)
+		}
+	} else {
+		t.Fatalf("Execute() error = %v (%T), want a WireModel()-carrying error", err, err)
+	}
+}
+
+func TestOpenAICompatExecutor_ExecuteStreamPayloadOverrideWireModelReflectsFinalBody(t *testing.T) {
+	const requestedModel = "gpt-4o-mini"
+	const overrideModel = "compat-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(openaiCompatStructuredNotFoundBody(overrideModel)))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("compat-test", openaiCompatOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("ExecuteStream() unexpectedly succeeded")
+	}
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	wmp, ok := err.(wireModelProvider)
+	if !ok {
+		t.Fatalf("ExecuteStream() error = %v (%T), want a WireModel()-carrying error", err, err)
+	}
+	if got := wmp.WireModel(); got != overrideModel {
+		t.Fatalf("WireModel() = %q, want %q", got, overrideModel)
+	}
+}

--- a/internal/runtime/executor/success_stream_wire_model_metadata_test.go
+++ b/internal/runtime/executor/success_stream_wire_model_metadata_test.go
@@ -1,0 +1,176 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// drainStream reads every chunk from a StreamResult, failing the test on any
+// chunk error, and returns the concatenated payload.
+func drainStream(t *testing.T, streamResult *cliproxyexecutor.StreamResult) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream chunk error: %v", chunk.Err)
+		}
+		buf.Write(chunk.Payload)
+	}
+	return buf.Bytes()
+}
+
+// TestOpenAICompatExecutor_ExecuteStreamSuccessReportsOverriddenWireModel
+// covers Codex/team-lead's finding at openai_compat_executor.go:576: a
+// SUCCESSFUL chat completion stream, after a payload-override rule rewrites
+// the outbound model, returned a StreamResult with no Metadata at all - so
+// wireModelOrSentStream fell back to the pre-override sent model. This proves
+// the fix (finalWireModel(translated, baseModel) attached to the success
+// StreamResult) on the happy path, not just the existing 404 coverage.
+func TestOpenAICompatExecutor_ExecuteStreamSuccessReportsOverriddenWireModel(t *testing.T) {
+	const requestedModel = "gpt-4o-mini"
+	const overrideModel = "compat-override-target-model"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("compat-test", openaiCompatOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed: %v", err)
+	}
+	drainStream(t, streamResult)
+
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire; test setup is wrong)", got, overrideModel)
+	}
+	wire, ok := streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != overrideModel {
+		t.Fatalf("StreamResult.Metadata[%s] = %v, want %q (finalWireModel must read the finished body on the success path)", cliproxyexecutor.WireModelMetadataKey, streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey], overrideModel)
+	}
+}
+
+// TestOpenAICompatExecutor_ImagesGenerationsStreamSuccessReportsWireModel
+// covers Codex/team-lead's finding at openai_compat_executor.go:693: a
+// successful images/generations stream returned a StreamResult with no
+// Metadata, so a thinking-suffixed requested model (which prepareOpenAICompat
+// -ImagesPayload strips before sending) was never distinguishable from the
+// actually-sent wire model downstream.
+func TestOpenAICompatExecutor_ImagesGenerationsStreamSuccessReportsWireModel(t *testing.T) {
+	const requestedModel = "compat-image(high)"
+	const wantWireModel = "compat-image"
+
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("event: image_generation.partial\ndata: {\"type\":\"image_generation.partial\"}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: []byte(`{"model":"` + requestedModel + `","prompt":"draw","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-image"),
+		Stream:       true,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestPathMetadataKey: "/v1/images/generations",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed: %v", err)
+	}
+	drainStream(t, streamResult)
+
+	if got := gjsonModel(gotBody); got != wantWireModel {
+		t.Fatalf("upstream saw model = %q, want %q (test setup is wrong)", got, wantWireModel)
+	}
+	wire, ok := streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != wantWireModel {
+		t.Fatalf("StreamResult.Metadata[%s] = %v, want %q (finalWireModel must read the finished body on the success path)", cliproxyexecutor.WireModelMetadataKey, streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey], wantWireModel)
+	}
+}
+
+// TestGeminiExecutor_ExecuteInteractionsStreamSuccessReportsOverriddenWireModel
+// covers Codex/team-lead's finding at gemini_executor.go:627: a SUCCESSFUL
+// interactions stream, after a payload-override rule rewrites the outbound
+// model, returned a StreamResult with no Metadata - so the conductor could
+// not tell what model was actually sent for a completed request.
+func TestGeminiExecutor_ExecuteInteractionsStreamSuccessReportsOverriddenWireModel(t *testing.T) {
+	const requestedModel = "gemini-3-flash"
+	const overrideModel = "gemini-interactions-override-target"
+
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"hi"}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.completed"}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(geminiInteractionsOverridePayloadConfig(requestedModel, overrideModel))
+	auth := &cliproxyauth.Auth{Provider: "gemini-interactions", Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"` + requestedModel + `","messages":[{"role":"user","content":"hi"}]}`)
+
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   requestedModel,
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+	if err != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed: %v", err)
+	}
+	drainStream(t, streamResult)
+
+	if got := gjsonModel(seenBody); got != overrideModel {
+		t.Fatalf("upstream saw model = %q, want override %q (payload override rule did not fire, or did not route through executeInteractionsStream; test setup is wrong)", got, overrideModel)
+	}
+	wire, ok := streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey].(string)
+	if !ok || wire != overrideModel {
+		t.Fatalf("StreamResult.Metadata[%s] = %v, want %q (finalWireModel must read the finished body on the success path)", cliproxyexecutor.WireModelMetadataKey, streamResult.Metadata[cliproxyexecutor.WireModelMetadataKey], overrideModel)
+	}
+}

--- a/sdk/cliproxy/auth/antigravity_credits_test.go
+++ b/sdk/cliproxy/auth/antigravity_credits_test.go
@@ -233,7 +233,7 @@ func TestIsAuthBlockedForModel_ClaudeWithCreditsStillBlockedDuringCooldown(t *te
 		UpdatedAt: time.Now(),
 	})
 
-	blocked, reason, _ := isAuthBlockedForModel(auth, "claude-sonnet-4-6", time.Now())
+	blocked, reason, _ := effectiveBlock(auth, "claude-sonnet-4-6", time.Now())
 	if !blocked || reason != blockReasonCooldown {
 		t.Fatalf("expected auth to be blocked during cooldown even with credits, got blocked=%v reason=%v", blocked, reason)
 	}
@@ -261,7 +261,7 @@ func TestIsAuthBlockedForModel_KeepsGeminiBlockedWithoutCreditsBypass(t *testing
 		UpdatedAt: time.Now(),
 	})
 
-	blocked, reason, _ := isAuthBlockedForModel(auth, "gemini-3-flash", time.Now())
+	blocked, reason, _ := effectiveBlock(auth, "gemini-3-flash", time.Now())
 	if !blocked || reason != blockReasonCooldown {
 		t.Fatalf("expected gemini model to remain blocked, got blocked=%v reason=%v", blocked, reason)
 	}

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -139,3 +139,38 @@ func authMetadataString(auth *Auth, key string) string {
 		return ""
 	}
 }
+
+// authCredentialIdentity returns the token value that changes when the
+// underlying credential itself is replaced (an operator re-login), as
+// opposed to a routine access-token refresh which keeps the same
+// refresh_token. Falls back to access_token for credentials with no
+// refresh_token (e.g. plain API keys), so identity is still comparable
+// for those too. Returns "" when neither is present.
+func authCredentialIdentity(auth *Auth) string {
+	if token := authMetadataString(auth, "refresh_token"); token != "" {
+		return token
+	}
+	return authMetadataString(auth, "access_token")
+}
+
+// sameAuthCredential reports whether next carries the same underlying
+// credential as existing, per authCredentialIdentity. Only a non-empty
+// incoming identity that differs from existing's counts as a genuinely
+// different credential - an incoming Auth with no identifiable token at
+// all (e.g. a caller that updates Status/Metadata fields other than the
+// token, or arrives before a later metadata merge fills them in) must not
+// be misread as a re-login and must not clear a live cooldown; a re-login
+// always writes a full token set, so that case is unaffected. When
+// existing itself has no identifiable token (e.g. non-OAuth entries), both
+// sides are unknown and treated as unchanged.
+func sameAuthCredential(existing, next *Auth) bool {
+	existingIdentity := authCredentialIdentity(existing)
+	if existingIdentity == "" {
+		return true
+	}
+	nextIdentity := authCredentialIdentity(next)
+	if nextIdentity == "" {
+		return true
+	}
+	return existingIdentity == nextIdentity
+}

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -140,17 +140,23 @@ func authMetadataString(auth *Auth, key string) string {
 	}
 }
 
-// authCredentialIdentity returns the token value that changes when the
-// underlying credential itself is replaced (an operator re-login), as
+// authCredentialIdentity returns the value that changes when the underlying
+// credential itself is replaced (an operator re-login or key rotation), as
 // opposed to a routine access-token refresh which keeps the same
-// refresh_token. Falls back to access_token for credentials with no
-// refresh_token (e.g. plain API keys), so identity is still comparable
-// for those too. Returns "" when neither is present.
+// refresh_token. Precedence: OAuth refresh_token, else OAuth access_token
+// (credentials with no refresh_token), else the AttributeAPIKey attribute
+// (plain API-key auths, which carry no OAuth metadata at all - see
+// AuthKind()/authHasOAuthMetadata() above and types.go's apiKey handling at
+// authAttribute(a, AttributeAPIKey)). Returns "" when none of these are
+// present.
 func authCredentialIdentity(auth *Auth) string {
 	if token := authMetadataString(auth, "refresh_token"); token != "" {
 		return token
 	}
-	return authMetadataString(auth, "access_token")
+	if token := authMetadataString(auth, "access_token"); token != "" {
+		return token
+	}
+	return authAttribute(auth, AttributeAPIKey)
 }
 
 // sameAuthCredential reports whether next carries the same underlying

--- a/sdk/cliproxy/auth/claude_ratelimit_cooldown_test.go
+++ b/sdk/cliproxy/auth/claude_ratelimit_cooldown_test.go
@@ -69,7 +69,7 @@ func TestAuthManager_ConcurrentSuccessDoesNotClearActiveCredentialCooldown(t *te
 
 	// Selecting any model on this credential must be blocked locally
 	for _, m := range []string{"claude-3-5-sonnet-20241022", "claude-3-opus-20240229", "claude-3-7-sonnet-20250219"} {
-		blocked, reason, next := isAuthBlockedForModel(updatedAuth, m, time.Now())
+		blocked, reason, next := effectiveBlock(updatedAuth, m, time.Now())
 		if !blocked {
 			t.Fatalf("model %q was unblocked despite active 7d credential cooldown", m)
 		}
@@ -135,7 +135,7 @@ func TestAuthManager_UpdatePreservesActiveCredentialCooldown(t *testing.T) {
 		t.Fatalf("credential cooldown was lost after Update: quota=%+v", persistedAuth.Quota)
 	}
 
-	blocked, reason, _ := isAuthBlockedForModel(persistedAuth, "claude-3-5-sonnet-20241022", time.Now())
+	blocked, reason, _ := effectiveBlock(persistedAuth, "claude-3-5-sonnet-20241022", time.Now())
 	if !blocked || reason != blockReasonCooldown {
 		t.Fatalf("model unblocked after Update: blocked=%v reason=%v", blocked, reason)
 	}
@@ -184,7 +184,7 @@ func TestAuthManager_DisableCoolingDoesNotPermanentlyBlock(t *testing.T) {
 	// Must NOT be blocked when cooling is disabled
 	for _, m := range []string{"claude-3-5-sonnet-20241022", "claude-3-opus-20240229"} {
 		updatedAuth, _ := manager.GetByID(auth.ID)
-		blocked, _, _ := isAuthBlockedForModel(updatedAuth, m, time.Now())
+		blocked, _, _ := effectiveBlock(updatedAuth, m, time.Now())
 		if blocked {
 			t.Fatalf("model %q was blocked even though cooling is disabled", m)
 		}
@@ -228,13 +228,13 @@ func TestAuthManager_NonClaudeProvider_Model429DoesNotBlockSiblingModels(t *test
 
 	// gpt-4o should be blocked
 	updatedAuth, _ := manager.GetByID(auth.ID)
-	blocked4o, _, _ := isAuthBlockedForModel(updatedAuth, "gpt-4o", time.Now())
+	blocked4o, _, _ := effectiveBlock(updatedAuth, "gpt-4o", time.Now())
 	if !blocked4o {
 		t.Fatal("gpt-4o should be blocked after 429")
 	}
 
 	// gpt-4o-mini MUST remain selectable (unaffected by sibling model 429)
-	blockedMini, _, _ := isAuthBlockedForModel(updatedAuth, "gpt-4o-mini", time.Now())
+	blockedMini, _, _ := effectiveBlock(updatedAuth, "gpt-4o-mini", time.Now())
 	if blockedMini {
 		t.Fatal("gpt-4o-mini was incorrectly blocked by sibling model 429")
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -50,6 +50,8 @@ type Result struct {
 	Provider string
 	// Model is the upstream model identifier used for the request.
 	Model string
+	// UpstreamModel is the actual provider model attempted after alias resolution.
+	UpstreamModel string
 	// RouteModel is the requested logical route model before alias resolution.
 	RouteModel string
 	// Success marks whether the execution succeeded.

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -8,9 +8,20 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
-func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryDoesNotBlockAuth(t *testing.T) {
+func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryBlocksAuthIndefinitely(t *testing.T) {
 	t.Parallel()
 
+	// This intentionally documents a behavior change from the delta review's
+	// item 3 ("no field-specific shortcuts... decide per model via the same
+	// predicate the selector uses"): isAuthBlockedForModel's own matched-state
+	// branch (selector.go) already treats a state with Unavailable=true and
+	// no deadlines at all as an indefinite block - availabilityBlock returns
+	// (true, ..., zero) for that combination, and the matched-model loop
+	// returns that block immediately when next.IsZero(). The pre-fix
+	// aggregation shortcut disagreed with the selector on this exact case
+	// (it read Unavailable=true + zero NextRetryAfter as "not blocking"),
+	// which is precisely the shortcut/selector divergence item 3 removed.
+	// Aggregation must now agree with the live per-model selector here too.
 	now := time.Now()
 	model := "test-model"
 	auth := &Auth{
@@ -25,11 +36,11 @@ func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryDoesNotBlockAut
 
 	updateAggregatedAvailability(auth, now)
 
-	if auth.Unavailable {
-		t.Fatalf("auth.Unavailable = true, want false")
+	if !auth.Unavailable {
+		t.Fatalf("auth.Unavailable = false, want true (matches isAuthBlockedForModel's own indefinite-block behavior for Unavailable=true with no deadlines)")
 	}
 	if !auth.NextRetryAfter.IsZero() {
-		t.Fatalf("auth.NextRetryAfter = %v, want zero", auth.NextRetryAfter)
+		t.Fatalf("auth.NextRetryAfter = %v, want zero (indefinite block has no known deadline)", auth.NextRetryAfter)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -13,7 +13,7 @@ func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryBlocksAuthIndef
 
 	// This intentionally documents a behavior change from the delta review's
 	// item 3 ("no field-specific shortcuts... decide per model via the same
-	// predicate the selector uses"): isAuthBlockedForModel's own matched-state
+	// predicate the selector uses"): effectiveBlock's own matched-state
 	// branch (selector.go) already treats a state with Unavailable=true and
 	// no deadlines at all as an indefinite block - availabilityBlock returns
 	// (true, ..., zero) for that combination, and the matched-model loop
@@ -37,7 +37,7 @@ func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryBlocksAuthIndef
 	updateAggregatedAvailability(auth, now)
 
 	if !auth.Unavailable {
-		t.Fatalf("auth.Unavailable = false, want true (matches isAuthBlockedForModel's own indefinite-block behavior for Unavailable=true with no deadlines)")
+		t.Fatalf("auth.Unavailable = false, want true (matches effectiveBlock's own indefinite-block behavior for Unavailable=true with no deadlines)")
 	}
 	if !auth.NextRetryAfter.IsZero() {
 		t.Fatalf("auth.NextRetryAfter = %v, want zero (indefinite block has no known deadline)", auth.NextRetryAfter)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1979,10 +1979,12 @@ func isExplicitModelNotFoundMessage(message, requestedModel string) bool {
 	if lower == "" {
 		return false
 	}
-	normalized := strings.NewReplacer("-", "_", " ", "_").Replace(lower)
-	if strings.Contains(normalized, "model_not_found") || strings.Contains(normalized, "unknown_model") {
-		return true
-	}
+	// A free substring match on "model_not_found"/"unknown_model" anywhere in
+	// the message over-classifies: it fires regardless of which model is
+	// actually named (e.g. an unrelated model's error, or an HTML page whose
+	// title happens to contain the phrase). Every branch below instead
+	// requires the message to name THIS requestedModel in the identified
+	// position via trimRequestedModelReference/isMissingModelPhrase.
 	// Gemini/Vertex/AI Studio's "models/<id> is not found ..." grammar is
 	// NOT checked here on message text alone - it additionally requires
 	// error.status == "NOT_FOUND" from the same "error" object, which this

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -342,9 +342,26 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 	return nil
 }
 
+// restoreCooldownRecordLocked mirrors authCooldownStateRecord/
+// modelCooldownStateRecord's use of availabilityBlock: a record is still
+// live if EITHER record.NextRetryAfter or record.Quota.NextRecoverAt is
+// still in the future, and the restored NextRetryAfter is the effective
+// (longer) of the two - not record.NextRetryAfter alone - so a process
+// restart between an expired short NextRetryAfter and a still-active
+// NextRecoverAt does not silently drop the cooldown. A legacy record with
+// NextRecoverAt zero (or, for a quota-exceeded record, backfilled from
+// NextRetryAfter just below) behaves exactly as before this fix.
 func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time) bool {
 	authID := strings.TrimSpace(record.AuthID)
-	if authID == "" || record.NextRetryAfter.IsZero() || !record.NextRetryAfter.After(now) {
+	if authID == "" {
+		return false
+	}
+	quota := record.Quota
+	if quota.Exceeded && quota.NextRecoverAt.IsZero() {
+		quota.NextRecoverAt = record.NextRetryAfter
+	}
+	blocked, _, next := availabilityBlock(true, quota.Exceeded, record.NextRetryAfter, quota.NextRecoverAt, now)
+	if !blocked || next.IsZero() {
 		return false
 	}
 	auth := m.auths[authID]
@@ -357,15 +374,11 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	}
 	reason := strings.TrimSpace(record.Reason)
 	model := strings.TrimSpace(record.Model)
-	quota := record.Quota
-	if quota.Exceeded && quota.NextRecoverAt.IsZero() {
-		quota.NextRecoverAt = record.NextRetryAfter
-	}
 
 	if model == "" {
 		auth.Unavailable = true
 		auth.Status = StatusError
-		auth.NextRetryAfter = record.NextRetryAfter
+		auth.NextRetryAfter = next
 		applyCooldownFields(&auth.Quota, quota)
 		auth.Quota = mergeQuotaObservation(auth.Quota, quota)
 		auth.Generation++
@@ -382,7 +395,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 		Unavailable:    true,
 		Status:         StatusError,
 		StatusMessage:  reason,
-		NextRetryAfter: record.NextRetryAfter,
+		NextRetryAfter: next,
 		Quota:          quota,
 		LastError:      cloneError(record.LastError),
 		UpdatedAt:      updatedAt,
@@ -676,8 +689,24 @@ func cooldownErrorEqual(a, b *Error) bool {
 		a.HTTPStatus == b.HTTPStatus
 }
 
+// authCooldownStateRecord builds the persisted record for a credential-level
+// cooldown. Whether a record exists at all, and what deadline it carries, is
+// decided by availabilityBlock - the same function the in-memory selector
+// uses to decide whether this auth is blocked - rather than by NextRetryAfter
+// alone. A later failure of a different kind (e.g. a transient 5xx) can
+// shorten auth.NextRetryAfter without touching auth.Quota.NextRecoverAt (see
+// notFoundRetryAfter/preserveLongerCooldown); checking NextRetryAfter alone
+// would silently drop the record - and the cooldown it protects - the moment
+// the shortened deadline passes, even though the credential is still blocked
+// in memory until the longer NextRecoverAt. The persisted NextRetryAfter is
+// the effective (longer) deadline availabilityBlock returns, so a `.cds`
+// file always shows the deadline that is actually in force.
 func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bool) {
-	if auth == nil || !auth.Unavailable || auth.NextRetryAfter.IsZero() || !auth.NextRetryAfter.After(now) {
+	if auth == nil {
+		return CooldownStateRecord{}, false
+	}
+	blocked, _, next := availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+	if !blocked || next.IsZero() {
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
@@ -685,7 +714,7 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 		AuthID:         auth.ID,
 		AuthFile:       cooldownAuthFile(auth),
 		Status:         "cooling",
-		NextRetryAfter: auth.NextRetryAfter,
+		NextRetryAfter: next,
 		Reason:         cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
 		Quota:          cooldownFieldsOf(auth.Quota),
 		LastError:      cloneError(auth.LastError),
@@ -693,9 +722,16 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 	}, true
 }
 
+// modelCooldownStateRecord mirrors authCooldownStateRecord for a per-model
+// cooldown; see its comment for why the gate and the persisted deadline both
+// come from availabilityBlock instead of NextRetryAfter alone.
 func modelCooldownStateRecord(auth *Auth, model string, state *ModelState, now time.Time) (CooldownStateRecord, bool) {
 	model = strings.TrimSpace(model)
-	if auth == nil || state == nil || model == "" || !state.Unavailable || state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(now) {
+	if auth == nil || state == nil || model == "" {
+		return CooldownStateRecord{}, false
+	}
+	blocked, _, next := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+	if !blocked || next.IsZero() {
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
@@ -704,7 +740,7 @@ func modelCooldownStateRecord(auth *Auth, model string, state *ModelState, now t
 		AuthFile:       cooldownAuthFile(auth),
 		Model:          model,
 		Status:         "cooling",
-		NextRetryAfter: state.NextRetryAfter,
+		NextRetryAfter: next,
 		Reason:         cooldownReason(state.StatusMessage, state.Quota, state.LastError),
 		Quota:          cooldownFieldsOf(state.Quota),
 		LastError:      cloneError(state.LastError),

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -807,7 +807,20 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 
 					statusCode := statusCodeFromResult(result.Error)
 					if isModelSupportResultError(result.Error) {
+						// Route through the same stored-deadline mechanism as
+						// explicit not-found (preserveLongerCooldown +
+						// applyCooldownFields onto state.Quota), so a racing
+						// generic 404/5xx for the same key cannot shorten this
+						// 12h deadline, and this deadline in turn survives a
+						// racing generic 404 the same way explicit not-found does.
 						next := now.Add(12 * time.Hour)
+						next = preserveLongerCooldown(state.Quota, next)
+						applyCooldownFields(&state.Quota, QuotaState{
+							Exceeded:      true,
+							Reason:        "model_not_supported",
+							NextRecoverAt: next,
+							BackoffLevel:  state.Quota.BackoffLevel,
+						})
 						state.NextRetryAfter = next
 					} else if isCloudflareChallengeResultError(result.Error) {
 						next, backoffLevel := nextCloudflareCooldown(state.Quota.BackoffLevel, disableCooling, now)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1998,10 +1998,18 @@ func isRequestInvalidError(err error) bool {
 
 // preserveLongerCooldown keeps an existing cooldown deadline if it extends
 // further into the future than a newly computed one, so a later failure of a
-// different kind (429 vs. explicit not-found) cannot shorten an active
-// cooldown recorded by an earlier failure.
+// different kind (429 vs. explicit not-found, Cloudflare challenge vs.
+// generic 404) cannot shorten an active cooldown recorded by an earlier
+// failure. This intentionally does not require existing.Exceeded: a generic
+// 404's short backoff is stored in NextRecoverAt without Exceeded set (see
+// the else branch below notFoundRetryAfter), and a later Cloudflare
+// challenge or shorter 429 must still not overwrite it with a shorter
+// deadline. Every caller of preserveLongerCooldown always overwrites
+// existing.NextRecoverAt afterward via applyCooldownFields/direct
+// assignment, so there is no legitimate caller relying on this function to
+// let a later, unrelated failure shorten an active deadline.
 func preserveLongerCooldown(existing QuotaState, next time.Time) time.Time {
-	if existing.Exceeded && existing.NextRecoverAt.After(next) {
+	if existing.NextRecoverAt.After(next) {
 		return existing.NextRecoverAt
 	}
 	return next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -853,9 +853,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								} else {
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								}
-								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
-									next = state.Quota.NextRecoverAt
-								}
+								next = preserveLongerCooldown(state.Quota, next)
 							}
 							state.NextRetryAfter = next
 							applyCooldownFields(&state.Quota, QuotaState{
@@ -1981,6 +1979,17 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
+// preserveLongerCooldown keeps an existing cooldown deadline if it extends
+// further into the future than a newly computed one, so a later failure of a
+// different kind (429 vs. explicit not-found) cannot shorten an active
+// cooldown recorded by an earlier failure.
+func preserveLongerCooldown(existing QuotaState, next time.Time) time.Time {
+	if existing.Exceeded && existing.NextRecoverAt.After(next) {
+		return existing.NextRecoverAt
+	}
+	return next
+}
+
 func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *QuotaState, now time.Time, disableCooling bool) time.Time {
 	if disableCooling {
 		return time.Time{}
@@ -1988,7 +1997,13 @@ func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *Quo
 	if isExplicitModelNotFoundError(resultErr, requestedModel) {
 		next := now.Add(12 * time.Hour)
 		if retryState != nil {
-			retryState.NextRecoverAt = next
+			next = preserveLongerCooldown(*retryState, next)
+			applyCooldownFields(retryState, QuotaState{
+				Exceeded:      true,
+				Reason:        "model_not_found",
+				NextRecoverAt: next,
+				BackoffLevel:  retryState.BackoffLevel,
+			})
 		}
 		return next
 	}
@@ -2103,9 +2118,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			} else {
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 			}
-			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
-				next = auth.Quota.NextRecoverAt
-			}
+			next = preserveLongerCooldown(auth.Quota, next)
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -424,26 +424,81 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 
 	// modelCooldownStateRecord only ever persists a record for a BLOCKED
 	// model (see its !blocked early-return) - an available sibling never
-	// gets one. So restoring a single model-scoped record into a fresh
-	// Manager necessarily leaves auth.ModelStates holding only the cooling
-	// model(s), never the siblings that were selectable before shutdown.
-	// updateAggregatedAvailability's sweep treats an ABSENT entry the same
-	// as an unavailable one (allUnavailable starts true and is only
-	// lowered by entries actually present), so calling it unconditionally
-	// here would mark the whole credential unavailable from a single
-	// restored model - even though isAuthBlockedForModel's own model!=""
-	// path (used by every real selection call) already blocks just that
-	// model correctly. Only let this restore LOWER auth.Unavailable
-	// (e.g. a previously-restored auth-level record clears once a model
-	// comes back), never RAISE it on the strength of one partially
-	// restored model map: that escalation is exactly what would make a
-	// multi-model credential go dark after a restart over one cooling
-	// sibling.
+	// gets one. So restoring model-scoped records into a fresh Manager
+	// necessarily leaves auth.ModelStates holding only the cooling
+	// model(s); a sibling that was selectable before shutdown either has
+	// no entry at all, or - if this credential's whole registered model
+	// set was cooling - has no entry for the same reason every other
+	// model doesn't: none of them needed a fresh state, they all got one
+	// from their own persisted record. updateAggregatedAvailability's
+	// sweep treats an ABSENT entry the same as an unavailable one
+	// (allUnavailable starts true and is only lowered by entries actually
+	// present), so calling it unconditionally here would mark the whole
+	// credential unavailable from a single restored model even when
+	// siblings exist and are selectable - even though isAuthBlockedForModel's
+	// own model!="" path (used by every real selection call) already
+	// blocks just that model correctly. Only let this restore RAISE
+	// auth.Unavailable when the restored model-state map is PROVABLY
+	// COMPLETE: every model this credential is actually registered for
+	// (read fresh from the model registry, not from the record) has a
+	// restored, blocked state. Otherwise only let it LOWER
+	// auth.Unavailable (e.g. a previously-restored auth-level record
+	// clears once a model comes back) - never raise it on the strength of
+	// a model set that might just be partially restored.
 	wasUnavailable := auth.Unavailable
 	updateAggregatedAvailability(auth, now)
-	if !wasUnavailable && auth.Unavailable {
+	if !wasUnavailable && auth.Unavailable && !m.restoredModelSetIsComplete(auth, now) {
 		auth.Unavailable = false
 		auth.NextRetryAfter = time.Time{}
+	}
+	return true
+}
+
+// restoredModelSetIsComplete reports whether every model currently
+// registered for this credential in the global model registry has a
+// restored ModelState entry that is itself blocked. Only in that case can a
+// restored model-state map be trusted to prove the credential is entirely
+// down - modelCooldownStateRecord never persists a record for an available
+// model, so an incomplete restored set (the registry lists a model with no
+// corresponding restored state) must never be read as "everything is
+// unavailable."
+func (m *Manager) restoredModelSetIsComplete(auth *Auth, now time.Time) bool {
+	if m == nil || auth == nil || len(auth.ModelStates) == 0 {
+		return false
+	}
+	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(auth.ID)
+	if len(supportedModels) == 0 {
+		return false
+	}
+	required := make(map[string]struct{}, len(supportedModels))
+	for _, model := range supportedModels {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		key := m.selectionModelKeyForAuth(auth, model.ID)
+		if key == "" {
+			key = canonicalModelKey(model.ID)
+		}
+		if key == "" {
+			continue
+		}
+		required[key] = struct{}{}
+	}
+	if len(required) == 0 {
+		return false
+	}
+	for key := range required {
+		state, ok := auth.ModelStates[key]
+		if !ok || state == nil {
+			return false
+		}
+		if state.Status == StatusDisabled {
+			continue
+		}
+		blocked, _, _ := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+		if !blocked {
+			return false
+		}
 	}
 	return true
 }
@@ -1364,15 +1419,29 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		stateUnavailable := false
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
-		} else if state.Unavailable {
-			if state.NextRetryAfter.IsZero() {
-				stateUnavailable = false
-			} else if state.NextRetryAfter.After(now) {
+		} else {
+			// Decide per model via the same predicate the selector uses
+			// (isAuthBlockedForModel's matched-model path calls
+			// availabilityBlock with these exact five values) instead of a
+			// field-specific shortcut that only looked at
+			// state.Unavailable/NextRetryAfter. A generic 404 stores its
+			// backoff in state.Quota.NextRecoverAt without setting
+			// state.Quota.Exceeded; a shortcut keyed off NextRetryAfter
+			// alone loses that recovery time the moment a concurrent,
+			// shorter-lived error (e.g. a transient 5xx) overwrites
+			// NextRetryAfter and then expires - availabilityBlock
+			// considers both NextRetryAfter and NextRecoverAt and takes
+			// whichever is later, so it can't be fooled that way.
+			blocked, _, next := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+			if blocked {
 				stateUnavailable = true
-				if earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry) {
-					earliestRetry = state.NextRetryAfter
+				if !next.IsZero() && (earliestRetry.IsZero() || next.Before(earliestRetry)) {
+					earliestRetry = next
 				}
-			} else {
+			} else if state.Unavailable {
+				// Every recovery signal has expired - clear the stale
+				// flags instead of leaving them set, mirroring the
+				// previous self-healing behavior.
 				state.Unavailable = false
 				state.NextRetryAfter = time.Time{}
 			}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1986,7 +1986,11 @@ func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *Quo
 		return time.Time{}
 	}
 	if isExplicitModelNotFoundError(resultErr, requestedModel) {
-		return now.Add(12 * time.Hour)
+		next := now.Add(12 * time.Hour)
+		if retryState != nil {
+			retryState.NextRecoverAt = next
+		}
+		return next
 	}
 	if retryState != nil && retryState.NextRecoverAt.After(now) {
 		return retryState.NextRecoverAt

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -736,6 +736,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		return
 	}
 	modelKey := canonicalModelKey(result.Model)
+	classificationModel := strings.TrimSpace(result.UpstreamModel)
+	if classificationModel == "" {
+		classificationModel = result.Model
+	}
 
 	var authSnapshot *Auth
 	cooldownStateChanged := false
@@ -834,12 +838,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = next
 							}
 						case 404:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(12 * time.Hour)
-								state.NextRetryAfter = next
-							}
+							state.NextRetryAfter = notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
+							state.Unavailable = !state.NextRetryAfter.IsZero()
 						case 429:
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
@@ -917,7 +917,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, classificationModel, now, disableCooling)
 			}
 		}
 
@@ -1981,7 +1981,47 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *QuotaState, now time.Time, disableCooling bool) time.Time {
+	if disableCooling {
+		return time.Time{}
+	}
+	if isExplicitModelNotFoundError(resultErr, requestedModel) {
+		return now.Add(12 * time.Hour)
+	}
+	if retryState != nil && retryState.NextRecoverAt.After(now) {
+		return retryState.NextRecoverAt
+	}
+
+	baseRetryAt := nextTransientErrorRetryAfter(now)
+	if baseRetryAt.IsZero() {
+		return time.Time{}
+	}
+	backoffLevel := 0
+	if retryState != nil && retryState.BackoffLevel > 0 {
+		backoffLevel = retryState.BackoffLevel
+	}
+	cooldown := baseRetryAt.Sub(now)
+	for level := 0; level < backoffLevel && cooldown < quotaBackoffMax; level++ {
+		if cooldown > quotaBackoffMax/2 {
+			cooldown = quotaBackoffMax
+			break
+		}
+		cooldown *= 2
+	}
+	if cooldown > quotaBackoffMax {
+		cooldown = quotaBackoffMax
+	}
+	if retryState != nil && cooldown < quotaBackoffMax {
+		retryState.BackoffLevel = backoffLevel + 1
+	}
+	next := now.Add(cooldown)
+	if retryState != nil {
+		retryState.NextRecoverAt = next
+	}
+	return next
+}
+
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, attemptedModel string, now time.Time, disableCooling bool) {
 	if auth == nil {
 		return
 	}
@@ -2042,11 +2082,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 	case 404:
 		auth.StatusMessage = "not_found"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(12 * time.Hour)
-		}
+		auth.NextRetryAfter = notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	case 429:
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1823,7 +1823,7 @@ func containsStructuredModelNotFound(value any, requestedModel string) bool {
 					if isModelNotFoundIdentifier(text) {
 						return true
 					}
-				case "type":
+				case "type", "status":
 					if isModelNotFoundIdentifier(text) {
 						return true
 					}
@@ -1892,6 +1892,13 @@ func isExplicitModelNotFoundMessage(message, requestedModel string) bool {
 	if strings.Contains(normalized, "model_not_found") || strings.Contains(normalized, "unknown_model") {
 		return true
 	}
+	// Gemini/Vertex/AI Studio's documented missing-model shape: message
+	// "models/<id> is not found for API version ..., or is not supported
+	// for ...". The "models/" prefix (no space) falls outside the generic
+	// "model " / "model:" prefix grammar below, so it needs its own check.
+	if isGeminiModelNotFoundMessage(lower, requestedModel) {
+		return true
+	}
 	for _, prefix := range []string{"no such model", "unknown model"} {
 		if lower != prefix && !strings.HasPrefix(lower, prefix+" ") && !strings.HasPrefix(lower, prefix+":") {
 			continue
@@ -1954,12 +1961,42 @@ func trimRequestedModelReference(value, requestedModel string) (string, bool) {
 }
 
 func isMissingModelPhrase(value string) bool {
-	switch strings.Trim(value, " .!;\t\r\n") {
-	case "not found", "was not found", "could not be found", "does not exist", "doesn't exist", "not exist", "is unknown":
-		return true
-	default:
+	trimmed := strings.Trim(value, " .!;\t\r\n")
+	for _, phrase := range []string{"not found", "was not found", "could not be found", "does not exist", "doesn't exist", "not exist", "is unknown"} {
+		if trimmed == phrase {
+			return true
+		}
+		// Ollama's shape appends guidance after the phrase, e.g.
+		// `model '<id>' not found, try pulling it first` - accept a
+		// comma/semicolon-delimited continuation without accepting an
+		// unrelated word run-on (`not founder` etc.).
+		if strings.HasPrefix(trimmed, phrase+",") || strings.HasPrefix(trimmed, phrase+";") {
+			return true
+		}
+	}
+	return false
+}
+
+// isGeminiModelNotFoundMessage recognizes the official Gemini/Vertex/AI
+// Studio missing-model 404 message shape:
+//
+//	"models/<id> is not found for API version v1beta, or is not supported
+//	for bidiGenerateContent. Call ListModels to see the list of available
+//	models and their supported methods."
+//
+// lower must already be lowercased and trimmed of leading/trailing
+// whitespace and sentence punctuation (see isExplicitModelNotFoundMessage).
+func isGeminiModelNotFoundMessage(lower, requestedModel string) bool {
+	const prefix = "models/"
+	if !strings.HasPrefix(lower, prefix) {
 		return false
 	}
+	remainder := strings.TrimPrefix(lower, prefix)
+	suffix, matches := trimRequestedModelReference(remainder, requestedModel)
+	if !matches {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(suffix), "is not found")
 }
 
 // isRequestInvalidError returns true if the error represents a client request

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1807,7 +1807,62 @@ func isStructuredModelNotFoundError(message, requestedModel string) bool {
 	if errJSON := json.Unmarshal([]byte(strings.TrimSpace(message)), &payload); errJSON != nil {
 		return false
 	}
+	if isGeminiStructuredNotFound(payload, requestedModel) {
+		return true
+	}
 	return containsStructuredModelNotFound(payload, requestedModel)
+}
+
+// isGeminiStructuredNotFound implements Gemini/Vertex/AI Studio's documented
+// missing-model shape: a top-level "error" object whose "status" field is
+// literally "NOT_FOUND" AND whose "message" field matches the documented
+// "models/<id> is not found for API version ..." grammar. Both conditions
+// are required and both must come from the SAME "error" object - a message
+// with the right text but no status field, or a status field that lives
+// outside "error" (e.g. at the JSON root, sibling to "error"), does not
+// count. This intentionally does not use the generic recursive
+// containsStructuredModelNotFound() walker, because that walker has no
+// concept of "am I inside error" and so cannot enforce the nesting
+// requirement.
+func isGeminiStructuredNotFound(payload any, requestedModel string) bool {
+	root, ok := payload.(map[string]any)
+	if !ok {
+		return false
+	}
+	var errObj map[string]any
+	for key, value := range root {
+		if strings.ToLower(strings.TrimSpace(key)) != "error" {
+			continue
+		}
+		if m, ok := value.(map[string]any); ok {
+			errObj = m
+		}
+		break
+	}
+	if errObj == nil {
+		return false
+	}
+	status, hasStatus := mapStringField(errObj, "status")
+	if !hasStatus || !isNotFoundErrorIdentifier(status) {
+		return false
+	}
+	message, _ := mapStringField(errObj, "message")
+	lower := strings.Trim(strings.ToLower(strings.TrimSpace(message)), " .!;\t\r\n")
+	return isGeminiModelNotFoundMessage(lower, requestedModel)
+}
+
+// mapStringField does a case-insensitive lookup of key within m, returning
+// the value and true only if it is present and is a JSON string.
+func mapStringField(m map[string]any, key string) (string, bool) {
+	target := strings.ToLower(strings.TrimSpace(key))
+	for k, v := range m {
+		if strings.ToLower(strings.TrimSpace(k)) != target {
+			continue
+		}
+		s, isString := v.(string)
+		return s, isString
+	}
+	return "", false
 }
 
 func containsStructuredModelNotFound(value any, requestedModel string) bool {
@@ -1823,7 +1878,7 @@ func containsStructuredModelNotFound(value any, requestedModel string) bool {
 					if isModelNotFoundIdentifier(text) {
 						return true
 					}
-				case "type", "status":
+				case "type":
 					if isModelNotFoundIdentifier(text) {
 						return true
 					}
@@ -1892,13 +1947,11 @@ func isExplicitModelNotFoundMessage(message, requestedModel string) bool {
 	if strings.Contains(normalized, "model_not_found") || strings.Contains(normalized, "unknown_model") {
 		return true
 	}
-	// Gemini/Vertex/AI Studio's documented missing-model shape: message
-	// "models/<id> is not found for API version ..., or is not supported
-	// for ...". The "models/" prefix (no space) falls outside the generic
-	// "model " / "model:" prefix grammar below, so it needs its own check.
-	if isGeminiModelNotFoundMessage(lower, requestedModel) {
-		return true
-	}
+	// Gemini/Vertex/AI Studio's "models/<id> is not found ..." grammar is
+	// NOT checked here on message text alone - it additionally requires
+	// error.status == "NOT_FOUND" from the same "error" object, which this
+	// function (message-only) cannot see. That combined check lives in
+	// isGeminiStructuredNotFound, called from isStructuredModelNotFoundError.
 	for _, prefix := range []string{"no such model", "unknown model"} {
 		if lower != prefix && !strings.HasPrefix(lower, prefix+" ") && !strings.HasPrefix(lower, prefix+":") {
 			continue
@@ -1966,13 +2019,14 @@ func isMissingModelPhrase(value string) bool {
 		if trimmed == phrase {
 			return true
 		}
-		// Ollama's shape appends guidance after the phrase, e.g.
-		// `model '<id>' not found, try pulling it first` - accept a
-		// comma/semicolon-delimited continuation without accepting an
-		// unrelated word run-on (`not founder` etc.).
-		if strings.HasPrefix(trimmed, phrase+",") || strings.HasPrefix(trimmed, phrase+";") {
-			return true
-		}
+	}
+	// Ollama's documented guidance suffix is this EXACT continuation, e.g.
+	// `model '<id>' not found, try pulling it first` - not a generic
+	// comma/semicolon-delimited run-on, which would also accept unrelated
+	// adversarial text after "not found" (`, but endpoint /v1/foo missing`,
+	// `; HTML endpoint page follows`).
+	if trimmed == "not found, try pulling it first" {
+		return true
 	}
 	return false
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -376,9 +376,6 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	model := strings.TrimSpace(record.Model)
 
 	if model == "" {
-		auth.Unavailable = true
-		auth.Status = StatusError
-		auth.NextRetryAfter = next
 		applyCooldownFields(&auth.Quota, quota)
 		auth.Quota = mergeQuotaObservation(auth.Quota, quota)
 		auth.Generation++
@@ -387,6 +384,28 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 			auth.StatusMessage = reason
 		}
 		auth.LastError = cloneError(record.LastError)
+		if len(auth.ModelStates) > 0 {
+			// This auth already has (or, since RestoreCooldownStates applies
+			// model-scoped records before auth-level ones, just received)
+			// per-model state. An auth-level record built from one cooling
+			// sibling's aggregate quota (see authCooldownStateRecord) must
+			// not force the whole credential unavailable here - re-derive
+			// auth.Unavailable/NextRetryAfter/Quota from the actual model
+			// states via updateAggregatedAvailability instead of trusting
+			// this record's own flags, so restore agrees with write
+			// regardless of record order.
+			updateAggregatedAvailability(auth, now)
+		} else {
+			// No per-model state exists for this credential at all, so the
+			// auth-level record IS the sole source of truth for a genuine
+			// credential-wide cooldown (e.g. a 401 or credential_quota) -
+			// updateAggregatedAvailability would otherwise treat "no model
+			// states" as "nothing is wrong" and wipe it via
+			// clearAggregatedAvailability.
+			auth.Unavailable = true
+			auth.Status = StatusError
+			auth.NextRetryAfter = next
+		}
 		return true
 	}
 
@@ -402,7 +421,30 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	})
 	auth.Generation++
 	auth.UpdatedAt = updatedAt
+
+	// modelCooldownStateRecord only ever persists a record for a BLOCKED
+	// model (see its !blocked early-return) - an available sibling never
+	// gets one. So restoring a single model-scoped record into a fresh
+	// Manager necessarily leaves auth.ModelStates holding only the cooling
+	// model(s), never the siblings that were selectable before shutdown.
+	// updateAggregatedAvailability's sweep treats an ABSENT entry the same
+	// as an unavailable one (allUnavailable starts true and is only
+	// lowered by entries actually present), so calling it unconditionally
+	// here would mark the whole credential unavailable from a single
+	// restored model - even though isAuthBlockedForModel's own model!=""
+	// path (used by every real selection call) already blocks just that
+	// model correctly. Only let this restore LOWER auth.Unavailable
+	// (e.g. a previously-restored auth-level record clears once a model
+	// comes back), never RAISE it on the strength of one partially
+	// restored model map: that escalation is exactly what would make a
+	// multi-model credential go dark after a restart over one cooling
+	// sibling.
+	wasUnavailable := auth.Unavailable
 	updateAggregatedAvailability(auth, now)
+	if !wasUnavailable && auth.Unavailable {
+		auth.Unavailable = false
+		auth.NextRetryAfter = time.Time{}
+	}
 	return true
 }
 
@@ -691,21 +733,33 @@ func cooldownErrorEqual(a, b *Error) bool {
 
 // authCooldownStateRecord builds the persisted record for a credential-level
 // cooldown. Whether a record exists at all, and what deadline it carries, is
-// decided by availabilityBlock - the same function the in-memory selector
-// uses to decide whether this auth is blocked - rather than by NextRetryAfter
-// alone. A later failure of a different kind (e.g. a transient 5xx) can
-// shorten auth.NextRetryAfter without touching auth.Quota.NextRecoverAt (see
+// decided by isAuthBlockedForModel(auth, "", now) - the same aggregate-vs-
+// credential logic the in-memory selector uses to decide whether the WHOLE
+// credential is blocked - rather than by availabilityBlock on auth.Quota
+// directly. updateAggregatedAvailability deliberately copies one cooling
+// sibling model's quota into auth.Quota (Reason "quota") while leaving
+// auth.Unavailable false when other models remain available; a raw
+// availabilityBlock call on auth.Quota alone cannot see that distinction and
+// would persist a credential-level record from that aggregate-only quota,
+// blocking every model for this credential after a restart even though only
+// one sibling was ever cooling. isAuthBlockedForModel(auth, "", now) already
+// encodes the exception (aggregate quota with Reason != "credential_quota"
+// and auth.Unavailable false does not block), so reusing it here keeps both
+// call sites in exact agreement.
+//
+// A later failure of a different kind (e.g. a transient 5xx) can shorten
+// auth.NextRetryAfter without touching auth.Quota.NextRecoverAt (see
 // notFoundRetryAfter/preserveLongerCooldown); checking NextRetryAfter alone
 // would silently drop the record - and the cooldown it protects - the moment
 // the shortened deadline passes, even though the credential is still blocked
 // in memory until the longer NextRecoverAt. The persisted NextRetryAfter is
-// the effective (longer) deadline availabilityBlock returns, so a `.cds`
-// file always shows the deadline that is actually in force.
+// the effective (longer) deadline availabilityBlock returns internally, so a
+// `.cds` file always shows the deadline that is actually in force.
 func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bool) {
 	if auth == nil {
 		return CooldownStateRecord{}, false
 	}
-	blocked, _, next := availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+	blocked, _, next := isAuthBlockedForModel(auth, "", now)
 	if !blocked || next.IsZero() {
 		return CooldownStateRecord{}, false
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -932,7 +932,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, classificationModel, now, disableCooling)
+				applyAuthFailureStateForModel(auth, result.Error, result.RetryAfter, classificationModel, now, disableCooling)
 			}
 		}
 
@@ -2057,7 +2057,19 @@ func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *Quo
 	return next
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, attemptedModel string, now time.Time, disableCooling bool) {
+// applyAuthFailureState preserves the original origin/dev signature so
+// existing callers/tests are untouched. It has no per-model context, so the
+// 404 branch classifies without a requested-model comparison (matching prior
+// behavior for this entrypoint).
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+	applyAuthFailureStateForModel(auth, resultErr, retryAfter, "", now, disableCooling)
+}
+
+// applyAuthFailureStateForModel is the model-aware variant used by callers
+// that know which model was attempted, so the 404 branch can classify an
+// explicit model-not-found against a longer stored deadline via
+// notFoundRetryAfter/preserveLongerCooldown.
+func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *time.Duration, attemptedModel string, now time.Time, disableCooling bool) {
 	if auth == nil {
 		return
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -384,24 +384,43 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 			auth.StatusMessage = reason
 		}
 		auth.LastError = cloneError(record.LastError)
+		scope := strings.TrimSpace(record.Scope)
+		if scope == cooldownScopeCredential {
+			// A genuine credential-wide failure (e.g. a 401): trust this
+			// record's own deadline directly and mark it via
+			// auth.CredentialCooldown so the updateAggregatedAvailability
+			// call below (and any later call triggered elsewhere, e.g. a
+			// sibling model success) cannot silently clear it before `next`
+			// just because ModelStates looks clean - a credential-wide
+			// failure blocks every model regardless of any individual
+			// model's state, so it must not be reduced to a ModelStates
+			// aggregation the way the legacy/aggregate-derived scope is.
+			auth.Unavailable = true
+			auth.Status = StatusError
+			auth.NextRetryAfter = next
+			auth.CredentialCooldown = true
+		}
 		if len(auth.ModelStates) > 0 {
 			// This auth already has (or, since RestoreCooldownStates applies
 			// model-scoped records before auth-level ones, just received)
-			// per-model state. An auth-level record built from one cooling
-			// sibling's aggregate quota (see authCooldownStateRecord) must
-			// not force the whole credential unavailable here - re-derive
-			// auth.Unavailable/NextRetryAfter/Quota from the actual model
-			// states via updateAggregatedAvailability instead of trusting
-			// this record's own flags, so restore agrees with write
-			// regardless of record order.
+			// per-model state. A legacy/aggregate-derived record (built from
+			// one cooling sibling's aggregate quota, see
+			// authCooldownStateRecord) must not force the whole credential
+			// unavailable here - re-derive auth.Unavailable/NextRetryAfter/
+			// Quota from the actual model states via
+			// updateAggregatedAvailability instead of trusting this
+			// record's own flags, so restore agrees with write regardless
+			// of record order. A credential-wide record (handled above)
+			// survives this call because updateAggregatedAvailability
+			// itself now preserves auth.CredentialCooldown while its
+			// deadline is still in force.
 			updateAggregatedAvailability(auth, now)
-		} else {
+		} else if scope != cooldownScopeCredential {
 			// No per-model state exists for this credential at all, so the
-			// auth-level record IS the sole source of truth for a genuine
-			// credential-wide cooldown (e.g. a 401 or credential_quota) -
-			// updateAggregatedAvailability would otherwise treat "no model
-			// states" as "nothing is wrong" and wipe it via
-			// clearAggregatedAvailability.
+			// auth-level record IS the sole source of truth for a
+			// legacy/aggregate-derived cooldown - updateAggregatedAvailability
+			// would otherwise treat "no model states" as "nothing is wrong"
+			// and wipe it via clearAggregatedAvailability.
 			auth.Unavailable = true
 			auth.Status = StatusError
 			auth.NextRetryAfter = next
@@ -512,6 +531,7 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		auth.Unavailable = false
 		auth.NextRetryAfter = time.Time{}
 		applyCooldownFields(&auth.Quota, QuotaState{})
+		auth.CredentialCooldown = false
 		auth.UpdatedAt = now
 		changed = true
 	}
@@ -761,6 +781,7 @@ func cooldownStateRecordEqual(a, b CooldownStateRecord) bool {
 		a.Model != b.Model ||
 		a.Status != b.Status ||
 		a.Reason != b.Reason ||
+		a.Scope != b.Scope ||
 		!a.NextRetryAfter.Equal(b.NextRetryAfter) ||
 		!a.UpdatedAt.Equal(b.UpdatedAt) ||
 		!cooldownQuotaEqual(a.Quota, b.Quota) {
@@ -810,6 +831,10 @@ func cooldownErrorEqual(a, b *Error) bool {
 // in memory until the longer NextRecoverAt. The persisted NextRetryAfter is
 // the effective (longer) deadline availabilityBlock returns internally, so a
 // `.cds` file always shows the deadline that is actually in force.
+//
+// The returned record's Scope also distinguishes a genuine credential-wide
+// failure (auth.CredentialCooldown, e.g. a 401) from an aggregate-derived
+// block, so restore can tell them apart - see restoreCooldownRecordLocked.
 func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bool) {
 	if auth == nil {
 		return CooldownStateRecord{}, false
@@ -818,6 +843,10 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 	if !blocked || next.IsZero() {
 		return CooldownStateRecord{}, false
 	}
+	scope := ""
+	if auth.CredentialCooldown {
+		scope = cooldownScopeCredential
+	}
 	return CooldownStateRecord{
 		Provider:       strings.TrimSpace(auth.Provider),
 		AuthID:         auth.ID,
@@ -825,6 +854,7 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 		Status:         "cooling",
 		NextRetryAfter: next,
 		Reason:         cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
+		Scope:          scope,
 		Quota:          cooldownFieldsOf(auth.Quota),
 		LastError:      cloneError(auth.LastError),
 		UpdatedAt:      auth.UpdatedAt,
@@ -1400,6 +1430,26 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		auth.Unavailable = true
 		return
+	}
+	if auth.CredentialCooldown {
+		// auth.Unavailable/NextRetryAfter were set directly by a genuine
+		// credential-wide failure (e.g. a 401), not derived from
+		// ModelStates - see applyAuthFailureStateForModel and
+		// restoreCooldownRecordLocked's cooldownScopeCredential branch. That
+		// signal must survive this recompute even when ModelStates is
+		// non-empty and otherwise clean: a credential-wide failure blocks
+		// every model regardless of any individual model's state, so
+		// deciding purely from ModelStates here would silently clear it
+		// before its own deadline (the exact defect this field exists to
+		// prevent). Once the deadline passes, the credential-wide signal no
+		// longer applies - clear the marker and fall through to the normal
+		// ModelStates-derived decision below (or clearAggregatedAvailability
+		// if ModelStates is empty).
+		if auth.NextRetryAfter.After(now) {
+			auth.Unavailable = true
+			return
+		}
+		auth.CredentialCooldown = false
 	}
 	if len(auth.ModelStates) == 0 {
 		clearAggregatedAvailability(auth)
@@ -2336,6 +2386,18 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
+	// This function writes Unavailable/NextRetryAfter/Quota directly on auth
+	// - it has no per-model context, so every outcome here is a genuine
+	// credential-wide failure, not something derived from ModelStates.
+	// Sync auth.CredentialCooldown to the final auth.Unavailable value on
+	// every exit path (including the early returns below) so
+	// updateAggregatedAvailability can tell this apart from an
+	// aggregate-derived block and never clear it early. Declared before the
+	// disableCooling-clearing defer so it runs after it (defers are LIFO)
+	// and observes the final, post-clearing value of auth.Unavailable.
+	defer func() {
+		auth.CredentialCooldown = auth.Unavailable
+	}()
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -824,6 +824,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						state.NextRetryAfter = next
 					} else if isCloudflareChallengeResultError(result.Error) {
 						next, backoffLevel := nextCloudflareCooldown(state.Quota.BackoffLevel, disableCooling, now)
+						// A racing challenge must not shorten a longer deadline
+						// already stored by an explicit not-found/unsupported-model
+						// classification for this model key.
+						next = preserveLongerCooldown(state.Quota, next)
 						state.NextRetryAfter = next
 						state.StatusMessage = "cloudflare challenge"
 						if auth.LastError != nil {
@@ -2079,6 +2083,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if isCloudflareChallengeResultError(resultErr) {
 		auth.StatusMessage = "cloudflare challenge"
 		next, backoffLevel := nextCloudflareCooldown(auth.Quota.BackoffLevel, disableCooling, now)
+		// A racing challenge must not shorten a longer deadline already
+		// stored by an explicit not-found classification for this auth.
+		next = preserveLongerCooldown(auth.Quota, next)
 		applyCooldownFields(&auth.Quota, QuotaState{
 			Exceeded:      true,
 			Reason:        "cloudflare challenge",

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1030,16 +1030,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = next
 							}
 						case 404:
+							existingModelRetryAfter := state.NextRetryAfter
 							next := notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
 							// A racing generic 404 for this model key must not
 							// shorten or clear a longer-lived cooldown already
-							// recorded for this model (e.g. a live 401) - same
-							// effective-deadline rule as the auth-level 404
-							// case below, applied per model key via the
-							// shared effectiveDeadline accessor.
-							if existingModelDeadline := effectiveDeadline(auth, modelKey, now); existingModelDeadline.After(next) {
-								next = existingModelDeadline
-							}
+							// recorded in this model's NextRetryAfter (e.g. a
+							// live 401) - same write-guard rule as the
+							// auth-level 404 case below, via maxDeadline.
+							next = maxDeadline(now, existingModelRetryAfter, next)
 							state.NextRetryAfter = next
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						case 429:
@@ -2328,6 +2326,24 @@ func preserveLongerCooldown(existing QuotaState, next time.Time) time.Time {
 	return next
 }
 
+// maxDeadline returns whichever of existing or next is the later deadline
+// that is still live (after now), or the zero Time if neither is. It is the
+// write-guard counterpart to preserveLongerCooldown, used by the two 404
+// branches below to stop a racing generic-404 recomputation from shortening
+// or clearing an already-longer NextRetryAfter recorded by an earlier
+// failure (e.g. a live 401/429) for the same auth or model key.
+//
+// Deliberately independent of effectiveBlock/effectiveDeadline in
+// selector.go: "preserve the longer of two deadlines" is write-guard
+// arithmetic, not a blocking-decision read, and the two must never be
+// routed through the same accessor.
+func maxDeadline(now, existing, next time.Time) time.Time {
+	if existing.After(now) && existing.After(next) {
+		return existing
+	}
+	return next
+}
+
 func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *QuotaState, now time.Time, disableCooling bool) time.Time {
 	if disableCooling {
 		return time.Time{}
@@ -2466,15 +2482,14 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 		}
 	case 404:
 		auth.StatusMessage = "not_found"
+		existingRetryAfter := auth.NextRetryAfter
 		next := notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
 		// A racing generic 404 must not shorten or clear a longer-lived
-		// credential-wide cooldown already recorded (e.g. a live 401) -
-		// same effective-deadline rule as preserveLongerCooldown, taken
-		// across both NextRetryAfter and Quota.NextRecoverAt via the
-		// shared effectiveDeadline accessor instead of one field alone.
-		if existingDeadline := effectiveDeadline(auth, "", now); existingDeadline.After(next) {
-			next = existingDeadline
-		}
+		// credential-wide cooldown already recorded in NextRetryAfter (e.g. a
+		// live 401) - same write-guard rule as preserveLongerCooldown
+		// (which notFoundRetryAfter already applies to Quota.NextRecoverAt
+		// internally), via maxDeadline for the NextRetryAfter field.
+		next = maxDeadline(now, existingRetryAfter, next)
 		auth.NextRetryAfter = next
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	case 429:

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1030,7 +1030,17 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = next
 							}
 						case 404:
-							state.NextRetryAfter = notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
+							existingModelRetryAfter := state.NextRetryAfter
+							next := notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
+							// A racing generic 404 for this model key must not
+							// shorten or clear a longer-lived cooldown already
+							// recorded in this model's NextRetryAfter (e.g. a
+							// live 401) - same effective-deadline rule as the
+							// auth-level 404 case above, applied per model key.
+							if existingModelRetryAfter.After(now) && existingModelRetryAfter.After(next) {
+								next = existingModelRetryAfter
+							}
+							state.NextRetryAfter = next
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						case 429:
 							var next time.Time

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -990,6 +990,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						// racing generic 404 the same way explicit not-found does.
 						next := now.Add(12 * time.Hour)
 						next = preserveLongerCooldown(state.Quota, next)
+						next = writeCooldownDeadline(now, false, state.NextRetryAfter, next)
 						applyCooldownFields(&state.Quota, QuotaState{
 							Exceeded:      true,
 							Reason:        "model_not_supported",
@@ -1003,6 +1004,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						// already stored by an explicit not-found/unsupported-model
 						// classification for this model key.
 						next = preserveLongerCooldown(state.Quota, next)
+						next = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, next)
 						state.NextRetryAfter = next
 						state.StatusMessage = "cloudflare challenge"
 						if auth.LastError != nil {
@@ -1015,29 +1017,33 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							BackoffLevel:  backoffLevel,
 						})
 					} else if isInvalidGrantResultError(result.Error) {
-						if disableCooling {
-							state.NextRetryAfter = time.Time{}
-						} else {
-							state.NextRetryAfter = now.Add(30 * time.Minute)
+						proposed := time.Time{}
+						if !disableCooling {
+							proposed = now.Add(30 * time.Minute)
 						}
+						state.NextRetryAfter = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, proposed)
 					} else {
 						switch statusCode {
 						case 401, 402, 403:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								next := now.Add(30 * time.Minute)
-								state.NextRetryAfter = next
+							proposed := time.Time{}
+							if !disableCooling {
+								proposed = now.Add(30 * time.Minute)
 							}
+							state.NextRetryAfter = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, proposed)
 						case 404:
-							existingModelRetryAfter := state.NextRetryAfter
 							next := notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
 							// A racing generic 404 for this model key must not
 							// shorten or clear a longer-lived cooldown already
 							// recorded in this model's NextRetryAfter (e.g. a
 							// live 401) - same write-guard rule as the
-							// auth-level 404 case below, via maxDeadline.
-							next = maxDeadline(now, existingModelRetryAfter, next)
+							// auth-level 404 case below, via
+							// writeCooldownDeadline. disableCooling is passed
+							// through so an explicit clear still wins (see
+							// finding 3 addendum: notFoundRetryAfter already
+							// returns zero when disableCooling, and a bare
+							// maxDeadline would wrongly restore the old
+							// deadline over that explicit zero).
+							next = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, next)
 							state.NextRetryAfter = next
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						case 429:
@@ -1055,6 +1061,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								}
 								next = preserveLongerCooldown(state.Quota, next)
 							}
+							next = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, next)
 							state.NextRetryAfter = next
 							applyCooldownFields(&state.Quota, QuotaState{
 								Exceeded:      true,
@@ -1067,10 +1074,19 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									if otherState != nil && otherState != state {
 										otherState.Unavailable = true
 										otherState.Status = StatusError
+										// A credential-scope 429 on this model
+										// must not shorten a sibling's own
+										// longer-lived deadline recorded in
+										// EITHER of its two fields (finding 3:
+										// a sibling's live 401 in
+										// NextRetryAfter was being lost here
+										// because only Quota.NextRecoverAt was
+										// compared).
 										otherNext := next
 										if otherState.Quota.Exceeded && otherState.Quota.NextRecoverAt.After(otherNext) {
 											otherNext = otherState.Quota.NextRecoverAt
 										}
+										otherNext = maxDeadline(now, otherState.NextRetryAfter, otherNext)
 										otherState.NextRetryAfter = otherNext
 										applyCooldownFields(&otherState.Quota, QuotaState{
 											Exceeded:      true,
@@ -1087,14 +1103,15 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								if auth.Quota.NextRecoverAt.After(authNext) {
 									authNext = auth.Quota.NextRecoverAt
 								}
+								authNext = maxDeadline(now, auth.NextRetryAfter, authNext)
 								auth.Quota.NextRecoverAt = authNext
 								auth.NextRetryAfter = authNext
 							}
 						case 408, 500, 502, 503, 504:
-							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.NextRetryAfter = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, recoverableFailureRetryAfter(now, disableCooling))
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
-							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.NextRetryAfter = writeCooldownDeadline(now, disableCooling, state.NextRetryAfter, recoverableFailureRetryAfter(now, disableCooling))
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						}
 					}
@@ -1435,29 +1452,35 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	if auth == nil {
 		return
 	}
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+	// auth.Unavailable/NextRetryAfter/Quota can carry a GENUINE
+	// credential-wide failure signal (e.g. a 401, or a credential-scope
+	// quota block) set directly by applyAuthFailureStateForModel or
+	// restoreCooldownRecordLocked's cooldownScopeCredential branch, not
+	// derived from ModelStates. That signal must survive this recompute
+	// even when ModelStates is non-empty and otherwise clean: a
+	// credential-wide failure blocks every model regardless of any
+	// individual model's state, so deciding purely from ModelStates here
+	// would silently clear it before its own deadline (the exact defect
+	// this field exists to prevent).
+	//
+	// The two genuine-scope fields (NextRetryAfter gated by
+	// CredentialCooldown, Quota.NextRecoverAt gated by
+	// Reason=="credential_quota") are checked TOGETHER via
+	// genuineCredentialDeadline (2026-09-04 review, finding 2): checking
+	// either field alone missed the case where one had independently
+	// expired while the other was still live. Once neither is live, both
+	// markers are cleared and control falls through to the normal
+	// ModelStates-derived decision below (or clearAggregatedAvailability if
+	// ModelStates is empty).
+	if genuineCredentialDeadline(auth, now).After(now) {
 		auth.Unavailable = true
 		return
 	}
 	if auth.CredentialCooldown {
-		// auth.Unavailable/NextRetryAfter were set directly by a genuine
-		// credential-wide failure (e.g. a 401), not derived from
-		// ModelStates - see applyAuthFailureStateForModel and
-		// restoreCooldownRecordLocked's cooldownScopeCredential branch. That
-		// signal must survive this recompute even when ModelStates is
-		// non-empty and otherwise clean: a credential-wide failure blocks
-		// every model regardless of any individual model's state, so
-		// deciding purely from ModelStates here would silently clear it
-		// before its own deadline (the exact defect this field exists to
-		// prevent). Once the deadline passes, the credential-wide signal no
-		// longer applies - clear the marker and fall through to the normal
-		// ModelStates-derived decision below (or clearAggregatedAvailability
-		// if ModelStates is empty).
-		if auth.NextRetryAfter.After(now) {
-			auth.Unavailable = true
-			return
-		}
 		auth.CredentialCooldown = false
+	}
+	if auth.Quota.Reason == "credential_quota" {
+		auth.Quota = QuotaState{}
 	}
 	if len(auth.ModelStates) == 0 {
 		clearAggregatedAvailability(auth)
@@ -1554,6 +1577,23 @@ func clearAggregatedAvailability(auth *Auth) {
 	applyCooldownFields(&auth.Quota, QuotaState{})
 }
 
+// hasModelError reports whether any model on auth is carrying an error
+// state. This is a fifth terminating-check site (2026-09-04 review,
+// answering the reviewer's open question at line 1571/original): a
+// ModelState CAN have LastError == nil while a longer Quota.NextRecoverAt
+// remains live, via restoreCooldownRecordLocked's model-scoped restore
+// path. That path calls mergeModelState(state, &ModelState{LastError:
+// cloneError(record.LastError), ...}); if the persisted record's LastError
+// was nil (not serialized, or genuinely absent) and the pre-existing
+// in-memory state's LastError was also nil, mergeModelState's nil-coalescing
+// (merged.LastError = cloneError(preferred.LastError); if nil, fall back to
+// the other side) leaves merged.LastError == nil while merged.NextRetryAfter
+// and merged.Quota.NextRecoverAt independently take the max of the two
+// sides regardless of LastError's nil-ness. Checking only NextRetryAfter
+// (as before) missed exactly that case when NextRetryAfter had
+// independently expired but Quota.NextRecoverAt was still live - so both
+// fields are checked here, mirroring availabilityBlock's own five-argument
+// shape.
 func hasModelError(auth *Auth, now time.Time) bool {
 	if auth == nil || len(auth.ModelStates) == 0 {
 		return false
@@ -1566,7 +1606,7 @@ func hasModelError(auth *Auth, now time.Time) bool {
 			return true
 		}
 		if state.Status == StatusError {
-			if state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)) {
+			if state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now) || state.Quota.NextRecoverAt.After(now)) {
 				return true
 			}
 		}
@@ -2344,6 +2384,23 @@ func maxDeadline(now, existing, next time.Time) time.Time {
 	return next
 }
 
+// writeCooldownDeadline is the one canonical write-guard every per-field
+// NextRetryAfter writer in this file goes through when recording a fresh
+// failure: max-on-write against the existing live value for that exact
+// field, so a later failure of any kind (a different status code, a
+// sibling-model aggregate write, a racing classification) can never
+// shorten or clear an already-longer deadline recorded by an earlier one
+// (2026-09-04 review, finding 3). disableCooling is an explicit
+// operator/test override to clear cooldowns outright, not a failure to be
+// preserved against, so it bypasses the max and takes proposed as-is
+// (which callers compute as the zero Time in that case).
+func writeCooldownDeadline(now time.Time, disableCooling bool, existing, proposed time.Time) time.Time {
+	if disableCooling {
+		return proposed
+	}
+	return maxDeadline(now, existing, proposed)
+}
+
 func notFoundRetryAfter(resultErr *Error, requestedModel string, retryState *QuotaState, now time.Time, disableCooling bool) time.Time {
 	if disableCooling {
 		return time.Time{}
@@ -2447,6 +2504,7 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 		// A racing challenge must not shorten a longer deadline already
 		// stored by an explicit not-found classification for this auth.
 		next = preserveLongerCooldown(auth.Quota, next)
+		next = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, next)
 		applyCooldownFields(&auth.Quota, QuotaState{
 			Exceeded:      true,
 			Reason:        "cloudflare challenge",
@@ -2458,38 +2516,37 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 	}
 	if isInvalidGrantResultError(resultErr) {
 		auth.StatusMessage = "invalid_grant"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		proposed := time.Time{}
+		if !disableCooling {
+			proposed = now.Add(30 * time.Minute)
 		}
+		auth.NextRetryAfter = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, proposed)
 		return
 	}
 	switch statusCode {
 	case 401:
 		auth.StatusMessage = "unauthorized"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		proposed := time.Time{}
+		if !disableCooling {
+			proposed = now.Add(30 * time.Minute)
 		}
+		auth.NextRetryAfter = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, proposed)
 	case 402, 403:
 		auth.StatusMessage = "payment_required"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		proposed := time.Time{}
+		if !disableCooling {
+			proposed = now.Add(30 * time.Minute)
 		}
+		auth.NextRetryAfter = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, proposed)
 	case 404:
 		auth.StatusMessage = "not_found"
-		existingRetryAfter := auth.NextRetryAfter
 		next := notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
 		// A racing generic 404 must not shorten or clear a longer-lived
 		// credential-wide cooldown already recorded in NextRetryAfter (e.g. a
 		// live 401) - same write-guard rule as preserveLongerCooldown
 		// (which notFoundRetryAfter already applies to Quota.NextRecoverAt
-		// internally), via maxDeadline for the NextRetryAfter field.
-		next = maxDeadline(now, existingRetryAfter, next)
+		// internally), via writeCooldownDeadline for the NextRetryAfter field.
+		next = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, next)
 		auth.NextRetryAfter = next
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	case 429:
@@ -2509,17 +2566,18 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 			}
 			next = preserveLongerCooldown(auth.Quota, next)
 		}
+		next = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, next)
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
-		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.NextRetryAfter = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, recoverableFailureRetryAfter(now, disableCooling))
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	default:
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
-		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.NextRetryAfter = writeCooldownDeadline(now, disableCooling, auth.NextRetryAfter, recoverableFailureRetryAfter(now, disableCooling))
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -454,7 +454,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	// (allUnavailable starts true and is only lowered by entries actually
 	// present), so calling it unconditionally here would mark the whole
 	// credential unavailable from a single restored model even when
-	// siblings exist and are selectable - even though isAuthBlockedForModel's
+	// siblings exist and are selectable - even though effectiveBlock's
 	// own model!="" path (used by every real selection call) already
 	// blocks just that model correctly. Only let this restore RAISE
 	// auth.Unavailable when the restored model-state map is PROVABLY
@@ -809,7 +809,7 @@ func cooldownErrorEqual(a, b *Error) bool {
 
 // authCooldownStateRecord builds the persisted record for a credential-level
 // cooldown. Whether a record exists at all, and what deadline it carries, is
-// decided by isAuthBlockedForModel(auth, "", now) - the same aggregate-vs-
+// decided by effectiveBlock(auth, "", now) - the same aggregate-vs-
 // credential logic the in-memory selector uses to decide whether the WHOLE
 // credential is blocked - rather than by availabilityBlock on auth.Quota
 // directly. updateAggregatedAvailability deliberately copies one cooling
@@ -818,7 +818,7 @@ func cooldownErrorEqual(a, b *Error) bool {
 // availabilityBlock call on auth.Quota alone cannot see that distinction and
 // would persist a credential-level record from that aggregate-only quota,
 // blocking every model for this credential after a restart even though only
-// one sibling was ever cooling. isAuthBlockedForModel(auth, "", now) already
+// one sibling was ever cooling. effectiveBlock(auth, "", now) already
 // encodes the exception (aggregate quota with Reason != "credential_quota"
 // and auth.Unavailable false does not block), so reusing it here keeps both
 // call sites in exact agreement.
@@ -839,7 +839,7 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 	if auth == nil {
 		return CooldownStateRecord{}, false
 	}
-	blocked, _, next := isAuthBlockedForModel(auth, "", now)
+	blocked, _, next := effectiveBlock(auth, "", now)
 	if !blocked || next.IsZero() {
 		return CooldownStateRecord{}, false
 	}
@@ -1030,15 +1030,15 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = next
 							}
 						case 404:
-							existingModelRetryAfter := state.NextRetryAfter
 							next := notFoundRetryAfter(result.Error, classificationModel, &state.Quota, now, disableCooling)
 							// A racing generic 404 for this model key must not
 							// shorten or clear a longer-lived cooldown already
-							// recorded in this model's NextRetryAfter (e.g. a
-							// live 401) - same effective-deadline rule as the
-							// auth-level 404 case above, applied per model key.
-							if existingModelRetryAfter.After(now) && existingModelRetryAfter.After(next) {
-								next = existingModelRetryAfter
+							// recorded for this model (e.g. a live 401) - same
+							// effective-deadline rule as the auth-level 404
+							// case below, applied per model key via the
+							// shared effectiveDeadline accessor.
+							if existingModelDeadline := effectiveDeadline(auth, modelKey, now); existingModelDeadline.After(next) {
+								next = existingModelDeadline
 							}
 							state.NextRetryAfter = next
 							state.Unavailable = !state.NextRetryAfter.IsZero()
@@ -1481,7 +1481,7 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 			stateUnavailable = true
 		} else {
 			// Decide per model via the same predicate the selector uses
-			// (isAuthBlockedForModel's matched-model path calls
+			// (effectiveBlock's matched-model path calls
 			// availabilityBlock with these exact five values) instead of a
 			// field-specific shortcut that only looked at
 			// state.Unavailable/NextRetryAfter. A generic 404 stores its
@@ -2466,14 +2466,14 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 		}
 	case 404:
 		auth.StatusMessage = "not_found"
-		existingRetryAfter := auth.NextRetryAfter
 		next := notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
 		// A racing generic 404 must not shorten or clear a longer-lived
-		// credential-wide cooldown already recorded in NextRetryAfter (e.g.
-		// a live 401) - same effective-deadline rule as preserveLongerCooldown,
-		// just taken across both fields instead of within Quota alone.
-		if existingRetryAfter.After(now) && existingRetryAfter.After(next) {
-			next = existingRetryAfter
+		// credential-wide cooldown already recorded (e.g. a live 401) -
+		// same effective-deadline rule as preserveLongerCooldown, taken
+		// across both NextRetryAfter and Quota.NextRecoverAt via the
+		// shared effectiveDeadline accessor instead of one field alone.
+		if existingDeadline := effectiveDeadline(auth, "", now); existingDeadline.After(next) {
+			next = existingDeadline
 		}
 		auth.NextRetryAfter = next
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1579,6 +1579,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.BackoffLevel = 0
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
+	auth.CredentialCooldown = false
 	auth.UpdatedAt = now
 }
 
@@ -2455,7 +2456,16 @@ func applyAuthFailureStateForModel(auth *Auth, resultErr *Error, retryAfter *tim
 		}
 	case 404:
 		auth.StatusMessage = "not_found"
-		auth.NextRetryAfter = notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
+		existingRetryAfter := auth.NextRetryAfter
+		next := notFoundRetryAfter(resultErr, attemptedModel, &auth.Quota, now, disableCooling)
+		// A racing generic 404 must not shorten or clear a longer-lived
+		// credential-wide cooldown already recorded in NextRetryAfter (e.g.
+		// a live 401) - same effective-deadline rule as preserveLongerCooldown,
+		// just taken across both fields instead of within Quota alone.
+		if existingRetryAfter.After(now) && existingRetryAfter.After(next) {
+			next = existingRetryAfter
+		}
+		auth.NextRetryAfter = next
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	case 429:
 		auth.StatusMessage = "quota exhausted"

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -739,7 +739,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			countTokensWireModel := preferWireModel(wireModelFromError(errExec), sentModel)
+			countTokensWireModel := preferWireModel(wireModelFromError(errExec), wireModelOrSent(resp, sentModel))
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: countTokensWireModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -1180,12 +1180,40 @@ func authSelectionModelFromOptions(opts cliproxyexecutor.Options, fallback strin
 // Claude stripping a thinking suffix, Kimi remapping an alias), so a
 // structured 404 naming the wire model classifies correctly.
 func wireModelOrSent(resp cliproxyexecutor.Response, sent string) string {
+	reported := ""
 	if resp.Metadata != nil {
 		if v, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string); ok {
-			if trimmed := strings.TrimSpace(v); trimmed != "" {
-				return trimmed
-			}
+			reported = strings.TrimSpace(v)
 		}
+	}
+	return preferWireModel(reported, sent)
+}
+
+// wireModelFromError extracts the wire model an executor attached to an
+// error via a WireModel() string method, mirroring wireModelOrSent's
+// Response.Metadata channel for paths (ExecuteStream) that return no
+// Response on failure and so must carry the wire model on the error itself.
+func wireModelFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	type wireModelProvider interface {
+		WireModel() string
+	}
+	var wmp wireModelProvider
+	if errors.As(err, &wmp) && wmp != nil {
+		return strings.TrimSpace(wmp.WireModel())
+	}
+	return ""
+}
+
+// preferWireModel returns the reported wire model when known, else the
+// pre-call sent model. Both wireModelOrSent (Response.Metadata) and
+// wireModelFromError (error-carried) funnel through here so every entry
+// point shares one precedence rule instead of repeating it.
+func preferWireModel(reported, sent string) string {
+	if reported != "" {
+		return reported
 	}
 	return sent
 }

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -1238,6 +1238,24 @@ func preferWireModel(reported, sent string) string {
 	return sent
 }
 
+// bootstrapStreamWireModel resolves the wire model for a stream bootstrap
+// failure Result. A bootstrap error can surface as a structured error value
+// (wireModelFromError, via a WireModel() wrapper) or, when ExecuteStream
+// already succeeded and only the first *chunk* was a structured failure
+// without that wrapper, as StreamResult.Metadata captured before the first
+// chunk was emitted (see wireModelOrSentStream). Checking wireModelFromError
+// alone and falling straight through to sent silently drops a normalized
+// model an executor already reported via metadata - the same class of gap
+// wireModelOrSentStream exists to close on the success path. Every bootstrap
+// Result constructor should funnel through here instead of calling
+// preferWireModel(wireModelFromError(err), sent) directly.
+func bootstrapStreamWireModel(bootstrapErr error, metadata map[string]any, sent string) string {
+	if reported := wireModelFromError(bootstrapErr); reported != "" {
+		return reported
+	}
+	return wireModelOrSentStream(metadata, sent)
+}
+
 func executionModelForAuthSelection(opts cliproxyexecutor.Options, model string) (string, bool) {
 	model = strings.TrimSpace(model)
 	if model == "" {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -1194,6 +1194,21 @@ func wireModelOrSent(resp cliproxyexecutor.Response, sent string) string {
 	return preferWireModel(reported, sent)
 }
 
+// wireModelOrSentStream mirrors wireModelOrSent for the streaming path: a
+// streaming executor that normalizes the model internally (Kimi remapping an
+// alias, Claude stripping a thinking suffix) reports the exact wire model via
+// StreamResult.Metadata, captured before the first chunk is emitted, since a
+// StreamResult carries no per-chunk Response to attach it to on success.
+func wireModelOrSentStream(metadata map[string]any, sent string) string {
+	reported := ""
+	if metadata != nil {
+		if v, ok := metadata[cliproxyexecutor.WireModelMetadataKey].(string); ok {
+			reported = strings.TrimSpace(v)
+		}
+	}
+	return preferWireModel(reported, sent)
+}
+
 // wireModelFromError extracts the wire model an executor attached to an
 // error via a WireModel() string method, mirroring wireModelOrSent's
 // Response.Metadata channel for paths (ExecuteStream) that return no

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -546,7 +546,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
+			wireModel := wireModelOrSent(resp, sentModel)
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: wireModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -1171,6 +1172,22 @@ func authSelectionModelFromOptions(opts cliproxyexecutor.Options, fallback strin
 		}
 	}
 	return fallback
+}
+
+// wireModelOrSent prefers the exact model an executor reports having placed
+// on the outbound upstream request (via Response.Metadata) over the
+// pre-call model captured before executor-internal normalization (e.g.
+// Claude stripping a thinking suffix, Kimi remapping an alias), so a
+// structured 404 naming the wire model classifies correctly.
+func wireModelOrSent(resp cliproxyexecutor.Response, sent string) string {
+	if resp.Metadata != nil {
+		if v, ok := resp.Metadata[cliproxyexecutor.WireModelMetadataKey].(string); ok {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return sent
 }
 
 func executionModelForAuthSelection(opts cliproxyexecutor.Options, model string) (string, bool) {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -545,7 +545,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -736,7 +736,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -509,6 +509,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			sentModel := execReq.Model
 			startExec := time.Now()
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -545,7 +546,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -700,6 +701,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			sentModel := execReq.Model
 			startExec := time.Now()
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -736,7 +738,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -739,7 +739,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
+			countTokensWireModel := preferWireModel(wireModelFromError(errExec), sentModel)
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: countTokensWireModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -750,8 +751,12 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				// Some Anthropic-compatible upstreams do not implement the
 				// count_tokens route and return a generic endpoint 404. Record
 				// the failure for hooks and metrics without suspending a model
-				// that remains usable through the messages endpoint.
-				if isCountTokensEndpointNotFoundError(errExec, execReq.Model) && (result.Error == nil || result.Error.Code != ErrorCodeForceCooldown) {
+				// that remains usable through the messages endpoint. Classify
+				// against the wire model an executor actually sent (e.g. Kimi's
+				// kimi-k3 -> k3 normalization), not the pre-normalization
+				// request model, or a 404 naming the wire model reads as
+				// endpoint-unsupported instead of explicit not-found.
+				if isCountTokensEndpointNotFoundError(errExec, countTokensWireModel) && (result.Error == nil || result.Error.Code != ErrorCodeForceCooldown) {
 					m.recordAvailabilityNeutralResult(execCtx, result)
 				} else {
 					if isCredentialScopedError(errExec) {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -546,7 +546,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			wireModel := wireModelOrSent(resp, sentModel)
+			wireModel := preferWireModel(wireModelFromError(errExec), wireModelOrSent(resp, sentModel))
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: wireModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1392,7 +1392,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
-			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
+			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(errExec), wireModelOrSent(resp, upstreamModel)), RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1392,7 +1392,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
-			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
+			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -239,7 +239,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 			}
-			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
+			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -240,7 +240,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 			}
-			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: wireModelOrSent(response, sentModel), RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
+			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(errExecute), wireModelOrSent(response, sentModel)), RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -189,6 +189,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, preparedAuth, routeModel, upstreamModel)
 				execReq = attachResolvedHomeModelInfo(execReq, selection.modelInfo)
 			}
+			sentModel := execReq.Model
 			if errCtx := execCtx.Err(); errCtx != nil {
 				releaseAttempt()
 				selection.End("attempt_canceled")
@@ -239,7 +240,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 			}
-			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
+			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -240,7 +240,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 			}
-			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
+			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: wireModelOrSent(response, sentModel), RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -184,7 +184,21 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		// token to the same auth file/ID) - the dead-grant recovery
 		// playbook depends on a re-login restoring service immediately,
 		// not leaving it blocked until the old credential's deadline.
-		if existing.CredentialCooldown && existing.NextRetryAfter.After(time.Now()) {
+		//
+		// The liveness check uses genuineCredentialDeadline rather than
+		// existing.NextRetryAfter alone (2026-09-04 review, finding 2):
+		// checking NextRetryAfter alone missed a case where
+		// CredentialCooldown was true, NextRetryAfter had independently
+		// expired, but existing.Quota.NextRecoverAt (Reason ==
+		// "credential_quota") was still live - genuineCredentialDeadline
+		// takes the max of both so neither field's expiry alone drops the
+		// other. The unconditional Quota-preserving block above already
+		// covers the credential_quota-only case (including a re-login,
+		// deliberately, so a rotated credential still honours a live
+		// quota-wide block); this block additionally covers
+		// CredentialCooldown's own scope and applies the re-login override.
+		updateNow := time.Now()
+		if existing.CredentialCooldown && genuineCredentialDeadline(existing, updateNow).After(updateNow) {
 			if sameAuthCredential(existing, auth) {
 				auth.Unavailable = existing.Unavailable
 				auth.NextRetryAfter = existing.NextRetryAfter

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -174,17 +174,29 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 				auth.Status = existing.Status
 			}
 		}
-		// A refreshed/clean Auth (e.g. after a token refresh) must not erase a
-		// live credential-wide cooldown (e.g. a 401) - the incoming Auth
-		// carries no cooldown context of its own, so without this the update
-		// would silently clear an active block before its deadline just
-		// because the new value looks clean.
+		// A refreshed/clean Auth (e.g. after a routine access-token refresh)
+		// must not erase a live credential-wide cooldown (e.g. a 401) - the
+		// incoming Auth carries no cooldown context of its own, so without
+		// this the update would silently clear an active block before its
+		// deadline just because the new value looks clean. But this must
+		// NOT apply when the incoming Auth is a genuinely different
+		// credential (an operator re-login writing a new refresh/access
+		// token to the same auth file/ID) - the dead-grant recovery
+		// playbook depends on a re-login restoring service immediately,
+		// not leaving it blocked until the old credential's deadline.
 		if existing.CredentialCooldown && existing.NextRetryAfter.After(time.Now()) {
-			auth.Unavailable = existing.Unavailable
-			auth.NextRetryAfter = existing.NextRetryAfter
-			auth.CredentialCooldown = existing.CredentialCooldown
-			if auth.Status == StatusActive {
-				auth.Status = existing.Status
+			if sameAuthCredential(existing, auth) {
+				auth.Unavailable = existing.Unavailable
+				auth.NextRetryAfter = existing.NextRetryAfter
+				auth.CredentialCooldown = existing.CredentialCooldown
+				if auth.Status == StatusActive {
+					auth.Status = existing.Status
+				}
+			} else {
+				auth.Unavailable = false
+				auth.NextRetryAfter = time.Time{}
+				auth.CredentialCooldown = false
+				auth.Status = StatusActive
 			}
 		}
 	}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -174,6 +174,19 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 				auth.Status = existing.Status
 			}
 		}
+		// A refreshed/clean Auth (e.g. after a token refresh) must not erase a
+		// live credential-wide cooldown (e.g. a 401) - the incoming Auth
+		// carries no cooldown context of its own, so without this the update
+		// would silently clear an active block before its deadline just
+		// because the new value looks clean.
+		if existing.CredentialCooldown && existing.NextRetryAfter.After(time.Now()) {
+			auth.Unavailable = existing.Unavailable
+			auth.NextRetryAfter = existing.NextRetryAfter
+			auth.CredentialCooldown = existing.CredentialCooldown
+			if auth.Status == StatusActive {
+				auth.Status = existing.Status
+			}
+		}
 	}
 	now := time.Now()
 	auth.UpdatedAt = now

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -235,16 +235,26 @@ func (m *Manager) clientModelProjectionForAuth(auth *Auth, routeModel string, no
 	}
 
 	state := existingModelState(auth, targetKey)
+	// Suspension is derived from effectiveBlock's own reason set
+	// (2026-09-04 review, finding 4), the same predicate selection uses,
+	// rather than a parallel set of direct-field reads that duplicated its
+	// logic and diverged from it: the old reads here recognised only
+	// Quota.Reason=="credential_quota" and the per-model fields, so a
+	// genuine credential-wide auth.CredentialCooldown/auth.NextRetryAfter
+	// block (e.g. a 401) was invisible to this projection even though
+	// effectiveBlock correctly rejected the model for selection - producing
+	// a false-available result. QuotaExceeded stays a separate, quota-only
+	// projection value, not folded into Suspended.
 	isSuspended := auth.Disabled || auth.Status == StatusDisabled
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+	if state != nil && state.Status == StatusDisabled {
+		isSuspended = true
+	}
+	if blocked, _, _ := effectiveBlock(auth, targetKey, now); blocked {
 		isSuspended = true
 	}
 	isQuotaExceeded := false
 	var suspendReason string
 	if state != nil {
-		if state.Status == StatusDisabled || state.Unavailable || (!state.NextRetryAfter.IsZero() && state.NextRetryAfter.After(now)) {
-			isSuspended = true
-		}
 		if state.Quota.Exceeded && (state.Quota.NextRecoverAt.IsZero() || state.Quota.NextRecoverAt.After(now)) {
 			isQuotaExceeded = true
 		}

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -301,7 +301,7 @@ func (m *Manager) filterExecutionModels(auth *Auth, routeModel string, candidate
 	out := make([]string, 0, len(candidates))
 	for _, upstreamModel := range candidates {
 		stateModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
-		blocked, _, _ := isAuthBlockedForModel(auth, stateModel, now)
+		blocked, _, _ := effectiveBlock(auth, stateModel, now)
 		if blocked {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1190,6 +1190,24 @@ func TestIsExplicitModelNotFoundError_ProviderShapes(t *testing.T) {
 			explicit: false,
 		},
 
+		// Adversarial negatives for the free-substring over-classification
+		// bug fixed in isExplicitModelNotFoundMessage: a message containing
+		// "model_not_found"/"unknown_model" as a substring, without naming
+		// THIS requestedModel in the identified position, must not classify
+		// as explicit. Source: team-lead final whole-branch review, 2026-09-03.
+		{
+			name:     "message names a different model, not the requested one",
+			body:     `{"error":{"message":"model other-model not found"}}`,
+			model:    "target-model",
+			explicit: false,
+		},
+		{
+			name:     "html body whose title happens to contain the requested model and not-found wording",
+			body:     `{"error":{"message":"<title>model target-model not found</title>"}}`,
+			model:    "target-model",
+			explicit: false,
+		},
+
 		// Codex: OpenAI Responses-style envelope, error.type ==
 		// "not_found_error" (see internal/runtime/executor/codex_executor_terminal.go:172).
 		// The exact missing-model message wording is COULD-NOT-DETERMINE - no

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -308,9 +308,34 @@ func (e notFoundWireModelExecutor) Execute(_ context.Context, _ *Auth, req clipr
 		Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
 	}
 }
-func (notFoundWireModelExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
-	return nil, nil
+func (e notFoundWireModelExecutor) ExecuteStream(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e.normalize == nil {
+		return nil, nil
+	}
+	// Mirrors ExecuteStream's real shape: no Response.Metadata channel exists
+	// on failure, so the wire model must ride on the error itself (see
+	// internal/runtime/executor's wireModelErr/withWireModel).
+	wire := e.normalize(req.Model)
+	return nil, wireModelStreamError{
+		err: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+		},
+		model: wire,
+	}
 }
+
+// wireModelStreamError simulates internal/runtime/executor's wireModelErr:
+// an error decorated with the wire model, exposed via WireModel(), that
+// still unwraps to the underlying classification error.
+type wireModelStreamError struct {
+	err   *Error
+	model string
+}
+
+func (e wireModelStreamError) Error() string     { return e.err.Error() }
+func (e wireModelStreamError) WireModel() string { return e.model }
+func (e wireModelStreamError) Unwrap() error     { return e.err }
 func (notFoundWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
 	return auth, nil
 }
@@ -323,9 +348,9 @@ func (notFoundWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Reque
 
 func TestExecuteExplicitNotFoundClassifiesAgainstReportedWireModel(t *testing.T) {
 	cases := []struct {
-		name       string
-		reqModel   string
-		normalize  func(string) string
+		name      string
+		reqModel  string
+		normalize func(string) string
 	}{
 		{
 			// Claude strips a "-thinking-32k" style suffix before sending the
@@ -381,6 +406,46 @@ func TestExecuteExplicitNotFoundClassifiesAgainstReportedWireModel(t *testing.T)
 				t.Fatalf("cooldown = %v, want about 12h (404 naming the reported wire model must classify as explicit not-found, not the short retry)", cooldown)
 			}
 		})
+	}
+}
+
+func TestExecuteStreamExplicitNotFoundClassifiesAgainstReportedWireModel(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "claude-opus-4-8-thinking-32k"
+	normalize := func(m string) string { return strings.TrimSuffix(m, "-thinking-32k") }
+	executor := notFoundWireModelExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "wire-model-stream-auth", Provider: "wire-model-vs-sent"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	if _, errExecute := manager.ExecuteStream(context.Background(), []string{"wire-model-vs-sent"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{}); errExecute == nil {
+		t.Fatal("ExecuteStream() unexpectedly succeeded")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteStream()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("ExecuteStream() did not record model cooldown state")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (stream 404 naming the reported wire model must classify as explicit not-found, not the short retry)", cooldown)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -366,6 +366,17 @@ func TestExecuteExplicitNotFoundClassifiesAgainstReportedWireModel(t *testing.T)
 			reqModel:  "kimi-k3",
 			normalize: func(m string) string { return strings.TrimPrefix(m, "kimi-") },
 		},
+		{
+			// A config payload-override rule rewrites the outbound body's
+			// top-level model field long after the pre-call normalization
+			// that computed the pre-override model (mirrors
+			// ApplyPayloadConfigWithRequestTracked/finalWireModel in
+			// internal/runtime/executor): the provider's 404 names the
+			// override target, not the client-requested model.
+			name:      "payload override rewrites model",
+			reqModel:  "claude-opus-4-8",
+			normalize: func(string) string { return "payload-override-target-model" },
+		},
 	}
 
 	for _, tc := range cases {

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1244,3 +1244,106 @@ type statusErrForTest struct {
 
 func (e statusErrForTest) Error() string   { return e.msg }
 func (e statusErrForTest) StatusCode() int { return e.code }
+
+// bootstrapWireModelExecutor mirrors a Kimi/Claude-style executor whose
+// ExecuteStream call itself succeeds (err == nil, StreamResult.Metadata
+// carries the normalized wire model, captured before any chunk is emitted),
+// but whose very FIRST chunk is a structured 404 that implements no
+// WireModel() method. readStreamBootstrap treats a first-chunk error as a
+// bootstrap failure (streaming never actually started from the conductor's
+// point of view), which is a different code path from a later chunk's error
+// (see kimiStyleWireModelExecutor/midStreamWireModelExecutor above, which
+// already succeed via the success-path wireModelOrSentStream resolution at
+// wrapStreamResult). Before this round's fix, every bootstrap Result
+// constructor in conductor_stream.go (:373/:393/:404/:419) resolved via
+// preferWireModel(wireModelFromError(bootstrapErr), sentModel) only -
+// wireModelFromError finds nothing (no WireModel() wrapper) and falls
+// through straight to the pre-normalization sent model, so classification
+// against the reported wire model never matches and the 12h explicit
+// not-found cooldown is missed entirely.
+type bootstrapWireModelExecutor struct {
+	normalize func(model string) string
+}
+
+func (e bootstrapWireModelExecutor) Identifier() string { return "bootstrap-wire-model" }
+func (e bootstrapWireModelExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e bootstrapWireModelExecutor) ExecuteStream(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	wire := e.normalize(req.Model)
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	ch <- cliproxyexecutor.StreamChunk{Err: &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+	}}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{
+		Chunks:   ch,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wire},
+	}, nil
+}
+func (bootstrapWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (bootstrapWireModelExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (bootstrapWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+// TestExecuteStreamBootstrapFirstChunkClassifiesAgainstReportedWireModel
+// covers the delta review's must-fix item 2: a successful ExecuteStream call
+// whose first chunk is a structured 404 without a WireModel() wrapper, with
+// StreamResult.Metadata carrying the normalized wire model, must still
+// classify as an explicit not-found for that reported model and cool down
+// for about 12h - not silently misclassify against the un-normalized
+// pre-call model and fall back to a short transient-error backoff.
+func TestExecuteStreamBootstrapFirstChunkClassifiesAgainstReportedWireModel(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "kimi-k3-thinking-32k"
+	normalize := func(m string) string { return "k3" }
+	executor := bootstrapWireModelExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "bootstrap-wire-model-auth", Provider: "bootstrap-wire-model"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	// The single registered model is also the only execModel candidate, so
+	// once the bootstrap 404 cools it down there is nothing left to retry;
+	// ExecuteStream's own return value (error vs. an empty completed
+	// stream) is an orthogonal retry-exhaustion detail this test does not
+	// assert on - what item 2 is about is whether the cooldown state that
+	// gets recorded along the way classifies against the reported wire
+	// model. Drain whatever comes back so nothing leaks.
+	streamResult, _ := manager.ExecuteStream(context.Background(), []string{"bootstrap-wire-model"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{})
+	if streamResult != nil {
+		for range streamResult.Chunks {
+		}
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteStream()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("ExecuteStream() did not record model cooldown state from the bootstrap first-chunk error")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (bootstrap first-chunk 404 naming the executor-reported wire model, from StreamResult.Metadata on a successful ExecuteStream call, must classify as explicit not-found)", cooldown)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -176,6 +176,53 @@ func TestApplyAuthFailureStateExplicitNotFoundSurvivesRacingGeneric404(t *testin
 	}
 }
 
+func TestApplyAuthFailureStateExplicitNotFoundNeverShortensLongerCooldown(t *testing.T) {
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	explicit := &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound, Message: "model unavailable"}
+	rateLimited := &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"}
+	longRetryAfter := 24 * time.Hour
+	shortRetryAfter := 5 * time.Minute
+
+	// A long 429 window (e.g. a provider retry window beyond 12h) must survive
+	// a later explicit-404 for the same key: the 404 must not shorten it.
+	authLong429First := &Auth{ID: "auth-long-429-then-explicit"}
+	applyAuthFailureState(authLong429First, rateLimited, &longRetryAfter, "", now, false)
+	want429 := now.Add(longRetryAfter)
+	if !authLong429First.NextRetryAfter.Equal(want429) {
+		t.Fatalf("long-429 NextRetryAfter = %v, want %v", authLong429First.NextRetryAfter, want429)
+	}
+	applyAuthFailureState(authLong429First, explicit, nil, "", now, false)
+	if !authLong429First.NextRetryAfter.Equal(want429) {
+		t.Fatalf("explicit 404 shortened a longer 429 deadline: NextRetryAfter = %v, want unchanged %v", authLong429First.NextRetryAfter, want429)
+	}
+
+	// An explicit-404 recorded first must survive a later long 429: the 429
+	// must not lose to a stale short window, and here it is itself longer, so
+	// it applies (the max, not the 404, wins when the 429 is genuinely longer).
+	authExplicitThenLong429 := &Auth{ID: "auth-explicit-then-long-429"}
+	applyAuthFailureState(authExplicitThenLong429, explicit, nil, "", now, false)
+	want12h := now.Add(12 * time.Hour)
+	if !authExplicitThenLong429.NextRetryAfter.Equal(want12h) {
+		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitThenLong429.NextRetryAfter, want12h)
+	}
+	applyAuthFailureState(authExplicitThenLong429, rateLimited, &longRetryAfter, "", now, false)
+	if !authExplicitThenLong429.NextRetryAfter.Equal(want429) {
+		t.Fatalf("explicit-then-long-429 NextRetryAfter = %v, want %v", authExplicitThenLong429.NextRetryAfter, want429)
+	}
+
+	// An explicit-404 recorded first must survive a later SHORT 429 for the
+	// same key: the shorter 429 window must not override the 12h deadline.
+	authExplicitThenShort429 := &Auth{ID: "auth-explicit-then-short-429"}
+	applyAuthFailureState(authExplicitThenShort429, explicit, nil, "", now, false)
+	if !authExplicitThenShort429.NextRetryAfter.Equal(want12h) {
+		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitThenShort429.NextRetryAfter, want12h)
+	}
+	applyAuthFailureState(authExplicitThenShort429, rateLimited, &shortRetryAfter, "", now, false)
+	if !authExplicitThenShort429.NextRetryAfter.Equal(want12h) {
+		t.Fatalf("short 429 shortened the explicit 12h deadline: NextRetryAfter = %v, want unchanged %v", authExplicitThenShort429.NextRetryAfter, want12h)
+	}
+}
+
 // notFoundExecutionModelExecutor returns an explicit model-not-found error that
 // names the model actually present on the request it receives, so the test can
 // tell whether the caller classified the failure against the execution model

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -140,6 +140,39 @@ func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
 	}
 }
 
+func TestApplyAuthFailureStateExplicitNotFoundSurvivesRacingGeneric404(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	explicit := &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound, Message: "model unavailable"}
+
+	// explicit-404 then a racing generic-404 for the same key must not shorten the 12h deadline.
+	authExplicitFirst := &Auth{ID: "auth-explicit-then-generic"}
+	applyAuthFailureState(authExplicitFirst, explicit, nil, "", now, false)
+	want := now.Add(12 * time.Hour)
+	if !authExplicitFirst.NextRetryAfter.Equal(want) {
+		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitFirst.NextRetryAfter, want)
+	}
+	applyAuthFailureState(authExplicitFirst, generic, nil, "", now, false)
+	if !authExplicitFirst.NextRetryAfter.Equal(want) {
+		t.Fatalf("racing generic 404 shortened deadline: NextRetryAfter = %v, want unchanged %v", authExplicitFirst.NextRetryAfter, want)
+	}
+
+	// generic-404 then explicit-404 for the same key must land on the 12h deadline.
+	authGenericFirst := &Auth{ID: "auth-generic-then-explicit"}
+	applyAuthFailureState(authGenericFirst, generic, nil, "", now, false)
+	if got := authGenericFirst.NextRetryAfter; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("generic-first NextRetryAfter = %v, want %v", got, now.Add(time.Minute))
+	}
+	applyAuthFailureState(authGenericFirst, explicit, nil, "", now, false)
+	if !authGenericFirst.NextRetryAfter.Equal(want) {
+		t.Fatalf("generic-then-explicit NextRetryAfter = %v, want %v", authGenericFirst.NextRetryAfter, want)
+	}
+}
+
 func TestMarkResultAliasUsesAttemptedUpstreamModelForExplicitNotFound(t *testing.T) {
 	previousDisabled := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestMarkResultNotFoundCooldownPolicy(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetTransientErrorCooldownSeconds(0)
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		transientErrorCooldownSeconds.Store(previousTransient)
+		quotaCooldownDisabled.Store(previousDisabled)
+	})
+
+	tests := []struct {
+		name            string
+		err             *Error
+		disableCooling  bool
+		initialBackoff  int
+		wantMinCooldown time.Duration
+		wantMaxCooldown time.Duration
+		wantBackoff     int
+	}{
+		{
+			name:            "generic 404 starts short retry",
+			err:             &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"},
+			wantMinCooldown: 59 * time.Second,
+			wantMaxCooldown: 61 * time.Second,
+			wantBackoff:     1,
+		},
+		{
+			name:            "repeated generic 404 escalates",
+			err:             &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"},
+			initialBackoff:  1,
+			wantMinCooldown: 119 * time.Second,
+			wantMaxCooldown: 121 * time.Second,
+			wantBackoff:     2,
+		},
+		{
+			name:            "explicit model not found stays long",
+			err:             &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound, Message: "model unavailable"},
+			wantMinCooldown: 12*time.Hour - time.Second,
+			wantMaxCooldown: 12*time.Hour + time.Second,
+		},
+		{
+			name:           "disable cooling leaves retry unset",
+			err:            &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"},
+			disableCooling: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			quotaCooldownDisabled.Store(tc.disableCooling)
+			manager := NewManager(nil, nil, nil)
+			auth := &Auth{
+				ID:       "model-not-found-policy",
+				Provider: "codex",
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {Quota: QuotaState{BackoffLevel: tc.initialBackoff, NextRecoverAt: time.Now().Add(-time.Second)}},
+				},
+			}
+			if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+			before := time.Now()
+			manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Error: tc.err})
+			updated, ok := manager.GetByID(auth.ID)
+			if !ok || updated.ModelStates["gpt-5"] == nil {
+				t.Fatal("MarkResult() did not retain model cooldown state")
+			}
+			state := updated.ModelStates["gpt-5"]
+			if tc.wantMinCooldown == 0 {
+				if !state.NextRetryAfter.IsZero() {
+					t.Fatalf("NextRetryAfter = %v, want zero", state.NextRetryAfter)
+				}
+				return
+			}
+			cooldown := state.NextRetryAfter.Sub(before)
+			if cooldown < tc.wantMinCooldown || cooldown > tc.wantMaxCooldown {
+				t.Fatalf("cooldown = %v, want within [%v, %v]", cooldown, tc.wantMinCooldown, tc.wantMaxCooldown)
+			}
+			if state.Quota.BackoffLevel != tc.wantBackoff {
+				t.Fatalf("BackoffLevel = %d, want %d", state.Quota.BackoffLevel, tc.wantBackoff)
+			}
+			if tc.initialBackoff > 0 {
+				manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Success: true})
+				reset, _ := manager.GetByID(auth.ID)
+				if got := reset.ModelStates["gpt-5"].Quota.BackoffLevel; got != 0 {
+					t.Fatalf("successful result left BackoffLevel = %d, want 0", got)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	auth := &Auth{ID: "auth-not-found-policy"}
+	applyAuthFailureState(auth, generic, nil, "", now, false)
+	if want := now.Add(time.Minute); !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("first generic 404 NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
+	}
+	if auth.Quota.BackoffLevel != 1 {
+		t.Fatalf("first generic 404 BackoffLevel = %d, want 1", auth.Quota.BackoffLevel)
+	}
+
+	auth.Quota.NextRecoverAt = now.Add(-time.Second)
+	applyAuthFailureState(auth, generic, nil, "", now, false)
+	if want := now.Add(2 * time.Minute); !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("repeated generic 404 NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
+	}
+	if auth.Quota.BackoffLevel != 2 {
+		t.Fatalf("repeated generic 404 BackoffLevel = %d, want 2", auth.Quota.BackoffLevel)
+	}
+	clearAuthStateOnSuccess(auth, now)
+	if auth.Quota.BackoffLevel != 0 || !auth.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("success left auth retry state = %#v, want reset", auth.Quota)
+	}
+
+	explicit := &Auth{ID: "auth-explicit-model-not-found"}
+	applyAuthFailureState(explicit, &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound}, nil, "", now, false)
+	if want := now.Add(12 * time.Hour); !explicit.NextRetryAfter.Equal(want) {
+		t.Fatalf("explicit model-not-found NextRetryAfter = %v, want %v", explicit.NextRetryAfter, want)
+	}
+
+	disabled := &Auth{ID: "auth-not-found-disabled"}
+	applyAuthFailureState(disabled, generic, nil, "", now, true)
+	if !disabled.NextRetryAfter.IsZero() {
+		t.Fatalf("disabled cooling NextRetryAfter = %v, want zero", disabled.NextRetryAfter)
+	}
+}
+
+func TestMarkResultAliasUsesAttemptedUpstreamModelForExplicitNotFound(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "alias-explicit-model-not-found", Provider: "openai-compatibility"}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{
+		AuthID:        auth.ID,
+		Provider:      auth.Provider,
+		Model:         "public-alias",
+		UpstreamModel: "provider-model",
+		RouteModel:    "public-alias",
+		Error: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"error":{"type":"not_found_error","message":"model provider-model was not found"}}`,
+		},
+	})
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated.ModelStates["public-alias"] == nil {
+		t.Fatal("MarkResult() did not retain alias-keyed model state")
+	}
+	cooldown := updated.ModelStates["public-alias"].NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("alias explicit model-not-found cooldown = %v, want about 12h", cooldown)
+	}
+}
+
+func TestApplyAuthFailureStateUsesAttemptedUpstreamModelForExplicitNotFound(t *testing.T) {
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	auth := &Auth{ID: "auth-alias-explicit-model-not-found"}
+	err := &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model provider-model was not found"}}`,
+	}
+	applyAuthFailureState(auth, err, nil, "provider-model", now, false)
+	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("alias explicit model-not-found NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -968,3 +968,146 @@ func TestMarkResultGenericNotFoundSurvivesRacingShort429(t *testing.T) {
 		t.Fatalf("short 429 shortened the generic-404 deadline: NextRetryAfter = %v, want >= %v", updated.ModelStates["gpt-5"].NextRetryAfter, genericDeadline)
 	}
 }
+
+// TestIsExplicitModelNotFoundError_ProviderShapes covers Codex's finding
+// that isExplicitModelNotFoundError missed Gemini's official missing-model
+// 404 shape, plus every other provider family the gateway fronts. Positive
+// fixtures are the documented/observed missing-model error bodies per
+// provider; negatives are a generic 404 and an endpoint-not-found 404 for
+// each provider family, which must NOT classify as explicit (they belong on
+// the short transient-retry path, not the 12h cooldown).
+//
+// xAI and Kimi are OpenAI-compatible upstreams: both executors pass the raw
+// upstream body through as statusErr.msg (kimi_executor.go:201,
+// xai_executor_execute.go), so any body conforming to the OpenAI envelope
+// (error.code == "model_not_found") is already structurally covered by the
+// "openai explicit not-found" case below - COULD-NOT-DETERMINE applies only
+// to their exact message wording: no captured fixture or documented string
+// for xAI's or Kimi's missing-model response exists in this repo, so no
+// provider-specific grammar was added or claimed for either.
+func TestIsExplicitModelNotFoundError_ProviderShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		model    string
+		explicit bool
+	}{
+		// Gemini / Vertex / AI Studio: error.status == "NOT_FOUND", message
+		// "models/<id> is not found for API version ..., or is not
+		// supported for ...". Source: Codex review comment on #5472,
+		// 2026-09-03T18:12:51Z, sdk/cliproxy/auth/conductor_cooldown.go:2022.
+		{
+			name:     "gemini explicit not-found",
+			body:     `{"error":{"code":404,"message":"models/gemini-2.5-flash is not found for API version v1beta, or is not supported for bidiGenerateContent. Call ListModels to see the list of available models and their supported methods.","status":"NOT_FOUND"}}`,
+			model:    "gemini-2.5-flash",
+			explicit: true,
+		},
+		{
+			name:     "gemini generic 404 without model reference",
+			body:     `{"error":{"code":404,"message":"Requested entity was not found.","status":"NOT_FOUND"}}`,
+			model:    "gemini-2.5-flash",
+			explicit: false,
+		},
+		{
+			name:     "gemini endpoint not found",
+			body:     `{"error":{"code":404,"message":"method not found for API version v1beta.","status":"NOT_FOUND"}}`,
+			model:    "gemini-2.5-flash",
+			explicit: false,
+		},
+
+		// Anthropic: error.type == "not_found_error", message "model: <id>".
+		// Already covered pre-fix via the "type" key + "model:" prefix
+		// grammar; included here as a documented positive control.
+		{
+			name:     "anthropic explicit not-found",
+			body:     `{"type":"error","error":{"type":"not_found_error","message":"model: claude-not-a-real-model"}}`,
+			model:    "claude-not-a-real-model",
+			explicit: true,
+		},
+		{
+			name:     "anthropic generic 404",
+			body:     `{"type":"error","error":{"type":"not_found_error","message":"resource not found"}}`,
+			model:    "claude-not-a-real-model",
+			explicit: false,
+		},
+
+		// OpenAI: error.code == "model_not_found". Already covered
+		// pre-fix via the "code" key alone; included as a positive control.
+		{
+			name:     "openai explicit not-found",
+			body:     `{"error":{"message":"The model 'gpt-not-a-real-model' does not exist","type":"invalid_request_error","param":null,"code":"model_not_found"}}`,
+			model:    "gpt-not-a-real-model",
+			explicit: true,
+		},
+		{
+			name:     "openai generic 404",
+			body:     `{"error":{"message":"Unknown request URL.","type":"invalid_request_error","param":null,"code":null}}`,
+			model:    "gpt-not-a-real-model",
+			explicit: false,
+		},
+
+		// OpenAI-compatible / Ollama: two documented message shapes -
+		// `model "<id>" not found` and `model '<id>' not found, try
+		// pulling it first`.
+		{
+			name:     "ollama double-quoted not-found",
+			body:     `{"error":"model \"llama-not-a-real-model\" not found"}`,
+			model:    "llama-not-a-real-model",
+			explicit: true,
+		},
+		{
+			name:     "ollama single-quoted not-found with guidance suffix",
+			body:     `{"error":"model 'llama-not-a-real-model' not found, try pulling it first"}`,
+			model:    "llama-not-a-real-model",
+			explicit: true,
+		},
+		{
+			name:     "ollama generic 404",
+			body:     `{"error":"not found"}`,
+			model:    "llama-not-a-real-model",
+			explicit: false,
+		},
+
+		// Codex: OpenAI Responses-style envelope, error.type ==
+		// "not_found_error" (see internal/runtime/executor/codex_executor_terminal.go:172).
+		// The exact missing-model message wording is COULD-NOT-DETERMINE -
+		// no captured fixture or documented string exists in this repo for
+		// Codex's specific phrasing, so this fixture only exercises the
+		// type+model-reference combination already covered by the
+		// pre-existing "type" key path, not a Codex-specific grammar addition.
+		{
+			name:     "codex explicit not-found (type+model combo, wording unverified)",
+			body:     `{"error":{"type":"not_found_error","code":"model_not_found","message":"model: codex-not-a-real-model"}}`,
+			model:    "codex-not-a-real-model",
+			explicit: true,
+		},
+		{
+			name:     "codex generic 404",
+			body:     `{"error":{"type":"not_found_error","code":"not_found","message":"resource not found"}}`,
+			model:    "codex-not-a-real-model",
+			explicit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := statusErrForTest{code: http.StatusNotFound, msg: tt.body}
+			got := isExplicitModelNotFoundError(err, tt.model)
+			if got != tt.explicit {
+				t.Fatalf("isExplicitModelNotFoundError(%q, %q) = %v, want %v", tt.body, tt.model, got, tt.explicit)
+			}
+		})
+	}
+}
+
+// statusErrForTest is a minimal error carrying a raw upstream body as its
+// Error() text, mirroring how executors (openai_compat_executor.go's
+// statusErr, kimi_executor.go, xai_executor_*.go) surface the unparsed
+// response body for downstream structured-error classification.
+type statusErrForTest struct {
+	code int
+	msg  string
+}
+
+func (e statusErrForTest) Error() string   { return e.msg }
+func (e statusErrForTest) StatusCode() int { return e.code }

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -102,6 +102,68 @@ func TestMarkResultNotFoundCooldownPolicy(t *testing.T) {
 	}
 }
 
+func TestMarkResultUnsupportedModelSurvivesRacingGeneric404(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetTransientErrorCooldownSeconds(0)
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		transientErrorCooldownSeconds.Store(previousTransient)
+		quotaCooldownDisabled.Store(previousDisabled)
+	})
+
+	unsupported := &Error{HTTPStatus: http.StatusBadRequest, Message: "requested model is not supported"}
+	generic404 := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+
+	newAuth := func(id string) (*Manager, *Auth) {
+		manager := NewManager(nil, nil, nil)
+		auth := &Auth{ID: id, Provider: "codex", ModelStates: map[string]*ModelState{
+			"gpt-5": {},
+		}}
+		if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		return manager, auth
+	}
+	cooldownFor := func(manager *Manager, authID string, before time.Time) time.Duration {
+		updated, ok := manager.GetByID(authID)
+		if !ok || updated.ModelStates["gpt-5"] == nil {
+			t.Fatal("MarkResult() did not retain model cooldown state")
+		}
+		return updated.ModelStates["gpt-5"].NextRetryAfter.Sub(before)
+	}
+
+	// unsupported-model 400 first, then a racing generic 404 for the same key
+	// must not shorten the 12h deadline.
+	managerA, authA := newAuth("unsupported-then-generic-404")
+	before := time.Now()
+	managerA.MarkResult(context.Background(), Result{AuthID: authA.ID, Provider: "codex", Model: "gpt-5", Error: unsupported})
+	cooldown := cooldownFor(managerA, authA.ID, before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("unsupported-model cooldown = %v, want about 12h", cooldown)
+	}
+	managerA.MarkResult(context.Background(), Result{AuthID: authA.ID, Provider: "codex", Model: "gpt-5", Error: generic404})
+	cooldown = cooldownFor(managerA, authA.ID, before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("racing generic 404 shortened unsupported-model deadline: cooldown = %v, want unchanged ~12h", cooldown)
+	}
+
+	// generic 404 first, then an unsupported-model 400 for the same key must
+	// land on the 12h deadline.
+	managerB, authB := newAuth("generic-404-then-unsupported")
+	before = time.Now()
+	managerB.MarkResult(context.Background(), Result{AuthID: authB.ID, Provider: "codex", Model: "gpt-5", Error: generic404})
+	cooldown = cooldownFor(managerB, authB.ID, before)
+	if cooldown < 59*time.Second || cooldown > 61*time.Second {
+		t.Fatalf("generic-404-first cooldown = %v, want about 1m", cooldown)
+	}
+	managerB.MarkResult(context.Background(), Result{AuthID: authB.ID, Provider: "codex", Model: "gpt-5", Error: unsupported})
+	cooldown = cooldownFor(managerB, authB.ID, before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("generic-then-unsupported cooldown = %v, want about 12h", cooldown)
+	}
+}
+
 func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
 	previousTransient := transientErrorCooldownSeconds.Load()
 	SetTransientErrorCooldownSeconds(0)
@@ -489,6 +551,80 @@ func TestMarkResultAliasUsesAttemptedUpstreamModelForExplicitNotFound(t *testing
 	cooldown := updated.ModelStates["public-alias"].NextRetryAfter.Sub(before)
 	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
 		t.Fatalf("alias explicit model-not-found cooldown = %v, want about 12h", cooldown)
+	}
+}
+
+// notFoundCountTokensWireModelExecutor simulates Kimi's countTokensUpstream
+// path: it normalizes the request model (e.g. "kimi-k3" -> "k3") before
+// sending it upstream, and its 404 names the normalized model. CountTokens
+// returns a zero Response on every error path (see
+// internal/runtime/executor/claude_executor_tokens.go), so the wire model
+// must ride on the error, mirroring ExecuteStream's wireModelErr.
+type notFoundCountTokensWireModelExecutor struct {
+	normalize func(model string) string
+}
+
+func (e notFoundCountTokensWireModelExecutor) Identifier() string { return "count-tokens-wire-model" }
+func (notFoundCountTokensWireModelExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (notFoundCountTokensWireModelExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (notFoundCountTokensWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e notFoundCountTokensWireModelExecutor) CountTokens(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	wire := e.normalize(req.Model)
+	return cliproxyexecutor.Response{}, wireModelStreamError{
+		err: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+		},
+		model: wire,
+	}
+}
+func (notFoundCountTokensWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteCountExplicitNotFoundClassifiesAgainstReportedWireModelNotEndpointNeutral(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "kimi-k3"
+	normalize := func(m string) string { return strings.TrimPrefix(m, "kimi-") }
+	executor := notFoundCountTokensWireModelExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "count-tokens-wire-model-auth", Provider: "count-tokens-wire-model"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	if _, errCount := manager.ExecuteCount(context.Background(), []string{"count-tokens-wire-model"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{}); errCount == nil {
+		t.Fatal("ExecuteCount() unexpectedly succeeded")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteCount()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("ExecuteCount() did not record model cooldown state")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (a count_tokens 404 naming the reported wire model must classify as explicit not-found, not availability-neutral endpoint-unsupported)", cooldown)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -848,26 +848,21 @@ func TestExecuteStreamMidStreamChunkErrorClassifiesAgainstReportedWireModel(t *t
 		t.Fatalf("ExecuteStream() unexpectedly failed before streaming began: %v", errExecute)
 	}
 	for range streamResult.Chunks {
-		// Drain to let wrapStreamResult observe the terminal chunk error and
-		// record the Result.
+		// Drain to completion. wrapStreamResult's emit() calls
+		// m.recordExecutionResult synchronously BEFORE forwarding the
+		// terminal errored chunk on the (unbuffered) out channel, so by the
+		// time this range loop observes that chunk (and later the closed
+		// channel), the record is already visible per Go's channel
+		// happens-before guarantee — no extra synchronization needed.
 	}
 
-	// wrapStreamResult records asynchronously as it forwards chunks; give it
-	// a moment to finish before reading state.
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteStream()")
+	}
 	var state *ModelState
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		updated, ok := manager.GetByID(auth.ID)
-		if !ok {
-			t.Fatal("auth not found after ExecuteStream()")
-		}
-		for _, candidate := range updated.ModelStates {
-			state = candidate
-		}
-		if state != nil {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	for _, candidate := range updated.ModelStates {
+		state = candidate
 	}
 	if state == nil {
 		t.Fatal("ExecuteStream() did not record model cooldown state from the mid-stream chunk error")

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestMarkResultNotFoundCooldownPolicy(t *testing.T) {
@@ -170,6 +173,72 @@ func TestApplyAuthFailureStateExplicitNotFoundSurvivesRacingGeneric404(t *testin
 	applyAuthFailureState(authGenericFirst, explicit, nil, "", now, false)
 	if !authGenericFirst.NextRetryAfter.Equal(want) {
 		t.Fatalf("generic-then-explicit NextRetryAfter = %v, want %v", authGenericFirst.NextRetryAfter, want)
+	}
+}
+
+// notFoundExecutionModelExecutor returns an explicit model-not-found error that
+// names the model actually present on the request it receives, so the test can
+// tell whether the caller classified the failure against the execution model
+// (what was sent) or the selection model (what routing picked).
+type notFoundExecutionModelExecutor struct{}
+
+func (notFoundExecutionModelExecutor) Identifier() string { return "selection-vs-execution" }
+func (notFoundExecutionModelExecutor) Execute(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model ` + req.Model + ` was not found"}}`,
+	}
+}
+func (notFoundExecutionModelExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (notFoundExecutionModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (notFoundExecutionModelExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (notFoundExecutionModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteExplicitNotFoundClassifiesAgainstExecutionModelNotSelectionModel(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(notFoundExecutionModelExecutor{})
+	auth := &Auth{ID: "selection-vs-execution-auth", Provider: "selection-vs-execution"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "selection-model"}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.AuthSelectionModelMetadataKey: "selection-model",
+	}}
+	before := time.Now()
+	if _, errExecute := manager.Execute(context.Background(), []string{"selection-vs-execution"}, cliproxyexecutor.Request{Model: "execution-model"}, opts); errExecute == nil {
+		t.Fatal("Execute() unexpectedly succeeded")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after Execute()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("Execute() did not record model cooldown state")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (execution-model 404 must not be classified against the selection model and get the short retry)", cooldown)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1014,6 +1014,18 @@ func TestIsExplicitModelNotFoundError_ProviderShapes(t *testing.T) {
 			model:    "gemini-2.5-flash",
 			explicit: false,
 		},
+		{
+			name:     "gemini not-found message without status field",
+			body:     `{"error":{"code":404,"message":"models/gemini-2.5-flash is not found for API version v1beta, or is not supported for bidiGenerateContent."}}`,
+			model:    "gemini-2.5-flash",
+			explicit: false,
+		},
+		{
+			name:     "gemini not-found message with status at JSON root, not nested under error",
+			body:     `{"status":"NOT_FOUND","error":{"code":404,"message":"models/gemini-2.5-flash is not found for API version v1beta, or is not supported for bidiGenerateContent."}}`,
+			model:    "gemini-2.5-flash",
+			explicit: false,
+		},
 
 		// Anthropic: error.type == "not_found_error", message "model: <id>".
 		// Already covered pre-fix via the "type" key + "model:" prefix
@@ -1067,20 +1079,25 @@ func TestIsExplicitModelNotFoundError_ProviderShapes(t *testing.T) {
 			model:    "llama-not-a-real-model",
 			explicit: false,
 		},
+		{
+			name:     "ollama not-found with unrelated adversarial comma continuation",
+			body:     `{"error":"model 'llama-not-a-real-model' not found, but endpoint /v1/foo missing"}`,
+			model:    "llama-not-a-real-model",
+			explicit: false,
+		},
+		{
+			name:     "ollama not-found with unrelated adversarial semicolon continuation",
+			body:     `{"error":"model 'llama-not-a-real-model' not found; HTML endpoint page follows"}`,
+			model:    "llama-not-a-real-model",
+			explicit: false,
+		},
 
 		// Codex: OpenAI Responses-style envelope, error.type ==
 		// "not_found_error" (see internal/runtime/executor/codex_executor_terminal.go:172).
-		// The exact missing-model message wording is COULD-NOT-DETERMINE -
-		// no captured fixture or documented string exists in this repo for
-		// Codex's specific phrasing, so this fixture only exercises the
-		// type+model-reference combination already covered by the
-		// pre-existing "type" key path, not a Codex-specific grammar addition.
-		{
-			name:     "codex explicit not-found (type+model combo, wording unverified)",
-			body:     `{"error":{"type":"not_found_error","code":"model_not_found","message":"model: codex-not-a-real-model"}}`,
-			model:    "codex-not-a-real-model",
-			explicit: true,
-		},
+		// The exact missing-model message wording is COULD-NOT-DETERMINE - no
+		// captured fixture or documented string exists in this repo for
+		// Codex's specific phrasing. Left uncovered by a fixture, same as
+		// xAI/Kimi below, rather than testing an invented wording.
 		{
 			name:     "codex generic 404",
 			body:     `{"error":{"type":"not_found_error","code":"not_found","message":"resource not found"}}`,

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -172,7 +172,7 @@ func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
 	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
 	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
 	auth := &Auth{ID: "auth-not-found-policy"}
-	applyAuthFailureState(auth, generic, nil, "", now, false)
+	applyAuthFailureStateForModel(auth, generic, nil, "", now, false)
 	if want := now.Add(time.Minute); !auth.NextRetryAfter.Equal(want) {
 		t.Fatalf("first generic 404 NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
 	}
@@ -181,7 +181,7 @@ func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
 	}
 
 	auth.Quota.NextRecoverAt = now.Add(-time.Second)
-	applyAuthFailureState(auth, generic, nil, "", now, false)
+	applyAuthFailureStateForModel(auth, generic, nil, "", now, false)
 	if want := now.Add(2 * time.Minute); !auth.NextRetryAfter.Equal(want) {
 		t.Fatalf("repeated generic 404 NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
 	}
@@ -194,13 +194,13 @@ func TestApplyAuthFailureStateNotFoundCooldownPolicy(t *testing.T) {
 	}
 
 	explicit := &Auth{ID: "auth-explicit-model-not-found"}
-	applyAuthFailureState(explicit, &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound}, nil, "", now, false)
+	applyAuthFailureStateForModel(explicit, &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound}, nil, "", now, false)
 	if want := now.Add(12 * time.Hour); !explicit.NextRetryAfter.Equal(want) {
 		t.Fatalf("explicit model-not-found NextRetryAfter = %v, want %v", explicit.NextRetryAfter, want)
 	}
 
 	disabled := &Auth{ID: "auth-not-found-disabled"}
-	applyAuthFailureState(disabled, generic, nil, "", now, true)
+	applyAuthFailureStateForModel(disabled, generic, nil, "", now, true)
 	if !disabled.NextRetryAfter.IsZero() {
 		t.Fatalf("disabled cooling NextRetryAfter = %v, want zero", disabled.NextRetryAfter)
 	}
@@ -217,23 +217,23 @@ func TestApplyAuthFailureStateExplicitNotFoundSurvivesRacingGeneric404(t *testin
 
 	// explicit-404 then a racing generic-404 for the same key must not shorten the 12h deadline.
 	authExplicitFirst := &Auth{ID: "auth-explicit-then-generic"}
-	applyAuthFailureState(authExplicitFirst, explicit, nil, "", now, false)
+	applyAuthFailureStateForModel(authExplicitFirst, explicit, nil, "", now, false)
 	want := now.Add(12 * time.Hour)
 	if !authExplicitFirst.NextRetryAfter.Equal(want) {
 		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitFirst.NextRetryAfter, want)
 	}
-	applyAuthFailureState(authExplicitFirst, generic, nil, "", now, false)
+	applyAuthFailureStateForModel(authExplicitFirst, generic, nil, "", now, false)
 	if !authExplicitFirst.NextRetryAfter.Equal(want) {
 		t.Fatalf("racing generic 404 shortened deadline: NextRetryAfter = %v, want unchanged %v", authExplicitFirst.NextRetryAfter, want)
 	}
 
 	// generic-404 then explicit-404 for the same key must land on the 12h deadline.
 	authGenericFirst := &Auth{ID: "auth-generic-then-explicit"}
-	applyAuthFailureState(authGenericFirst, generic, nil, "", now, false)
+	applyAuthFailureStateForModel(authGenericFirst, generic, nil, "", now, false)
 	if got := authGenericFirst.NextRetryAfter; !got.Equal(now.Add(time.Minute)) {
 		t.Fatalf("generic-first NextRetryAfter = %v, want %v", got, now.Add(time.Minute))
 	}
-	applyAuthFailureState(authGenericFirst, explicit, nil, "", now, false)
+	applyAuthFailureStateForModel(authGenericFirst, explicit, nil, "", now, false)
 	if !authGenericFirst.NextRetryAfter.Equal(want) {
 		t.Fatalf("generic-then-explicit NextRetryAfter = %v, want %v", authGenericFirst.NextRetryAfter, want)
 	}
@@ -249,12 +249,12 @@ func TestApplyAuthFailureStateExplicitNotFoundNeverShortensLongerCooldown(t *tes
 	// A long 429 window (e.g. a provider retry window beyond 12h) must survive
 	// a later explicit-404 for the same key: the 404 must not shorten it.
 	authLong429First := &Auth{ID: "auth-long-429-then-explicit"}
-	applyAuthFailureState(authLong429First, rateLimited, &longRetryAfter, "", now, false)
+	applyAuthFailureStateForModel(authLong429First, rateLimited, &longRetryAfter, "", now, false)
 	want429 := now.Add(longRetryAfter)
 	if !authLong429First.NextRetryAfter.Equal(want429) {
 		t.Fatalf("long-429 NextRetryAfter = %v, want %v", authLong429First.NextRetryAfter, want429)
 	}
-	applyAuthFailureState(authLong429First, explicit, nil, "", now, false)
+	applyAuthFailureStateForModel(authLong429First, explicit, nil, "", now, false)
 	if !authLong429First.NextRetryAfter.Equal(want429) {
 		t.Fatalf("explicit 404 shortened a longer 429 deadline: NextRetryAfter = %v, want unchanged %v", authLong429First.NextRetryAfter, want429)
 	}
@@ -263,12 +263,12 @@ func TestApplyAuthFailureStateExplicitNotFoundNeverShortensLongerCooldown(t *tes
 	// must not lose to a stale short window, and here it is itself longer, so
 	// it applies (the max, not the 404, wins when the 429 is genuinely longer).
 	authExplicitThenLong429 := &Auth{ID: "auth-explicit-then-long-429"}
-	applyAuthFailureState(authExplicitThenLong429, explicit, nil, "", now, false)
+	applyAuthFailureStateForModel(authExplicitThenLong429, explicit, nil, "", now, false)
 	want12h := now.Add(12 * time.Hour)
 	if !authExplicitThenLong429.NextRetryAfter.Equal(want12h) {
 		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitThenLong429.NextRetryAfter, want12h)
 	}
-	applyAuthFailureState(authExplicitThenLong429, rateLimited, &longRetryAfter, "", now, false)
+	applyAuthFailureStateForModel(authExplicitThenLong429, rateLimited, &longRetryAfter, "", now, false)
 	if !authExplicitThenLong429.NextRetryAfter.Equal(want429) {
 		t.Fatalf("explicit-then-long-429 NextRetryAfter = %v, want %v", authExplicitThenLong429.NextRetryAfter, want429)
 	}
@@ -276,11 +276,11 @@ func TestApplyAuthFailureStateExplicitNotFoundNeverShortensLongerCooldown(t *tes
 	// An explicit-404 recorded first must survive a later SHORT 429 for the
 	// same key: the shorter 429 window must not override the 12h deadline.
 	authExplicitThenShort429 := &Auth{ID: "auth-explicit-then-short-429"}
-	applyAuthFailureState(authExplicitThenShort429, explicit, nil, "", now, false)
+	applyAuthFailureStateForModel(authExplicitThenShort429, explicit, nil, "", now, false)
 	if !authExplicitThenShort429.NextRetryAfter.Equal(want12h) {
 		t.Fatalf("explicit-first NextRetryAfter = %v, want %v", authExplicitThenShort429.NextRetryAfter, want12h)
 	}
-	applyAuthFailureState(authExplicitThenShort429, rateLimited, &shortRetryAfter, "", now, false)
+	applyAuthFailureStateForModel(authExplicitThenShort429, rateLimited, &shortRetryAfter, "", now, false)
 	if !authExplicitThenShort429.NextRetryAfter.Equal(want12h) {
 		t.Fatalf("short 429 shortened the explicit 12h deadline: NextRetryAfter = %v, want unchanged %v", authExplicitThenShort429.NextRetryAfter, want12h)
 	}
@@ -635,7 +635,7 @@ func TestApplyAuthFailureStateUsesAttemptedUpstreamModelForExplicitNotFound(t *t
 		HTTPStatus: http.StatusNotFound,
 		Message:    `{"error":{"type":"not_found_error","message":"model provider-model was not found"}}`,
 	}
-	applyAuthFailureState(auth, err, nil, "provider-model", now, false)
+	applyAuthFailureStateForModel(auth, err, nil, "provider-model", now, false)
 	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
 		t.Fatalf("alias explicit model-not-found NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
 	}
@@ -698,12 +698,12 @@ func TestApplyAuthFailureStateModelNotFoundSurvivesRacingCloudflareChallenge(t *
 	challenge := &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge-platform detected"}
 
 	auth := &Auth{ID: "auth-not-found-then-challenge"}
-	applyAuthFailureState(auth, explicitNotFound, nil, "gpt-5", now, false)
+	applyAuthFailureStateForModel(auth, explicitNotFound, nil, "gpt-5", now, false)
 	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
 		t.Fatalf("explicit not-found NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
 	}
 
-	applyAuthFailureState(auth, challenge, nil, "gpt-5", now.Add(time.Minute), false)
+	applyAuthFailureStateForModel(auth, challenge, nil, "gpt-5", now.Add(time.Minute), false)
 	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
 		t.Fatalf("racing cloudflare challenge shortened explicit not-found deadline: NextRetryAfter = %v, want unchanged %v", auth.NextRetryAfter, want)
 	}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -785,3 +785,191 @@ func TestExecuteCountReadsWireModelFromResponseMetadataNotJustError(t *testing.T
 		t.Fatalf("explicit not-found (via Response.Metadata) cooldown = %v, want about 12h (endpoint-neutral misclassification: wire model not read from resp.Metadata)", cooldown)
 	}
 }
+
+// midStreamWireModelExecutor mirrors an OpenAICompat-style executor whose
+// ExecuteStream call itself succeeds (HTTP 200, err == nil) but whose SSE
+// body contains a structured 404 arriving as a later frame. The conductor
+// only ever observes this via StreamChunk.Err from the returned channel
+// (see wrapStreamResult in conductor_stream.go), never via ExecuteStream's
+// return error — so this is the shape Codex's item (b) finding targeted.
+type midStreamWireModelExecutor struct {
+	normalize func(model string) string
+}
+
+func (e midStreamWireModelExecutor) Identifier() string { return "mid-stream-wire-model" }
+func (e midStreamWireModelExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e midStreamWireModelExecutor) ExecuteStream(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	wire := e.normalize(req.Model)
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{}}]}\n\n")}
+	ch <- cliproxyexecutor.StreamChunk{Err: wireModelStreamError{
+		err: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+		},
+		model: wire,
+	}}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+}
+func (midStreamWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (midStreamWireModelExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (midStreamWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteStreamMidStreamChunkErrorClassifiesAgainstReportedWireModel(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "claude-opus-4-8-thinking-32k"
+	normalize := func(m string) string { return strings.TrimSuffix(m, "-thinking-32k") }
+	executor := midStreamWireModelExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "mid-stream-wire-model-auth", Provider: "mid-stream-wire-model"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	streamResult, errExecute := manager.ExecuteStream(context.Background(), []string{"mid-stream-wire-model"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed before streaming began: %v", errExecute)
+	}
+	for range streamResult.Chunks {
+		// Drain to let wrapStreamResult observe the terminal chunk error and
+		// record the Result.
+	}
+
+	// wrapStreamResult records asynchronously as it forwards chunks; give it
+	// a moment to finish before reading state.
+	var state *ModelState
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, ok := manager.GetByID(auth.ID)
+		if !ok {
+			t.Fatal("auth not found after ExecuteStream()")
+		}
+		for _, candidate := range updated.ModelStates {
+			state = candidate
+		}
+		if state != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if state == nil {
+		t.Fatal("ExecuteStream() did not record model cooldown state from the mid-stream chunk error")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (mid-stream chunk error naming the reported wire model must classify as explicit not-found, not the short retry)", cooldown)
+	}
+}
+
+// TestApplyAuthFailureStateGenericNotFoundSurvivesRacingCloudflareChallenge
+// covers Codex's item (c) finding: a generic-404 backoff is stored in
+// NextRecoverAt WITHOUT Exceeded set (see notFoundRetryAfter's non-explicit
+// branch), so preserveLongerCooldown's old Exceeded-gated guard let a later
+// Cloudflare challenge overwrite it with a shorter deadline. The fix drops
+// the Exceeded requirement so ANY active (future) NextRecoverAt is honored.
+func TestApplyAuthFailureStateGenericNotFoundSurvivesRacingCloudflareChallenge(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic404 := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	challenge := &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge detected"}
+
+	auth := &Auth{ID: "auth-generic-404-then-challenge"}
+	// Escalate the generic-404 backoff a few times so its stored deadline is
+	// clearly longer than a fresh level-0 Cloudflare cooldown, isolating the
+	// Exceeded-gating bug from a coincidental tie in magnitude.
+	for i := 0; i < 3; i++ {
+		applyAuthFailureStateForModel(auth, generic404, nil, "", now, false)
+	}
+	if auth.Quota.Exceeded {
+		t.Fatalf("generic 404 unexpectedly set Exceeded = true (test premise requires the non-Exceeded storage path)")
+	}
+	genericDeadline := auth.NextRetryAfter
+	if !genericDeadline.After(now) {
+		t.Fatalf("generic 404 NextRetryAfter = %v, want after %v", genericDeadline, now)
+	}
+
+	applyAuthFailureStateForModel(auth, challenge, nil, "", now, false)
+	if auth.NextRetryAfter.Before(genericDeadline) {
+		t.Fatalf("Cloudflare challenge shortened the generic-404 deadline: NextRetryAfter = %v, want >= %v", auth.NextRetryAfter, genericDeadline)
+	}
+}
+
+// TestMarkResultGenericNotFoundSurvivesRacingShort429 covers the model-scoped
+// half of Codex's item (c) finding: MarkResult's 429 branch (unlike
+// applyAuthFailureStateForModel's auth-scoped 429 branch, which sets
+// Exceeded=true before calling preserveLongerCooldown and so is
+// self-satisfying either way) calls preserveLongerCooldown(state.Quota, next)
+// BEFORE setting Exceeded on this failure, so it genuinely reads whatever
+// Exceeded was left by the PRIOR failure. A generic-404 leaves Exceeded
+// unset, so the old Exceeded-gated guard let a later, shorter 429 overwrite
+// it; the fix (dropping the Exceeded requirement) closes that gap.
+func TestMarkResultGenericNotFoundSurvivesRacingShort429(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetTransientErrorCooldownSeconds(0)
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		transientErrorCooldownSeconds.Store(previousTransient)
+		quotaCooldownDisabled.Store(previousDisabled)
+	})
+
+	generic404 := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	rateLimited := &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"}
+	shortRetryAfter := 5 * time.Second
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "generic-404-then-short-429", Provider: "codex", ModelStates: map[string]*ModelState{
+		"gpt-5": {},
+	}}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	// Escalate a few times so the generic-404 deadline is clearly longer than
+	// a fresh level-0 429 cooldown, isolating the Exceeded-gating bug from a
+	// coincidental tie in magnitude.
+	for i := 0; i < 3; i++ {
+		manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Error: generic404})
+	}
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated.ModelStates["gpt-5"] == nil {
+		t.Fatal("MarkResult() did not retain model cooldown state")
+	}
+	if updated.ModelStates["gpt-5"].Quota.Exceeded {
+		t.Fatalf("generic 404 unexpectedly set Exceeded = true (test premise requires the non-Exceeded storage path)")
+	}
+	genericDeadline := updated.ModelStates["gpt-5"].NextRetryAfter
+	if !genericDeadline.After(before) {
+		t.Fatalf("generic 404 NextRetryAfter = %v, want after %v", genericDeadline, before)
+	}
+
+	manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Error: rateLimited, RetryAfter: &shortRetryAfter})
+	updated, ok = manager.GetByID(auth.ID)
+	if !ok || updated.ModelStates["gpt-5"] == nil {
+		t.Fatal("MarkResult() did not retain model cooldown state after 429")
+	}
+	if updated.ModelStates["gpt-5"].NextRetryAfter.Before(genericDeadline) {
+		t.Fatalf("short 429 shortened the generic-404 deadline: NextRetryAfter = %v, want >= %v", updated.ModelStates["gpt-5"].NextRetryAfter, genericDeadline)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -786,6 +786,104 @@ func TestExecuteCountReadsWireModelFromResponseMetadataNotJustError(t *testing.T
 	}
 }
 
+// kimiStyleWireModelExecutor mirrors a Kimi/Claude-style executor whose
+// ExecuteStream call succeeds (a normal payload chunk is emitted first) but
+// which normalized the requested model internally before sending it upstream
+// (e.g. Kimi remapping "kimi-k3-thinking-32k" to "k3"). It reports that wire
+// model via StreamResult.Metadata[WireModelMetadataKey], captured before the
+// first chunk, exactly like Kimi/Claude's real ExecuteStream now does. A
+// LATER chunk in the same stream carries a structured 404 error that itself
+// implements no WireModel() method (unlike wireModelStreamError below),
+// forcing classification to fall back through wireModelOrSentStream's
+// Metadata resolution rather than the error-carried path - this is Codex's
+// "propagate the wire model for successful streams" finding.
+type kimiStyleWireModelExecutor struct {
+	normalize func(model string) string
+}
+
+func (e kimiStyleWireModelExecutor) Identifier() string { return "kimi-style-wire-model" }
+func (e kimiStyleWireModelExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e kimiStyleWireModelExecutor) ExecuteStream(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	wire := e.normalize(req.Model)
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{}}]}\n\n")}
+	ch <- cliproxyexecutor.StreamChunk{Err: &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+	}}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{
+		Chunks:   ch,
+		Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wire},
+	}, nil
+}
+func (kimiStyleWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (kimiStyleWireModelExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (kimiStyleWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+// TestExecuteStreamSuccessPathPropagatesReportedWireModel covers Codex's
+// "Propagate the wire model for successful streams" finding: ExecuteStream
+// itself returns no error (streamResult.Metadata carries the executor's
+// reported wire model instead of a WireModel()-carrying error), and a later
+// mid-stream frame names that wire model as not-found without implementing
+// WireModel() itself. Classification must still resolve to the wire model
+// via StreamResult.Metadata, not the pre-normalization request model - a
+// pre-fix conductor would classify against the un-normalized request model
+// and never match, missing the 12h explicit-not-found cooldown entirely.
+func TestExecuteStreamSuccessPathPropagatesReportedWireModel(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "kimi-k3-thinking-32k"
+	normalize := func(m string) string { return "k3" }
+	executor := kimiStyleWireModelExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "kimi-style-wire-model-auth", Provider: "kimi-style-wire-model"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	streamResult, errExecute := manager.ExecuteStream(context.Background(), []string{"kimi-style-wire-model"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() unexpectedly failed before streaming began: %v", errExecute)
+	}
+	for range streamResult.Chunks {
+		// Drain to completion; see the happens-before note on
+		// TestExecuteStreamMidStreamChunkErrorClassifiesAgainstReportedWireModel
+		// above for why no extra synchronization is needed here.
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteStream()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("ExecuteStream() did not record model cooldown state from the mid-stream chunk error")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("cooldown = %v, want about 12h (mid-stream error naming the executor-reported wire model, from a successful ExecuteStream call, must classify as explicit not-found via StreamResult.Metadata)", cooldown)
+	}
+}
+
 // midStreamWireModelExecutor mirrors an OpenAICompat-style executor whose
 // ExecuteStream call itself succeeds (HTTP 200, err == nil) but whose SSE
 // body contains a structured 404 arriving as a later frame. The conductor

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,6 +287,100 @@ func TestExecuteExplicitNotFoundClassifiesAgainstExecutionModelNotSelectionModel
 	cooldown := state.NextRetryAfter.Sub(before)
 	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
 		t.Fatalf("cooldown = %v, want about 12h (execution-model 404 must not be classified against the selection model and get the short retry)", cooldown)
+	}
+}
+
+// notFoundWireModelExecutor simulates an executor that normalizes the
+// request model internally (e.g. stripping a thinking suffix, remapping an
+// alias) before sending it upstream: it reports the normalized model via
+// Response.Metadata[WireModelMetadataKey], and its 404 names that normalized
+// model, not the pre-normalization req.Model the conductor sent it.
+type notFoundWireModelExecutor struct {
+	normalize func(model string) string
+}
+
+func (e notFoundWireModelExecutor) Identifier() string { return "wire-model-vs-sent" }
+func (e notFoundWireModelExecutor) Execute(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	wire := e.normalize(req.Model)
+	resp := cliproxyexecutor.Response{Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wire}}
+	return resp, &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+	}
+}
+func (notFoundWireModelExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (notFoundWireModelExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (notFoundWireModelExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (notFoundWireModelExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteExplicitNotFoundClassifiesAgainstReportedWireModel(t *testing.T) {
+	cases := []struct {
+		name       string
+		reqModel   string
+		normalize  func(string) string
+	}{
+		{
+			// Claude strips a "-thinking-32k" style suffix before sending the
+			// model upstream; the provider's 404 names the stripped model.
+			name:      "claude thinking suffix stripped",
+			reqModel:  "claude-opus-4-8-thinking-32k",
+			normalize: func(m string) string { return strings.TrimSuffix(m, "-thinking-32k") },
+		},
+		{
+			// Kimi strips the "kimi-" prefix before sending the model
+			// upstream; the provider's 404 names the stripped model.
+			name:      "kimi alias stripped",
+			reqModel:  "kimi-k3",
+			normalize: func(m string) string { return strings.TrimPrefix(m, "kimi-") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			previousDisabled := quotaCooldownDisabled.Load()
+			quotaCooldownDisabled.Store(false)
+			t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+			manager := NewManager(nil, nil, nil)
+			executor := notFoundWireModelExecutor{normalize: tc.normalize}
+			manager.RegisterExecutor(executor)
+			auth := &Auth{ID: "wire-model-auth-" + tc.name, Provider: "wire-model-vs-sent"}
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: tc.reqModel}})
+			t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+			if _, err := manager.Register(context.Background(), auth); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+
+			before := time.Now()
+			if _, errExecute := manager.Execute(context.Background(), []string{"wire-model-vs-sent"}, cliproxyexecutor.Request{Model: tc.reqModel}, cliproxyexecutor.Options{}); errExecute == nil {
+				t.Fatal("Execute() unexpectedly succeeded")
+			}
+
+			updated, ok := manager.GetByID(auth.ID)
+			if !ok {
+				t.Fatal("auth not found after Execute()")
+			}
+			var state *ModelState
+			for _, candidate := range updated.ModelStates {
+				state = candidate
+			}
+			if state == nil {
+				t.Fatal("Execute() did not record model cooldown state")
+			}
+			cooldown := state.NextRetryAfter.Sub(before)
+			if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+				t.Fatalf("cooldown = %v, want about 12h (404 naming the reported wire model must classify as explicit not-found, not the short retry)", cooldown)
+			}
+		})
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -640,3 +640,148 @@ func TestApplyAuthFailureStateUsesAttemptedUpstreamModelForExplicitNotFound(t *t
 		t.Fatalf("alias explicit model-not-found NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
 	}
 }
+
+func TestMarkResultModelNotFoundSurvivesRacingCloudflareChallenge(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetTransientErrorCooldownSeconds(0)
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		transientErrorCooldownSeconds.Store(previousTransient)
+		quotaCooldownDisabled.Store(previousDisabled)
+	})
+
+	explicitNotFound := &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound, Message: "model gpt-5 not found"}
+	challenge := &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge-platform detected"}
+
+	newAuth := func(id string) (*Manager, *Auth) {
+		manager := NewManager(nil, nil, nil)
+		auth := &Auth{ID: id, Provider: "codex", ModelStates: map[string]*ModelState{
+			"gpt-5": {},
+		}}
+		if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		return manager, auth
+	}
+	cooldownFor := func(manager *Manager, authID string, before time.Time) time.Duration {
+		updated, ok := manager.GetByID(authID)
+		if !ok || updated.ModelStates["gpt-5"] == nil {
+			t.Fatal("MarkResult() did not retain model cooldown state")
+		}
+		return updated.ModelStates["gpt-5"].NextRetryAfter.Sub(before)
+	}
+
+	// explicit not-found first (12h), then a racing Cloudflare challenge for
+	// the same model key must not shorten the stored deadline.
+	manager, auth := newAuth("not-found-then-challenge")
+	before := time.Now()
+	manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Error: explicitNotFound})
+	cooldown := cooldownFor(manager, auth.ID, before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("explicit not-found cooldown = %v, want about 12h", cooldown)
+	}
+	manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: "codex", Model: "gpt-5", Error: challenge})
+	cooldown = cooldownFor(manager, auth.ID, before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("racing cloudflare challenge shortened explicit not-found deadline: cooldown = %v, want unchanged ~12h", cooldown)
+	}
+}
+
+func TestApplyAuthFailureStateModelNotFoundSurvivesRacingCloudflareChallenge(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 17, 30, 0, 0, time.UTC)
+	explicitNotFound := &Error{Code: "model_not_found", HTTPStatus: http.StatusNotFound, Message: "model gpt-5 not found"}
+	challenge := &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge-platform detected"}
+
+	auth := &Auth{ID: "auth-not-found-then-challenge"}
+	applyAuthFailureState(auth, explicitNotFound, nil, "gpt-5", now, false)
+	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("explicit not-found NextRetryAfter = %v, want %v", auth.NextRetryAfter, want)
+	}
+
+	applyAuthFailureState(auth, challenge, nil, "gpt-5", now.Add(time.Minute), false)
+	if want := now.Add(12 * time.Hour); !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("racing cloudflare challenge shortened explicit not-found deadline: NextRetryAfter = %v, want unchanged %v", auth.NextRetryAfter, want)
+	}
+}
+
+// notFoundCountTokensResponseMetadataExecutor simulates a custom CountTokens
+// executor that follows the public Response.Metadata contract
+// (cliproxyexecutor.WireModelMetadataKey) instead of the error-carried
+// wireModelStreamError channel used by the Claude/Kimi executors: it returns
+// a non-zero Response naming the normalized model alongside a plain error
+// with no WireModel() method. If the classification path only reads
+// wireModelFromError, it falls back to the pre-call sent model here and
+// misclassifies an explicit not-found as an endpoint-neutral 404.
+type notFoundCountTokensResponseMetadataExecutor struct {
+	normalize func(model string) string
+}
+
+func (e notFoundCountTokensResponseMetadataExecutor) Identifier() string {
+	return "count-tokens-response-metadata"
+}
+func (notFoundCountTokensResponseMetadataExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (notFoundCountTokensResponseMetadataExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (notFoundCountTokensResponseMetadataExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+func (e notFoundCountTokensResponseMetadataExecutor) CountTokens(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	wire := e.normalize(req.Model)
+	resp := cliproxyexecutor.Response{Metadata: map[string]any{cliproxyexecutor.WireModelMetadataKey: wire}}
+	err := &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"not_found_error","message":"model ` + wire + ` was not found"}}`,
+	}
+	return resp, err
+}
+func (notFoundCountTokensResponseMetadataExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestExecuteCountReadsWireModelFromResponseMetadataNotJustError(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+
+	manager := NewManager(nil, nil, nil)
+	reqModel := "kimi-k3"
+	normalize := func(m string) string { return strings.TrimPrefix(m, "kimi-") }
+	executor := notFoundCountTokensResponseMetadataExecutor{normalize: normalize}
+	manager.RegisterExecutor(executor)
+	auth := &Auth{ID: "count-tokens-response-metadata-auth", Provider: "count-tokens-response-metadata"}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: reqModel}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	before := time.Now()
+	if _, errCount := manager.ExecuteCount(context.Background(), []string{"count-tokens-response-metadata"}, cliproxyexecutor.Request{Model: reqModel}, cliproxyexecutor.Options{}); errCount == nil {
+		t.Fatal("ExecuteCount() unexpectedly succeeded")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatal("auth not found after ExecuteCount()")
+	}
+	var state *ModelState
+	for _, candidate := range updated.ModelStates {
+		state = candidate
+	}
+	if state == nil {
+		t.Fatal("ExecuteCount() did not record model cooldown state")
+	}
+	cooldown := state.NextRetryAfter.Sub(before)
+	if cooldown < 12*time.Hour-time.Second || cooldown > 12*time.Hour+time.Second {
+		t.Fatalf("explicit not-found (via Response.Metadata) cooldown = %v, want about 12h (endpoint-neutral misclassification: wire model not read from resp.Metadata)", cooldown)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1347,3 +1347,81 @@ func TestExecuteStreamBootstrapFirstChunkClassifiesAgainstReportedWireModel(t *t
 		t.Fatalf("cooldown = %v, want about 12h (bootstrap first-chunk 404 naming the executor-reported wire model, from StreamResult.Metadata on a successful ExecuteStream call, must classify as explicit not-found)", cooldown)
 	}
 }
+
+func TestApplyAuthFailureStateCredentialCooldownSurvivesRacingGeneric404(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	unauthorized := &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}
+	deadline := now.Add(30 * time.Minute)
+
+	// 401 then a racing generic 404 for the same credential must not
+	// shorten the 30-minute credential-wide deadline down to the generic
+	// 404's short transient backoff.
+	auth401First := &Auth{ID: "auth-401-then-404"}
+	applyAuthFailureStateForModel(auth401First, unauthorized, nil, "", now, false)
+	if !auth401First.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("401 NextRetryAfter = %v, want %v", auth401First.NextRetryAfter, deadline)
+	}
+	applyAuthFailureStateForModel(auth401First, generic, nil, "", now, false)
+	if !auth401First.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("racing generic 404 shortened deadline: NextRetryAfter = %v, want unchanged %v", auth401First.NextRetryAfter, deadline)
+	}
+	if !auth401First.Unavailable {
+		t.Fatalf("auth401First.Unavailable = false, want true")
+	}
+
+	// Generic 404 then 401 for the same credential must land on the
+	// 30-minute deadline too - the 401 branch always sets its own 30-minute
+	// window unconditionally, which is never shorter than a generic 404's
+	// transient backoff.
+	auth404First := &Auth{ID: "auth-404-then-401"}
+	applyAuthFailureStateForModel(auth404First, generic, nil, "", now, false)
+	if got := auth404First.NextRetryAfter; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("generic-first NextRetryAfter = %v, want %v", got, now.Add(time.Minute))
+	}
+	applyAuthFailureStateForModel(auth404First, unauthorized, nil, "", now, false)
+	if !auth404First.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("generic-then-401 NextRetryAfter = %v, want %v", auth404First.NextRetryAfter, deadline)
+	}
+}
+
+func TestApplyAuthFailureStateCredentialCooldownRacingGeneric404MutationControl(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	deadline := now.Add(30 * time.Minute)
+
+	// Mimic the pre-fix generic-404 branch directly (unconditional
+	// overwrite, no preserved-existing-deadline check) to confirm it
+	// reproduces the exact defect this pair of tests guards against.
+	auth := &Auth{ID: "auth-401-mc", Unavailable: true, Status: StatusError, NextRetryAfter: deadline, CredentialCooldown: true}
+	preFixNext := notFoundRetryAfter(generic, "", &auth.Quota, now, false)
+	if !preFixNext.Before(deadline) {
+		t.Fatalf("expected the pre-fix computed NextRetryAfter (%v) to be shorter than the live 401 deadline (%v)", preFixNext, deadline)
+	}
+}
+
+func TestClearAuthStateOnSuccessClearsCredentialCooldown(t *testing.T) {
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	auth := &Auth{
+		ID:                 "auth-cleared-on-success",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     now.Add(30 * time.Minute),
+		CredentialCooldown: true,
+	}
+	clearAuthStateOnSuccess(auth, now)
+	if auth.CredentialCooldown {
+		t.Fatalf("clearAuthStateOnSuccess() left CredentialCooldown = true, want false")
+	}
+	if auth.Unavailable || !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("clearAuthStateOnSuccess() left cooldown state = %+v, want fully cleared", auth)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1425,3 +1425,89 @@ func TestClearAuthStateOnSuccessClearsCredentialCooldown(t *testing.T) {
 		t.Fatalf("clearAuthStateOnSuccess() left cooldown state = %+v, want fully cleared", auth)
 	}
 }
+
+func TestMarkResultModelCooldownSurvivesRacingGeneric404(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetTransientErrorCooldownSeconds(0)
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		transientErrorCooldownSeconds.Store(previousTransient)
+		quotaCooldownDisabled.Store(previousDisabled)
+	})
+
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	unauthorized := &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}
+
+	newAuth := func(id string) (*Manager, *Auth) {
+		manager := NewManager(nil, nil, nil)
+		auth := &Auth{ID: id, Provider: "codex", ModelStates: map[string]*ModelState{
+			"gpt-5": {},
+		}}
+		if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		return manager, auth
+	}
+	retryAfterFor := func(manager *Manager, authID string) time.Time {
+		updated, ok := manager.GetByID(authID)
+		if !ok || updated.ModelStates["gpt-5"] == nil {
+			t.Fatal("MarkResult() did not retain model cooldown state")
+		}
+		return updated.ModelStates["gpt-5"].NextRetryAfter
+	}
+
+	// A 401 for this model key sets a 30-minute deadline; a racing generic
+	// 404 for the same key must not shorten it down to the 404's short
+	// transient backoff.
+	managerLonger, authLonger := newAuth("model-401-then-404")
+	before := time.Now()
+	managerLonger.MarkResult(context.Background(), Result{AuthID: authLonger.ID, Provider: "codex", Model: "gpt-5", Error: unauthorized})
+	deadline := retryAfterFor(managerLonger, authLonger.ID)
+	if cooldown := deadline.Sub(before); cooldown < 30*time.Minute-time.Second || cooldown > 30*time.Minute+time.Second {
+		t.Fatalf("401 cooldown = %v, want about 30m", cooldown)
+	}
+	managerLonger.MarkResult(context.Background(), Result{AuthID: authLonger.ID, Provider: "codex", Model: "gpt-5", Error: generic})
+	if got := retryAfterFor(managerLonger, authLonger.ID); !got.Equal(deadline) {
+		t.Fatalf("racing generic 404 shortened model deadline: NextRetryAfter = %v, want unchanged %v", got, deadline)
+	}
+
+	// Control: a generic 404 recorded first (short transient backoff) must
+	// be extended by a later, genuinely longer 401 for the same key - the
+	// preserve-longer rule must not pin the deadline to whichever error
+	// landed first.
+	managerShorter, authShorter := newAuth("model-404-then-401")
+	before = time.Now()
+	managerShorter.MarkResult(context.Background(), Result{AuthID: authShorter.ID, Provider: "codex", Model: "gpt-5", Error: generic})
+	shortDeadline := retryAfterFor(managerShorter, authShorter.ID)
+	if cooldown := shortDeadline.Sub(before); cooldown < 59*time.Second || cooldown > 61*time.Second {
+		t.Fatalf("generic-404-first cooldown = %v, want about 1m", cooldown)
+	}
+	managerShorter.MarkResult(context.Background(), Result{AuthID: authShorter.ID, Provider: "codex", Model: "gpt-5", Error: unauthorized})
+	longDeadline := retryAfterFor(managerShorter, authShorter.ID)
+	if cooldown := longDeadline.Sub(before); cooldown < 30*time.Minute-time.Second || cooldown > 30*time.Minute+time.Second {
+		t.Fatalf("generic-then-401 cooldown = %v, want about 30m (extended)", cooldown)
+	}
+	if !longDeadline.After(shortDeadline) {
+		t.Fatalf("longer 401 did not extend the shorter generic-404 deadline: got %v, want after %v", longDeadline, shortDeadline)
+	}
+}
+
+func TestMarkResultModelCooldownRacingGeneric404MutationControl(t *testing.T) {
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	now := time.Date(2026, 9, 3, 14, 42, 0, 0, time.UTC)
+	generic := &Error{HTTPStatus: http.StatusNotFound, Message: "Not Found"}
+	deadline := now.Add(30 * time.Minute)
+
+	// Mimic the pre-fix model-level generic-404 branch directly (unconditional
+	// overwrite, no preserved-existing-deadline check) to confirm it would
+	// reproduce the exact defect this pair of tests guards against.
+	state := &ModelState{NextRetryAfter: deadline, Unavailable: true, Status: StatusError}
+	preFixNext := notFoundRetryAfter(generic, "", &state.Quota, now, false)
+	if !preFixNext.Before(deadline) {
+		t.Fatalf("expected the pre-fix computed NextRetryAfter (%v) to be shorter than the live model deadline (%v)", preFixNext, deadline)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1853,10 +1853,10 @@ func TestManager_UnknownUpstreamErrorRotatesAndPenalizesModelOnly(t *testing.T) 
 	}
 
 	now := time.Now()
-	if blocked, _, _ := isAuthBlockedForModel(updatedBad, model, now); !blocked {
+	if blocked, _, _ := effectiveBlock(updatedBad, model, now); !blocked {
 		t.Fatal("expected the failing model to be blocked on that credential")
 	}
-	if blocked, reason, _ := isAuthBlockedForModel(updatedBad, siblingModel, now); blocked {
+	if blocked, reason, _ := effectiveBlock(updatedBad, siblingModel, now); blocked {
 		t.Fatalf("sibling model was blocked on the same credential (reason=%v); the penalty must stay scoped to (credential, model)", reason)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -363,9 +363,9 @@ func TestManager_RefreshAuth_ExpiredAccessTokenBlockedFromSelection(t *testing.T
 		},
 	}
 
-	blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", time.Now())
+	blocked, reason, _ := effectiveBlock(auth, "gpt-5", time.Now())
 	if !blocked {
-		t.Fatal("isAuthBlockedForModel should return blocked=true for expired access token")
+		t.Fatal("effectiveBlock should return blocked=true for expired access token")
 	}
 	_ = reason
 }

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -463,7 +463,7 @@ func (m *Manager) availableAuthsForRouteModelWithPriorityMode(auths []*Auth, pro
 	var earliest time.Time
 	for _, candidate := range auths {
 		checkModel := m.selectionModelForAuth(candidate, routeModel)
-		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
+		blocked, reason, next := effectiveBlock(candidate, checkModel, now)
 		if !blocked {
 			priority := authPriority(candidate)
 			availableByPriority[priority] = append(availableByPriority[priority], candidate)
@@ -951,7 +951,7 @@ func (m *Manager) requestRetryRoundExclusions(retryRound int, defaultRequestRetr
 }
 
 func retryRoundAvailabilityForAuth(auth *Auth, model string, now time.Time) (bool, time.Time) {
-	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	blocked, reason, next := effectiveBlock(auth, model, now)
 	if !blocked {
 		return true, time.Time{}
 	}
@@ -2070,7 +2070,7 @@ func (m *Manager) warnLogAuthUnavailable(ctx context.Context, providers []string
 		}
 		totalCandidates++
 		checkModel := m.selectionModelForAuth(candidate, model)
-		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
+		blocked, reason, next := effectiveBlock(candidate, checkModel, now)
 		if blocked && reason == blockReasonCooldown {
 			coolingSummaries = append(coolingSummaries, authCoolingSummary(candidate, checkModel, next, now))
 		}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -370,7 +370,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, bootstrapErr, m.runtimeConfigSnapshot())
 			if okAction {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: bootstrapStreamWireModel(bootstrapErr, streamResult.Metadata, sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -390,7 +390,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: bootstrapStreamWireModel(bootstrapErr, streamResult.Metadata, sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -401,7 +401,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: bootstrapStreamWireModel(bootstrapErr, streamResult.Metadata, sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -416,7 +416,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: bootstrapStreamWireModel(bootstrapErr, streamResult.Metadata, sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -282,7 +282,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			streamWireModel := preferWireModel(wireModelFromError(errStream), sentModel)
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: streamWireModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -228,6 +228,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if executionModel == "" {
 			execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, execModel)
 		}
+		sentModel := execReq.Model
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
@@ -281,7 +282,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true
@@ -367,7 +368,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, bootstrapErr, m.runtimeConfigSnapshot())
 			if okAction {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -387,7 +388,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -398,7 +399,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -413,7 +414,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true
@@ -431,7 +432,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				upstreamErr = currentErr
 			}
 			warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), emptyErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr
@@ -447,7 +448,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			remaining = closedCh
 		}
 		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, execModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, sentModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -120,7 +120,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 	}
 }
 
-func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel, routeModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, opts cliproxyexecutor.Options) *cliproxyexecutor.StreamResult {
+func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel, upstreamModel, routeModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, opts cliproxyexecutor.Options) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	streamStart := time.Now()
 	go func() {
@@ -138,7 +138,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				warnLogUpstreamFailure(ctx, entry, provider, resultModel, auth, time.Since(streamStart), chunk.Err)
 				rerr := resultErrorFromError(chunk.Err)
 				action, okAction := matchRequestScopedErrorAction(auth, chunk.Err, m.runtimeConfigSnapshot())
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: opts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: false, Error: rerr, Options: opts}
 				applyRequestScopedActionToResult(action, okAction, &result)
 				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			}
@@ -197,7 +197,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 		}
 		if !failed && (ephemeralResult || claudeOAuthRequestCancellation(ctx, auth, nil) == nil) {
-			m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: true, Options: opts}, auth, ephemeralResult)
+			m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: true, Options: opts}, auth, ephemeralResult)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
@@ -281,7 +281,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true
@@ -367,7 +367,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, bootstrapErr, m.runtimeConfigSnapshot())
 			if okAction {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -387,7 +387,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -398,7 +398,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -413,7 +413,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true
@@ -431,7 +431,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				upstreamErr = currentErr
 			}
 			warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), emptyErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr
@@ -447,7 +447,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			remaining = closedCh
 		}
 		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, execModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -450,7 +450,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			remaining = closedCh
 		}
 		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, sentModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
+		streamWireModel := wireModelOrSentStream(streamResult.Metadata, sentModel)
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamWireModel, routeModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult, execOpts), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -138,7 +138,8 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				warnLogUpstreamFailure(ctx, entry, provider, resultModel, auth, time.Since(streamStart), chunk.Err)
 				rerr := resultErrorFromError(chunk.Err)
 				action, okAction := matchRequestScopedErrorAction(auth, chunk.Err, m.runtimeConfigSnapshot())
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: false, Error: rerr, Options: opts}
+				chunkWireModel := preferWireModel(wireModelFromError(chunk.Err), upstreamModel)
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: chunkWireModel, RouteModel: routeModel, Success: false, Error: rerr, Options: opts}
 				applyRequestScopedActionToResult(action, okAction, &result)
 				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			}
@@ -369,7 +370,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, bootstrapErr, m.runtimeConfigSnapshot())
 			if okAction {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -389,7 +390,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -400,7 +401,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -415,7 +416,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: sentModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: preferWireModel(wireModelFromError(bootstrapErr), sentModel), RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true

--- a/sdk/cliproxy/auth/conductor_subsecond_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_subsecond_cooldown_test.go
@@ -125,7 +125,7 @@ func TestApplyAuthFailureState_429SubSecondRetryAfter_EnforcesMinimumCooldownFlo
 		Message:    "RESOURCE_EXHAUSTED",
 	}
 
-	applyAuthFailureState(auth, quotaErr, &subSecond, now, false)
+	applyAuthFailureState(auth, quotaErr, &subSecond, "", now, false)
 
 	if auth.NextRetryAfter.IsZero() {
 		t.Fatal("expected NextRetryAfter to be set")

--- a/sdk/cliproxy/auth/conductor_subsecond_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_subsecond_cooldown_test.go
@@ -125,7 +125,7 @@ func TestApplyAuthFailureState_429SubSecondRetryAfter_EnforcesMinimumCooldownFlo
 		Message:    "RESOURCE_EXHAUSTED",
 	}
 
-	applyAuthFailureState(auth, quotaErr, &subSecond, "", now, false)
+	applyAuthFailureState(auth, quotaErr, &subSecond, now, false)
 
 	if auth.NextRetryAfter.IsZero() {
 		t.Fatal("expected NextRetryAfter to be set")

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -522,3 +522,98 @@ func TestManager_Update_EmptyIncomingIdentityPreservesCredentialCooldown(t *test
 		t.Fatalf("expected NextRetryAfter to remain %v, got %v", deadline, updated.NextRetryAfter)
 	}
 }
+
+// TestManager_Update_SameAPIKeyPreservesCredentialCooldown covers a plain
+// API-key auth (no OAuth metadata at all) whose Update carries the SAME
+// api_key attribute - this must be treated like a routine refresh and must
+// preserve a live credential cooldown.
+func TestManager_Update_SameAPIKeyPreservesCredentialCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-apikey-refresh",
+		Provider:           "openai",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Attributes:         map[string]string{AttributeAPIKey: "sk-same-key"},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	updated, err := m.Update(context.Background(), &Auth{
+		ID:         "auth-401-apikey-refresh",
+		Provider:   "openai",
+		Status:     StatusActive,
+		Attributes: map[string]string{AttributeAPIKey: "sk-same-key"},
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+	if !updated.Unavailable || !updated.CredentialCooldown {
+		t.Fatalf("expected cooldown preserved for same api_key, got Unavailable=%v CredentialCooldown=%v", updated.Unavailable, updated.CredentialCooldown)
+	}
+	if !updated.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("expected NextRetryAfter to remain %v, got %v", deadline, updated.NextRetryAfter)
+	}
+}
+
+// TestManager_Update_RotatedAPIKeyClearsCredentialCooldown covers the
+// rotation case: a plain API-key auth whose Update carries a DIFFERENT
+// api_key attribute is a genuinely different credential and must clear a
+// live credential cooldown, same as an OAuth re-login.
+func TestManager_Update_RotatedAPIKeyClearsCredentialCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-apikey-rotate",
+		Provider:           "openai",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Attributes:         map[string]string{AttributeAPIKey: "sk-old-key"},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	updated, err := m.Update(context.Background(), &Auth{
+		ID:         "auth-401-apikey-rotate",
+		Provider:   "openai",
+		Status:     StatusActive,
+		Attributes: map[string]string{AttributeAPIKey: "sk-new-key"},
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+	if updated.Unavailable || updated.CredentialCooldown {
+		t.Fatalf("expected cooldown cleared for rotated api_key, got Unavailable=%v CredentialCooldown=%v", updated.Unavailable, updated.CredentialCooldown)
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter cleared, got %v", updated.NextRetryAfter)
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("expected Status = StatusActive, got %v", updated.Status)
+	}
+}
+
+// TestManager_Update_APIKeyIdentityMutationControl confirms sameAuthCredential
+// is load-bearing for the API-key case: without it, a rotated api_key would
+// be indistinguishable from a routine update and the cooldown would be
+// carried over unconditionally.
+func TestManager_Update_APIKeyIdentityMutationControl(t *testing.T) {
+	existing := &Auth{ID: "auth-apikey-mc", Provider: "openai", Attributes: map[string]string{AttributeAPIKey: "sk-old-key"}}
+	rotated := &Auth{ID: "auth-apikey-mc", Provider: "openai", Attributes: map[string]string{AttributeAPIKey: "sk-new-key"}}
+	if sameAuthCredential(existing, rotated) {
+		t.Fatalf("sameAuthCredential() = true for a rotated api_key, want false")
+	}
+	same := &Auth{ID: "auth-apikey-mc", Provider: "openai", Attributes: map[string]string{AttributeAPIKey: "sk-old-key"}}
+	if !sameAuthCredential(existing, same) {
+		t.Fatalf("sameAuthCredential() = false for an unchanged api_key, want true")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -351,3 +351,174 @@ func TestManager_Update_CredentialCooldownMutationControl(t *testing.T) {
 		t.Fatalf("mutation-control clean auth unexpectedly carries cooldown fields: %+v", clean)
 	}
 }
+
+func TestManager_Update_SameCredentialRefreshPreservesCredentialCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-refresh",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token-abc",
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// A routine access-token refresh rotates access_token but keeps the
+	// same refresh_token - same underlying credential, cooldown must
+	// survive.
+	updated, errUpdate := m.Update(context.Background(), &Auth{
+		ID:       "auth-401-refresh",
+		Provider: "claude",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "fresh-access-token",
+			"refresh_token": "refresh-token-abc",
+		},
+	})
+	if errUpdate != nil {
+		t.Fatalf("update auth: %v", errUpdate)
+	}
+	if !updated.Unavailable || !updated.CredentialCooldown || !updated.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("Update() with same refresh_token = %+v, want cooldown preserved until %v", updated, deadline)
+	}
+}
+
+func TestManager_Update_NewCredentialReLoginClearsCredentialCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-relogin",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token-old",
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// An operator re-login writes a genuinely different credential (new
+	// refresh_token) to the same auth file/ID - the old cooldown must not
+	// carry over, so re-login restores service immediately per the
+	// dead-grant recovery playbook.
+	updated, errUpdate := m.Update(context.Background(), &Auth{
+		ID:       "auth-401-relogin",
+		Provider: "claude",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "refresh-token-new",
+		},
+	})
+	if errUpdate != nil {
+		t.Fatalf("update auth: %v", errUpdate)
+	}
+	if updated.Unavailable || updated.CredentialCooldown || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("Update() with new refresh_token = %+v, want cooldown cleared", updated)
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("Update() with new refresh_token Status = %v, want %v", updated.Status, StatusActive)
+	}
+}
+
+func TestManager_Update_CredentialIdentityMutationControl(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-relogin-mc",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Metadata: map[string]any{
+			"refresh_token": "refresh-token-old",
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Mimic the pre-fix behavior directly: unconditionally preserving the
+	// cooldown regardless of credential identity. Confirms this test would
+	// have failed to catch the regression without the sameAuthCredential
+	// check, i.e. that the check is load-bearing.
+	m.mu.Lock()
+	existing := m.auths["auth-401-relogin-mc"]
+	m.mu.Unlock()
+	if existing == nil {
+		t.Fatalf("expected existing auth to be present")
+	}
+	unconditional := &Auth{ID: "auth-401-relogin-mc", Provider: "claude", Status: StatusActive, Metadata: map[string]any{"refresh_token": "refresh-token-new"}}
+	// pre-fix: no identity check at all
+	unconditional.Unavailable = existing.Unavailable
+	unconditional.NextRetryAfter = existing.NextRetryAfter
+	unconditional.CredentialCooldown = existing.CredentialCooldown
+	if !unconditional.CredentialCooldown {
+		t.Fatalf("expected the unconditional pre-fix simulation to carry the cooldown over")
+	}
+	if sameAuthCredential(existing, unconditional) {
+		t.Fatalf("sameAuthCredential() = true for a rotated refresh_token, want false")
+	}
+}
+
+// TestManager_Update_EmptyIncomingIdentityPreservesCredentialCooldown covers
+// an Update call whose incoming Auth carries no token metadata at all (e.g.
+// a caller updating only Status/Attributes, or one that runs before a later
+// metadata merge fills in the tokens). This must NOT be misread as a
+// different credential and must NOT clear a live cooldown - only a
+// non-empty incoming identity that differs from existing's should do that.
+func TestManager_Update_EmptyIncomingIdentityPreservesCredentialCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-empty-identity",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+		Metadata: map[string]any{
+			"access_token":  "stale-access-token",
+			"refresh_token": "refresh-token-abc",
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	updated, err := m.Update(context.Background(), &Auth{
+		ID:       "auth-401-empty-identity",
+		Provider: "claude",
+		Status:   StatusActive,
+	})
+	if err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+	if !updated.Unavailable {
+		t.Fatalf("expected Unavailable to remain true for an update with no incoming identity")
+	}
+	if !updated.CredentialCooldown {
+		t.Fatalf("expected CredentialCooldown to remain true for an update with no incoming identity")
+	}
+	if !updated.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("expected NextRetryAfter to remain %v, got %v", deadline, updated.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -281,9 +281,9 @@ func TestManager_Update_PreservesCredentialCooldownUntilDeadline(t *testing.T) {
 	if !updated.Unavailable || !updated.CredentialCooldown || !updated.NextRetryAfter.Equal(deadline) {
 		t.Fatalf("Update() while cooldown live = %+v, want Unavailable/CredentialCooldown preserved until %v", updated, deadline)
 	}
-	blocked, _, next := isAuthBlockedForModel(updated, "", time.Now())
+	blocked, _, next := effectiveBlock(updated, "", time.Now())
 	if !blocked || !next.Equal(deadline) {
-		t.Fatalf("isAuthBlockedForModel(auth, \"\", now) after Update = blocked=%v next=%v, want blocked until %v", blocked, next, deadline)
+		t.Fatalf("effectiveBlock(auth, \"\", now) after Update = blocked=%v next=%v, want blocked until %v", blocked, next, deadline)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -251,3 +251,103 @@ func TestManager_Update_ActiveInheritsModelStates(t *testing.T) {
 		t.Fatalf("expected BackoffLevel to be %d, got %d", backoffLevel, state.Quota.BackoffLevel)
 	}
 }
+
+func TestManager_Update_PreservesCredentialCooldownUntilDeadline(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// A refreshed/clean Auth carries no cooldown fields of its own - e.g. a
+	// token refresh completing while the 401 block is still live.
+	updated, errUpdate := m.Update(context.Background(), &Auth{
+		ID:       "auth-401",
+		Provider: "claude",
+		Status:   StatusActive,
+	})
+	if errUpdate != nil {
+		t.Fatalf("update auth: %v", errUpdate)
+	}
+	if !updated.Unavailable || !updated.CredentialCooldown || !updated.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("Update() while cooldown live = %+v, want Unavailable/CredentialCooldown preserved until %v", updated, deadline)
+	}
+	blocked, _, next := isAuthBlockedForModel(updated, "", time.Now())
+	if !blocked || !next.Equal(deadline) {
+		t.Fatalf("isAuthBlockedForModel(auth, \"\", now) after Update = blocked=%v next=%v, want blocked until %v", blocked, next, deadline)
+	}
+}
+
+func TestManager_Update_ClearsCredentialCooldownAfterDeadline(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	pastDeadline := now.Add(-time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-expired",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     pastDeadline,
+		CredentialCooldown: true,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	updated, errUpdate := m.Update(context.Background(), &Auth{
+		ID:       "auth-401-expired",
+		Provider: "claude",
+		Status:   StatusActive,
+	})
+	if errUpdate != nil {
+		t.Fatalf("update auth: %v", errUpdate)
+	}
+	if updated.Unavailable || updated.CredentialCooldown {
+		t.Fatalf("Update() after deadline passed = %+v, want cooldown cleared", updated)
+	}
+}
+
+func TestManager_Update_CredentialCooldownMutationControl(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:                 "auth-401-mc",
+		Provider:           "claude",
+		Unavailable:        true,
+		Status:             StatusError,
+		NextRetryAfter:     deadline,
+		CredentialCooldown: true,
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Mimic the pre-fix Update path directly: a clean incoming Auth applied
+	// with no existing.CredentialCooldown preservation at all loses the
+	// cooldown outright, reproducing the original defect this test guards
+	// against (see the guarded branch added to Manager.Update).
+	m.mu.Lock()
+	existing := m.auths["auth-401-mc"]
+	m.mu.Unlock()
+	if existing == nil || !existing.CredentialCooldown || !existing.NextRetryAfter.After(now) {
+		t.Fatalf("expected existing auth to carry a live credential cooldown, got %+v", existing)
+	}
+	clean := &Auth{ID: "auth-401-mc", Provider: "claude", Status: StatusActive}
+	if !existing.CredentialCooldown && existing.NextRetryAfter.After(now) {
+		clean.Unavailable = existing.Unavailable
+		clean.NextRetryAfter = existing.NextRetryAfter
+	}
+	if clean.Unavailable || clean.CredentialCooldown || !clean.NextRetryAfter.IsZero() {
+		t.Fatalf("mutation-control clean auth unexpectedly carries cooldown fields: %+v", clean)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -202,10 +202,10 @@ func TestRecoverableUnknownFailuresHaveFiniteCooldown(t *testing.T) {
 			if nextRetryAfter.IsZero() {
 				t.Fatal("recoverable failure has no retry deadline")
 			}
-			if blocked, _, _ := isAuthBlockedForModel(updated, testCase.model, time.Now()); !blocked {
+			if blocked, _, _ := effectiveBlock(updated, testCase.model, time.Now()); !blocked {
 				t.Fatal("auth was not blocked during recoverable failure cooldown")
 			}
-			if blocked, _, _ := isAuthBlockedForModel(updated, testCase.model, nextRetryAfter.Add(time.Nanosecond)); blocked {
+			if blocked, _, _ := effectiveBlock(updated, testCase.model, nextRetryAfter.Add(time.Nanosecond)); blocked {
 				t.Fatal("auth did not automatically recover after retry deadline")
 			}
 		})

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -117,7 +117,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, "", now, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +127,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, "", now.Add(100*time.Millisecond), false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +136,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, "", now.Add(2*time.Second), false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,7 +146,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, "", now.Add(3*time.Second), false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -117,7 +117,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, "", now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +127,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, "", now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +136,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, "", now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,7 +146,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, "", now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}

--- a/sdk/cliproxy/auth/cooldown_state.go
+++ b/sdk/cliproxy/auth/cooldown_state.go
@@ -17,17 +17,29 @@ import (
 
 // CooldownStateRecord is a persisted runtime cooldown snapshot for one auth/model pair.
 type CooldownStateRecord struct {
-	Provider       string     `json:"provider,omitempty"`
-	AuthID         string     `json:"auth_id"`
-	AuthFile       string     `json:"-"`
-	Model          string     `json:"model,omitempty"`
-	Status         string     `json:"status,omitempty"`
-	NextRetryAfter time.Time  `json:"next_retry_after"`
-	Reason         string     `json:"reason,omitempty"`
-	Quota          QuotaState `json:"quota,omitempty"`
-	LastError      *Error     `json:"last_error,omitempty"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	Provider       string    `json:"provider,omitempty"`
+	AuthID         string    `json:"auth_id"`
+	AuthFile       string    `json:"-"`
+	Model          string    `json:"model,omitempty"`
+	Status         string    `json:"status,omitempty"`
+	NextRetryAfter time.Time `json:"next_retry_after"`
+	Reason         string    `json:"reason,omitempty"`
+	// Scope distinguishes an auth-level (Model == "") record's origin: either
+	// cooldownScopeCredential (a genuine credential-wide failure, e.g. a 401,
+	// where Unavailable/NextRetryAfter/Quota were set directly and must
+	// survive aggregation until this deadline) or empty/legacy (derived from
+	// ModelStates aggregation - the current, pre-existing behavior, kept as
+	// the default for backward compatibility with records written before
+	// this field existed). Unused for a model-scoped record.
+	Scope     string     `json:"scope,omitempty"`
+	Quota     QuotaState `json:"quota,omitempty"`
+	LastError *Error     `json:"last_error,omitempty"`
+	UpdatedAt time.Time  `json:"updated_at"`
 }
+
+// cooldownScopeCredential marks a CooldownStateRecord as a genuine
+// credential-wide cooldown. See CooldownStateRecord.Scope.
+const cooldownScopeCredential = "credential"
 
 // CooldownStateStore persists runtime cooldown state independently from auth tokens.
 type CooldownStateStore interface {

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -1308,3 +1308,179 @@ func TestUpdateAggregatedAvailabilityGenericNotFoundMutationControl(t *testing.T
 		t.Fatal("pre-fix wipe followed by availabilityBlock(false, false, ...) unexpectedly still blocks - mutation control precondition broken, update this test")
 	}
 }
+
+// TestRestoreCooldownStatesCredentialWideSurvivesCleanModelStates covers the
+// delta review's second must-fix item: a genuine credential-wide failure
+// (e.g. a 401, applied directly to auth.Unavailable/NextRetryAfter by
+// applyAuthFailureStateForModel, with no per-model context at all) must not
+// be silently cleared by updateAggregatedAvailability just because this
+// credential also happens to carry clean historical ModelStates entries
+// (models it has served successfully before, with no error state of their
+// own). Before this fix, restoreCooldownRecordLocked's model=="" branch
+// unconditionally re-derived auth.Unavailable from ModelStates the moment
+// ModelStates was non-empty, discarding the persisted 401's own deadline the
+// instant any clean sibling model state existed. The fix persists an
+// explicit Scope=credential marker on the auth-level record and threads it
+// through to auth.CredentialCooldown, which updateAggregatedAvailability now
+// checks before ever consulting ModelStates.
+func TestRestoreCooldownStatesCredentialWideSurvivesCleanModelStates(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	store := &recordingCooldownStateStore{
+		load: []CooldownStateRecord{
+			{
+				Provider:       "claude",
+				AuthID:         "auth-401",
+				Model:          "",
+				Status:         "cooling",
+				NextRetryAfter: deadline,
+				Reason:         "unauthorized",
+				Scope:          cooldownScopeCredential,
+				UpdatedAt:      now,
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	auth := &Auth{
+		ID:       "auth-401",
+		Provider: "claude",
+		Status:   StatusActive,
+		// Clean historical model states: this credential has served these
+		// models before with no error of their own. This is exactly the
+		// condition Codex flagged as silently clearing a genuine
+		// credential-wide cooldown.
+		ModelStates: map[string]*ModelState{
+			"claude-opus":  {Status: StatusActive},
+			"claude-haiku": {Status: StatusActive},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	restored, ok := manager.GetByID("auth-401")
+	if !ok {
+		t.Fatal("restored auth was not found")
+	}
+	if !restored.Unavailable {
+		t.Fatal("restored auth.Unavailable = false, want true (credential-wide 401 must survive clean sibling model states)")
+	}
+	if !restored.CredentialCooldown {
+		t.Fatal("restored auth.CredentialCooldown = false, want true")
+	}
+	if !restored.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("restored auth.NextRetryAfter = %v, want %v", restored.NextRetryAfter, deadline)
+	}
+	if blocked, _, next := isAuthBlockedForModel(restored, "", now); !blocked || !next.Equal(deadline) {
+		t.Fatalf("isAuthBlockedForModel(auth, \"\", now) = (%v, _, %v), want (true, _, %v)", blocked, next, deadline)
+	}
+	// Every individual model must be blocked too - a credential-wide failure
+	// blocks everything, not just the aggregate query.
+	if blocked, _, _ := isAuthBlockedForModel(restored, "claude-opus", now); !blocked {
+		t.Fatal("isAuthBlockedForModel(auth, \"claude-opus\", now) = false, want true")
+	}
+
+	// Once the deadline has actually passed, the credential-wide block must
+	// lift - this is a deadline, not a permanent flag.
+	afterDeadline := deadline.Add(time.Second)
+	if blocked, _, _ := isAuthBlockedForModel(restored, "", afterDeadline); blocked {
+		t.Fatal("isAuthBlockedForModel(auth, \"\", afterDeadline) = true, want false once the credential-wide deadline has passed")
+	}
+}
+
+// TestRestoreCooldownStatesLegacyAuthRecordRoundTrip confirms a record
+// written before the Scope field existed (Scope == "", the zero value)
+// keeps its pre-existing behavior on restore: an auth-level record is still
+// re-derived from ModelStates whenever any exist, exactly as before this
+// round's fix. This is the documented backward-compatibility default from
+// the delta review - only an explicit Scope=credential marker changes
+// behavior.
+func TestRestoreCooldownStatesLegacyAuthRecordRoundTrip(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	store := &recordingCooldownStateStore{
+		load: []CooldownStateRecord{
+			{
+				Provider:       "claude",
+				AuthID:         "auth-legacy",
+				Model:          "",
+				Status:         "cooling",
+				NextRetryAfter: deadline,
+				Reason:         "unauthorized",
+				// Scope intentionally left unset (zero value), simulating a
+				// record persisted by a build before this field existed.
+				UpdatedAt: now,
+			},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	auth := &Auth{
+		ID:       "auth-legacy",
+		Provider: "claude",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"claude-opus": {Status: StatusActive},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	restored, ok := manager.GetByID("auth-legacy")
+	if !ok {
+		t.Fatal("restored auth was not found")
+	}
+	// Unchanged pre-existing behavior: a legacy auth-level record with
+	// ModelStates present is re-derived from ModelStates, not trusted
+	// directly - the clean sibling clears it.
+	if restored.Unavailable {
+		t.Fatal("restored auth.Unavailable = true, want false (legacy Scope=\"\" record must keep the pre-existing ModelStates-derived behavior)")
+	}
+	if restored.CredentialCooldown {
+		t.Fatal("restored auth.CredentialCooldown = true, want false for a legacy record")
+	}
+}
+
+// TestRestoreCooldownStatesCredentialWideMutationControl is a mutation
+// control for the credential-scope fix: reverting
+// restoreCooldownRecordLocked's model=="" branch to unconditionally call
+// updateAggregatedAvailability whenever ModelStates is non-empty (ignoring
+// record.Scope entirely, as before this round) must be caught by
+// TestRestoreCooldownStatesCredentialWideSurvivesCleanModelStates.
+func TestRestoreCooldownStatesCredentialWideMutationControl(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	auth := &Auth{
+		ID:       "auth-401",
+		Provider: "claude",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"claude-opus": {Status: StatusActive},
+		},
+	}
+	// Directly re-execute the pre-fix branch: unconditional
+	// updateAggregatedAvailability whenever ModelStates is non-empty,
+	// without ever consulting a Scope marker.
+	auth.Unavailable = true
+	auth.Status = StatusError
+	auth.NextRetryAfter = deadline
+	if len(auth.ModelStates) > 0 {
+		updateAggregatedAvailability(auth, now)
+	}
+	if auth.Unavailable {
+		t.Fatal("pre-fix unconditional updateAggregatedAvailability unexpectedly still reports unavailable - mutation control precondition broken, update this test")
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 type recordingCooldownStateStore struct {
@@ -999,5 +1000,311 @@ func TestAuthCooldownStateRecordAgreesWithSelectorOnWriteSideGate(t *testing.T) 
 	}
 	if _, ok := authCooldownStateRecord(auth, now); ok {
 		t.Fatal("authCooldownStateRecord() must agree with isAuthBlockedForModel(auth, \"\", now) and skip the record")
+	}
+}
+
+// TestRestoreCooldownStatesAllModelsCoolingBlocksCredential covers the delta
+// review's must-fix item 1: when the registered model set for a credential
+// is PROVABLY COMPLETE - every model the registry lists for this credential
+// has a restored, blocked ModelState - restore must raise auth.Unavailable,
+// not just lower it. Without this, a credential whose every model is
+// cooling would restore into a selectable-looking state, the opposite of
+// the escalation-suppression fix's intent.
+func TestRestoreCooldownStatesAllModelsCoolingBlocksCredential(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(12 * time.Hour)
+
+	llamaState := &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: deadline,
+		},
+		NextRetryAfter: deadline,
+		UpdatedAt:      now,
+	}
+	mistralState := &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: deadline,
+		},
+		NextRetryAfter: deadline,
+		UpdatedAt:      now,
+	}
+	auth := &Auth{
+		ID:       "auth-all-cooling",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"llama3":  llamaState,
+			"mistral": mistralState,
+		},
+	}
+	llamaRecord, ok := modelCooldownStateRecord(auth, "llama3", llamaState, now)
+	if !ok {
+		t.Fatal("modelCooldownStateRecord(llama3) = false, want true")
+	}
+	mistralRecord, ok := modelCooldownStateRecord(auth, "mistral", mistralState, now)
+	if !ok {
+		t.Fatal("modelCooldownStateRecord(mistral) = false, want true")
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("auth-all-cooling", "openai-compat", []*registry.ModelInfo{{ID: "llama3"}, {ID: "mistral"}})
+	t.Cleanup(func() { reg.UnregisterClient("auth-all-cooling") })
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-all-cooling", Provider: "openai-compat", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	if !manager.restoreCooldownRecordLocked(llamaRecord, now) {
+		manager.mu.Unlock()
+		t.Fatal("restoreCooldownRecordLocked(llama3) = false, want true")
+	}
+	if !manager.restoreCooldownRecordLocked(mistralRecord, now) {
+		manager.mu.Unlock()
+		t.Fatal("restoreCooldownRecordLocked(mistral) = false, want true")
+	}
+	manager.mu.Unlock()
+
+	restoredAuth, ok := manager.GetByID("auth-all-cooling")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "llama3", now); !blocked {
+		t.Fatal("isAuthBlockedForModel(llama3) = not blocked after restoring both cooling models, want blocked")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "mistral", now); !blocked {
+		t.Fatal("isAuthBlockedForModel(mistral) = not blocked after restoring both cooling models, want blocked")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); !blocked {
+		t.Fatal("isAuthBlockedForModel(\"\") = selectable after restoring every registered model as cooling, want blocked (registry set is provably complete)")
+	}
+	if !restoredAuth.Unavailable {
+		t.Fatal("restoredAuth.Unavailable = false after restoring every registered model as cooling, want true")
+	}
+}
+
+// TestRestoreCooldownStatesPartialModelSetStaysSelectable re-confirms the
+// original P1 scenario now that restore can escalate: with the registry
+// listing a sibling model that has NO restored state, the restored set is
+// not provably complete, so restore must still only lower - never raise -
+// auth.Unavailable.
+func TestRestoreCooldownStatesPartialModelSetStaysSelectable(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(12 * time.Hour)
+
+	llamaState := &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: deadline,
+		},
+		NextRetryAfter: deadline,
+		UpdatedAt:      now,
+	}
+	auth := &Auth{
+		ID:       "auth-partial",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"llama3": llamaState,
+		},
+	}
+	llamaRecord, ok := modelCooldownStateRecord(auth, "llama3", llamaState, now)
+	if !ok {
+		t.Fatal("modelCooldownStateRecord(llama3) = false, want true")
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("auth-partial", "openai-compat", []*registry.ModelInfo{{ID: "llama3"}, {ID: "mistral"}})
+	t.Cleanup(func() { reg.UnregisterClient("auth-partial") })
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-partial", Provider: "openai-compat", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(llamaRecord, now)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked(llama3) = false, want true")
+	}
+
+	restoredAuth, ok := manager.GetByID("auth-partial")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); blocked {
+		t.Fatal("isAuthBlockedForModel(\"\") = blocked when the registry lists an unrestored sibling (mistral), want selectable - the restored set is not provably complete")
+	}
+	if restoredAuth.Unavailable {
+		t.Fatal("restoredAuth.Unavailable = true when the restored model set is not provably complete, want false")
+	}
+}
+
+// TestRestoreCooldownStatesModelSetCompletenessMutationControl is a
+// mutation control for the item-1 fix: reverting restoreCooldownRecordLocked
+// to always suppress the escalation (its pre-this-round behavior) must be
+// caught by TestRestoreCooldownStatesAllModelsCoolingBlocksCredential.
+func TestRestoreCooldownStatesModelSetCompletenessMutationControl(t *testing.T) {
+	now := time.Now()
+	auth := &Auth{
+		ID:       "auth-gate-complete",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"only-model": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: now.Add(time.Hour),
+				UpdatedAt:      now,
+			},
+		},
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("auth-gate-complete", "openai-compat", []*registry.ModelInfo{{ID: "only-model"}})
+	t.Cleanup(func() { reg.UnregisterClient("auth-gate-complete") })
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-gate-complete", Provider: "openai-compat", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	registered := manager.auths["auth-gate-complete"]
+	manager.mu.Unlock()
+	if !manager.restoredModelSetIsComplete(mergeAuthModelStates(registered, auth), now) {
+		t.Fatal("restoredModelSetIsComplete() = false for a registry set fully covered by restored, blocked states, want true")
+	}
+}
+
+// mergeAuthModelStates copies model states from src onto a shallow clone of
+// dst for the completeness-gate mutation control, without going through the
+// full restore path (which is already covered end-to-end by the other two
+// tests in this group).
+func mergeAuthModelStates(dst, src *Auth) *Auth {
+	if dst == nil || src == nil {
+		return dst
+	}
+	dst.ModelStates = src.ModelStates
+	return dst
+}
+
+// TestUpdateAggregatedAvailabilityPreservesGenericNotFoundThroughSiblingSuccess
+// covers the delta review's must-fix item 3, reproducing the exact sequence
+// from Codex's finding: a generic (non-explicit) 404 stores its backoff in
+// state.Quota.NextRecoverAt while leaving state.Quota.Exceeded false (see
+// notFoundRetryAfter's non-explicit branch, which writes
+// retryState.NextRecoverAt directly with no applyCooldownFields call). A
+// concurrent, shorter-lived 5xx then overwrites state.NextRetryAfter with an
+// earlier deadline without touching Quota at all. Once that shorter
+// NextRetryAfter passes, a sibling model's success calls
+// updateAggregatedAvailability. Pre-fix, the aggregation loop decided
+// per-model unavailability from state.Unavailable + state.NextRetryAfter
+// alone: once NextRetryAfter was in the past it unconditionally cleared
+// BOTH state.Unavailable and state.NextRetryAfter, discarding the still
+// future state.Quota.NextRecoverAt with no attempt to consult it - and
+// availabilityBlock's own bypass (`!unavailable && !quotaExceeded`) then
+// ignores NextRecoverAt too, so the model becomes selectable hours before
+// its generic-404 backoff actually expires. Post-fix, aggregation decides
+// via the same availabilityBlock predicate the selector itself uses, fed
+// state.Unavailable (still true - nothing clears it prematurely) alongside
+// both deadlines, so it keeps blocking until the later of the two expires.
+func TestUpdateAggregatedAvailabilityPreservesGenericNotFoundThroughSiblingSuccess(t *testing.T) {
+	now := time.Now()
+	shortenedRetryAfter := now.Add(30 * time.Second)   // the concurrent 5xx's shorter deadline
+	genericNotFoundRecoverAt := now.Add(2 * time.Hour) // the original generic-404 backoff
+
+	problemState := &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: shortenedRetryAfter,
+		Quota: QuotaState{
+			Exceeded:      false,
+			NextRecoverAt: genericNotFoundRecoverAt,
+		},
+		UpdatedAt: now,
+	}
+	siblingState := &ModelState{Status: StatusActive}
+	auth := &Auth{
+		ID:       "auth-generic-404",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"problem-model": problemState,
+			"sibling-model": siblingState,
+		},
+	}
+
+	// The shortened NextRetryAfter has now passed, but the generic-404's
+	// own NextRecoverAt (2h out) has not. A sibling success triggers
+	// aggregation at this later time.
+	afterShortDeadline := now.Add(31 * time.Second)
+	updateAggregatedAvailability(auth, afterShortDeadline)
+
+	if blocked, _, next := isAuthBlockedForModel(auth, "problem-model", afterShortDeadline); !blocked {
+		t.Fatalf("isAuthBlockedForModel(problem-model) = not blocked at %v after a sibling success, want blocked until %v (generic-404 NextRecoverAt) - got next=%v", afterShortDeadline, genericNotFoundRecoverAt, next)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "sibling-model", afterShortDeadline); blocked {
+		t.Fatal("isAuthBlockedForModel(sibling-model) = blocked, want selectable")
+	}
+
+	// Confirm the deadline itself is honored: once genericNotFoundRecoverAt
+	// has actually passed, the model must become selectable again.
+	afterLongDeadline := genericNotFoundRecoverAt.Add(time.Second)
+	updateAggregatedAvailability(auth, afterLongDeadline)
+	if blocked, _, _ := isAuthBlockedForModel(auth, "problem-model", afterLongDeadline); blocked {
+		t.Fatal("isAuthBlockedForModel(problem-model) = still blocked after genericNotFoundRecoverAt has passed, want selectable")
+	}
+}
+
+// TestUpdateAggregatedAvailabilityGenericNotFoundMutationControl is a
+// mutation control for item 3: reverting updateAggregatedAvailability's
+// per-model decision to the pre-fix field-specific shortcut (NextRetryAfter
+// alone, unconditionally clearing Unavailable/NextRetryAfter once it
+// expires) must be caught by
+// TestUpdateAggregatedAvailabilityPreservesGenericNotFoundThroughSiblingSuccess.
+func TestUpdateAggregatedAvailabilityGenericNotFoundMutationControl(t *testing.T) {
+	now := time.Now()
+	afterShortDeadline := now.Add(31 * time.Second)
+
+	// Directly re-execute the pre-fix per-model decision to document the
+	// exact gate this test group protects, independent of the full
+	// updateAggregatedAvailability call.
+	state := &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(30 * time.Second),
+		Quota: QuotaState{
+			Exceeded:      false,
+			NextRecoverAt: now.Add(2 * time.Hour),
+		},
+	}
+	preFixStateUnavailable := false
+	if state.Status == StatusDisabled {
+		preFixStateUnavailable = true
+	} else if state.Unavailable {
+		if state.NextRetryAfter.IsZero() {
+			preFixStateUnavailable = false
+		} else if state.NextRetryAfter.After(afterShortDeadline) {
+			preFixStateUnavailable = true
+		} else {
+			preFixStateUnavailable = false // the pre-fix wipe branch
+		}
+	}
+	if preFixStateUnavailable {
+		t.Fatal("pre-fix field-specific shortcut unexpectedly still reports unavailable - mutation control precondition broken, update this test")
+	}
+	blocked, _, _ := availabilityBlock(false, false, time.Time{}, state.Quota.NextRecoverAt, afterShortDeadline)
+	if blocked {
+		t.Fatal("pre-fix wipe followed by availabilityBlock(false, false, ...) unexpectedly still blocks - mutation control precondition broken, update this test")
 	}
 }

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -501,6 +501,198 @@ func TestManager_RestoreCooldownStates(t *testing.T) {
 	}
 }
 
+// TestCooldownEffectiveDeadlineSurvivesRestartAcrossShorterNextRetryAfter
+// reproduces the sequence Codex flagged at conductor_cooldown.go:2154: an
+// explicit not-found classification escalates Quota.NextRecoverAt (and
+// initially NextRetryAfter) to a 12h deadline, then a later, unrelated
+// transient 5xx overwrites NextRetryAfter alone with a much shorter
+// deadline (see the 408/500/502/503/504 branch of
+// applyAuthFailureStateForModel, which never touches Quota.NextRecoverAt).
+// Gating persistence and restore on NextRetryAfter alone would silently
+// drop the cooldown - and the credential would come back online early -
+// the moment the short deadline passes, even though the credential is
+// still blocked in memory (via availabilityBlock) until the long
+// Quota.NextRecoverAt deadline. This asserts the persisted record survives
+// past the short deadline, carries the effective (long) deadline as its
+// NextRetryAfter - so a `.cds` file is a truthful acceptance instrument -
+// and that restoring it into a brand new Manager still blocks until the
+// long deadline.
+func TestCooldownEffectiveDeadlineSurvivesRestartAcrossShorterNextRetryAfter(t *testing.T) {
+	now := time.Now()
+	longDeadline := now.Add(12 * time.Hour)
+	shortDeadline := now.Add(time.Minute)
+
+	auth := &Auth{
+		ID:             "auth-1",
+		Provider:       "xai",
+		Unavailable:    true,
+		Status:         StatusError,
+		NextRetryAfter: shortDeadline, // shortened by the later 5xx
+		Quota: QuotaState{
+			Exceeded:      true, // set true, and left untouched, by the earlier not-found escalation
+			Reason:        "model_not_found",
+			NextRecoverAt: longDeadline,
+		},
+	}
+
+	// Simulate a persistence tick that runs after the short deadline has
+	// passed but well before the long one.
+	afterShortDeadline := shortDeadline.Add(time.Minute)
+	record, ok := authCooldownStateRecord(auth, afterShortDeadline)
+	if !ok {
+		t.Fatal("authCooldownStateRecord() = false after the short NextRetryAfter expired, want true because Quota.NextRecoverAt is still active")
+	}
+	if !record.NextRetryAfter.Equal(longDeadline) {
+		t.Fatalf("persisted NextRetryAfter = %v, want the effective (long) deadline %v so the .cds file reflects the deadline actually in force", record.NextRetryAfter, longDeadline)
+	}
+	if !record.Quota.NextRecoverAt.Equal(longDeadline) {
+		t.Fatalf("persisted Quota.NextRecoverAt = %v, want %v", record.Quota.NextRecoverAt, longDeadline)
+	}
+
+	// Restore into a brand new Manager, as if the process had restarted at
+	// a point after the short deadline but before the long one.
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-1", Provider: "xai", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	restartAt := afterShortDeadline.Add(time.Minute)
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(record, restartAt)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked() = false at a time between the short and long deadlines, want true")
+	}
+
+	restoredAuth, ok := manager.GetByID("auth-1")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if !restoredAuth.Unavailable {
+		t.Fatal("restored auth.Unavailable = false, want true")
+	}
+	if !restoredAuth.NextRetryAfter.Equal(longDeadline) {
+		t.Fatalf("restored auth.NextRetryAfter = %v, want the effective (long) deadline %v", restoredAuth.NextRetryAfter, longDeadline)
+	}
+	blocked, _, next := availabilityBlock(restoredAuth.Unavailable, restoredAuth.Quota.Exceeded, restoredAuth.NextRetryAfter, restoredAuth.Quota.NextRecoverAt, restartAt)
+	if !blocked {
+		t.Fatal("availabilityBlock() = not blocked for the restored auth, want blocked until the long deadline")
+	}
+	if !next.Equal(longDeadline) {
+		t.Fatalf("availabilityBlock() next = %v, want the long deadline %v", next, longDeadline)
+	}
+}
+
+// TestCooldownRestoreHonorsNextRecoverAtOnAHandBuiltRecord isolates the
+// restore-side gate from the persist-side fix above: it feeds
+// restoreCooldownRecordLocked a record whose NextRetryAfter is already
+// shortened (as authCooldownStateRecord would have written before this fix,
+// or as any pre-existing `.cds` file on disk still does until it is next
+// rewritten) while Quota.NextRecoverAt carries the true, longer deadline.
+// Restore must still honor the record and adopt the effective deadline.
+func TestCooldownRestoreHonorsNextRecoverAtOnAHandBuiltRecord(t *testing.T) {
+	now := time.Now()
+	longDeadline := now.Add(12 * time.Hour)
+	shortDeadline := now.Add(time.Minute)
+	restartAt := shortDeadline.Add(time.Minute) // after short, well before long
+
+	record := CooldownStateRecord{
+		Provider:       "xai",
+		AuthID:         "auth-hand-built",
+		Status:         "cooling",
+		NextRetryAfter: shortDeadline,
+		Reason:         "model_not_found",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "model_not_found",
+			NextRecoverAt: longDeadline,
+		},
+	}
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-hand-built", Provider: "xai", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(record, restartAt)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked() = false for a record whose NextRetryAfter already expired but Quota.NextRecoverAt is still active, want true")
+	}
+	restoredAuth, ok := manager.GetByID("auth-hand-built")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if !restoredAuth.NextRetryAfter.Equal(longDeadline) {
+		t.Fatalf("restored NextRetryAfter = %v, want the effective (long) deadline %v", restoredAuth.NextRetryAfter, longDeadline)
+	}
+}
+
+// TestCooldownRecordLegacyRoundTripWithoutNextRecoverAt covers a genuinely
+// legacy on-disk record: only NextRetryAfter was ever meaningful for it
+// (Quota.NextRecoverAt is its zero value, as it always has been for a plain
+// transient-error cooldown that never went through the not-found/quota
+// escalation paths). It must persist and restore exactly as it did before
+// this fix - gated on, and carrying, NextRetryAfter alone.
+func TestCooldownRecordLegacyRoundTripWithoutNextRecoverAt(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(30 * time.Minute)
+
+	auth := &Auth{
+		ID:             "auth-legacy",
+		Provider:       "xai",
+		Unavailable:    true,
+		Status:         StatusError,
+		NextRetryAfter: deadline,
+		// Quota left at its zero value: no Exceeded, no NextRecoverAt.
+	}
+
+	record, ok := authCooldownStateRecord(auth, now)
+	if !ok {
+		t.Fatal("authCooldownStateRecord() = false for a live legacy-shaped cooldown, want true")
+	}
+	if !record.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("persisted NextRetryAfter = %v, want %v (unchanged, no NextRecoverAt to take the max against)", record.NextRetryAfter, deadline)
+	}
+	if !record.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("persisted Quota.NextRecoverAt = %v, want zero for a legacy record", record.Quota.NextRecoverAt)
+	}
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-legacy", Provider: "xai", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+
+	// Before the deadline: restores exactly as before.
+	beforeDeadline := deadline.Add(-time.Minute)
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(record, beforeDeadline)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked() = false before the legacy deadline, want true")
+	}
+	restoredAuth, ok := manager.GetByID("auth-legacy")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if !restoredAuth.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("restored NextRetryAfter = %v, want %v", restoredAuth.NextRetryAfter, deadline)
+	}
+
+	// After the deadline: a legacy record with no NextRecoverAt to fall
+	// back on is correctly treated as expired, exactly like before this fix.
+	manager2 := NewManager(nil, nil, nil)
+	if _, errRegister := manager2.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-legacy", Provider: "xai", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	afterDeadline := deadline.Add(time.Minute)
+	manager2.mu.Lock()
+	restoredAfter := manager2.restoreCooldownRecordLocked(record, afterDeadline)
+	manager2.mu.Unlock()
+	if restoredAfter {
+		t.Fatal("restoreCooldownRecordLocked() = true past a legacy record's only deadline, want false")
+	}
+}
+
 func TestManager_RestoreCooldownStatesCanonicalizesThinkingSuffixes(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	laterRetry := now.Add(2 * time.Hour)

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -807,3 +807,197 @@ func TestManagerResultSaveWaitsForCooldownStoreTransition(t *testing.T) {
 		t.Fatalf("new store save count = %d, want 1", got)
 	}
 }
+
+// TestAuthCooldownStateRecordSkipsAggregateOnlyQuotaWithAvailableSibling
+// reproduces the P1 Codex finding on discussion_r3927779676: aggregating
+// one cooling model's quota into auth.Quota (via updateAggregatedAvailability)
+// while leaving auth.Unavailable false, because a sibling model remains
+// available, must NOT itself cause authCooldownStateRecord to emit a
+// credential-level record. A raw availabilityBlock(auth.Quota...) call
+// cannot see the aggregate-vs-credential distinction and would persist a
+// record that blocks the WHOLE credential (all models) after a restart,
+// even though only one of several sibling models was ever cooling. This
+// asserts persist skips the auth-level record, and that a fresh Manager
+// restoring only the model-scoped record still leaves the sibling
+// selectable while the cooled model stays blocked.
+func TestAuthCooldownStateRecordSkipsAggregateOnlyQuotaWithAvailableSibling(t *testing.T) {
+	now := time.Now()
+	longDeadline := now.Add(12 * time.Hour)
+
+	auth := &Auth{
+		ID:       "auth-multi",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"llama3": {
+				Status:      StatusError,
+				Unavailable: true,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: longDeadline,
+				},
+				NextRetryAfter: longDeadline,
+				UpdatedAt:      now,
+			},
+			"mistral": {
+				Status: StatusActive,
+			},
+		},
+	}
+	// Mirror what updateAggregatedAvailability actually does: copy the
+	// cooling sibling's quota into auth.Quota while leaving auth.Unavailable
+	// false because "mistral" is still available.
+	updateAggregatedAvailability(auth, now)
+	if auth.Unavailable {
+		t.Fatal("auth.Unavailable = true after aggregation with an available sibling, want false (precondition for this test)")
+	}
+	if !auth.Quota.Exceeded {
+		t.Fatal("auth.Quota.Exceeded = false after aggregation, want true (precondition: aggregate quota was copied)")
+	}
+
+	if _, ok := authCooldownStateRecord(auth, now); ok {
+		t.Fatal("authCooldownStateRecord() = true from an aggregate-only quota with an available sibling, want false")
+	}
+
+	llamaRecord, ok := modelCooldownStateRecord(auth, "llama3", auth.ModelStates["llama3"], now)
+	if !ok {
+		t.Fatal("modelCooldownStateRecord(llama3) = false, want true")
+	}
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-multi", Provider: "openai-compat", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(llamaRecord, now)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked(llama3) = false, want true")
+	}
+
+	restoredAuth, ok := manager.GetByID("auth-multi")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "mistral", now); blocked {
+		t.Fatal("isAuthBlockedForModel(mistral) = blocked after restoring only the llama3 model record, want selectable")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "llama3", now); !blocked {
+		t.Fatal("isAuthBlockedForModel(llama3) = not blocked after restore, want blocked until the cooldown deadline")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); blocked {
+		t.Fatal("isAuthBlockedForModel(\"\") = blocked for the whole credential after restoring one cooling sibling, want selectable per the aggregate exception")
+	}
+
+	// Self-reinforcement guard: if restore had left restoredAuth.Unavailable
+	// true, the next persist cycle's authCooldownStateRecord call would see
+	// !auth.Unavailable fail, write a fresh credential-level record from
+	// nothing but the surviving model-scoped state, and the credential would
+	// never recover across a second restart. Confirm the persist path agrees
+	// the credential is selectable one cycle after restore.
+	if _, ok := authCooldownStateRecord(restoredAuth, now); ok {
+		t.Fatal("authCooldownStateRecord() = true one persist cycle after restoring one cooling sibling, want false (would re-darken the credential on the next restart)")
+	}
+}
+
+// TestAuthCooldownStateRecordPersistsGenuineCredentialLevel401 covers the
+// companion case: a real credential-wide cooldown (e.g. a 401, with no
+// per-model states at all) must still persist and, on restore into a fresh
+// Manager, block every model - proving the P1 fix's write-side reuse of
+// isAuthBlockedForModel didn't accidentally suppress genuine credential-level
+// records, and the restore-side fix didn't route this case through
+// updateAggregatedAvailability (which would wipe it via
+// clearAggregatedAvailability when ModelStates is empty).
+func TestAuthCooldownStateRecordPersistsGenuineCredentialLevel401(t *testing.T) {
+	now := time.Now()
+	deadline := now.Add(time.Hour)
+
+	auth := &Auth{
+		ID:             "auth-401",
+		Provider:       "openai-compat",
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: deadline,
+		LastError:      &Error{Message: "unauthorized", HTTPStatus: 401},
+		UpdatedAt:      now,
+	}
+
+	record, ok := authCooldownStateRecord(auth, now)
+	if !ok {
+		t.Fatal("authCooldownStateRecord() = false for a genuine credential-level 401 cooldown, want true")
+	}
+	if !record.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("persisted NextRetryAfter = %v, want %v", record.NextRetryAfter, deadline)
+	}
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-401", Provider: "openai-compat", Status: StatusActive}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.mu.Lock()
+	restored := manager.restoreCooldownRecordLocked(record, now)
+	manager.mu.Unlock()
+	if !restored {
+		t.Fatal("restoreCooldownRecordLocked() = false for the credential-level 401 record, want true")
+	}
+
+	restoredAuth, ok := manager.GetByID("auth-401")
+	if !ok {
+		t.Fatal("restored auth not found")
+	}
+	if !restoredAuth.Unavailable {
+		t.Fatal("restored auth.Unavailable = false, want true (genuine credential-level cooldown must survive restore)")
+	}
+	for _, model := range []string{"", "any-model", "another-model"} {
+		if blocked, _, _ := isAuthBlockedForModel(restoredAuth, model, now); !blocked {
+			t.Fatalf("isAuthBlockedForModel(%q) = not blocked after restoring a credential-level 401, want blocked", model)
+		}
+	}
+}
+
+// TestAuthCooldownStateRecordAgreesWithSelectorOnWriteSideGate is a direct,
+// standalone assertion that authCooldownStateRecord agrees with
+// isAuthBlockedForModel(auth, "", now) on the same in-memory auth (no
+// restore round-trip). It does not by itself prove the write-side fix is
+// exercised - that proof is the mutation-control run recorded in the P1
+// report (reverting authCooldownStateRecord to call
+// availabilityBlock(auth.Quota...) directly is caught by
+// TestAuthCooldownStateRecordSkipsAggregateOnlyQuotaWithAvailableSibling).
+// This test exists so a reviewer can see the exact gate condition without
+// cross-referencing that other test.
+func TestAuthCooldownStateRecordAgreesWithSelectorOnWriteSideGate(t *testing.T) {
+	now := time.Now()
+	auth := &Auth{
+		ID:       "auth-gate",
+		Provider: "openai-compat",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"cooling-model": {
+				Status:      StatusError,
+				Unavailable: true,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: now.Add(12 * time.Hour),
+				},
+				NextRetryAfter: now.Add(12 * time.Hour),
+				UpdatedAt:      now,
+			},
+			"available-model": {Status: StatusActive},
+		},
+	}
+	updateAggregatedAvailability(auth, now)
+
+	// isAuthBlockedForModel(auth, "", now) is the exact function the fixed
+	// authCooldownStateRecord now calls; assert it agrees the credential is
+	// NOT blocked here - this is the gate whose removal would regress to
+	// the old bug.
+	blocked, _, _ := isAuthBlockedForModel(auth, "", now)
+	if blocked {
+		t.Fatal("isAuthBlockedForModel(auth, \"\", now) = blocked from an aggregate-only quota with an available sibling, want selectable")
+	}
+	if _, ok := authCooldownStateRecord(auth, now); ok {
+		t.Fatal("authCooldownStateRecord() must agree with isAuthBlockedForModel(auth, \"\", now) and skip the record")
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -881,14 +881,14 @@ func TestAuthCooldownStateRecordSkipsAggregateOnlyQuotaWithAvailableSibling(t *t
 	if !ok {
 		t.Fatal("restored auth not found")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "mistral", now); blocked {
-		t.Fatal("isAuthBlockedForModel(mistral) = blocked after restoring only the llama3 model record, want selectable")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "mistral", now); blocked {
+		t.Fatal("effectiveBlock(mistral) = blocked after restoring only the llama3 model record, want selectable")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "llama3", now); !blocked {
-		t.Fatal("isAuthBlockedForModel(llama3) = not blocked after restore, want blocked until the cooldown deadline")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "llama3", now); !blocked {
+		t.Fatal("effectiveBlock(llama3) = not blocked after restore, want blocked until the cooldown deadline")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); blocked {
-		t.Fatal("isAuthBlockedForModel(\"\") = blocked for the whole credential after restoring one cooling sibling, want selectable per the aggregate exception")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "", now); blocked {
+		t.Fatal("effectiveBlock(\"\") = blocked for the whole credential after restoring one cooling sibling, want selectable per the aggregate exception")
 	}
 
 	// Self-reinforcement guard: if restore had left restoredAuth.Unavailable
@@ -906,7 +906,7 @@ func TestAuthCooldownStateRecordSkipsAggregateOnlyQuotaWithAvailableSibling(t *t
 // companion case: a real credential-wide cooldown (e.g. a 401, with no
 // per-model states at all) must still persist and, on restore into a fresh
 // Manager, block every model - proving the P1 fix's write-side reuse of
-// isAuthBlockedForModel didn't accidentally suppress genuine credential-level
+// effectiveBlock didn't accidentally suppress genuine credential-level
 // records, and the restore-side fix didn't route this case through
 // updateAggregatedAvailability (which would wipe it via
 // clearAggregatedAvailability when ModelStates is empty).
@@ -951,15 +951,15 @@ func TestAuthCooldownStateRecordPersistsGenuineCredentialLevel401(t *testing.T) 
 		t.Fatal("restored auth.Unavailable = false, want true (genuine credential-level cooldown must survive restore)")
 	}
 	for _, model := range []string{"", "any-model", "another-model"} {
-		if blocked, _, _ := isAuthBlockedForModel(restoredAuth, model, now); !blocked {
-			t.Fatalf("isAuthBlockedForModel(%q) = not blocked after restoring a credential-level 401, want blocked", model)
+		if blocked, _, _ := effectiveBlock(restoredAuth, model, now); !blocked {
+			t.Fatalf("effectiveBlock(%q) = not blocked after restoring a credential-level 401, want blocked", model)
 		}
 	}
 }
 
 // TestAuthCooldownStateRecordAgreesWithSelectorOnWriteSideGate is a direct,
 // standalone assertion that authCooldownStateRecord agrees with
-// isAuthBlockedForModel(auth, "", now) on the same in-memory auth (no
+// effectiveBlock(auth, "", now) on the same in-memory auth (no
 // restore round-trip). It does not by itself prove the write-side fix is
 // exercised - that proof is the mutation-control run recorded in the P1
 // report (reverting authCooldownStateRecord to call
@@ -990,16 +990,16 @@ func TestAuthCooldownStateRecordAgreesWithSelectorOnWriteSideGate(t *testing.T) 
 	}
 	updateAggregatedAvailability(auth, now)
 
-	// isAuthBlockedForModel(auth, "", now) is the exact function the fixed
+	// effectiveBlock(auth, "", now) is the exact function the fixed
 	// authCooldownStateRecord now calls; assert it agrees the credential is
 	// NOT blocked here - this is the gate whose removal would regress to
 	// the old bug.
-	blocked, _, _ := isAuthBlockedForModel(auth, "", now)
+	blocked, _, _ := effectiveBlock(auth, "", now)
 	if blocked {
-		t.Fatal("isAuthBlockedForModel(auth, \"\", now) = blocked from an aggregate-only quota with an available sibling, want selectable")
+		t.Fatal("effectiveBlock(auth, \"\", now) = blocked from an aggregate-only quota with an available sibling, want selectable")
 	}
 	if _, ok := authCooldownStateRecord(auth, now); ok {
-		t.Fatal("authCooldownStateRecord() must agree with isAuthBlockedForModel(auth, \"\", now) and skip the record")
+		t.Fatal("authCooldownStateRecord() must agree with effectiveBlock(auth, \"\", now) and skip the record")
 	}
 }
 
@@ -1077,14 +1077,14 @@ func TestRestoreCooldownStatesAllModelsCoolingBlocksCredential(t *testing.T) {
 	if !ok {
 		t.Fatal("restored auth not found")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "llama3", now); !blocked {
-		t.Fatal("isAuthBlockedForModel(llama3) = not blocked after restoring both cooling models, want blocked")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "llama3", now); !blocked {
+		t.Fatal("effectiveBlock(llama3) = not blocked after restoring both cooling models, want blocked")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "mistral", now); !blocked {
-		t.Fatal("isAuthBlockedForModel(mistral) = not blocked after restoring both cooling models, want blocked")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "mistral", now); !blocked {
+		t.Fatal("effectiveBlock(mistral) = not blocked after restoring both cooling models, want blocked")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); !blocked {
-		t.Fatal("isAuthBlockedForModel(\"\") = selectable after restoring every registered model as cooling, want blocked (registry set is provably complete)")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "", now); !blocked {
+		t.Fatal("effectiveBlock(\"\") = selectable after restoring every registered model as cooling, want blocked (registry set is provably complete)")
 	}
 	if !restoredAuth.Unavailable {
 		t.Fatal("restoredAuth.Unavailable = false after restoring every registered model as cooling, want true")
@@ -1143,8 +1143,8 @@ func TestRestoreCooldownStatesPartialModelSetStaysSelectable(t *testing.T) {
 	if !ok {
 		t.Fatal("restored auth not found")
 	}
-	if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "", now); blocked {
-		t.Fatal("isAuthBlockedForModel(\"\") = blocked when the registry lists an unrestored sibling (mistral), want selectable - the restored set is not provably complete")
+	if blocked, _, _ := effectiveBlock(restoredAuth, "", now); blocked {
+		t.Fatal("effectiveBlock(\"\") = blocked when the registry lists an unrestored sibling (mistral), want selectable - the restored set is not provably complete")
 	}
 	if restoredAuth.Unavailable {
 		t.Fatal("restoredAuth.Unavailable = true when the restored model set is not provably complete, want false")
@@ -1250,19 +1250,19 @@ func TestUpdateAggregatedAvailabilityPreservesGenericNotFoundThroughSiblingSucce
 	afterShortDeadline := now.Add(31 * time.Second)
 	updateAggregatedAvailability(auth, afterShortDeadline)
 
-	if blocked, _, next := isAuthBlockedForModel(auth, "problem-model", afterShortDeadline); !blocked {
-		t.Fatalf("isAuthBlockedForModel(problem-model) = not blocked at %v after a sibling success, want blocked until %v (generic-404 NextRecoverAt) - got next=%v", afterShortDeadline, genericNotFoundRecoverAt, next)
+	if blocked, _, next := effectiveBlock(auth, "problem-model", afterShortDeadline); !blocked {
+		t.Fatalf("effectiveBlock(problem-model) = not blocked at %v after a sibling success, want blocked until %v (generic-404 NextRecoverAt) - got next=%v", afterShortDeadline, genericNotFoundRecoverAt, next)
 	}
-	if blocked, _, _ := isAuthBlockedForModel(auth, "sibling-model", afterShortDeadline); blocked {
-		t.Fatal("isAuthBlockedForModel(sibling-model) = blocked, want selectable")
+	if blocked, _, _ := effectiveBlock(auth, "sibling-model", afterShortDeadline); blocked {
+		t.Fatal("effectiveBlock(sibling-model) = blocked, want selectable")
 	}
 
 	// Confirm the deadline itself is honored: once genericNotFoundRecoverAt
 	// has actually passed, the model must become selectable again.
 	afterLongDeadline := genericNotFoundRecoverAt.Add(time.Second)
 	updateAggregatedAvailability(auth, afterLongDeadline)
-	if blocked, _, _ := isAuthBlockedForModel(auth, "problem-model", afterLongDeadline); blocked {
-		t.Fatal("isAuthBlockedForModel(problem-model) = still blocked after genericNotFoundRecoverAt has passed, want selectable")
+	if blocked, _, _ := effectiveBlock(auth, "problem-model", afterLongDeadline); blocked {
+		t.Fatal("effectiveBlock(problem-model) = still blocked after genericNotFoundRecoverAt has passed, want selectable")
 	}
 }
 
@@ -1377,20 +1377,20 @@ func TestRestoreCooldownStatesCredentialWideSurvivesCleanModelStates(t *testing.
 	if !restored.NextRetryAfter.Equal(deadline) {
 		t.Fatalf("restored auth.NextRetryAfter = %v, want %v", restored.NextRetryAfter, deadline)
 	}
-	if blocked, _, next := isAuthBlockedForModel(restored, "", now); !blocked || !next.Equal(deadline) {
-		t.Fatalf("isAuthBlockedForModel(auth, \"\", now) = (%v, _, %v), want (true, _, %v)", blocked, next, deadline)
+	if blocked, _, next := effectiveBlock(restored, "", now); !blocked || !next.Equal(deadline) {
+		t.Fatalf("effectiveBlock(auth, \"\", now) = (%v, _, %v), want (true, _, %v)", blocked, next, deadline)
 	}
 	// Every individual model must be blocked too - a credential-wide failure
 	// blocks everything, not just the aggregate query.
-	if blocked, _, _ := isAuthBlockedForModel(restored, "claude-opus", now); !blocked {
-		t.Fatal("isAuthBlockedForModel(auth, \"claude-opus\", now) = false, want true")
+	if blocked, _, _ := effectiveBlock(restored, "claude-opus", now); !blocked {
+		t.Fatal("effectiveBlock(auth, \"claude-opus\", now) = false, want true")
 	}
 
 	// Once the deadline has actually passed, the credential-wide block must
 	// lift - this is a deadline, not a permanent flag.
 	afterDeadline := deadline.Add(time.Second)
-	if blocked, _, _ := isAuthBlockedForModel(restored, "", afterDeadline); blocked {
-		t.Fatal("isAuthBlockedForModel(auth, \"\", afterDeadline) = true, want false once the credential-wide deadline has passed")
+	if blocked, _, _ := effectiveBlock(restored, "", afterDeadline); blocked {
+		t.Fatal("effectiveBlock(auth, \"\", afterDeadline) = true, want false once the credential-wide deadline has passed")
 	}
 }
 

--- a/sdk/cliproxy/auth/effective_deadline_test.go
+++ b/sdk/cliproxy/auth/effective_deadline_test.go
@@ -1,0 +1,266 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEffectiveDeadline is a table test with one control per field: each
+// field alone contributing the max, credential-vs-model precedence when
+// both are live, the all-zero case, and the all-past case. effectiveDeadline
+// must ignore modelKey entirely when it does not resolve to a ModelState.
+func TestEffectiveDeadline(t *testing.T) {
+	now := time.Now()
+	future := func(d time.Duration) time.Time { return now.Add(d) }
+	past := func(d time.Duration) time.Time { return now.Add(-d) }
+
+	tests := []struct {
+		name     string
+		auth     *Auth
+		modelKey string
+		want     time.Time
+	}{
+		{
+			name: "nil auth",
+			auth: nil,
+			want: time.Time{},
+		},
+		{
+			name: "all zero",
+			auth: &Auth{},
+			want: time.Time{},
+		},
+		{
+			name: "all past ignored",
+			auth: &Auth{
+				NextRetryAfter: past(time.Minute),
+				Quota:          QuotaState{NextRecoverAt: past(2 * time.Minute)},
+			},
+			want: time.Time{},
+		},
+		{
+			name: "auth.NextRetryAfter alone is the max",
+			auth: &Auth{
+				NextRetryAfter: future(10 * time.Minute),
+			},
+			want: future(10 * time.Minute),
+		},
+		{
+			name: "auth.Quota.NextRecoverAt alone is the max",
+			auth: &Auth{
+				Quota: QuotaState{NextRecoverAt: future(15 * time.Minute)},
+			},
+			want: future(15 * time.Minute),
+		},
+		{
+			name: "credential NextRetryAfter beats credential NextRecoverAt",
+			auth: &Auth{
+				NextRetryAfter: future(30 * time.Minute),
+				Quota:          QuotaState{NextRecoverAt: future(5 * time.Minute)},
+			},
+			want: future(30 * time.Minute),
+		},
+		{
+			name: "credential NextRecoverAt beats credential NextRetryAfter",
+			auth: &Auth{
+				NextRetryAfter: future(2 * time.Minute),
+				Quota:          QuotaState{NextRecoverAt: future(45 * time.Minute)},
+			},
+			want: future(45 * time.Minute),
+		},
+		{
+			name: "modelKey empty ignores a live ModelState",
+			auth: &Auth{
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(time.Hour)},
+				},
+			},
+			modelKey: "",
+			want:     time.Time{},
+		},
+		{
+			name: "modelKey with no matching state ignored",
+			auth: &Auth{
+				NextRetryAfter: future(time.Minute),
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(time.Hour)},
+				},
+			},
+			modelKey: "claude-4",
+			want:     future(time.Minute),
+		},
+		{
+			name: "model NextRetryAfter alone is the max",
+			auth: &Auth{
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(20 * time.Minute)},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     future(20 * time.Minute),
+		},
+		{
+			name: "model Quota.NextRecoverAt alone is the max",
+			auth: &Auth{
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {Quota: QuotaState{NextRecoverAt: future(25 * time.Minute)}},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     future(25 * time.Minute),
+		},
+		{
+			name: "credential deadline beats a shorter model deadline",
+			auth: &Auth{
+				NextRetryAfter: future(time.Hour),
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(5 * time.Minute)},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     future(time.Hour),
+		},
+		{
+			name: "model deadline beats a shorter credential deadline",
+			auth: &Auth{
+				NextRetryAfter: future(5 * time.Minute),
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(time.Hour)},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     future(time.Hour),
+		},
+		{
+			name: "canonicalModelKey does not fold case, so a differently-cased map key does not match",
+			auth: &Auth{
+				ModelStates: map[string]*ModelState{
+					"GPT-5": {NextRetryAfter: future(12 * time.Minute)},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveDeadline(tt.auth, tt.modelKey, now)
+			if !got.Equal(tt.want) {
+				t.Fatalf("effectiveDeadline() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveBlock covers effectiveBlock's reason precedence: disabled
+// beats everything, credential-level cooldown/quota blocks every model,
+// a matched model-level block reports blockReasonCooldown/blockReasonOther
+// per availabilityBlock's existing rule, and a clean auth is never blocked.
+func TestEffectiveBlock(t *testing.T) {
+	now := time.Now()
+	future := func(d time.Duration) time.Time { return now.Add(d) }
+
+	t.Run("nil auth is blocked with blockReasonOther", func(t *testing.T) {
+		blocked, reason, until := effectiveBlock(nil, "gpt-5", now)
+		if !blocked || reason != blockReasonOther || !until.IsZero() {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("disabled auth beats a live credential cooldown", func(t *testing.T) {
+		a := &Auth{
+			Disabled:           true,
+			CredentialCooldown: true,
+			Unavailable:        true,
+			NextRetryAfter:     future(time.Hour),
+		}
+		blocked, reason, until := effectiveBlock(a, "", now)
+		if !blocked || reason != blockReasonDisabled || !until.IsZero() {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("credential-wide cooldown blocks every model regardless of clean model state", func(t *testing.T) {
+		a := &Auth{
+			CredentialCooldown: true,
+			Unavailable:        true,
+			NextRetryAfter:     future(30 * time.Minute),
+			ModelStates: map[string]*ModelState{
+				"gpt-5": {Status: StatusActive},
+			},
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonCooldown || !until.Equal(future(30*time.Minute)) {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("credential_quota blocks every model", func(t *testing.T) {
+		a := &Auth{
+			Quota: QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: future(10 * time.Minute)},
+			ModelStates: map[string]*ModelState{
+				"gpt-5": {Status: StatusActive},
+			},
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonCooldown || !until.Equal(future(10*time.Minute)) {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("matched model-level cooldown reports blockReasonOther when not quota", func(t *testing.T) {
+		a := &Auth{
+			ModelStates: map[string]*ModelState{
+				"gpt-5": {Unavailable: true, NextRetryAfter: future(5 * time.Minute)},
+			},
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonOther || !until.Equal(future(5*time.Minute)) {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("matched model-level quota reports blockReasonCooldown", func(t *testing.T) {
+		a := &Auth{
+			ModelStates: map[string]*ModelState{
+				"gpt-5": {Quota: QuotaState{Exceeded: true, NextRecoverAt: future(5 * time.Minute)}},
+			},
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonCooldown || !until.Equal(future(5*time.Minute)) {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("model disabled state returns blockReasonDisabled immediately", func(t *testing.T) {
+		a := &Auth{
+			ModelStates: map[string]*ModelState{
+				"gpt-5": {Status: StatusDisabled},
+			},
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonDisabled || !until.IsZero() {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("clean auth with no model states is never blocked", func(t *testing.T) {
+		a := &Auth{}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if blocked || reason != blockReasonNone || !until.IsZero() {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+
+	t.Run("no ModelStates falls back to auth-level availabilityBlock", func(t *testing.T) {
+		a := &Auth{
+			Unavailable:    true,
+			NextRetryAfter: future(5 * time.Minute),
+		}
+		blocked, reason, until := effectiveBlock(a, "gpt-5", now)
+		if !blocked || reason != blockReasonOther || !until.Equal(future(5*time.Minute)) {
+			t.Fatalf("got (%v,%v,%v)", blocked, reason, until)
+		}
+	})
+}

--- a/sdk/cliproxy/auth/effective_deadline_test.go
+++ b/sdk/cliproxy/auth/effective_deadline_test.go
@@ -81,13 +81,25 @@ func TestEffectiveDeadline(t *testing.T) {
 		{
 			name: "modelKey with no matching state ignored",
 			auth: &Auth{
-				NextRetryAfter: future(time.Minute),
+				CredentialCooldown: true,
+				NextRetryAfter:     future(time.Minute),
 				ModelStates: map[string]*ModelState{
 					"gpt-5": {NextRetryAfter: future(time.Hour)},
 				},
 			},
 			modelKey: "claude-4",
 			want:     future(time.Minute),
+		},
+		{
+			name: "modelKey with no matching state and no genuine credential scope ignores the aggregate too",
+			auth: &Auth{
+				NextRetryAfter: future(time.Minute),
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(time.Hour)},
+				},
+			},
+			modelKey: "claude-4",
+			want:     time.Time{},
 		},
 		{
 			name: "model NextRetryAfter alone is the max",
@@ -110,7 +122,19 @@ func TestEffectiveDeadline(t *testing.T) {
 			want:     future(25 * time.Minute),
 		},
 		{
-			name: "credential deadline beats a shorter model deadline",
+			name: "genuine credential deadline beats a shorter model deadline",
+			auth: &Auth{
+				CredentialCooldown: true,
+				NextRetryAfter:     future(time.Hour),
+				ModelStates: map[string]*ModelState{
+					"gpt-5": {NextRetryAfter: future(5 * time.Minute)},
+				},
+			},
+			modelKey: "gpt-5",
+			want:     future(time.Hour),
+		},
+		{
+			name: "aggregate-only (non-genuine) credential deadline does not beat a shorter model deadline",
 			auth: &Auth{
 				NextRetryAfter: future(time.Hour),
 				ModelStates: map[string]*ModelState{
@@ -118,7 +142,7 @@ func TestEffectiveDeadline(t *testing.T) {
 				},
 			},
 			modelKey: "gpt-5",
-			want:     future(time.Hour),
+			want:     future(5 * time.Minute),
 		},
 		{
 			name: "model deadline beats a shorter credential deadline",

--- a/sdk/cliproxy/auth/review_c5a17c60_fixes_test.go
+++ b/sdk/cliproxy/auth/review_c5a17c60_fixes_test.go
@@ -1,0 +1,329 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// This file covers the fixes for the 2026-09-04 adversarial review of
+// c5a17c60 (four confirmed HIGH findings). Each test is named after the
+// finding it closes and, where the review specified an exact probe recipe,
+// follows that recipe.
+
+// --- Finding 1: cross-model cooldown contamination -------------------------
+
+// TestEffectiveDeadline_SiblingIsolation is the permanent regression control
+// for finding 1: an aggregate-only auth deadline (Quota.Reason=="quota",
+// copied up from a DIFFERENT model by updateAggregatedAvailability) must not
+// apply to a clean sibling model, while a GENUINE credential-wide deadline
+// (CredentialCooldown / Quota.Reason=="credential_quota") must still apply
+// to every model. This is the same shape of probe the review ran against
+// 8a0d987d^ (which passed) and c5a17c60 (which failed) - kept in-repo so the
+// regression cannot silently return.
+func TestEffectiveDeadline_SiblingIsolation(t *testing.T) {
+	now := time.Now()
+	future := func(d time.Duration) time.Time { return now.Add(d) }
+
+	t.Run("aggregate-only auth deadline from a sibling model does not leak", func(t *testing.T) {
+		a := &Auth{
+			// Derived by updateAggregatedAvailability from model A's 2h
+			// quota block - NOT a genuine credential-wide failure.
+			NextRetryAfter: future(2 * time.Hour),
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future(2 * time.Hour)},
+			ModelStates: map[string]*ModelState{
+				"model-a": {Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future(2 * time.Hour)}},
+				"model-b": {}, // clean sibling
+			},
+		}
+		got := effectiveDeadline(a, "model-b", now)
+		if !got.IsZero() {
+			t.Fatalf("effectiveDeadline(model-b) = %v, want zero (aggregate-only deadline must not contaminate a clean sibling)", got)
+		}
+	})
+
+	t.Run("genuine CredentialCooldown deadline still applies to every model", func(t *testing.T) {
+		a := &Auth{
+			CredentialCooldown: true,
+			NextRetryAfter:     future(30 * time.Minute),
+			ModelStates: map[string]*ModelState{
+				"model-b": {},
+			},
+		}
+		got := effectiveDeadline(a, "model-b", now)
+		if !got.Equal(future(30 * time.Minute)) {
+			t.Fatalf("effectiveDeadline(model-b) = %v, want %v (genuine credential-wide deadline must apply to every model)", got, future(30*time.Minute))
+		}
+	})
+
+	t.Run("genuine credential_quota deadline still applies to every model", func(t *testing.T) {
+		a := &Auth{
+			Quota: QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: future(45 * time.Minute)},
+			ModelStates: map[string]*ModelState{
+				"model-b": {},
+			},
+		}
+		got := effectiveDeadline(a, "model-b", now)
+		if !got.Equal(future(45 * time.Minute)) {
+			t.Fatalf("effectiveDeadline(model-b) = %v, want %v (genuine credential_quota deadline must apply to every model)", got, future(45*time.Minute))
+		}
+	})
+
+	t.Run("credential-level query (modelKey empty) still sees the aggregate unconditionally", func(t *testing.T) {
+		a := &Auth{
+			NextRetryAfter: future(2 * time.Hour),
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future(2 * time.Hour)},
+		}
+		got := effectiveDeadline(a, "", now)
+		if !got.Equal(future(2 * time.Hour)) {
+			t.Fatalf("effectiveDeadline(\"\") = %v, want %v (credential-level query wants the aggregate too)", got, future(2*time.Hour))
+		}
+	})
+}
+
+// TestManagerMarkResult_SiblingModelNotContaminatedByAggregate is an
+// end-to-end version of the same probe the review ran against MarkResult:
+// model A gets a 2h quota cooldown, model B is clean, then an ordinary 404
+// on B must compute B's own short backoff rather than inheriting A's 2h
+// aggregate deadline.
+func TestManagerMarkResult_SiblingModelNotContaminatedByAggregate(t *testing.T) {
+	previousGlobal := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousGlobal) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-sibling", Provider: "claude", Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	longQuota := 3 * time.Hour
+	m.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   auth.Provider,
+		Model:      "model-a",
+		RetryAfter: &longQuota,
+		Error:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "model-b",
+		Error:    &Error{HTTPStatus: http.StatusNotFound, Message: "model not found: model-b"},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["model-b"] == nil || updated.ModelStates["model-a"] == nil {
+		t.Fatalf("model states missing: %#v", updated)
+	}
+	now := time.Now()
+	// auth.Quota is now the aggregate over BOTH models (dominated by model-a's
+	// long quota cooldown); the bug this test guards is effectiveBlock/
+	// effectiveDeadline for model-b picking that aggregate up as if it were a
+	// genuine credential-wide deadline. model-b's own effective deadline must
+	// equal its own state's deadline, not the (much longer) aggregate.
+	ownDeadline := effectiveDeadline(updated, "model-b", now)
+	bState := updated.ModelStates["model-b"]
+	wantOwn := laterFutureDeadline(now, bState.NextRetryAfter, bState.Quota.NextRecoverAt)
+	if !ownDeadline.Equal(wantOwn) {
+		t.Fatalf("effectiveDeadline(model-b) = %v, want model-b's own deadline %v (must not inherit model-a's aggregate)", ownDeadline, wantOwn)
+	}
+	if updated.Quota.Reason != "quota" {
+		t.Fatalf("auth.Quota.Reason = %q, want aggregate-only %q (test premise check)", updated.Quota.Reason, "quota")
+	}
+	if !updated.Quota.NextRecoverAt.After(wantOwn) {
+		t.Fatalf("test premise not met: aggregate NextRecoverAt %v must be later than model-b's own deadline %v", updated.Quota.NextRecoverAt, wantOwn)
+	}
+}
+
+// --- Finding 2: single-field genuine-credential gates missed the other field ---
+
+// TestUpdateAggregatedAvailability_UnifiesGenuineScopeFields: CredentialCooldown
+// is true, NextRetryAfter has independently expired, but Quota.NextRecoverAt
+// (Reason=="credential_quota") is still live 2h out. The old code checked
+// only NextRetryAfter and cleared the credential-wide block early.
+func TestUpdateAggregatedAvailability_UnifiesGenuineScopeFields(t *testing.T) {
+	now := time.Now()
+	a := &Auth{
+		CredentialCooldown: true,
+		NextRetryAfter:     now.Add(-time.Minute), // expired
+		Quota:              QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(2 * time.Hour)},
+	}
+	updateAggregatedAvailability(a, now)
+	if !a.Unavailable {
+		t.Fatalf("Unavailable = false, want true (live Quota.NextRecoverAt must keep the credential blocked)")
+	}
+	blocked, _, until := effectiveBlock(a, "", now)
+	if !blocked || !until.Equal(a.Quota.NextRecoverAt) {
+		t.Fatalf("effectiveBlock = (%v,_,%v), want blocked until %v", blocked, until, a.Quota.NextRecoverAt)
+	}
+}
+
+// TestManagerUpdate_RefreshPreservesLiveQuotaEvenWhenNextRetryAfterExpired
+// is the :187 refresh case: a routine Update (e.g. after an access-token
+// refresh) with a clean incoming Auth must not drop a live
+// Quota.NextRecoverAt just because CredentialCooldown/NextRetryAfter alone
+// looked expired.
+func TestManagerUpdate_RefreshPreservesLiveQuotaEvenWhenNextRetryAfterExpired(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	now := time.Now()
+
+	existing := &Auth{
+		ID:                 "auth-refresh",
+		Provider:           "claude",
+		Status:             StatusActive,
+		CredentialCooldown: true,
+		Unavailable:        true,
+		NextRetryAfter:     now.Add(-time.Minute), // expired
+		Quota:              QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: now.Add(2 * time.Hour)},
+	}
+	if _, err := m.Register(context.Background(), existing); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	// A clean refreshed Auth for the SAME credential (same ID, no rotated
+	// refresh/access token attributes => sameAuthCredential is expected true).
+	if _, err := m.Update(context.Background(), &Auth{
+		ID:       "auth-refresh",
+		Provider: "claude",
+		Status:   StatusActive,
+	}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	updated, ok := m.GetByID("auth-refresh")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if !updated.Quota.NextRecoverAt.Equal(existing.Quota.NextRecoverAt) || !updated.Quota.Exceeded {
+		t.Fatalf("Quota = %+v, want preserved live credential_quota cooldown %+v", updated.Quota, existing.Quota)
+	}
+	if !updated.Unavailable {
+		t.Fatalf("Unavailable = false, want true (live Quota.NextRecoverAt must keep the refreshed auth blocked)")
+	}
+}
+
+// --- Finding 3: writers destroying the only longer deadline ----------------
+
+// TestManagerMarkResult_WriterOrderRecipes reproduces the three orderings
+// the review confirmed shortened a deadline that should have been preserved.
+func TestManagerMarkResult_WriterOrderRecipes(t *testing.T) {
+	previousGlobal := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousGlobal) })
+
+	t.Run("model 401 then transient 500 does not shorten the 401 deadline", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		auth := &Auth{ID: "auth-recipe-1", Provider: "claude", Status: StatusActive}
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		m.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: auth.Provider, Model: "m", Error: &Error{HTTPStatus: http.StatusUnauthorized}})
+		updated, _ := m.GetByID(auth.ID)
+		firstDeadline := updated.ModelStates["m"].NextRetryAfter
+		if firstDeadline.IsZero() {
+			t.Fatalf("expected a cooldown after 401")
+		}
+		m.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: auth.Provider, Model: "m", Error: &Error{HTTPStatus: http.StatusInternalServerError}})
+		updated, _ = m.GetByID(auth.ID)
+		secondDeadline := updated.ModelStates["m"].NextRetryAfter
+		if secondDeadline.Before(firstDeadline) {
+			t.Fatalf("transient 500 shortened the deadline: %v -> %v", firstDeadline, secondDeadline)
+		}
+	})
+
+	t.Run("model 401 then short 429 does not shorten the 401 deadline", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		auth := &Auth{ID: "auth-recipe-2", Provider: "claude", Status: StatusActive}
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		m.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: auth.Provider, Model: "m", Error: &Error{HTTPStatus: http.StatusUnauthorized}})
+		updated, _ := m.GetByID(auth.ID)
+		firstDeadline := updated.ModelStates["m"].NextRetryAfter
+		if firstDeadline.IsZero() {
+			t.Fatalf("expected a cooldown after 401")
+		}
+		short := 10 * time.Second
+		m.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: auth.Provider, Model: "m", RetryAfter: &short, Error: &Error{HTTPStatus: http.StatusTooManyRequests}})
+		updated, _ = m.GetByID(auth.ID)
+		secondDeadline := updated.ModelStates["m"].NextRetryAfter
+		if secondDeadline.Before(firstDeadline) {
+			t.Fatalf("short 429 shortened the deadline: %v -> %v", firstDeadline, secondDeadline)
+		}
+	})
+
+	t.Run("credential-scope 429 on model A does not shorten sibling model B's longer 401", func(t *testing.T) {
+		m := NewManager(nil, nil, nil)
+		auth := &Auth{ID: "auth-recipe-3", Provider: "claude", Status: StatusActive}
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("Register() error = %v", err)
+		}
+		m.MarkResult(context.Background(), Result{AuthID: auth.ID, Provider: auth.Provider, Model: "model-b", Error: &Error{HTTPStatus: http.StatusUnauthorized}})
+		updated, _ := m.GetByID(auth.ID)
+		bDeadline := updated.ModelStates["model-b"].NextRetryAfter
+		if bDeadline.IsZero() {
+			t.Fatalf("expected a cooldown for model-b after 401")
+		}
+		short := 10 * time.Second
+		m.MarkResult(context.Background(), Result{
+			AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+			RetryAfter:      &short,
+			CredentialScope: true,
+			Error:           &Error{HTTPStatus: http.StatusTooManyRequests},
+		})
+		updated, _ = m.GetByID(auth.ID)
+		bAfter := updated.ModelStates["model-b"].NextRetryAfter
+		if bAfter.Before(bDeadline) {
+			t.Fatalf("credential-scope 429 on model-a shortened sibling model-b's deadline: %v -> %v", bDeadline, bAfter)
+		}
+	})
+}
+
+// --- Finding 4: registry projection false-available path -------------------
+
+// TestClientModelProjectionForAuth_GenuineCredentialCooldownSuspendsModel is
+// the projection case: a credential-wide 401 with model A otherwise clean
+// must report Suspended=true, not the false-available result the direct
+// field reads produced.
+func TestClientModelProjectionForAuth_GenuineCredentialCooldownSuspendsModel(t *testing.T) {
+	now := time.Now()
+	m := &Manager{}
+	auth := &Auth{
+		CredentialCooldown: true,
+		Unavailable:        true,
+		NextRetryAfter:     now.Add(30 * time.Minute),
+		ModelStates: map[string]*ModelState{
+			"model-a": {Status: StatusActive},
+		},
+	}
+	projection := m.clientModelProjectionForAuth(auth, "model-a", now)
+	if !projection.Suspended {
+		t.Fatalf("Suspended = false, want true (genuine credential-wide cooldown must suspend every model)")
+	}
+}
+
+// --- Fifth site: hasModelError missing a live Quota.NextRecoverAt ----------
+
+// TestHasModelError_LiveQuotaWithNilLastError answers the reviewer's open
+// question about line 1571 (hasModelError): a ModelState can have
+// LastError == nil while a longer Quota.NextRecoverAt remains live, and
+// hasModelError must report true for it.
+func TestHasModelError_LiveQuotaWithNilLastError(t *testing.T) {
+	now := time.Now()
+	a := &Auth{
+		ModelStates: map[string]*ModelState{
+			"m": {
+				Status:         StatusError,
+				Unavailable:    true,
+				LastError:      nil,
+				NextRetryAfter: now.Add(-time.Minute), // expired
+				Quota:          QuotaState{Exceeded: true, NextRecoverAt: now.Add(time.Hour)},
+			},
+		},
+	}
+	if !hasModelError(a, now) {
+		t.Fatalf("hasModelError = false, want true (live Quota.NextRecoverAt with nil LastError must still count)")
+	}
+}

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -865,7 +865,7 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 	entry.meta = meta
 	entry.auth = meta.auth
 	entry.nextRetryAt = time.Time{}
-	blocked, reason, next := isAuthBlockedForModel(meta.auth, m.modelKey, now)
+	blocked, reason, next := effectiveBlock(meta.auth, m.modelKey, now)
 	switch {
 	case !blocked:
 		entry.state = scheduledStateReady
@@ -908,7 +908,7 @@ func (m *modelScheduler) demoteExpiredTokensLocked(now time.Time) bool {
 			continue
 		}
 		if exp, ok := entry.auth.AccessTokenExpirationTime(); ok && !exp.IsZero() && !exp.After(now) {
-			blocked, reason, next := isAuthBlockedForModel(entry.auth, m.modelKey, now)
+			blocked, reason, next := effectiveBlock(entry.auth, m.modelKey, now)
 			if blocked {
 				switch {
 				case reason == blockReasonCooldown:
@@ -942,7 +942,7 @@ func (m *modelScheduler) promoteExpiredLocked(now time.Time) {
 		if entry.nextRetryAt.IsZero() || entry.nextRetryAt.After(now) {
 			continue
 		}
-		blocked, reason, next := isAuthBlockedForModel(entry.auth, m.modelKey, now)
+		blocked, reason, next := effectiveBlock(entry.auth, m.modelKey, now)
 		switch {
 		case !blocked:
 			entry.state = scheduledStateReady

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -808,6 +808,14 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
 	}
+	// A genuine credential-wide cooldown (e.g. a 401) blocks every model
+	// regardless of any individual model's own ModelStates entry - a clean
+	// per-model state does not mean the credential itself is usable. Without
+	// this check, the matched-model branch below decides solely from that
+	// model's own state and can miss a real credential-wide block entirely.
+	if auth.CredentialCooldown && auth.Unavailable && auth.NextRetryAfter.After(now) {
+		return true, blockReasonCooldown, auth.NextRetryAfter
+	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			modelKey := canonicalModelKey(model)

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -471,7 +471,7 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 	available = make(map[int][]*Auth)
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
-		blocked, reason, next := isAuthBlockedForModel(candidate, model, now)
+		blocked, reason, next := effectiveBlock(candidate, model, now)
 		if !blocked {
 			priority := authPriority(candidate)
 			available[priority] = append(available[priority], candidate)
@@ -795,30 +795,43 @@ func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, op
 	return available[0], nil
 }
 
-func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, blockReason, time.Time) {
+// effectiveBlock reports whether auth is currently blocked for modelKey (or
+// at the credential level alone when modelKey is ""), and if so, the
+// reason and the deadline it clears at. It subsumes the former
+// effectiveBlock; every former caller of that name now calls this
+// one - see selector.go's laterFutureDeadline/effectiveDeadline for the
+// shared deadline arithmetic this and availabilityBlock both build on.
+func effectiveBlock(auth *Auth, modelKey string, now time.Time) (bool, blockReason, time.Time) {
 	if auth == nil {
 		return true, blockReasonOther, time.Time{}
 	}
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
+	// Exception, documented in the PR body: token expiry is not a cooldown
+	// deadline field covered by effectiveDeadline - it is a hard cutoff
+	// independent of any NextRetryAfter/NextRecoverAt value, so it is left
+	// as a direct read here rather than folded into that accessor.
 	if exp, ok := auth.AccessTokenExpirationTime(); ok && !exp.IsZero() && !exp.After(now) {
 		return true, blockReasonOther, time.Time{}
 	}
-	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
-		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
+	// A genuine credential-wide cooldown (either a credential_quota window
+	// or a CredentialCooldown-marked failure, e.g. a 401) blocks every
+	// model regardless of any individual model's own ModelStates entry - a
+	// clean per-model state does not mean the credential itself is usable.
+	// Both conditions resolve to the same blockReasonCooldown, so they
+	// share one effectiveDeadline(auth, "", now) call for the deadline
+	// arithmetic instead of two independent field reads.
+	credQuotaLive := auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota"
+	credCooldownLive := auth.CredentialCooldown && auth.Unavailable
+	if credQuotaLive || credCooldownLive {
+		if next := effectiveDeadline(auth, "", now); !next.IsZero() {
+			return true, blockReasonCooldown, next
+		}
 	}
-	// A genuine credential-wide cooldown (e.g. a 401) blocks every model
-	// regardless of any individual model's own ModelStates entry - a clean
-	// per-model state does not mean the credential itself is usable. Without
-	// this check, the matched-model branch below decides solely from that
-	// model's own state and can miss a real credential-wide block entirely.
-	if auth.CredentialCooldown && auth.Unavailable && auth.NextRetryAfter.After(now) {
-		return true, blockReasonCooldown, auth.NextRetryAfter
-	}
-	if model != "" {
+	if modelKey != "" {
 		if len(auth.ModelStates) > 0 {
-			modelKey := canonicalModelKey(model)
+			modelKey := canonicalModelKey(modelKey)
 			matched := false
 			blocked := false
 			blockedReason := blockReasonNone
@@ -862,18 +875,58 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	return availabilityBlock(auth.Unavailable, quotaExceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
 }
 
+// laterFutureDeadline returns the latest of deadlines that is still after
+// now, or the zero Time when none of them are. This is the single piece of
+// arithmetic shared by availabilityBlock and effectiveDeadline so the two
+// can never disagree about which of several deadline fields is currently
+// live and which one wins when more than one is.
+func laterFutureDeadline(now time.Time, deadlines ...time.Time) time.Time {
+	var next time.Time
+	for _, candidate := range deadlines {
+		if candidate.After(now) && (next.IsZero() || candidate.After(next)) {
+			next = candidate
+		}
+	}
+	return next
+}
+
+// effectiveDeadline is the single accessor for "what is the latest live
+// cooldown deadline for auth" across every field that can hold one:
+// auth.NextRetryAfter, auth.Quota.NextRecoverAt, and, when modelKey
+// resolves to an existing ModelState, that state's own NextRetryAfter and
+// Quota.NextRecoverAt too. modelKey may be a raw model string or an
+// already-canonical key - it is canonicalized here before matching against
+// auth.ModelStates keys, the same way effectiveBlock's per-model loop
+// does. Fields that are zero, or already in the past, do not contribute;
+// the result is the zero Time when nothing is currently live. Pass "" for
+// modelKey to get the credential-level deadline alone.
+func effectiveDeadline(auth *Auth, modelKey string, now time.Time) time.Time {
+	if auth == nil {
+		return time.Time{}
+	}
+	next := laterFutureDeadline(now, auth.NextRetryAfter, auth.Quota.NextRecoverAt)
+	modelKey = canonicalModelKey(modelKey)
+	if modelKey == "" || len(auth.ModelStates) == 0 {
+		return next
+	}
+	for stateModel, state := range auth.ModelStates {
+		if state == nil || canonicalModelKey(stateModel) != modelKey {
+			continue
+		}
+		if candidate := laterFutureDeadline(now, state.NextRetryAfter, state.Quota.NextRecoverAt); candidate.After(next) {
+			next = candidate
+		}
+	}
+	return next
+}
+
 func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextRecoverAt, now time.Time) (bool, blockReason, time.Time) {
 	if !unavailable && !quotaExceeded {
 		return false, blockReasonNone, time.Time{}
 	}
 
 	hasRecoveryTime := !nextRetryAfter.IsZero() || !nextRecoverAt.IsZero()
-	var next time.Time
-	for _, candidate := range []time.Time{nextRetryAfter, nextRecoverAt} {
-		if candidate.After(now) && (next.IsZero() || candidate.After(next)) {
-			next = candidate
-		}
-	}
+	next := laterFutureDeadline(now, nextRetryAfter, nextRecoverAt)
 	if !next.IsZero() {
 		if quotaExceeded {
 			return true, blockReasonCooldown, next

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -825,8 +825,19 @@ func effectiveBlock(auth *Auth, modelKey string, now time.Time) (bool, blockReas
 	credQuotaLive := auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota"
 	credCooldownLive := auth.CredentialCooldown && auth.Unavailable
 	if credQuotaLive || credCooldownLive {
+		// Route through availabilityBlock, the same primitive the per-model
+		// loop and fallback below use, rather than returning a bespoke
+		// tuple here - effectiveBlock is built ON availabilityBlock, not
+		// beside it. effectiveDeadline supplies the combined deadline
+		// (credential NextRetryAfter/Quota.NextRecoverAt); quotaExceeded is
+		// passed as true unconditionally because a live credential-wide
+		// cooldown is always reported as blockReasonCooldown here,
+		// regardless of whether it originated from credential_quota or a
+		// CredentialCooldown-marked failure like a 401.
 		if next := effectiveDeadline(auth, "", now); !next.IsZero() {
-			return true, blockReasonCooldown, next
+			if blocked, _, until := availabilityBlock(true, true, next, time.Time{}, now); blocked {
+				return true, blockReasonCooldown, until
+			}
 		}
 	}
 	if modelKey != "" {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -901,22 +901,60 @@ func laterFutureDeadline(now time.Time, deadlines ...time.Time) time.Time {
 	return next
 }
 
+// genuineCredentialDeadline returns the latest live deadline held by a
+// GENUINE credential-wide cooldown field on auth: auth.NextRetryAfter only
+// counts when auth.CredentialCooldown marks it as a real credential-wide
+// failure (e.g. a 401), and auth.Quota.NextRecoverAt only counts when
+// auth.Quota.Reason is "credential_quota". Either field can also hold an
+// AGGREGATE-ONLY value instead - auth.NextRetryAfter/auth.Quota copied up
+// from ModelStates by updateAggregatedAvailability (which stamps
+// Reason="quota", not "credential_quota", for that case) - and an
+// aggregate-only value must never be mistaken for a deadline that applies
+// to every model; see effectiveDeadline's modelKey!="" branch, which is the
+// only reason this distinction exists.
+func genuineCredentialDeadline(auth *Auth, now time.Time) time.Time {
+	if auth == nil {
+		return time.Time{}
+	}
+	var next time.Time
+	if auth.CredentialCooldown {
+		next = laterFutureDeadline(now, next, auth.NextRetryAfter)
+	}
+	if auth.Quota.Reason == "credential_quota" {
+		next = laterFutureDeadline(now, next, auth.Quota.NextRecoverAt)
+	}
+	return next
+}
+
 // effectiveDeadline is the single accessor for "what is the latest live
-// cooldown deadline for auth" across every field that can hold one:
-// auth.NextRetryAfter, auth.Quota.NextRecoverAt, and, when modelKey
-// resolves to an existing ModelState, that state's own NextRetryAfter and
-// Quota.NextRecoverAt too. modelKey may be a raw model string or an
-// already-canonical key - it is canonicalized here before matching against
-// auth.ModelStates keys, the same way effectiveBlock's per-model loop
-// does. Fields that are zero, or already in the past, do not contribute;
-// the result is the zero Time when nothing is currently live. Pass "" for
-// modelKey to get the credential-level deadline alone.
+// cooldown deadline for auth" - at the credential level alone (modelKey ==
+// "") or for a specific model (modelKey != ""). modelKey may be a raw model
+// string or an already-canonical key - it is canonicalized here before
+// matching against auth.ModelStates keys, the same way effectiveBlock's
+// per-model loop does. Fields that are zero, or already in the past, do not
+// contribute; the result is the zero Time when nothing is currently live.
+//
+// Credential-level and model-level queries deliberately use different rules
+// for auth.NextRetryAfter/auth.Quota.NextRecoverAt (2026-09-04 review,
+// finding 1 - cross-model cooldown contamination): a credential-level query
+// (modelKey=="") wants the credential's OWN observable state as a whole, so
+// it uses those two fields unconditionally, aggregate-derived or not - that
+// aggregate IS the answer to "is this credential, taken as a whole,
+// available." A model-level query, in contrast, must not let an
+// aggregate-only value that was actually derived from a DIFFERENT sibling
+// model leak onto this one; only a genuine credential-wide deadline
+// (see genuineCredentialDeadline) may apply to every model.
 func effectiveDeadline(auth *Auth, modelKey string, now time.Time) time.Time {
 	if auth == nil {
 		return time.Time{}
 	}
-	next := laterFutureDeadline(now, auth.NextRetryAfter, auth.Quota.NextRecoverAt)
 	modelKey = canonicalModelKey(modelKey)
+	var next time.Time
+	if modelKey == "" {
+		next = laterFutureDeadline(now, auth.NextRetryAfter, auth.Quota.NextRecoverAt)
+	} else {
+		next = genuineCredentialDeadline(auth, now)
+	}
 	if modelKey == "" || len(auth.ModelStates) == 0 {
 		return next
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -571,7 +571,7 @@ func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsBlocked(t *testing.T
 		},
 	}
 
-	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	blocked, reason, next := effectiveBlock(auth, model, now)
 	if !blocked {
 		t.Fatalf("blocked = false, want true")
 	}
@@ -588,9 +588,9 @@ func TestIsAuthBlockedForModel_AuthQuotaExceededWithoutRecoveryIsBlocked(t *test
 
 	auth := &Auth{ID: "a", Quota: QuotaState{Exceeded: true}}
 	for _, model := range []string{"", "test-model"} {
-		blocked, reason, next := isAuthBlockedForModel(auth, model, time.Now())
+		blocked, reason, next := effectiveBlock(auth, model, time.Now())
 		if !blocked || reason != blockReasonOther || !next.IsZero() {
-			t.Fatalf("isAuthBlockedForModel(%q) = %v, %v, %v; want true, other, zero", model, blocked, reason, next)
+			t.Fatalf("effectiveBlock(%q) = %v, %v, %v; want true, other, zero", model, blocked, reason, next)
 		}
 	}
 }
@@ -608,9 +608,9 @@ func TestIsAuthBlockedForModel_ExpiredRecoveryIsAvailable(t *testing.T) {
 			NextRecoverAt: now.Add(-time.Second),
 		},
 	}
-	blocked, reason, next := isAuthBlockedForModel(auth, "", now)
+	blocked, reason, next := effectiveBlock(auth, "", now)
 	if blocked || reason != blockReasonNone || !next.IsZero() {
-		t.Fatalf("isAuthBlockedForModel() = %v, %v, %v; want false, none, zero", blocked, reason, next)
+		t.Fatalf("effectiveBlock() = %v, %v, %v; want false, none, zero", blocked, reason, next)
 	}
 }
 
@@ -684,9 +684,9 @@ func TestIsAuthBlockedForModel_ThinkingSuffixStatesBlockCanonicalModel(t *testin
 	}
 
 	for _, model := range []string{"test-model", "test-model(medium)", "test-model(low)"} {
-		blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+		blocked, reason, next := effectiveBlock(auth, model, now)
 		if !blocked || reason != blockReasonCooldown || !next.Equal(laterRetry) {
-			t.Fatalf("isAuthBlockedForModel(%q) = %v, %v, %v; want true, cooldown, %v", model, blocked, reason, next, laterRetry)
+			t.Fatalf("effectiveBlock(%q) = %v, %v, %v; want true, cooldown, %v", model, blocked, reason, next, laterRetry)
 		}
 	}
 }

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -92,6 +92,14 @@ type Auth struct {
 	NextRefreshAfter time.Time `json:"next_refresh_after"`
 	// NextRetryAfter is the earliest time a retry should retrigger.
 	NextRetryAfter time.Time `json:"next_retry_after"`
+	// CredentialCooldown marks that Unavailable/NextRetryAfter/Quota were set
+	// directly by a genuine credential-wide failure (e.g. a 401 or a
+	// credential-scoped 429), not derived from ModelStates. Aggregation
+	// (updateAggregatedAvailability) must not silently clear this before
+	// NextRetryAfter/Quota.NextRecoverAt actually passes, even when
+	// ModelStates is non-empty and otherwise clean - a credential-wide
+	// failure blocks every model regardless of any individual model's state.
+	CredentialCooldown bool `json:"credential_cooldown,omitempty"`
 	// ModelStates tracks per-model runtime availability data.
 	ModelStates map[string]*ModelState `json:"model_states,omitempty"`
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -228,6 +228,14 @@ func ResponseFormatOrSource(opts Options) sdktranslator.Format {
 	return opts.SourceFormat
 }
 
+// WireModelMetadataKey is the Response.Metadata key an executor sets to the
+// exact model string it placed on the outbound upstream request, once known
+// (before or after the call completes). Executors that normalize the model
+// internally (stripping a thinking suffix, remapping an alias) should
+// populate this so callers can classify upstream errors against the model
+// the provider actually saw, instead of the pre-normalization request model.
+const WireModelMetadataKey = "wire_model"
+
 // Response wraps either a full provider response or metadata for streaming flows.
 type Response struct {
 	// Payload is the provider response in the executor format.

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -261,6 +261,16 @@ type StreamResult struct {
 	Headers http.Header
 	// Chunks is the channel of streaming payload units.
 	Chunks <-chan StreamChunk
+	// Metadata exposes optional structured data about the stream, captured
+	// before streaming begins. Executors that normalize the model internally
+	// on a streaming request (stripping a thinking suffix, remapping an
+	// alias) should set Metadata[WireModelMetadataKey] to the exact model
+	// placed on the outbound upstream request, mirroring Response.Metadata's
+	// contract on the non-streaming path, so a successful stream's recorded
+	// Result.UpstreamModel - and any mid-stream structured 404 without its
+	// own WireModel() - can be classified against the wire model instead of
+	// the pre-normalization request model.
+	Metadata map[string]any
 }
 
 // StatusError represents an error that carries an HTTP-like status code.


### PR DESCRIPTION
**Problem**: any upstream 404 currently cools the responding credential for 12 hours. A transient 404 hitting both credentials of a two-credential pool takes the whole pool offline, returning 503 auth_unavailable, for what would have been a 12-hour outage.

**Change**: a generic 404 now routes through the existing transient-retry path, backing off 1 → 2 → 4 minutes capped at 30, instead of the long cooldown. An explicit model-not-found 404 still gets the full 12-hour cooldown, since that failure mode is not transient. The disable-cooling setting is respected either way, and both the model-scoped and auth-scoped call sites are updated.

**Tests**: policy tests for MarkResult and applyAuthFailureState covering both 404 branches, plus mutation controls that fail if the transient path is removed.


## Cooldown deadlines
Availability is the later of Auth.NextRetryAfter and Quota.NextRecoverAt; explicit model-not-found, unsupported-model and generic-404 backoffs are stored in NextRecoverAt via preserveLongerCooldown so no later result shortens them; transient statuses only update NextRetryAfter, as before.

Aggregation now agrees with the live selector's existing semantics: an `Unavailable=true` auth with zero deadlines was already treated by the selector as an indefinite block, so `updateAggregatedAvailability` was corrected to match rather than clear it, and `TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryDoesNotBlockAuth` was renamed to `...BlocksAuthIndefinitely` as a deliberate contract correction, not a silent test change.

## Wire model
Executors report the model actually sent (after normalization and payload overrides) via Response.Metadata[WireModelMetadataKey] or, on error paths and mid-stream frames, a 404-only error wrapper exposing WireModel(); the conductor resolves error-carried, then response-carried, then the pre-call model at every Result site. Providers whose route model is fixed by URL path or reset after payload rules (Gemini main path, Vertex, AI Studio, Codex, xAI) are unaffected.


## Effective-deadline accessor

Every "is this cooldown still live" comparison against `Auth.NextRetryAfter`, `Auth.Quota.NextRecoverAt`, or a `ModelState`'s own copies of those fields is now routed through two functions in `selector.go`:

- `laterFutureDeadline(now, deadlines...) time.Time` - shared arithmetic: latest of the given deadlines that is still after `now`, or zero.
- `effectiveDeadline(auth, modelKey, now) time.Time` - the single accessor: max over `auth.NextRetryAfter`, `auth.Quota.NextRecoverAt`, and (when `modelKey` resolves to a `ModelState`) that state's own `NextRetryAfter`/`Quota.NextRecoverAt`.
- `effectiveBlock(auth, modelKey, now) (blocked bool, reason blockReason, until time.Time)` - built on `effectiveDeadline`; subsumes the former `isAuthBlockedForModel` (renamed everywhere it was called). Its credential-level gate folds the `credential_quota` and `CredentialCooldown` checks into one `effectiveDeadline` call, since both already returned `blockReasonCooldown`.

`availabilityBlock` is now a thin wrapper over `laterFutureDeadline` rather than a second copy of the max-future-deadline loop, so it and `effectiveDeadline` cannot compute a different answer for the same fields.

This fixes the `selector.go:817` P2 (Codex `discussion_r3931969412`, "Honor the effective credential cooldown deadline") by construction: that raw `auth.NextRetryAfter.After(now)` read is now inside `effectiveBlock`, the one place that decides liveness.

The two racing-404 guards (model-level, added in `f7a36c0a`, and the pre-existing auth-level one) now compare the proposed new deadline against `effectiveDeadline(auth, modelKey, now)` / `effectiveDeadline(auth, "", now)` instead of a single hand-picked field snapshot - a strict superset of the previous guard (a longer credential-level cooldown now also protects a per-model 404 recomputation, and vice versa), not a narrowing.

**Grep proving no raw read remains outside the accessor, unannotated:**

```
rg -n 'NextRetryAfter|NextRecoverAt' sdk/cliproxy/auth --type go | rg -v 'effectiveDeadline|effectiveBlock|_test.go'
```

161 hits remain. Annotated by category:

- **Write-sites** (struct field assignment, struct-literal construction, type declaration, doc comment mentioning the field name): the large majority - e.g. every `auth.NextRetryAfter = ...` / `state.NextRetryAfter = ...` / `NextRecoverAt: next` in `conductor_cooldown.go`, the field declarations and doc comments in `types.go`, `cooldown_state.go`, `error_events.go`, `quota_signals.go`.
- **`availabilityBlock` internal calls** (`selector.go:847/865/875`, `conductor_cooldown.go:363/517/872/1495`, `conductor_selection.go:975`) - the shared scalar primitive itself, or callers passing a synthetic/single-entity field set (a `CooldownStateRecord` before it's applied to `auth`, or one `ModelState` in a loop with its own early-return-on-`Disabled` precedence) that isn't naturally an `(auth, modelKey)` pair; these are the primitive `effectiveDeadline`/`effectiveBlock` are themselves built on, not a second, divergent path.
- **Comparisons between two already-computed deadlines, not against `now`** (earliest-of / latest-of aggregation): `conductor_cooldown.go:1073` (sibling `ModelState` aggregation), `1089`/`1535` (auth-level quota-recover merge), `1514` (named exception in the original instruction), `2325` (`preserveLongerCooldown`).
- **`IsZero()`-only gates with no `now` comparison at all**: `conductor_cooldown.go:360/530/542/1364/1427/1430/2413`.
- **`selector.go:805`** (inside `effectiveBlock`) - `AccessTokenExpirationTime()` is a hard cutoff independent of any cooldown deadline field (named exception in the original instruction).
- **Single-field-only gates in narrowly-scoped, already-heavily-commented state-machine functions**, where substituting the combined `effectiveDeadline` (auth + model max) would be over-broad and change which flag/field gates the decision: `conductor_lifecycle.go:169/187` (`Update()`'s re-login-vs-refresh preserve logic, which branches on *which* field was live to decide which preserved-fields set to apply), `conductor_models.go:239/245/248` (a client-facing suspended/quota-exceeded projection that intentionally reports on one field at a time), `conductor_selection.go:961` (credential-quota-only gate), `conductor_cooldown.go:949/1358/1361/1440/1458/1540/1571/2348/2522` (`MarkResult`'s success branch, `isModelStateActiveCooldown`, `updateAggregatedAvailability`, `notFoundRetryAfter`, `quotaCooldownAfterFailure` - each reads exactly the one field its own local invariant is about).

**Tests**: `effective_deadline_test.go` - `TestEffectiveDeadline` (table test, one control per field: each field alone as the max, credential-vs-model precedence both directions, all-zero, all-past, no-match-by-modelKey) and `TestEffectiveBlock` (disabled beats a live cooldown, credential-wide cooldown/quota blocks every model regardless of a clean model state, matched model-level reason precedence, model-`Disabled` short-circuit, clean auth never blocked, `ModelStates`-empty fallback). Full `sdk/cliproxy/auth` suite green, `go vet` clean, `gofmt` clean, `-race` clean.


## Terminating check (2026-09-04 amendment)

Grep: `rg -n '(NextRetryAfter|NextRecoverAt)\.(After|Before)\((now|time\.Now\(\))\)' sdk/cliproxy/auth --type go | rg -v '_test.go|func laterFutureDeadline|func maxDeadline'`

Expected remaining hits: **15**. A reviewer re-running this grep should get exactly 15 lines.

Two named exclusions, restated exactly:
- `selector.go:805` — token expiry (refresh, not block).
- `conductor_cooldown.go:1514` (`preserveLongerCooldown` call site inside the 429 branch's earliest-of) — earliest-of between two deadlines, not itself one of the two After/Before-comparison helpers being asked about here (the actual field-comparison arithmetic for that call lives inside `preserveLongerCooldown`/`maxDeadline`, not at this call site).

Each of the 15 remaining hits, with the single semantic decision it makes:

| Site | Decision the comparison makes | Semantic reason it's outside the two helpers |
|---|---|---|
| `conductor_selection.go:961` | Retry-round eligibility *category* (credential_quota vs model-level) | Runs only after `effectiveBlock` already returned blocked=true above it; not re-deciding blocked, classifying why. |
| `conductor_selection.go:2019` | Human-readable remaining-time string for a log line | Formats an already-decided deadline for display; not a blocking decision. |
| `conductor_cooldown.go:949` | Whether to retain vs. reset the credential's own quota record on a *success* result | Write-path retention decision on success, not a read of "is this blocked." |
| `conductor_cooldown.go:1356` | Is this model's own cooldown record currently active | **No semantic reason — blocking decision, convert candidate.** Duplicates `availabilityBlock`'s per-model liveness check outside it. |
| `conductor_cooldown.go:1359` | Is this model's own quota record currently active | **No semantic reason — blocking decision, convert candidate.** Same function (`isModelStateActiveCooldown`) as the line above. |
| `conductor_cooldown.go:1438` | Whether to set `auth.Unavailable=true` while recomputing the aggregate flag | Generator of the `Unavailable` field `effectiveBlock` later reads; can't be defined in terms of its own reader. |
| `conductor_cooldown.go:1456` | Whether a credential-wide cooldown marker survives an aggregate recompute | Same generator function/reasoning as 1438 (`updateAggregatedAvailability`). |
| `conductor_cooldown.go:1538` | Whether to retain the existing auth-level quota window during aggregate recompute | Same generator function/reasoning as 1438/1456. |
| `conductor_cooldown.go:1569` | Whether any model has a live error/cooldown, for a has-model-error summary flag | Diagnostic/summary detector, not the traffic-routing block decision. |
| `conductor_cooldown.go:2364` | Computing the proposed deadline value itself inside `notFoundRetryAfter` (generic-404 branch) | Write-path arithmetic producing the "next" value the `maxDeadline` guard compares against; not a blocking read. |
| `conductor_cooldown.go:2537` | Computing the next quota window on a failure (`quotaCooldownAfterFailure`) | Generator of a proposed deadline value, not a blocking read. |
| `conductor_models.go:239` | Credential-level `isSuspended` flag for a client-facing model projection | **No semantic reason — blocking decision, convert candidate.** Duplicates `effectiveBlock`'s credential gate outside it. |
| `conductor_models.go:245` | Model-level `isSuspended` flag for the same client-facing projection | **No semantic reason — blocking decision, convert candidate.** Same function (`clientModelProjectionForAuth`) as above. |
| `conductor_models.go:248` | Model-level `isQuotaExceeded` flag for the same projection | **No semantic reason — blocking decision, convert candidate.** Same function as above; a second flag alongside `isSuspended`. |
| `conductor_lifecycle.go:169` | Whether to carry the old credential's quota cooldown forward into a fresh `Auth` during `Update` | Merge/carry-forward decision between two `Auth` snapshots, not a live traffic-block read. |
| `conductor_lifecycle.go:187` | Whether to carry the old credential's `CredentialCooldown` marker forward during `Update` | Same merge/carry-forward function/reasoning as 169. |

**5 candidates flagged for conversion, pending sol-reviewer's ruling:** `conductor_cooldown.go:1356`, `conductor_cooldown.go:1359` (both in `isModelStateActiveCooldown`), `conductor_models.go:239`, `:245`, `:248` (all three in `clientModelProjectionForAuth`). These three functions independently re-derive a live-cooldown/is-blocked boolean per model or per credential, in parallel with `effectiveBlock`/`availabilityBlock`, rather than calling them. Not converted in this pass per instruction: do not convert unasked.


## Independent review of c5a17c60 (2026-09-04): NOT MERGEABLE, four HIGH findings fixed

An independent sol-reviewer leg ran adversarial probes (each with a positive/negative control) against `c5a17c60` and returned **NOT MERGEABLE** with four confirmed HIGH findings. All four are fixed at `e985bd98`; the reviewer's own scope-limit note was correct: the `TestEffectiveDeadline` arithmetic test was real, but scope/applicability - where all four findings live - was uncovered.

1. **Cross-model cooldown contamination** (`selector.go`, `effectiveDeadline`). Model A gets a 2h quota cooldown; `updateAggregatedAvailability` copies it into `auth.Quota` as aggregate-only (`Reason: "quota"`) while model B stays clean. A later 404 on B called `effectiveDeadline(auth, "model-b", now)`, which unconditionally included `auth.Quota.NextRecoverAt` and extended B to A's 2h deadline. Confirmed by an actual `MarkResult` probe; a regression control on `8a0d987d^` passed the same test, proving this commit introduced it. **Fix**: new `genuineCredentialDeadline(auth, now)` helper - `auth.NextRetryAfter` only counts when `auth.CredentialCooldown` is true, `auth.Quota.NextRecoverAt` only counts when `Reason == "credential_quota"`. `effectiveDeadline`'s `modelKey != ""` branch now uses this instead of the unconditional pair; the `modelKey == ""` branch is untouched (a credential-level query legitimately wants the aggregate too).

2. **Single-field genuine-scope gates missed the sibling field.** `updateAggregatedAvailability` (`conductor_cooldown.go`) checked `CredentialCooldown`+`NextRetryAfter` and `Quota.Reason=="credential_quota"`+`NextRecoverAt` as two separate early-return guards; if `CredentialCooldown` was true but `NextRetryAfter` had independently expired while `Quota.NextRecoverAt` was still live, the guard cleared the block early. Same defect in `conductor_lifecycle.go`'s `Update()` refresh-preserve logic at the `CredentialCooldown` branch (line ~187): a routine token refresh replaced a still-blocked auth with a clean one. **Fix**: both sites now gate on `genuineCredentialDeadline(...).After(now)` (unified max of both fields) instead of the single field. The unconditional `credential_quota`-only preserve block in `Update()` (~line 169, which deliberately has no same-credential gate, so a live quota-wide block survives even a re-login) is unchanged - only the `CredentialCooldown` branch's liveness check was widened.

3. **Writers destroying the only longer deadline.** Multiple `NextRetryAfter` writers in `MarkResult`'s model-level switch and `applyAuthFailureStateForModel`'s auth-level switch overwrote the field outright or preserved only `Quota.NextRecoverAt`, so a later failure of any kind (a transient 500, a short 429) could shorten an already-longer stored deadline (a model 401, a credential-scope 429's sibling propagation). Confirmed three ways: 401→500, 401→short-429, and a credential-scope 429 on model A shortening sibling model B's live 401. **Fix**: every per-field writer now routes through a new canonical `writeCooldownDeadline(now, disableCooling, existing, proposed)` helper (checks `disableCooling` first, else maxes against `existing` via `maxDeadline`) or a direct `maxDeadline` call for the sibling-propagation/aggregate sub-writes inside the 429 branch - a max-on-write, never-shorten rule applied uniformly instead of point-fixed per site.

4. **False-available registry projection.** `clientModelProjectionForAuth` (`conductor_models.go`) recognised only `Quota.Reason=="credential_quota"` plus per-model fields; it never checked `auth.CredentialCooldown`/`auth.NextRetryAfter`, so a genuine credential-wide 401 with an otherwise-clean model produced `Suspended=false` while `effectiveBlock`/selection correctly rejected the model. **Fix**: `isSuspended` is now derived from `effectiveBlock(auth, targetKey, now)`'s own blocked result (plus the `Disabled` short-circuits), the same predicate selection uses, instead of a parallel direct-field-read implementation. `isQuotaExceeded` stays a separate, quota-only projection value, unchanged.

**Fifth terminating-check site, answered.** The reviewer flagged `hasModelError` (`conductor_cooldown.go`) as unverified: can a `ModelState` have `LastError == nil` while a longer `Quota.NextRecoverAt` remains live? Yes - via `restoreCooldownRecordLocked`'s model-scoped restore path: it calls `mergeModelState(state, &ModelState{LastError: cloneError(record.LastError), ...})`, and if the persisted `record.LastError` was nil (not serialized, or genuinely absent) while the pre-existing in-memory state's `LastError` was also nil, `mergeModelState`'s nil-coalescing leaves `merged.LastError == nil` while `merged.NextRetryAfter`/`merged.Quota.NextRecoverAt` independently take the max of both sides regardless of `LastError`'s nil-ness. `hasModelError` now also checks `state.Quota.NextRecoverAt.After(now)`, not just `NextRetryAfter`.

**Updated terminating-check count**: **10** (down from 15), via `rg -n --glob '*.go' --glob '!**/*_test.go' 'Next(RetryAfter|RecoverAt)\.After\((now|time\.Now\(\))\)' sdk/cliproxy/auth`. The 5 sites that converted (`conductor_cooldown.go:1356/1359`, `conductor_models.go:239/245/248` in the old line numbering) are gone because they now call `effectiveBlock`/`genuineCredentialDeadline` instead of comparing a raw field; the remaining 10 are field-specific write-path arithmetic (`preserveLongerCooldown`/`quotaCooldownAfterFailure`-style deadline construction) or classification/metadata decisions - the same "OK" category the review itself audited for the untouched sites.

**Tests added** (`review_c5a17c60_fixes_test.go`, plus two new cases in `effective_deadline_test.go`): sibling-isolation at both the `effectiveDeadline` unit level and end-to-end through `MarkResult` (kept as a **permanent** regression control, same shape as the reviewer's `8a0d987d^` control), the `CredentialCooldown` refresh-preserve case for finding 2, all three writer-order recipes for finding 3, the projection case for finding 4, and the `hasModelError` nil-`LastError`/live-quota case.

**Verification**: `go build ./...` clean, `go vet ./sdk/cliproxy/auth/...` clean, `gofmt -l sdk/cliproxy/auth` clean, full `go test ./sdk/cliproxy/auth/... -count=1` green, `go test -race ./sdk/cliproxy/auth/... -count=1` green. Head verified at `e985bd98` on both this PR and the upstream PR (`router-for-me/CLIProxyAPI#5472`), pushed once.
