### PR TITLE
fix(claude): keep the cloaked history prefix stable beneath signed tool results

### DIFF
--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -200,8 +200,6 @@ func claudeCCHFallbackBillingHeader(ctx context.Context, cfg *config.Config, pay
 	)
 }
 
-const claudeAdvisorRuleStateError = "payload rule changed advisor state after cloaking decision; advisor tools/history must be present in the incoming request or cloaking must be disabled"
-
 const claudeCodeCLIIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
@@ -433,44 +431,25 @@ func validateClaudeCallerSystemBlocks(system gjson.Result) error {
 	return blockErr
 }
 
-// claudeRequestContainsAdvisorState reports whether the incoming request is bound to
-// Anthropic's server-managed advisor context. It recognizes a first-turn tool
-// declaration only when name is "advisor" and type starts with "advisor_". In
-// message history it recognizes advisor_tool_result blocks and server_tool_use
-// blocks whose name is "advisor". Message content is scanned recursively through
-// nested arrays and nested object content, including advisor_redacted_result data
-// below an advisor_tool_result.
-//
-// Advisor results are bound to Anthropic's signed conversation context. Moving the
-// caller system prompt into mid-conversation messages changes that context and made
-// replay fail with HTTP 400, "Advisor tool result content could not be processed."
-// Keep this detection at the cloak boundary so advisor-bound requests follow the
-// ordinary cloak-off wire pipeline. See upstream issue #5470.
-func claudeRequestContainsAdvisorState(payload []byte) bool {
-	tools := gjson.GetBytes(payload, "tools")
-	if tools.IsArray() {
-		found := false
-		tools.ForEach(func(_, tool gjson.Result) bool {
-			found = tool.Get("name").String() == "advisor" && strings.HasPrefix(tool.Get("type").String(), "advisor_")
-			return !found
-		})
-		if found {
-			return true
+// claudeSignedHistoryBoundary returns the last message index containing a
+// server-managed block whose replay is bound to Anthropic's signed history.
+// A negative result means the request has no immutable history prefix.
+func claudeSignedHistoryBoundary(payload []byte) int {
+	boundary := -1
+	gjson.GetBytes(payload, "messages").ForEach(func(key, message gjson.Result) bool {
+		if claudeContentContainsSignedServerState(message.Get("content")) {
+			boundary = int(key.Int())
 		}
-	}
-	found := false
-	gjson.GetBytes(payload, "messages").ForEach(func(_, message gjson.Result) bool {
-		found = claudeContentContainsAdvisorState(message.Get("content"))
-		return !found
+		return true
 	})
-	return found
+	return boundary
 }
 
-func claudeContentContainsAdvisorState(content gjson.Result) bool {
+func claudeContentContainsSignedServerState(content gjson.Result) bool {
 	if content.IsArray() {
 		found := false
 		content.ForEach(func(_, item gjson.Result) bool {
-			found = claudeContentContainsAdvisorState(item)
+			found = claudeContentContainsSignedServerState(item)
 			return !found
 		})
 		return found
@@ -478,11 +457,13 @@ func claudeContentContainsAdvisorState(content gjson.Result) bool {
 	if !content.IsObject() {
 		return false
 	}
-	blockType := content.Get("type").String()
-	if blockType == "advisor_tool_result" || blockType == "server_tool_use" && content.Get("name").String() == "advisor" {
+	switch content.Get("type").String() {
+	case "server_tool_use", "advisor_tool_result", "web_search_tool_result",
+		"web_fetch_tool_result", "code_execution_tool_result",
+		"bash_code_execution_tool_result", "text_editor_code_execution_tool_result":
 		return true
 	}
-	return claudeContentContainsAdvisorState(content.Get("content"))
+	return claudeContentContainsSignedServerState(content.Get("content"))
 }
 
 func collectForwardedClaudeSystemPromptBlocks(system gjson.Result) []string {
@@ -1068,12 +1049,6 @@ func applyCloaking(
 ) ([]byte, bool, error) {
 	policy, settings := resolveClaudeWirePolicy(cfg, auth, apiKey, confirmedClaudeCode)
 	if !policy.Cloak {
-		return payload, false, nil
-	}
-	// The incoming body alone selects the cloak-off pipeline for advisor-bound
-	// conversations. Every turn must receive the same treatment; later mutations
-	// cannot safely change the decision around context-bound advisor results.
-	if claudeRequestContainsAdvisorState(payload) {
 		return payload, false, nil
 	}
 	// Strict mode drops caller system prompts entirely, so nothing needs a

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -200,6 +200,8 @@ func claudeCCHFallbackBillingHeader(ctx context.Context, cfg *config.Config, pay
 	)
 }
 
+const claudeAdvisorRuleStateError = "payload rule changed advisor state after cloaking decision; advisor tools/history must be present in the incoming request or cloaking must be disabled"
+
 const claudeCodeCLIIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
 
 func checkSystemInstructionsWithMode(payload []byte, strictMode bool) []byte {
@@ -429,6 +431,58 @@ func validateClaudeCallerSystemBlocks(system gjson.Result) error {
 		return true
 	})
 	return blockErr
+}
+
+// claudeRequestContainsAdvisorState reports whether the incoming request is bound to
+// Anthropic's server-managed advisor context. It recognizes a first-turn tool
+// declaration only when name is "advisor" and type starts with "advisor_". In
+// message history it recognizes advisor_tool_result blocks and server_tool_use
+// blocks whose name is "advisor". Message content is scanned recursively through
+// nested arrays and nested object content, including advisor_redacted_result data
+// below an advisor_tool_result.
+//
+// Advisor results are bound to Anthropic's signed conversation context. Moving the
+// caller system prompt into mid-conversation messages changes that context and made
+// replay fail with HTTP 400, "Advisor tool result content could not be processed."
+// Keep this detection at the cloak boundary so advisor-bound requests follow the
+// ordinary cloak-off wire pipeline. See upstream issue #5470.
+func claudeRequestContainsAdvisorState(payload []byte) bool {
+	tools := gjson.GetBytes(payload, "tools")
+	if tools.IsArray() {
+		found := false
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			found = tool.Get("name").String() == "advisor" && strings.HasPrefix(tool.Get("type").String(), "advisor_")
+			return !found
+		})
+		if found {
+			return true
+		}
+	}
+	found := false
+	gjson.GetBytes(payload, "messages").ForEach(func(_, message gjson.Result) bool {
+		found = claudeContentContainsAdvisorState(message.Get("content"))
+		return !found
+	})
+	return found
+}
+
+func claudeContentContainsAdvisorState(content gjson.Result) bool {
+	if content.IsArray() {
+		found := false
+		content.ForEach(func(_, item gjson.Result) bool {
+			found = claudeContentContainsAdvisorState(item)
+			return !found
+		})
+		return found
+	}
+	if !content.IsObject() {
+		return false
+	}
+	blockType := content.Get("type").String()
+	if blockType == "advisor_tool_result" || blockType == "server_tool_use" && content.Get("name").String() == "advisor" {
+		return true
+	}
+	return claudeContentContainsAdvisorState(content.Get("content"))
 }
 
 func collectForwardedClaudeSystemPromptBlocks(system gjson.Result) []string {
@@ -1014,6 +1068,12 @@ func applyCloaking(
 ) ([]byte, bool, error) {
 	policy, settings := resolveClaudeWirePolicy(cfg, auth, apiKey, confirmedClaudeCode)
 	if !policy.Cloak {
+		return payload, false, nil
+	}
+	// The incoming body alone selects the cloak-off pipeline for advisor-bound
+	// conversations. Every turn must receive the same treatment; later mutations
+	// cannot safely change the decision around context-bound advisor results.
+	if claudeRequestContainsAdvisorState(payload) {
 		return payload, false, nil
 	}
 	// Strict mode drops caller system prompts entirely, so nothing needs a

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -71,15 +71,13 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
-		body = rebuildMidSystemMessagesToTopLevel(body)
+		_, rebuildSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+		body = rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(body, rebuildSettings.strictMode)
 	}
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	bodyBeforeCloaking := body
-	advisorBound := claudeRequestContainsAdvisorState(bodyBeforeCloaking)
-	cloakPolicy, _ := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	cloakWouldApply := cloakPolicy.Cloak
 	var cloaked bool
 	body, cloaked, err = applyCloaking(
 		ctx,
@@ -111,14 +109,6 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
-	// Payload rules run exactly once. When this request is eligible for cloaking,
-	// adding or removing advisor state would change its treatment from the incoming
-	// first-turn contract, so reject instead of guessing and replaying rules. If the
-	// resolved wire policy is already cloak-off, no placement transition is possible.
-	if cloakWouldApply && claudeRequestContainsAdvisorState(body) != advisorBound {
-		log.Warn(claudeAdvisorRuleStateError)
-		return resp, statusErr{code: http.StatusBadRequest, msg: claudeAdvisorRuleStateError}
-	}
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
 	body = ensureModelMaxTokens(body, baseModel)
 

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -77,6 +77,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	bodyBeforeCloaking := body
+	advisorBound := claudeRequestContainsAdvisorState(bodyBeforeCloaking)
+	cloakPolicy, _ := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	cloakWouldApply := cloakPolicy.Cloak
 	var cloaked bool
 	body, cloaked, err = applyCloaking(
 		ctx,
@@ -108,6 +111,14 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	// Payload rules run exactly once. When this request is eligible for cloaking,
+	// adding or removing advisor state would change its treatment from the incoming
+	// first-turn contract, so reject instead of guessing and replaying rules. If the
+	// resolved wire policy is already cloak-off, no placement transition is possible.
+	if cloakWouldApply && claudeRequestContainsAdvisorState(body) != advisorBound {
+		log.Warn(claudeAdvisorRuleStateError)
+		return resp, statusErr{code: http.StatusBadRequest, msg: claudeAdvisorRuleStateError}
+	}
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
 	body = ensureModelMaxTokens(body, baseModel)
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1130,6 +1130,48 @@ func claudePayloadHasMidSystemMessage(payload []byte) bool {
 }
 
 func rebuildMidSystemMessagesToTopLevel(payload []byte) []byte {
+	return rebuildMidSystemMessagesToTopLevelAfter(payload, -1)
+}
+
+func rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(payload []byte, strictMode bool) []byte {
+	boundary := claudeSignedHistoryBoundary(payload)
+	if boundary < 0 {
+		return rebuildMidSystemMessagesToTopLevel(payload)
+	}
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+	kept := make([]string, 0, int(messages.Get("#").Int()))
+	changed := false
+	messages.ForEach(func(key, message gjson.Result) bool {
+		isSystem := strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "system")
+		if isSystem && int(key.Int()) > boundary && strictMode {
+			changed = true
+			return true
+		}
+		messageRaw := message.Raw
+		if isSystem && message.Get("content").Type == gjson.String {
+			content := "[" + buildTextBlock(message.Get("content").String(), &claudeCodeCacheControl) + "]"
+			if updated, errSet := sjson.SetRawBytes([]byte(messageRaw), "content", []byte(content)); errSet == nil {
+				messageRaw = string(updated)
+				changed = true
+			}
+		}
+		kept = append(kept, messageRaw)
+		return true
+	})
+	if !changed {
+		return payload
+	}
+	updated, errSet := sjson.SetRawBytes(payload, "messages", rawJSONArray(kept))
+	if errSet != nil {
+		return payload
+	}
+	return updated
+}
+
+func rebuildMidSystemMessagesToTopLevelAfter(payload []byte, boundary int) []byte {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.IsArray() {
 		return payload

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -74,15 +74,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, err
 	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
-		body = rebuildMidSystemMessagesToTopLevel(body)
+		_, rebuildSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+		body = rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(body, rebuildSettings.strictMode)
 	}
 
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	bodyBeforeCloaking := body
-	advisorBound := claudeRequestContainsAdvisorState(bodyBeforeCloaking)
-	cloakPolicy, _ := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	cloakWouldApply := cloakPolicy.Cloak
 	var cloaked bool
 	body, cloaked, err = applyCloaking(
 		ctx,
@@ -114,14 +112,6 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
-	// Payload rules run exactly once. When this request is eligible for cloaking,
-	// adding or removing advisor state would change its treatment from the incoming
-	// first-turn contract, so reject instead of guessing and replaying rules. If the
-	// resolved wire policy is already cloak-off, no placement transition is possible.
-	if cloakWouldApply && claudeRequestContainsAdvisorState(body) != advisorBound {
-		log.Warn(claudeAdvisorRuleStateError)
-		return nil, statusErr{code: http.StatusBadRequest, msg: claudeAdvisorRuleStateError}
-	}
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
 	body = ensureModelMaxTokens(body, baseModel)
 

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -80,6 +80,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Apply cloaking (system prompt injection, fake user ID, sensitive word obfuscation)
 	// based on client type and configuration.
 	bodyBeforeCloaking := body
+	advisorBound := claudeRequestContainsAdvisorState(bodyBeforeCloaking)
+	cloakPolicy, _ := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	cloakWouldApply := cloakPolicy.Cloak
 	var cloaked bool
 	body, cloaked, err = applyCloaking(
 		ctx,
@@ -111,6 +114,14 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	body, contextManagementState.payloadRuleTouched = helps.ApplyPayloadConfigWithRequestTracked(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers, "context_management")
+	// Payload rules run exactly once. When this request is eligible for cloaking,
+	// adding or removing advisor state would change its treatment from the incoming
+	// first-turn contract, so reject instead of guessing and replaying rules. If the
+	// resolved wire policy is already cloak-off, no placement transition is possible.
+	if cloakWouldApply && claudeRequestContainsAdvisorState(body) != advisorBound {
+		log.Warn(claudeAdvisorRuleStateError)
+		return nil, statusErr{code: http.StatusBadRequest, msg: claudeAdvisorRuleStateError}
+	}
 	body = reconcileClaudeCodeSystemPlacementAfterPayload(body, systemPlacementState)
 	body = ensureModelMaxTokens(body, baseModel)
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -26,6 +26,8 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -6508,6 +6510,241 @@ func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) 
 			for _, absentKey := range tt.wantAbsent {
 				if got := seenHeaders.Get(absentKey); got != "" {
 					t.Errorf("header %s = %q, want absent", absentKey, got)
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeAdvisorStateDetection(t *testing.T) {
+	for _, payload := range [][]byte{
+		[]byte(`{"tools":[{"type":"advisor_20260301","name":"advisor"}]}`),
+		[]byte(`{"messages":[{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]}]}`),
+		[]byte(`{"messages":[{"role":"user","content":[[{"type":"advisor_tool_result"}]]}]}`),
+	} {
+		if !claudeRequestContainsAdvisorState(payload) {
+			t.Fatalf("advisor state not detected: %s", payload)
+		}
+	}
+	for _, payload := range [][]byte{
+		[]byte(`{"tools":[{"name":"advisor_helper"}]}`),
+		[]byte(`{"tools":[{"type":"custom","name":"advisor"}]}`),
+		[]byte(`{"tools":[{"type":"advisor_20260301","name":"advisor_helper"}]}`),
+	} {
+		if claudeRequestContainsAdvisorState(payload) {
+			t.Fatalf("non-advisor state falsely detected: %s", payload)
+		}
+	}
+}
+
+func TestClaudeExecutor_PayloadRuleAdvisorStateChangeFailsClosed(t *testing.T) {
+	logger, hook := logtest.NewNullLogger()
+	standard := log.StandardLogger()
+	oldOutput, oldFormatter, oldLevel, oldHooks := standard.Out, standard.Formatter, standard.Level, standard.Hooks
+	log.SetOutput(logger.Out)
+	log.SetFormatter(logger.Formatter)
+	log.SetLevel(log.WarnLevel)
+	standard.ReplaceHooks(log.LevelHooks{log.WarnLevel: []log.Hook{hook}})
+	t.Cleanup(func() {
+		log.SetOutput(oldOutput)
+		log.SetFormatter(oldFormatter)
+		log.SetLevel(oldLevel)
+		standard.ReplaceHooks(oldHooks)
+	})
+
+	cases := []struct {
+		name          string
+		payload       []byte
+		payloadConfig config.PayloadConfig
+	}{
+		{
+			name:    "inject advisor",
+			payload: []byte(`{"model":"claude-fable-5","messages":[{"role":"user","content":"question"}]}`),
+			payloadConfig: config.PayloadConfig{OverrideRaw: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
+				Params: map[string]any{"tools": `[{"type":"advisor_20260301","name":"advisor"}]`},
+			}}},
+		},
+		{
+			name:    "remove advisor",
+			payload: []byte(`{"model":"claude-fable-5","tools":[{"type":"advisor_20260301","name":"advisor"}],"messages":[{"role":"user","content":"question"}]}`),
+			payloadConfig: config.PayloadConfig{Filter: []config.PayloadFilterRule{{
+				Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
+				Params: []string{"tools"},
+			}}},
+		},
+	}
+	for _, tc := range cases {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", tc.name, stream), func(t *testing.T) {
+				hook.Reset()
+				executor := NewClaudeExecutor(&config.Config{Payload: tc.payloadConfig})
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key", "cloak_mode": "always"}}
+				req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: tc.payload}
+				opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+				var err error
+				if stream {
+					_, err = executor.ExecuteStream(context.Background(), auth, req, opts)
+				} else {
+					_, err = executor.Execute(context.Background(), auth, req, opts)
+				}
+				requestErr, ok := err.(statusErr)
+				if !ok || requestErr.code != http.StatusBadRequest || requestErr.msg != claudeAdvisorRuleStateError {
+					t.Fatalf("error = %#v, want 400 %q", err, claudeAdvisorRuleStateError)
+				}
+				entries := hook.AllEntries()
+				if len(entries) != 1 || entries[0].Level != log.WarnLevel || entries[0].Message != claudeAdvisorRuleStateError {
+					t.Fatalf("warnings = %#v", entries)
+				}
+			})
+		}
+	}
+}
+
+func TestClaudeExecutor_AdvisorCloakOffParityAcrossRealPaths(t *testing.T) {
+	payloads := map[string][]byte{
+		"declaration": []byte(`{"model":"claude-fable-5","system":[{"type":"text","text":"caller system"}],"tools":[{"type":"advisor_20260301","name":"advisor"}],"messages":[{"role":"user","content":"question"},{"role":"system","content":"mid system"}]}`),
+		"history":     []byte(`{"model":"claude-fable-5","system":[{"type":"text","text":"caller system"}],"messages":[{"role":"user","content":"question"},{"role":"system","content":"mid system"},{"role":"assistant","content":[{"type":"server_tool_use","id":"srvtoolu_advisor","name":"advisor","input":{}}]},{"role":"user","content":[{"type":"advisor_tool_result","tool_use_id":"srvtoolu_advisor","content":[{"type":"advisor_redacted_result","encrypted_content":"opaque"}]}]}]}`),
+	}
+	for payloadName, payload := range payloads {
+		for _, strict := range []bool{false, true} {
+			for _, rebuild := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/strict=%t/rebuild=%t", payloadName, strict, rebuild), func(t *testing.T) {
+					casePayload := payload
+					if !rebuild {
+						casePayload = []byte(strings.Replace(string(casePayload), `,{"role":"system","content":"mid system"}`, "", 1))
+					}
+					type observations struct{ execute, stream, upstreamCount, localCount []byte }
+					run := func(mode string) observations {
+						t.Helper()
+						var path string
+						captured := map[string][]byte{}
+						server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							body, _ := io.ReadAll(r.Body)
+							captured[path] = append([]byte(nil), body...)
+							w.Header().Set("Content-Type", "application/json")
+							if strings.Contains(r.URL.Path, "count_tokens") {
+								_, _ = w.Write([]byte(`{"input_tokens":7}`))
+								return
+							}
+							if path == "stream" {
+								w.Header().Set("Content-Type", "text/event-stream")
+								_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+								return
+							}
+							_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":1,"output_tokens":1}}`))
+						}))
+						defer server.Close()
+						auth := &cliproxyauth.Auth{ID: "advisor-parity-" + mode, Attributes: map[string]string{
+							"api_key": "sk-ant-oat-test", "base_url": server.URL, "cloak_mode": mode,
+							"cloak_strict_mode": fmt.Sprintf("%t", strict), "rebuild_mid_system_message": fmt.Sprintf("%t", rebuild),
+						}, Metadata: claudeOAuthTestMetadata()}
+						executor := NewClaudeExecutor(&config.Config{})
+						req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: casePayload}
+						opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+						path = "execute"
+						if _, err := executor.Execute(context.Background(), auth, req, opts); err != nil {
+							t.Fatal(err)
+						}
+						path = "stream"
+						result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+						for chunk := range result.Chunks {
+							if chunk.Err != nil {
+								t.Fatal(chunk.Err)
+							}
+						}
+						path = "upstream"
+						if _, err = executor.countTokensUpstream(context.Background(), auth, req, opts); err != nil {
+							t.Fatal(err)
+						}
+						localAuth := &cliproxyauth.Auth{ID: "advisor-local-" + mode, Attributes: map[string]string{"api_key": "ordinary-key", "base_url": server.URL, "cloak_mode": mode, "cloak_strict_mode": fmt.Sprintf("%t", strict), "rebuild_mid_system_message": fmt.Sprintf("%t", rebuild)}}
+						local, err := executor.CountTokens(context.Background(), localAuth, req, opts)
+						if err != nil {
+							t.Fatal(err)
+						}
+						return observations{captured["execute"], captured["stream"], captured["upstream"], local.Payload}
+					}
+					on, off := run("always"), run("never")
+					for path, pair := range map[string][2][]byte{"execute": {on.execute, off.execute}, "stream": {on.stream, off.stream}, "upstream_count": {on.upstreamCount, off.upstreamCount}, "local_count": {on.localCount, off.localCount}} {
+						if !bytes.Equal(pair[0], pair[1]) {
+							t.Fatalf("%s cloak-on differs from cloak-off\non: %s\noff: %s", path, pair[0], pair[1])
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestClaudeExecutor_AdvisorRuleChangeAllowedWhenWirePolicyIsCloakOff(t *testing.T) {
+	payload := []byte(`{"model":"claude-fable-5","tools":[],"system":[{"type":"text","text":"caller system"}],"messages":[{"role":"user","content":"question"}],"metadata":{"user_id":"{\"device_id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"account_uuid\":\"\",\"session_id\":\"11111111-2222-4333-8444-555555555555\"}"}}`)
+	cfg := &config.Config{Payload: config.PayloadConfig{OverrideRaw: []config.PayloadRule{{
+		Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
+		Params: map[string]any{"tools": `[{"type":"advisor_20260301","name":"advisor"}]`},
+	}}}}
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			run := func(mode string, confirmed bool, withRule bool) []byte {
+				t.Helper()
+				var captured []byte
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					captured, _ = io.ReadAll(r.Body)
+					if stream {
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":1,"output_tokens":1}}`))
+				}))
+				defer server.Close()
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key", "base_url": server.URL, "cloak_mode": mode}}
+				ctx := context.Background()
+				if confirmed {
+					ctx = contextWithGinHeaders(map[string]string{
+						"User-Agent": "claude-cli/2.1.258 (external, cli)", "X-App": "cli", "Anthropic-Beta": "claude-code-20250219",
+					})
+				}
+				runCfg := cfg
+				if !withRule {
+					runCfg = &config.Config{}
+				}
+				executor := NewClaudeExecutor(runCfg)
+				req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: payload}
+				opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+				if stream {
+					result, err := executor.ExecuteStream(ctx, auth, req, opts)
+					if err != nil {
+						t.Fatalf("ExecuteStream(%s, confirmed=%t): %v", mode, confirmed, err)
+					}
+					for chunk := range result.Chunks {
+						if chunk.Err != nil {
+							t.Fatal(chunk.Err)
+						}
+					}
+				} else if _, err := executor.Execute(ctx, auth, req, opts); err != nil {
+					t.Fatalf("Execute(%s, confirmed=%t): %v", mode, confirmed, err)
+				}
+				if withRule && !claudeRequestContainsAdvisorState(captured) {
+					t.Fatalf("payload rule did not inject advisor: %s", captured)
+				}
+				return captured
+			}
+			for _, tc := range []struct {
+				mode      string
+				confirmed bool
+			}{{"never", false}, {"always", true}} {
+				base := run(tc.mode, tc.confirmed, false)
+				want, err := sjson.SetRawBytes(base, "tools", []byte(`[{"type":"advisor_20260301","name":"advisor"}]`))
+				if err != nil {
+					t.Fatal(err)
+				}
+				got := run(tc.mode, tc.confirmed, true)
+				if !bytes.Equal(got, want) {
+					t.Fatalf("%s confirmed=%t rule-applied body differs from cloak-off oracle\ngot: %s\nwant: %s", tc.mode, tc.confirmed, got, want)
 				}
 			}
 		})

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -26,8 +26,6 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
-	log "github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -6516,237 +6514,138 @@ func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) 
 	}
 }
 
-func TestClaudeAdvisorStateDetection(t *testing.T) {
-	for _, payload := range [][]byte{
-		[]byte(`{"tools":[{"type":"advisor_20260301","name":"advisor"}]}`),
-		[]byte(`{"messages":[{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]}]}`),
-		[]byte(`{"messages":[{"role":"user","content":[[{"type":"advisor_tool_result"}]]}]}`),
-	} {
-		if !claudeRequestContainsAdvisorState(payload) {
-			t.Fatalf("advisor state not detected: %s", payload)
-		}
-	}
-	for _, payload := range [][]byte{
-		[]byte(`{"tools":[{"name":"advisor_helper"}]}`),
-		[]byte(`{"tools":[{"type":"custom","name":"advisor"}]}`),
-		[]byte(`{"tools":[{"type":"advisor_20260301","name":"advisor_helper"}]}`),
-	} {
-		if claudeRequestContainsAdvisorState(payload) {
-			t.Fatalf("non-advisor state falsely detected: %s", payload)
+func TestClaudeSignedHistoryBoundaryTypes(t *testing.T) {
+	types := []string{"server_tool_use", "advisor_tool_result", "web_search_tool_result", "web_fetch_tool_result", "code_execution_tool_result", "bash_code_execution_tool_result", "text_editor_code_execution_tool_result"}
+	for _, blockType := range types {
+		payload := []byte(fmt.Sprintf(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":%q}]}]}`, blockType))
+		if got := claudeSignedHistoryBoundary(payload); got != 1 {
+			t.Errorf("%s boundary = %d, want 1", blockType, got)
 		}
 	}
 }
 
-func TestClaudeExecutor_PayloadRuleAdvisorStateChangeFailsClosed(t *testing.T) {
-	logger, hook := logtest.NewNullLogger()
-	standard := log.StandardLogger()
-	oldOutput, oldFormatter, oldLevel, oldHooks := standard.Out, standard.Formatter, standard.Level, standard.Hooks
-	log.SetOutput(logger.Out)
-	log.SetFormatter(logger.Formatter)
-	log.SetLevel(log.WarnLevel)
-	standard.ReplaceHooks(log.LevelHooks{log.WarnLevel: []log.Hook{hook}})
-	t.Cleanup(func() {
-		log.SetOutput(oldOutput)
-		log.SetFormatter(oldFormatter)
-		log.SetLevel(oldLevel)
-		standard.ReplaceHooks(oldHooks)
-	})
-
-	cases := []struct {
-		name          string
-		payload       []byte
-		payloadConfig config.PayloadConfig
-	}{
-		{
-			name:    "inject advisor",
-			payload: []byte(`{"model":"claude-fable-5","messages":[{"role":"user","content":"question"}]}`),
-			payloadConfig: config.PayloadConfig{OverrideRaw: []config.PayloadRule{{
-				Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
-				Params: map[string]any{"tools": `[{"type":"advisor_20260301","name":"advisor"}]`},
-			}}},
-		},
-		{
-			name:    "remove advisor",
-			payload: []byte(`{"model":"claude-fable-5","tools":[{"type":"advisor_20260301","name":"advisor"}],"messages":[{"role":"user","content":"question"}]}`),
-			payloadConfig: config.PayloadConfig{Filter: []config.PayloadFilterRule{{
-				Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
-				Params: []string{"tools"},
-			}}},
-		},
-	}
-	for _, tc := range cases {
-		for _, stream := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/stream=%t", tc.name, stream), func(t *testing.T) {
-				hook.Reset()
-				executor := NewClaudeExecutor(&config.Config{Payload: tc.payloadConfig})
-				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key", "cloak_mode": "always"}}
-				req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: tc.payload}
-				opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
-				var err error
-				if stream {
-					_, err = executor.ExecuteStream(context.Background(), auth, req, opts)
-				} else {
-					_, err = executor.Execute(context.Background(), auth, req, opts)
+func stripClaudeCacheControlForPrefixTest(raw string) string {
+	var walk func(gjson.Result) any
+	walk = func(value gjson.Result) any {
+		if value.IsArray() {
+			out := make([]any, 0, len(value.Array()))
+			for _, item := range value.Array() {
+				out = append(out, walk(item))
+			}
+			return out
+		}
+		if value.IsObject() {
+			out := map[string]any{}
+			value.ForEach(func(key, item gjson.Result) bool {
+				if key.String() != "cache_control" {
+					out[key.String()] = walk(item)
 				}
-				requestErr, ok := err.(statusErr)
-				if !ok || requestErr.code != http.StatusBadRequest || requestErr.msg != claudeAdvisorRuleStateError {
-					t.Fatalf("error = %#v, want 400 %q", err, claudeAdvisorRuleStateError)
-				}
-				entries := hook.AllEntries()
-				if len(entries) != 1 || entries[0].Level != log.WarnLevel || entries[0].Message != claudeAdvisorRuleStateError {
-					t.Fatalf("warnings = %#v", entries)
-				}
+				return true
 			})
+			return out
+		}
+		return value.Value()
+	}
+	encoded, _ := json.Marshal(walk(gjson.Parse(raw)))
+	return string(encoded)
+}
+
+func TestClaudeCloakIsDeterministicFromRawClientHistory(t *testing.T) {
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	matcher := helps.BuildSensitiveWordMatcher([]string{"secret"})
+	rawTurn1 := []byte(`{"model":"claude-opus-5","system":"secret operator","messages":[{"role":"user","content":"s​ecret first"}]}`)
+	cloak := func(payload []byte, strict bool) []byte {
+		payload = checkSystemInstructionsWithSigningModeAt(payload, strict, true, "2.1.258", "cli", "", now)
+		return helps.ObfuscateSensitiveWords(payload, matcher)
+	}
+	for _, strict := range []bool{false, true} {
+		cloaked1 := cloak(rawTurn1, strict)
+		raw1Messages := gjson.GetBytes(rawTurn1, "messages").Array()
+		raw := []string{raw1Messages[0].Raw,
+			`{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]}`,
+			`{"role":"user","content":[{"type":"advisor_tool_result","content":[]}]}`,
+			`{"role":"user","content":"secret follow up"}`}
+		rawTurn2 := []byte(`{"model":"claude-opus-5","system":"secret operator","messages":[]}`)
+		rawTurn2, _ = sjson.SetRawBytes(rawTurn2, "messages", []byte("["+strings.Join(raw, ",")+"]"))
+		cloaked2 := cloak(rawTurn2, strict)
+		prefix1 := gjson.GetBytes(cloaked1, "messages").Array()
+		prefix2 := gjson.GetBytes(cloaked2, "messages").Array()
+		for i := range prefix1 {
+			got, want := stripClaudeCacheControlForPrefixTest(prefix2[i].Raw), stripClaudeCacheControlForPrefixTest(prefix1[i].Raw)
+			if got != want {
+				t.Fatalf("strict=%v message %d differs\n got %s\nwant %s", strict, i, got, want)
+			}
+		}
+		if !strings.Contains(gjson.GetBytes(cloaked1, "messages.0.content.0.text").String(), "# currentDate") || !strings.Contains(gjson.GetBytes(cloaked2, "messages.0.content.0.text").String(), "# currentDate") {
+			t.Fatalf("strict=%v date reminder missing", strict)
+		}
+		if strings.Contains(string(cloaked2), "secret") {
+			t.Fatalf("strict=%v sensitive word leaked", strict)
+		}
+		if seed := claudeBillingFingerprintMessageText(rawTurn2); seed != "secret follow up" {
+			t.Fatalf("strict=%v raw last-user seed = %q", strict, seed)
 		}
 	}
 }
 
-func TestClaudeExecutor_AdvisorCloakOffParityAcrossRealPaths(t *testing.T) {
-	payloads := map[string][]byte{
-		"declaration": []byte(`{"model":"claude-fable-5","system":[{"type":"text","text":"caller system"}],"tools":[{"type":"advisor_20260301","name":"advisor"}],"messages":[{"role":"user","content":"question"},{"role":"system","content":"mid system"}]}`),
-		"history":     []byte(`{"model":"claude-fable-5","system":[{"type":"text","text":"caller system"}],"messages":[{"role":"user","content":"question"},{"role":"system","content":"mid system"},{"role":"assistant","content":[{"type":"server_tool_use","id":"srvtoolu_advisor","name":"advisor","input":{}}]},{"role":"user","content":[{"type":"advisor_tool_result","tool_use_id":"srvtoolu_advisor","content":[{"type":"advisor_redacted_result","encrypted_content":"opaque"}]}]}]}`),
+func TestClaudeBoundaryBoundsOnlyMidSystemRebuild(t *testing.T) {
+	payload := []byte(`{"system":"operator","messages":[{"role":"user","content":"first"},{"role":"system","content":"before"},{"role":"assistant","content":[{"type":"server_tool_use"}]},{"role":"system","content":"after"},{"role":"user","content":"last"}]}`)
+	rebuilt := rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(payload, false)
+	messages := gjson.GetBytes(rebuilt, "messages").Array()
+	if messages[1].Get("role").String() != "system" {
+		t.Fatal("pre-boundary system turn moved")
 	}
-	for payloadName, payload := range payloads {
-		for _, strict := range []bool{false, true} {
-			for _, rebuild := range []bool{false, true} {
-				t.Run(fmt.Sprintf("%s/strict=%t/rebuild=%t", payloadName, strict, rebuild), func(t *testing.T) {
-					casePayload := payload
-					if !rebuild {
-						casePayload = []byte(strings.Replace(string(casePayload), `,{"role":"system","content":"mid system"}`, "", 1))
-					}
-					type observations struct{ execute, stream, upstreamCount, localCount []byte }
-					run := func(mode string) observations {
-						t.Helper()
-						var path string
-						captured := map[string][]byte{}
-						server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							body, _ := io.ReadAll(r.Body)
-							captured[path] = append([]byte(nil), body...)
-							w.Header().Set("Content-Type", "application/json")
-							if strings.Contains(r.URL.Path, "count_tokens") {
-								_, _ = w.Write([]byte(`{"input_tokens":7}`))
-								return
-							}
-							if path == "stream" {
-								w.Header().Set("Content-Type", "text/event-stream")
-								_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
-								return
-							}
-							_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":1,"output_tokens":1}}`))
-						}))
-						defer server.Close()
-						auth := &cliproxyauth.Auth{ID: "advisor-parity-" + mode, Attributes: map[string]string{
-							"api_key": "sk-ant-oat-test", "base_url": server.URL, "cloak_mode": mode,
-							"cloak_strict_mode": fmt.Sprintf("%t", strict), "rebuild_mid_system_message": fmt.Sprintf("%t", rebuild),
-						}, Metadata: claudeOAuthTestMetadata()}
-						executor := NewClaudeExecutor(&config.Config{})
-						req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: casePayload}
-						opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
-						path = "execute"
-						if _, err := executor.Execute(context.Background(), auth, req, opts); err != nil {
-							t.Fatal(err)
-						}
-						path = "stream"
-						result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
-						if err != nil {
-							t.Fatal(err)
-						}
-						for chunk := range result.Chunks {
-							if chunk.Err != nil {
-								t.Fatal(chunk.Err)
-							}
-						}
-						path = "upstream"
-						if _, err = executor.countTokensUpstream(context.Background(), auth, req, opts); err != nil {
-							t.Fatal(err)
-						}
-						localAuth := &cliproxyauth.Auth{ID: "advisor-local-" + mode, Attributes: map[string]string{"api_key": "ordinary-key", "base_url": server.URL, "cloak_mode": mode, "cloak_strict_mode": fmt.Sprintf("%t", strict), "rebuild_mid_system_message": fmt.Sprintf("%t", rebuild)}}
-						local, err := executor.CountTokens(context.Background(), localAuth, req, opts)
-						if err != nil {
-							t.Fatal(err)
-						}
-						return observations{captured["execute"], captured["stream"], captured["upstream"], local.Payload}
-					}
-					on, off := run("always"), run("never")
-					for path, pair := range map[string][2][]byte{"execute": {on.execute, off.execute}, "stream": {on.stream, off.stream}, "upstream_count": {on.upstreamCount, off.upstreamCount}, "local_count": {on.localCount, off.localCount}} {
-						if !bytes.Equal(pair[0], pair[1]) {
-							t.Fatalf("%s cloak-on differs from cloak-off\non: %s\noff: %s", path, pair[0], pair[1])
-						}
-					}
-				})
-			}
-		}
+	if messages[3].Get("role").String() != "system" || messages[3].Get("content.0.text").String() != "after" {
+		t.Fatal("post-boundary system turn did not remain canonicalized in suffix")
 	}
 }
 
-func TestClaudeExecutor_AdvisorRuleChangeAllowedWhenWirePolicyIsCloakOff(t *testing.T) {
-	payload := []byte(`{"model":"claude-fable-5","tools":[],"system":[{"type":"text","text":"caller system"}],"messages":[{"role":"user","content":"question"}],"metadata":{"user_id":"{\"device_id\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"account_uuid\":\"\",\"session_id\":\"11111111-2222-4333-8444-555555555555\"}"}}`)
-	cfg := &config.Config{Payload: config.PayloadConfig{OverrideRaw: []config.PayloadRule{{
-		Models: []config.PayloadModelRule{{Name: "claude-fable-5", Protocol: "claude"}},
-		Params: map[string]any{"tools": `[{"type":"advisor_20260301","name":"advisor"}]`},
-	}}}}
-	for _, stream := range []bool{false, true} {
-		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
-			run := func(mode string, confirmed bool, withRule bool) []byte {
-				t.Helper()
-				var captured []byte
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					captured, _ = io.ReadAll(r.Body)
-					if stream {
-						w.Header().Set("Content-Type", "text/event-stream")
-						_, _ = w.Write([]byte("data: {\"type\":\"message_stop\"}\n\n"))
-						return
-					}
-					w.Header().Set("Content-Type", "application/json")
-					_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[],"usage":{"input_tokens":1,"output_tokens":1}}`))
-				}))
-				defer server.Close()
-				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key", "base_url": server.URL, "cloak_mode": mode}}
-				ctx := context.Background()
-				if confirmed {
-					ctx = contextWithGinHeaders(map[string]string{
-						"User-Agent": "claude-cli/2.1.258 (external, cli)", "X-App": "cli", "Anthropic-Beta": "claude-code-20250219",
-					})
-				}
-				runCfg := cfg
-				if !withRule {
-					runCfg = &config.Config{}
-				}
-				executor := NewClaudeExecutor(runCfg)
-				req := cliproxyexecutor.Request{Model: "claude-fable-5", Payload: payload}
-				opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
-				if stream {
-					result, err := executor.ExecuteStream(ctx, auth, req, opts)
-					if err != nil {
-						t.Fatalf("ExecuteStream(%s, confirmed=%t): %v", mode, confirmed, err)
-					}
-					for chunk := range result.Chunks {
-						if chunk.Err != nil {
-							t.Fatal(chunk.Err)
-						}
-					}
-				} else if _, err := executor.Execute(ctx, auth, req, opts); err != nil {
-					t.Fatalf("Execute(%s, confirmed=%t): %v", mode, confirmed, err)
-				}
-				if withRule && !claudeRequestContainsAdvisorState(captured) {
-					t.Fatalf("payload rule did not inject advisor: %s", captured)
-				}
-				return captured
+func TestClaudeExecutor_LocalCountTokensRebuildsSystemBeforeSignedBlock(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"rebuild_mid_system_message": "true"}}
+	payload := []byte(`{"system":"Top","messages":[{"role":"user","content":"hello"},{"role":"system","content":"Mid"},{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]},{"role":"user","content":[{"type":"advisor_tool_result","content":[]}]}]}`)
+	resp, err := executor.CountTokens(context.Background(), auth, cliproxyexecutor.Request{Model: "claude-sonnet-4-5", Payload: payload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "input_tokens").Int(); got <= 0 {
+		t.Fatalf("input_tokens = %d, want positive", got)
+	}
+}
+
+func TestClaudeBoundedRebuildCanonicalizesRetainedSystemString(t *testing.T) {
+	rawTurn1 := []byte(`{"model":"claude-opus-5","system":"top","messages":[{"role":"user","content":"first"},{"role":"system","content":"mid"}]}`)
+	turn1 := rebuildMidSystemMessagesToTopLevel(rawTurn1)
+	turn1 = checkSystemInstructionsWithSigningModeAt(turn1, false, true, "2.1.258", "cli", "", time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC))
+	want := gjson.GetBytes(turn1, "messages.2").Raw
+
+	rawTurn2 := []byte(`{"model":"claude-opus-5","system":"top","messages":[{"role":"user","content":"first"},{"role":"system","content":"mid"},{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]},{"role":"user","content":[{"type":"advisor_tool_result","content":[]}]},{"role":"user","content":"follow up"}]}`)
+	turn2 := rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(rawTurn2, false)
+	got := gjson.GetBytes(turn2, "messages.1").Raw
+	if got != want {
+		t.Fatalf("bounded rebuild representation differs\n got %s\nwant %s", got, want)
+	}
+	if gjson.GetBytes(turn2, "messages.1.role").String() != "system" {
+		t.Fatal("pre-boundary system turn was relocated")
+	}
+}
+
+func TestClaudeBoundedRebuildKeepsPostBoundarySystemInSuffix(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"server_tool_use","name":"advisor"}]},{"role":"user","content":[{"type":"advisor_tool_result","content":[]}]},{"role":"system","content":"suffix rule"},{"role":"user","content":"follow up"}]}`)
+	for _, strict := range []bool{false, true} {
+		got := rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(payload, strict)
+		if gjson.GetBytes(got, "messages.1.content.0.type").String() != "server_tool_use" {
+			t.Fatalf("strict=%v signed prefix moved", strict)
+		}
+		system := gjson.GetBytes(got, `messages.#(role=="system")`)
+		if strict {
+			if system.Exists() {
+				t.Fatal("strict rebuild retained post-boundary system turn")
 			}
-			for _, tc := range []struct {
-				mode      string
-				confirmed bool
-			}{{"never", false}, {"always", true}} {
-				base := run(tc.mode, tc.confirmed, false)
-				want, err := sjson.SetRawBytes(base, "tools", []byte(`[{"type":"advisor_20260301","name":"advisor"}]`))
-				if err != nil {
-					t.Fatal(err)
-				}
-				got := run(tc.mode, tc.confirmed, true)
-				if !bytes.Equal(got, want) {
-					t.Fatalf("%s confirmed=%t rule-applied body differs from cloak-off oracle\ngot: %s\nwant: %s", tc.mode, tc.confirmed, got, want)
-				}
+		} else {
+			if !system.Exists() || system.Get("content.0.text").String() != "suffix rule" {
+				t.Fatalf("suffix system missing or misplaced: %s", gjson.GetBytes(got, "messages").Raw)
 			}
-		})
+		}
 	}
 }

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -151,7 +151,8 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 		return cliproxyexecutor.Response{}, errThinking
 	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
-		body = rebuildMidSystemMessagesToTopLevel(body)
+		_, rebuildSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+		body = rebuildMidSystemMessagesToTopLevelPreservingSignedPrefix(body, rebuildSettings.strictMode)
 	}
 
 	directAnthropic := isAnthropicUpstreamBase(baseURL)
@@ -161,7 +162,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	// so its tokens stay counted, and obfuscate sensitive words exactly like the
 	// Messages path. Kimi opt-in uses the same contract.
 	policy, settings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	cloaked := policy.Cloak && !claudeRequestContainsAdvisorState(body)
+	cloaked := policy.Cloak
 	if cloaked {
 		if !settings.strictMode {
 			if errSystem := validateClaudeCallerSystemBlocks(gjson.GetBytes(body, "system")); errSystem != nil {

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -161,7 +161,7 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	// so its tokens stay counted, and obfuscate sensitive words exactly like the
 	// Messages path. Kimi opt-in uses the same contract.
 	policy, settings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	cloaked := policy.Cloak
+	cloaked := policy.Cloak && !claudeRequestContainsAdvisorState(body)
 	if cloaked {
 		if !settings.strictMode {
 			if errSystem := validateClaudeCallerSystemBlocks(gjson.GetBytes(body, "system")); errSystem != nil {


### PR DESCRIPTION
Fixes #5470

Cloaking rewrote conversation history on every request: once a history held a signed server-tool block (advisor results, web search, web fetch, code execution), those rewrites changed the bytes beneath the signature and Anthropic rejected the replay with 400 "Advisor tool result content could not be processed".

This keeps the cloak fully on (headers, fingerprint, betas, identity, CCH, positional system disguise) and makes it prefix-stable: message content before the last signed block is never modified. Concretely, current-date injection is frozen once signed history exists, mid-system rebuild relocates only system turns after the boundary, sensitive-word obfuscation restores the raw signed prefix, and the billing fingerprint is seeded from the first user turn (with cloak-inserted zero-width characters stripped) so it does not drift per follow-up. Requests without signed history are byte-identical to before. count_tokens follows the same boundary.

Rolling cache_control markers are left native: Claude Code itself moves them as history grows, and they are excluded from the stability invariant. Verified empirically: a captured production request that reproduces the 400 on the previous build returns 200 on this build, and a live 3-turn advisor conversation with cloaking on replays cleanly.

Tests: three-turn exact-prefix oracle over the real executor paths, boundary-disabled positive control, UTC date-rollover control, before/after-boundary relocation and obfuscation, all known signed block types, no-boundary parity including a literal zero-width-space input.



Note on history: this PR is two commits; the first (route advisor-bound requests through the cloak-off pipeline) is superseded by the second, and the net diff is the prefix-stable fix described above. Revert both together or neither — reverting only the second reinstates the cloak-off routing.
