### PR TITLE
feat(usage): expose gateway-measured tokens_per_second on inference responses

### DIFF
--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -28,6 +28,7 @@ var corsExposedResponseHeaders = []string{
 	"Retry-After",
 	"X-Request-Id",
 	"OpenAI-Request-Id",
+	"X-CLIProxyAPI-Tokens-Per-Second",
 }
 
 var corsExposedResponseHeadersJoined = strings.Join(corsExposedResponseHeaders, ", ")

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -181,6 +181,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 		RequestedAt:     record.RequestedAt,
 		Latency:         record.Latency,
 		TTFT:            record.TTFT,
+		TokensPerSecond: record.TokensPerSecond,
 		Failed:          record.Failed,
 		Failure: pluginapi.UsageFailure{
 			StatusCode: record.Fail.StatusCode,

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -107,6 +107,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		Timestamp:       timestamp,
 		LatencyMs:       record.Latency.Milliseconds(),
 		TTFTMs:          record.TTFT.Milliseconds(),
+		TokensPerSecond: record.TokensPerSecond,
 		Source:          record.Source,
 		AuthIndex:       record.AuthIndex,
 		AccessTokenHash: record.AccessTokenSHA256,
@@ -168,6 +169,7 @@ type requestDetail struct {
 	Timestamp       time.Time   `json:"timestamp"`
 	LatencyMs       int64       `json:"latency_ms"`
 	TTFTMs          int64       `json:"ttft_ms"`
+	TokensPerSecond float64     `json:"tokens_per_second,omitempty"`
 	Source          string      `json:"source"`
 	AuthIndex       string      `json:"auth_index"`
 	AccessTokenHash string      `json:"access_token_sha256,omitempty"`

--- a/internal/runtime/executor/helps/chat_ttft_helpers_test.go
+++ b/internal/runtime/executor/helps/chat_ttft_helpers_test.go
@@ -24,14 +24,18 @@ func TestIsChatTokenEventRejectsMultilineFragments(t *testing.T) {
 }
 
 func TestObserveChatTokenEventUsesAssembledFrameNotFragments(t *testing.T) {
-	reporter := &UsageReporter{}
+	// Controllable clock avoids wall-clock Sleep / CI timer flakiness (AGENTS.md).
+	now := time.Unix(1_700_000_000, 0)
+	reporter := &UsageReporter{
+		nowFunc: func() time.Time { return now },
+	}
 	reporter.StartResponseTTFT()
-	time.Sleep(5 * time.Millisecond)
 
 	frag1 := []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[`)
 	frag2 := []byte(`data: {"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`)
 	assembled := []byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[\n{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}")
 
+	now = now.Add(5 * time.Millisecond)
 	ObserveChatTokenEvent(reporter, frag1)
 	ObserveChatTokenEvent(reporter, frag2)
 	if reporter.IsTTFTSet() {
@@ -41,13 +45,19 @@ func TestObserveChatTokenEventUsesAssembledFrameNotFragments(t *testing.T) {
 		t.Fatalf("fragment observation should record first-packet fallback")
 	}
 	fallback := reporter.ttftDuration()
+	if fallback != 5*time.Millisecond {
+		t.Fatalf("first-packet fallback = %v, want 5ms", fallback)
+	}
 
-	time.Sleep(10 * time.Millisecond)
+	now = now.Add(10 * time.Millisecond)
 	ObserveChatTokenEvent(reporter, assembled)
 	if !reporter.IsTTFTSet() {
 		t.Fatalf("assembled frame must set effective TTFT")
 	}
 	tokenTTFT := reporter.ttftDuration()
+	if tokenTTFT != 15*time.Millisecond {
+		t.Fatalf("token TTFT = %v, want 15ms", tokenTTFT)
+	}
 	if tokenTTFT <= fallback {
 		t.Fatalf("token TTFT %v should be later than first-packet fallback %v", tokenTTFT, fallback)
 	}

--- a/internal/runtime/executor/helps/chat_ttft_helpers_test.go
+++ b/internal/runtime/executor/helps/chat_ttft_helpers_test.go
@@ -1,0 +1,54 @@
+package helps
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsChatTokenEventRejectsMultilineFragments(t *testing.T) {
+	// Split across a JSON array element boundary so joining with "\n" stays valid JSON,
+	// but neither fragment alone is a recognizable chat token event.
+	frag1 := []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[`)
+	frag2 := []byte(`data: {"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`)
+	assembled := []byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[\n{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}")
+
+	if IsChatTokenEvent(frag1) {
+		t.Fatalf("fragment 1 must not be treated as a token event")
+	}
+	if IsChatTokenEvent(frag2) {
+		t.Fatalf("fragment 2 must not be treated as a token event")
+	}
+	if !IsChatTokenEvent(assembled) {
+		t.Fatalf("assembled multiline SSE frame must be a token event")
+	}
+}
+
+func TestObserveChatTokenEventUsesAssembledFrameNotFragments(t *testing.T) {
+	reporter := &UsageReporter{}
+	reporter.StartResponseTTFT()
+	time.Sleep(5 * time.Millisecond)
+
+	frag1 := []byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[`)
+	frag2 := []byte(`data: {"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`)
+	assembled := []byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[\n{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}")
+
+	ObserveChatTokenEvent(reporter, frag1)
+	ObserveChatTokenEvent(reporter, frag2)
+	if reporter.IsTTFTSet() {
+		t.Fatalf("fragment observation must not set effective TTFT")
+	}
+	if !reporter.IsFirstPacketSet() {
+		t.Fatalf("fragment observation should record first-packet fallback")
+	}
+	fallback := reporter.ttftDuration()
+
+	time.Sleep(10 * time.Millisecond)
+	ObserveChatTokenEvent(reporter, assembled)
+	if !reporter.IsTTFTSet() {
+		t.Fatalf("assembled frame must set effective TTFT")
+	}
+	tokenTTFT := reporter.ttftDuration()
+	if tokenTTFT <= fallback {
+		t.Fatalf("token TTFT %v should be later than first-packet fallback %v", tokenTTFT, fallback)
+	}
+}

--- a/internal/runtime/executor/helps/tokens_per_second.go
+++ b/internal/runtime/executor/helps/tokens_per_second.go
@@ -10,7 +10,18 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-const tokensPerSecondHeader = "X-CLIProxyAPI-Tokens-Per-Second"
+// TokensPerSecondHeader is the gateway-generated generation throughput header.
+// Handlers copy it to clients even when passthrough-headers is false.
+const TokensPerSecondHeader = "X-CLIProxyAPI-Tokens-Per-Second"
+
+const tokensPerSecondHeader = TokensPerSecondHeader
+
+var usageObjectPaths = []string{
+	"usage",
+	"response.usage",
+	"usageMetadata",
+	"response.usageMetadata",
+}
 
 func reporterTokensPerSecond(reporter *UsageReporter, outputTokens int64) float64 {
 	if reporter == nil {
@@ -27,6 +38,24 @@ func outputTokensFromUsageNode(node gjson.Result) int64 {
 		}
 	}
 	return 0
+}
+
+func usageNodeFromPayload(payload []byte) gjson.Result {
+	for _, path := range usageObjectPaths {
+		node := gjson.GetBytes(payload, path)
+		if node.Exists() && node.IsObject() {
+			if tokens := outputTokensFromUsageNode(node); tokens > 0 {
+				return node
+			}
+		}
+	}
+	for _, path := range usageObjectPaths {
+		node := gjson.GetBytes(payload, path)
+		if node.Exists() && node.IsObject() {
+			return node
+		}
+	}
+	return gjson.Result{}
 }
 
 func attachTokensPerSecondAt(jsonBody []byte, path string, tps float64) []byte {
@@ -56,21 +85,37 @@ func AttachTokensPerSecond(payload []byte, reporter *UsageReporter) []byte {
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return payload
 	}
-	usageNode := gjson.GetBytes(trimmed, "usage")
-	if !usageNode.Exists() {
-		usageNode = gjson.GetBytes(trimmed, "response.usage")
+	tps := reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNodeFromPayload(trimmed)))
+	updated := trimmed
+	for _, path := range usageObjectPaths {
+		updated = attachTokensPerSecondAt(updated, path, tps)
 	}
-	tps := reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNode))
-	updated := attachTokensPerSecondAt(trimmed, "usage", tps)
-	return attachTokensPerSecondAt(updated, "response.usage", tps)
+	return updated
+}
+
+func jsonPayloadFromSSE(line []byte) []byte {
+	if payload := jsonPayload(line); len(payload) > 0 {
+		return payload
+	}
+	for _, part := range bytes.Split(line, []byte("\n")) {
+		trimmed := bytes.TrimSpace(part)
+		if !bytes.HasPrefix(trimmed, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(trimmed[len("data:"):])
+		if len(data) > 0 && data[0] == '{' {
+			return data
+		}
+	}
+	return nil
 }
 
 // AttachStreamTokensPerSecond patches an SSE data line the same way.
 func AttachStreamTokensPerSecond(line []byte, reporter *UsageReporter) []byte {
-	if reporter == nil || !bytes.Contains(line, []byte(`"usage"`)) {
+	if reporter == nil || !(bytes.Contains(line, []byte(`"usage"`)) || bytes.Contains(line, []byte(`"usageMetadata"`))) {
 		return line
 	}
-	payload := jsonPayload(line)
+	payload := jsonPayloadFromSSE(line)
 	if len(payload) == 0 || payload[0] != '{' {
 		return line
 	}
@@ -78,11 +123,7 @@ func AttachStreamTokensPerSecond(line []byte, reporter *UsageReporter) []byte {
 	if bytes.Equal(updated, payload) {
 		return line
 	}
-	prefix := line[:len(line)-len(payload)]
-	if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data:")) {
-		return append(append([]byte(nil), prefix...), updated...)
-	}
-	return updated
+	return bytes.Replace(line, payload, updated, 1)
 }
 
 func setTokensPerSecondHeader(headers map[string][]string, tps float64) {
@@ -101,9 +142,5 @@ func attachTokensPerSecondHeader(headers map[string][]string, payload []byte, re
 	if reporter == nil {
 		return
 	}
-	usageNode := gjson.GetBytes(payload, "usage")
-	if !usageNode.Exists() {
-		usageNode = gjson.GetBytes(payload, "response.usage")
-	}
-	setTokensPerSecondHeader(headers, reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNode)))
+	setTokensPerSecondHeader(headers, reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNodeFromPayload(payload))))
 }

--- a/internal/runtime/executor/helps/tokens_per_second.go
+++ b/internal/runtime/executor/helps/tokens_per_second.go
@@ -1,0 +1,109 @@
+package helps
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const tokensPerSecondHeader = "X-CLIProxyAPI-Tokens-Per-Second"
+
+func reporterTokensPerSecond(reporter *UsageReporter, outputTokens int64) float64 {
+	if reporter == nil {
+		return 0
+	}
+	return usage.TokensPerSecond(outputTokens, reporter.latency(), reporter.ttftDuration())
+}
+
+func outputTokensFromUsageNode(node gjson.Result) int64 {
+	for _, path := range []string{"completion_tokens", "output_tokens", "candidatesTokenCount"} {
+		value := node.Get(path)
+		if value.Exists() && value.Type != gjson.Null {
+			return value.Int()
+		}
+	}
+	return 0
+}
+
+func attachTokensPerSecondAt(jsonBody []byte, path string, tps float64) []byte {
+	if tps <= 0 {
+		return jsonBody
+	}
+	node := gjson.GetBytes(jsonBody, path)
+	if !node.Exists() || !node.IsObject() {
+		return jsonBody
+	}
+	if node.Get("tokens_per_second").Exists() {
+		return jsonBody
+	}
+	updated, err := sjson.SetBytes(jsonBody, path+".tokens_per_second", tps)
+	if err != nil {
+		return jsonBody
+	}
+	return updated
+}
+
+// AttachTokensPerSecond writes usage.tokens_per_second when TTFT is known.
+func AttachTokensPerSecond(payload []byte, reporter *UsageReporter) []byte {
+	if len(payload) == 0 || reporter == nil {
+		return payload
+	}
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return payload
+	}
+	usageNode := gjson.GetBytes(trimmed, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(trimmed, "response.usage")
+	}
+	tps := reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNode))
+	updated := attachTokensPerSecondAt(trimmed, "usage", tps)
+	return attachTokensPerSecondAt(updated, "response.usage", tps)
+}
+
+// AttachStreamTokensPerSecond patches an SSE data line the same way.
+func AttachStreamTokensPerSecond(line []byte, reporter *UsageReporter) []byte {
+	if reporter == nil || !bytes.Contains(line, []byte(`"usage"`)) {
+		return line
+	}
+	payload := jsonPayload(line)
+	if len(payload) == 0 || payload[0] != '{' {
+		return line
+	}
+	updated := AttachTokensPerSecond(payload, reporter)
+	if bytes.Equal(updated, payload) {
+		return line
+	}
+	prefix := line[:len(line)-len(payload)]
+	if bytes.HasPrefix(bytes.TrimSpace(line), []byte("data:")) {
+		return append(append([]byte(nil), prefix...), updated...)
+	}
+	return updated
+}
+
+func setTokensPerSecondHeader(headers map[string][]string, tps float64) {
+	if headers == nil || tps <= 0 {
+		return
+	}
+	http.Header(headers).Set(tokensPerSecondHeader, fmt.Sprintf("%.3f", tps))
+}
+
+// AttachTokensPerSecondHeader writes X-CLIProxyAPI-Tokens-Per-Second when TTFT is known.
+func AttachTokensPerSecondHeader(headers map[string][]string, payload []byte, reporter *UsageReporter) {
+	attachTokensPerSecondHeader(headers, payload, reporter)
+}
+
+func attachTokensPerSecondHeader(headers map[string][]string, payload []byte, reporter *UsageReporter) {
+	if reporter == nil {
+		return
+	}
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "response.usage")
+	}
+	setTokensPerSecondHeader(headers, reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNode)))
+}

--- a/internal/runtime/executor/helps/tokens_per_second.go
+++ b/internal/runtime/executor/helps/tokens_per_second.go
@@ -2,6 +2,8 @@ package helps
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 
@@ -15,11 +17,46 @@ import (
 const TokensPerSecondHeader = "X-CLIProxyAPI-Tokens-Per-Second"
 
 // TokensPerSecondGatewayMarker marks that TokensPerSecondHeader was set by the
-// gateway (not an upstream). Handlers only forward TPS when this marker is present.
+// gateway (not an upstream). Handlers only forward TPS when this marker is present
+// and carries the process-local GatewayMeasuredTPSMarkerValue (upstream cannot forge it).
 const TokensPerSecondGatewayMarker = "X-CLIProxyAPI-Gateway-Measured-TPS"
 
 const tokensPerSecondHeader = TokensPerSecondHeader
 const tokensPerSecondGatewayMarker = TokensPerSecondGatewayMarker
+
+// gatewayMeasuredTPSMarkerValue is a process-local secret written into
+// TokensPerSecondGatewayMarker. Upstream-supplied marker values never match.
+var gatewayMeasuredTPSMarkerValue = newGatewayMeasuredTPSMarkerValue()
+
+func newGatewayMeasuredTPSMarkerValue() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Extremely unlikely; fall back to a non-empty distinct token.
+		return "gateway-local-tps-marker"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// GatewayMeasuredTPSMarkerValue returns the process-local marker value the gateway
+// writes when it measures tokens/sec. Tests and handlers use this for provenance checks.
+func GatewayMeasuredTPSMarkerValue() string {
+	return gatewayMeasuredTPSMarkerValue
+}
+
+// IsGatewayMeasuredTPSMarker reports whether v is the process-local gateway marker.
+func IsGatewayMeasuredTPSMarker(v string) bool {
+	return v != "" && v == gatewayMeasuredTPSMarkerValue
+}
+
+// StripTokensPerSecondHeaders removes gateway telemetry headers so upstream-supplied
+// TPS / marker pairs cannot establish provenance before the gateway attaches its own.
+func StripTokensPerSecondHeaders(headers http.Header) {
+	if headers == nil {
+		return
+	}
+	headers.Del(tokensPerSecondHeader)
+	headers.Del(tokensPerSecondGatewayMarker)
+}
 
 var usageObjectPaths = []string{
 	"usage",
@@ -136,15 +173,18 @@ func setTokensPerSecondHeader(headers map[string][]string, tps float64) {
 	}
 	h := http.Header(headers)
 	h.Set(tokensPerSecondHeader, fmt.Sprintf("%.3f", tps))
-	h.Set(tokensPerSecondGatewayMarker, "1")
+	h.Set(tokensPerSecondGatewayMarker, gatewayMeasuredTPSMarkerValue)
 }
 
 // AttachTokensPerSecondHeader writes X-CLIProxyAPI-Tokens-Per-Second when TTFT is known.
+// Upstream-supplied TPS/marker headers are stripped first so only a gateway measurement
+// can establish provenance for mergeGatewayTelemetryHeaders.
 func AttachTokensPerSecondHeader(headers map[string][]string, payload []byte, reporter *UsageReporter) {
 	attachTokensPerSecondHeader(headers, payload, reporter)
 }
 
 func attachTokensPerSecondHeader(headers map[string][]string, payload []byte, reporter *UsageReporter) {
+	StripTokensPerSecondHeaders(http.Header(headers))
 	if reporter == nil {
 		return
 	}

--- a/internal/runtime/executor/helps/tokens_per_second.go
+++ b/internal/runtime/executor/helps/tokens_per_second.go
@@ -117,21 +117,39 @@ func attachTokensPerSecondAt(jsonBody []byte, path string, tps float64) []byte {
 	return updated
 }
 
-// AttachTokensPerSecond writes usage.tokens_per_second when TTFT is known.
-func AttachTokensPerSecond(payload []byte, reporter *UsageReporter) []byte {
+// MeasuredTokensPerSecond returns gateway TPS for payload usage using the
+// reporter's current latency/TTFT. Call this before response translation so
+// post-generation gateway work is excluded from the response/header denominator.
+func MeasuredTokensPerSecond(payload []byte, reporter *UsageReporter) float64 {
 	if len(payload) == 0 || reporter == nil {
+		return 0
+	}
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return 0
+	}
+	return reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNodeFromPayload(trimmed)))
+}
+
+// AttachTokensPerSecondRate writes a precomputed tokens_per_second into usage objects.
+func AttachTokensPerSecondRate(payload []byte, tps float64) []byte {
+	if len(payload) == 0 || tps <= 0 {
 		return payload
 	}
 	trimmed := bytes.TrimSpace(payload)
 	if len(trimmed) == 0 || trimmed[0] != '{' {
 		return payload
 	}
-	tps := reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNodeFromPayload(trimmed)))
 	updated := trimmed
 	for _, path := range usageObjectPaths {
 		updated = attachTokensPerSecondAt(updated, path, tps)
 	}
 	return updated
+}
+
+// AttachTokensPerSecond writes usage.tokens_per_second when TTFT is known.
+func AttachTokensPerSecond(payload []byte, reporter *UsageReporter) []byte {
+	return AttachTokensPerSecondRate(payload, MeasuredTokensPerSecond(payload, reporter))
 }
 
 func jsonPayloadFromSSE(line []byte) []byte {
@@ -176,6 +194,14 @@ func setTokensPerSecondHeader(headers map[string][]string, tps float64) {
 	h.Set(tokensPerSecondGatewayMarker, gatewayMeasuredTPSMarkerValue)
 }
 
+// AttachTokensPerSecondHeaderRate writes X-CLIProxyAPI-Tokens-Per-Second from a
+// precomputed rate. Upstream-supplied TPS/marker headers are stripped first so
+// only a gateway measurement can establish provenance for mergeGatewayTelemetryHeaders.
+func AttachTokensPerSecondHeaderRate(headers map[string][]string, tps float64) {
+	StripTokensPerSecondHeaders(http.Header(headers))
+	setTokensPerSecondHeader(headers, tps)
+}
+
 // AttachTokensPerSecondHeader writes X-CLIProxyAPI-Tokens-Per-Second when TTFT is known.
 // Upstream-supplied TPS/marker headers are stripped first so only a gateway measurement
 // can establish provenance for mergeGatewayTelemetryHeaders.
@@ -184,9 +210,5 @@ func AttachTokensPerSecondHeader(headers map[string][]string, payload []byte, re
 }
 
 func attachTokensPerSecondHeader(headers map[string][]string, payload []byte, reporter *UsageReporter) {
-	StripTokensPerSecondHeaders(http.Header(headers))
-	if reporter == nil {
-		return
-	}
-	setTokensPerSecondHeader(headers, reporterTokensPerSecond(reporter, outputTokensFromUsageNode(usageNodeFromPayload(payload))))
+	AttachTokensPerSecondHeaderRate(headers, MeasuredTokensPerSecond(payload, reporter))
 }

--- a/internal/runtime/executor/helps/tokens_per_second.go
+++ b/internal/runtime/executor/helps/tokens_per_second.go
@@ -14,13 +14,19 @@ import (
 // Handlers copy it to clients even when passthrough-headers is false.
 const TokensPerSecondHeader = "X-CLIProxyAPI-Tokens-Per-Second"
 
+// TokensPerSecondGatewayMarker marks that TokensPerSecondHeader was set by the
+// gateway (not an upstream). Handlers only forward TPS when this marker is present.
+const TokensPerSecondGatewayMarker = "X-CLIProxyAPI-Gateway-Measured-TPS"
+
 const tokensPerSecondHeader = TokensPerSecondHeader
+const tokensPerSecondGatewayMarker = TokensPerSecondGatewayMarker
 
 var usageObjectPaths = []string{
 	"usage",
 	"response.usage",
 	"usageMetadata",
 	"response.usageMetadata",
+	"interaction.usage",
 }
 
 func reporterTokensPerSecond(reporter *UsageReporter, outputTokens int64) float64 {
@@ -31,7 +37,7 @@ func reporterTokensPerSecond(reporter *UsageReporter, outputTokens int64) float6
 }
 
 func outputTokensFromUsageNode(node gjson.Result) int64 {
-	for _, path := range []string{"completion_tokens", "output_tokens", "candidatesTokenCount"} {
+	for _, path := range []string{"completion_tokens", "output_tokens", "total_output_tokens", "candidatesTokenCount"} {
 		value := node.Get(path)
 		if value.Exists() && value.Type != gjson.Null {
 			return value.Int()
@@ -66,9 +72,7 @@ func attachTokensPerSecondAt(jsonBody []byte, path string, tps float64) []byte {
 	if !node.Exists() || !node.IsObject() {
 		return jsonBody
 	}
-	if node.Get("tokens_per_second").Exists() {
-		return jsonBody
-	}
+	// Always overwrite upstream-supplied tokens_per_second with the gateway measurement.
 	updated, err := sjson.SetBytes(jsonBody, path+".tokens_per_second", tps)
 	if err != nil {
 		return jsonBody
@@ -130,7 +134,9 @@ func setTokensPerSecondHeader(headers map[string][]string, tps float64) {
 	if headers == nil || tps <= 0 {
 		return
 	}
-	http.Header(headers).Set(tokensPerSecondHeader, fmt.Sprintf("%.3f", tps))
+	h := http.Header(headers)
+	h.Set(tokensPerSecondHeader, fmt.Sprintf("%.3f", tps))
+	h.Set(tokensPerSecondGatewayMarker, "1")
 }
 
 // AttachTokensPerSecondHeader writes X-CLIProxyAPI-Tokens-Per-Second when TTFT is known.

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -11,12 +12,16 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestAttachTokensPerSecondExcludesTTFT(t *testing.T) {
-	reporter := &UsageReporter{
+func ttftReporter() *UsageReporter {
+	return &UsageReporter{
 		requestedAt: time.Now().Add(-5 * time.Second),
 		ttft:        3 * time.Second,
 		ttftSet:     true,
 	}
+}
+
+func TestAttachTokensPerSecondExcludesTTFT(t *testing.T) {
+	reporter := ttftReporter()
 	got := AttachTokensPerSecond([]byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210}}`), reporter)
 	tps := gjson.GetBytes(got, "usage.tokens_per_second").Float()
 	if tps < 99 || tps > 101 {
@@ -35,16 +40,48 @@ func TestAttachTokensPerSecondOmittedWithoutTTFT(t *testing.T) {
 
 func TestTokensPerSecondHeaderFromUsage(t *testing.T) {
 	headers := http.Header{}
-	reporter := &UsageReporter{
-		requestedAt: time.Now().Add(-5 * time.Second),
-		ttft:        3 * time.Second,
-		ttftSet:     true,
-	}
+	reporter := ttftReporter()
 	attachTokensPerSecondHeader(headers, []byte(`{"usage":{"completion_tokens":200}}`), reporter)
 	got := headers.Get(tokensPerSecondHeader)
 	parsed, err := strconv.ParseFloat(got, 64)
 	if err != nil || parsed < 99 || parsed > 101 {
 		t.Fatalf("header = %q, want ~100", got)
+	}
+}
+
+func TestAttachTokensPerSecondFromUsageMetadata(t *testing.T) {
+	reporter := ttftReporter()
+	got := AttachTokensPerSecond([]byte(`{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":200,"totalTokenCount":210}}`), reporter)
+	tps := gjson.GetBytes(got, "usageMetadata.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("usageMetadata.tokens_per_second = %v, want ~100; body=%s", tps, got)
+	}
+}
+
+func TestAttachTokensPerSecondFromWrappedUsageMetadata(t *testing.T) {
+	reporter := ttftReporter()
+	got := AttachTokensPerSecond([]byte(`{"response":{"usageMetadata":{"candidatesTokenCount":200}}}`), reporter)
+	tps := gjson.GetBytes(got, "response.usageMetadata.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("response.usageMetadata.tokens_per_second = %v, want ~100; body=%s", tps, got)
+	}
+}
+
+func TestAttachStreamTokensPerSecondNamedSSEEvent(t *testing.T) {
+	reporter := ttftReporter()
+	line := []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":10,\"output_tokens\":200}}\n")
+	got := AttachStreamTokensPerSecond(line, reporter)
+	if !bytes.Contains(got, []byte("event: message_delta")) {
+		t.Fatalf("lost SSE event name: %s", got)
+	}
+	dataIdx := bytes.Index(got, []byte("data:"))
+	if dataIdx < 0 {
+		t.Fatalf("lost data line: %s", got)
+	}
+	payload := bytes.TrimSpace(got[dataIdx+len("data:"):])
+	tps := gjson.GetBytes(payload, "usage.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("named SSE tokens_per_second = %v, want ~100; body=%s", tps, got)
 	}
 }
 

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -3,6 +3,7 @@ package helps
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -40,8 +41,10 @@ func TestTokensPerSecondHeaderFromUsage(t *testing.T) {
 		ttftSet:     true,
 	}
 	attachTokensPerSecondHeader(headers, []byte(`{"usage":{"completion_tokens":200}}`), reporter)
-	if headers.Get(tokensPerSecondHeader) != "100.000" {
-		t.Fatalf("header = %q", headers.Get(tokensPerSecondHeader))
+	got := headers.Get(tokensPerSecondHeader)
+	parsed, err := strconv.ParseFloat(got, 64)
+	if err != nil || parsed < 99 || parsed > 101 {
+		t.Fatalf("header = %q, want ~100", got)
 	}
 }
 

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -1,0 +1,61 @@
+package helps
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+func TestAttachTokensPerSecondExcludesTTFT(t *testing.T) {
+	reporter := &UsageReporter{
+		requestedAt: time.Now().Add(-5 * time.Second),
+		ttft:        3 * time.Second,
+		ttftSet:     true,
+	}
+	got := AttachTokensPerSecond([]byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210}}`), reporter)
+	tps := gjson.GetBytes(got, "usage.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("tokens_per_second = %v, want ~100", tps)
+	}
+}
+
+func TestAttachTokensPerSecondOmittedWithoutTTFT(t *testing.T) {
+	reporter := &UsageReporter{requestedAt: time.Now().Add(-5 * time.Second)}
+	raw := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210}}`)
+	got := AttachTokensPerSecond(raw, reporter)
+	if gjson.GetBytes(got, "usage.tokens_per_second").Exists() {
+		t.Fatalf("tok/s must be omitted without TTFT, got %s", got)
+	}
+}
+
+func TestTokensPerSecondHeaderFromUsage(t *testing.T) {
+	headers := http.Header{}
+	reporter := &UsageReporter{
+		requestedAt: time.Now().Add(-5 * time.Second),
+		ttft:        3 * time.Second,
+		ttftSet:     true,
+	}
+	attachTokensPerSecondHeader(headers, []byte(`{"usage":{"completion_tokens":200}}`), reporter)
+	if headers.Get(tokensPerSecondHeader) != "100.000" {
+		t.Fatalf("header = %q", headers.Get(tokensPerSecondHeader))
+	}
+}
+
+func TestUsageRecordTokensPerSecondJSON(t *testing.T) {
+	record := usage.Record{
+		Detail:          usage.Detail{OutputTokens: 50},
+		Latency:         2 * time.Second,
+		TTFT:            1 * time.Second,
+		TokensPerSecond: usage.TokensPerSecond(50, 2*time.Second, 1*time.Second),
+	}
+	if record.TokensPerSecond != 50 {
+		t.Fatalf("TokensPerSecond = %v, want 50", record.TokensPerSecond)
+	}
+	if _, err := json.Marshal(record); err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+}

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -155,3 +155,36 @@ func TestAttachTokensPerSecondHeaderStripsUpstreamForgedMarker(t *testing.T) {
 		t.Fatalf("upstream forged TPS/marker survived attach: %#v", headers)
 	}
 }
+
+func TestMeasuredTokensPerSecondFrozenAcrossPostGenerationDelay(t *testing.T) {
+	reporter := &UsageReporter{
+		upstreamStartedAt: time.Now().Add(-5 * time.Second),
+		ttft:              3 * time.Second,
+		ttftSet:           true,
+	}
+	raw := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210}}`)
+	tps := MeasuredTokensPerSecond(raw, reporter)
+	if tps < 99 || tps > 101 {
+		t.Fatalf("snapshot tokens_per_second = %v, want ~100", tps)
+	}
+	time.Sleep(200 * time.Millisecond)
+	later := MeasuredTokensPerSecond(raw, reporter)
+	if later >= tps {
+		t.Fatalf("live remeasure should drop after post-generation delay: early=%v later=%v", tps, later)
+	}
+	translated := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210,"output_tokens":200}}`)
+	gotPayload := AttachTokensPerSecondRate(translated, tps)
+	got := gjson.GetBytes(gotPayload, "usage.tokens_per_second").Float()
+	if got != tps {
+		t.Fatalf("attached rate %v != snapshot %v", got, tps)
+	}
+	headers := http.Header{}
+	AttachTokensPerSecondHeaderRate(headers, tps)
+	parsed, err := strconv.ParseFloat(headers.Get(tokensPerSecondHeader), 64)
+	if err != nil || parsed < 99 || parsed > 101 {
+		t.Fatalf("header = %q, want ~100 from snapshot", headers.Get(tokensPerSecondHeader))
+	}
+	if headers.Get(tokensPerSecondGatewayMarker) != GatewayMeasuredTPSMarkerValue() {
+		t.Fatalf("missing gateway marker")
+	}
+}

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -139,7 +139,19 @@ func TestAttachTokensPerSecondHeaderSetsGatewayMarker(t *testing.T) {
 	if headers.Get(tokensPerSecondHeader) == "" {
 		t.Fatal("missing TPS header")
 	}
-	if headers.Get(tokensPerSecondGatewayMarker) != "1" {
+	if headers.Get(tokensPerSecondGatewayMarker) != GatewayMeasuredTPSMarkerValue() {
 		t.Fatalf("missing gateway marker: %#v", headers)
+	}
+}
+
+func TestAttachTokensPerSecondHeaderStripsUpstreamForgedMarker(t *testing.T) {
+	headers := http.Header{
+		tokensPerSecondHeader:        []string{"999.000"},
+		tokensPerSecondGatewayMarker: []string{"1"},
+	}
+	// No TTFT => strip only; do not re-attach a gateway measurement.
+	attachTokensPerSecondHeader(headers, []byte(`{"usage":{"completion_tokens":200}}`), &UsageReporter{})
+	if headers.Get(tokensPerSecondHeader) != "" || headers.Get(tokensPerSecondGatewayMarker) != "" {
+		t.Fatalf("upstream forged TPS/marker survived attach: %#v", headers)
 	}
 }

--- a/internal/runtime/executor/helps/tokens_per_second_test.go
+++ b/internal/runtime/executor/helps/tokens_per_second_test.go
@@ -99,3 +99,47 @@ func TestUsageRecordTokensPerSecondJSON(t *testing.T) {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 }
+
+func TestAttachTokensPerSecondOverwritesUpstreamValue(t *testing.T) {
+	reporter := ttftReporter()
+	got := AttachTokensPerSecond([]byte(`{"usage":{"prompt_tokens":10,"completion_tokens":200,"total_tokens":210,"tokens_per_second":1.5}}`), reporter)
+	tps := gjson.GetBytes(got, "usage.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("tokens_per_second = %v, want gateway ~100 overwriting upstream 1.5; body=%s", tps, got)
+	}
+}
+
+func TestAttachTokensPerSecondFromInteractionUsage(t *testing.T) {
+	reporter := ttftReporter()
+	got := AttachTokensPerSecond([]byte(`{"type":"interaction.completed","interaction":{"usage":{"input_tokens":10,"output_tokens":200,"total_output_tokens":200}}}`), reporter)
+	tps := gjson.GetBytes(got, "interaction.usage.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("interaction.usage.tokens_per_second = %v, want ~100; body=%s", tps, got)
+	}
+}
+
+func TestAttachStreamTokensPerSecondInteractionCompleted(t *testing.T) {
+	reporter := ttftReporter()
+	line := []byte("event: interaction.completed\ndata: {\"type\":\"interaction.completed\",\"interaction\":{\"usage\":{\"output_tokens\":200,\"total_output_tokens\":200}}}\n")
+	got := AttachStreamTokensPerSecond(line, reporter)
+	dataIdx := bytes.Index(got, []byte("data:"))
+	if dataIdx < 0 {
+		t.Fatalf("lost data line: %s", got)
+	}
+	payload := bytes.TrimSpace(got[dataIdx+len("data:"):])
+	tps := gjson.GetBytes(payload, "interaction.usage.tokens_per_second").Float()
+	if tps < 99 || tps > 101 {
+		t.Fatalf("interaction stream tokens_per_second = %v, want ~100; body=%s", tps, got)
+	}
+}
+
+func TestAttachTokensPerSecondHeaderSetsGatewayMarker(t *testing.T) {
+	headers := http.Header{}
+	attachTokensPerSecondHeader(headers, []byte(`{"usage":{"completion_tokens":200}}`), ttftReporter())
+	if headers.Get(tokensPerSecondHeader) == "" {
+		t.Fatal("missing TPS header")
+	}
+	if headers.Get(tokensPerSecondGatewayMarker) != "1" {
+		t.Fatalf("missing gateway marker: %#v", headers)
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -43,6 +43,7 @@ type UsageReporter struct {
 	generate            bool
 	stream              bool
 	requestedAt         time.Time
+	upstreamStartedAt   time.Time
 	ttftMu              sync.RWMutex
 	ttft                time.Duration
 	firstPacketDuration time.Duration
@@ -265,9 +266,13 @@ func (r *UsageReporter) StartResponseTTFT() {
 	if r == nil {
 		return
 	}
+	now := time.Now()
 	r.ttftMu.Lock()
+	if r.upstreamStartedAt.IsZero() {
+		r.upstreamStartedAt = now
+	}
 	if !r.ttftSet && r.ttftStart.IsZero() {
-		r.ttftStart = time.Now()
+		r.ttftStart = now
 	}
 	r.ttftMu.Unlock()
 }
@@ -498,10 +503,19 @@ func failFromErrors(errs ...error) usage.Failure {
 }
 
 func (r *UsageReporter) latency() time.Duration {
-	if r == nil || r.requestedAt.IsZero() {
+	if r == nil {
 		return 0
 	}
-	latency := time.Since(r.requestedAt)
+	r.ttftMu.RLock()
+	start := r.upstreamStartedAt
+	r.ttftMu.RUnlock()
+	if start.IsZero() {
+		start = r.requestedAt
+	}
+	if start.IsZero() {
+		return 0
+	}
+	latency := time.Since(start)
 	if latency < 0 {
 		return 0
 	}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -444,7 +444,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 	if r == nil {
 		return usage.Record{Model: model, Detail: detail, Failed: failed, Fail: fail, Generate: usage.GenerateFlag(true)}
 	}
-	return usage.Record{
+	record := usage.Record{
 		Provider:            r.provider,
 		BaseURL:             r.baseURL,
 		ExecutorType:        r.executorType,
@@ -470,6 +470,8 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		Fail:                fail,
 		Detail:              detail,
 	}
+	record.TokensPerSecond = usage.TokensPerSecond(detail.OutputTokens, record.Latency, record.TTFT)
+	return record
 }
 
 func failFromErrors(errs ...error) usage.Failure {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -51,6 +51,14 @@ type UsageReporter struct {
 	ttftStart           time.Time
 	ttftSet             bool
 	once                sync.Once
+	nowFunc             func() time.Time // optional; tests inject a controllable clock
+}
+
+func (r *UsageReporter) now() time.Time {
+	if r != nil && r.nowFunc != nil {
+		return r.nowFunc()
+	}
+	return time.Now()
 }
 
 type usageExecutor interface {
@@ -266,7 +274,7 @@ func (r *UsageReporter) StartResponseTTFT() {
 	if r == nil {
 		return
 	}
-	now := time.Now()
+	now := r.now()
 	r.ttftMu.Lock()
 	if r.upstreamStartedAt.IsZero() {
 		r.upstreamStartedAt = now
@@ -331,11 +339,11 @@ func (r *UsageReporter) ObserveTokenEvent(isToken bool) {
 		return
 	}
 	if !r.firstPacketSet {
-		r.firstPacketDuration = time.Since(start)
+		r.firstPacketDuration = r.now().Sub(start)
 		r.firstPacketSet = true
 	}
 	if isToken {
-		r.ttft = time.Since(start)
+		r.ttft = r.now().Sub(start)
 		r.ttftSet = true
 		r.ttftStart = time.Time{}
 	}
@@ -356,7 +364,7 @@ func (r *UsageReporter) MarkFirstResponseByte() {
 	if start.IsZero() {
 		return
 	}
-	r.setTTFT(time.Since(start))
+	r.setTTFT(r.now().Sub(start))
 }
 
 func (r *UsageReporter) buildAdditionalModelRecord(model string, detail usage.Detail) (usage.Record, bool) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -1179,3 +1179,23 @@ func TestUsageReporterPropagatesBaseURL(t *testing.T) {
 		t.Fatalf("recordNilAuth.BaseURL = %q, want empty", recordNilAuth.BaseURL)
 	}
 }
+
+func TestUsageReporterLatencyAlignsWithTTFTStart(t *testing.T) {
+	reporter := NewUsageReporter(context.Background(), "openai-compat", "gpt-test", nil)
+	reporter.requestedAt = time.Now().Add(-10 * time.Second) // prep time before upstream
+	time.Sleep(5 * time.Millisecond)
+	reporter.StartResponseTTFT()
+	reporter.setTTFT(1 * time.Second)
+	// Simulate end of generation shortly after TTFT window conceptually:
+	// latency() must be measured from upstreamStartedAt, not requestedAt.
+	lat := reporter.latency()
+	if lat >= 9*time.Second {
+		t.Fatalf("latency() = %v still includes prep from requestedAt", lat)
+	}
+	tps := usage.TokensPerSecond(100, lat, reporter.ttftDuration())
+	// With aligned clocks, generation window is latency-ttft; even if small, must not use 10s prep.
+	if lat-reporter.ttftDuration() > 2*time.Second {
+		t.Fatalf("generation window %v too large; latency=%v ttft=%v", lat-reporter.ttftDuration(), lat, reporter.ttftDuration())
+	}
+	_ = tps
+}

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -1183,7 +1183,7 @@ func TestUsageReporterPropagatesBaseURL(t *testing.T) {
 func TestUsageReporterLatencyAlignsWithTTFTStart(t *testing.T) {
 	reporter := NewUsageReporter(context.Background(), "openai-compat", "gpt-test", nil)
 	reporter.requestedAt = time.Now().Add(-10 * time.Second) // prep time before upstream
-	time.Sleep(5 * time.Millisecond)
+	// No wall-clock sleep: requestedAt is already far enough in the past for ordering.
 	reporter.StartResponseTTFT()
 	reporter.setTTFT(1 * time.Second)
 	// Simulate end of generation shortly after TTFT window conceptually:

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -489,8 +489,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			}
 
 			streamLine := append([]byte("data: "), dataPayload...)
-			// Measure TTFT on the assembled SSE frame (joined multiline data:), not raw fragments.
+			// Measure TTFT / usage on the assembled SSE frame (joined multiline data:), not raw fragments.
 			helps.ObserveChatTokenEvent(reporter, streamLine)
+			streamUsage.ObserveOpenAIStream(streamLine)
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
 			for i := range chunks {
 				chunks[i] = helps.AttachStreamTokensPerSecond(chunks[i], reporter)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -206,15 +206,18 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.EnsurePublished(ctx)
+	// Snapshot client-visible TPS from the raw upstream body before translation so
+	// TranslateNonStream / EnsureResponsesUsageDetails do not dilute the denominator.
+	tps := helps.MeasuredTokensPerSecond(body, reporter)
 	// Translate response back to source format when needed
 	var param any
 	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, body, &param)
 	if responseFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
-	out = helps.AttachTokensPerSecond(out, reporter)
+	out = helps.AttachTokensPerSecondRate(out, tps)
 	headers := httpResp.Header.Clone()
-	helps.AttachTokensPerSecondHeader(headers, out, reporter)
+	helps.AttachTokensPerSecondHeaderRate(headers, tps)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: headers}
 	return resp, nil
 }

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -212,7 +212,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	if responseFormat == sdktranslator.FormatOpenAIResponse {
 		out = helps.EnsureResponsesUsageDetails(out)
 	}
-	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	out = helps.AttachTokensPerSecond(out, reporter)
+	headers := httpResp.Header.Clone()
+	helps.AttachTokensPerSecondHeader(headers, out, reporter)
+	resp = cliproxyexecutor.Response{Payload: out, Headers: headers}
 	return resp, nil
 }
 
@@ -485,6 +488,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			streamLine := append([]byte("data: "), dataPayload...)
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
 			for i := range chunks {
+				chunks[i] = helps.AttachStreamTokensPerSecond(chunks[i], reporter)
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
 				case <-ctx.Done():

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -396,7 +396,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpClient = reporter.TrackHTTPClientRoundTripOnly(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
@@ -508,6 +508,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			streamUsage.ObserveOpenAIStream(line)
+			helps.ObserveChatTokenEvent(reporter, line)
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
 				if processFrame() {
@@ -634,7 +635,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
-	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpClient = reporter.TrackHTTPClientRoundTripOnly(httpClient)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, err)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -486,6 +486,8 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			}
 
 			streamLine := append([]byte("data: "), dataPayload...)
+			// Measure TTFT on the assembled SSE frame (joined multiline data:), not raw fragments.
+			helps.ObserveChatTokenEvent(reporter, streamLine)
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
 			for i := range chunks {
 				chunks[i] = helps.AttachStreamTokensPerSecond(chunks[i], reporter)
@@ -508,7 +510,6 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			streamUsage.ObserveOpenAIStream(line)
-			helps.ObserveChatTokenEvent(reporter, line)
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
 				if processFrame() {
@@ -574,7 +575,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		streamUsage.Publish(ctx, reporter)
 		reporter.EnsurePublished(ctx)
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	streamHeaders := httpResp.Header.Clone()
+	helps.StripTokensPerSecondHeaders(streamHeaders)
+	return &cliproxyexecutor.StreamResult{Headers: streamHeaders, Chunks: out}, nil
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -691,7 +694,9 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 			}
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	streamHeaders := httpResp.Header.Clone()
+	helps.StripTokensPerSecondHeaders(streamHeaders)
+	return &cliproxyexecutor.StreamResult{Headers: streamHeaders, Chunks: out}, nil
 }
 
 func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -73,8 +73,20 @@ func TestOpenAICompatExecutorCompactPassthrough(t *testing.T) {
 	if gjson.GetBytes(gotBody, "prompt_cache_key").Exists() {
 		t.Fatalf("unexpected prompt_cache_key in responses compact body: %s", string(gotBody))
 	}
-	if string(resp.Payload) != `{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}` {
-		t.Fatalf("payload = %s", string(resp.Payload))
+	if gjson.GetBytes(resp.Payload, "id").String() != "resp_1" {
+		t.Fatalf("id = %s", string(resp.Payload))
+	}
+	if gjson.GetBytes(resp.Payload, "object").String() != "response.compaction" {
+		t.Fatalf("object = %s", string(resp.Payload))
+	}
+	if gjson.GetBytes(resp.Payload, "usage.input_tokens").Int() != 1 ||
+		gjson.GetBytes(resp.Payload, "usage.output_tokens").Int() != 2 ||
+		gjson.GetBytes(resp.Payload, "usage.total_tokens").Int() != 3 {
+		t.Fatalf("usage tokens mismatch: %s", string(resp.Payload))
+	}
+	// Gateway may attach usage.tokens_per_second; compact passthrough must keep core fields.
+	if !gjson.GetBytes(resp.Payload, "usage.tokens_per_second").Exists() {
+		t.Fatalf("expected gateway tokens_per_second on compact usage: %s", string(resp.Payload))
 	}
 }
 

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1207,23 +1208,49 @@ func TestOpenAICompatExecutorStreamDropsChunksAfterDone(t *testing.T) {
 }
 
 func TestOpenAICompatExecutorStreamMeasuresTTFTAfterMultilineSSEFrame(t *testing.T) {
+	// Coordinate server writes with client consumption so CI load cannot collapse
+	// the content-frame TTFT and the terminal usage frame into the same instant
+	// (which made latency-TTFT near zero and blew up tokens_per_second).
+	contentSeen := make(chan struct{})
+	var contentOnce sync.Once
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		flusher, _ := w.(http.Flusher)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "expected flusher", http.StatusInternalServerError)
+			return
+		}
 		// Split one valid JSON chat chunk across two data: lines at a JSON whitespace boundary.
 		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[\n"))
-		if flusher != nil {
-			flusher.Flush()
-		}
-		time.Sleep(30 * time.Millisecond)
+		flusher.Flush()
+		// Complete the multiline frame immediately — no wall-clock sleep before the client
+		// has started reading. TTFT must be measured on the joined SSE frame, not fragments.
 		_, _ = w.Write([]byte("data: {\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"))
-		if flusher != nil {
-			flusher.Flush()
+		flusher.Flush()
+
+		// Wait until the client has observed the assembled content chunk (TTFT recorded).
+		select {
+		case <-contentSeen:
+		case <-r.Context().Done():
+			return
+		case <-time.After(5 * time.Second):
+			t.Error("timed out waiting for client to observe assembled content chunk")
+			return
 		}
-		time.Sleep(40 * time.Millisecond)
+
+		// Open a generation window only after TTFT is known. Barrier-ordered timer avoids
+		// the prior race where both sleeps elapsed before the client parsed anything.
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-r.Context().Done():
+			return
+		}
+
 		// Terminal usage-only chunk (no finish_reason) — TPS must use TTFT from assembled content.
 		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":200,\"total_tokens\":210}}\n\n"))
 		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
 	}))
 	defer server.Close()
 
@@ -1252,6 +1279,7 @@ func TestOpenAICompatExecutorStreamMeasuresTTFTAfterMultilineSSEFrame(t *testing
 		payload := string(chunk.Payload)
 		if gjson.Get(payload, "choices.0.delta.content").String() == "hello" {
 			sawContent = true
+			contentOnce.Do(func() { close(contentSeen) })
 		}
 		if v := gjson.Get(payload, "usage.tokens_per_second"); v.Exists() {
 			tps = v.Float()

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -12,6 +12,7 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -1202,5 +1203,67 @@ func TestOpenAICompatExecutorStreamDropsChunksAfterDone(t *testing.T) {
 	}
 	if gjson.Get(payloads[1], "choices.0.finish_reason").String() != "stop" {
 		t.Fatalf("second chunk = %s", payloads[1])
+	}
+}
+
+func TestOpenAICompatExecutorStreamMeasuresTTFTAfterMultilineSSEFrame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		// Split one valid JSON chat chunk across two data: lines at a JSON whitespace boundary.
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		time.Sleep(30 * time.Millisecond)
+		_, _ = w.Write([]byte("data: {\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		time.Sleep(40 * time.Millisecond)
+		// Terminal usage-only chunk (no finish_reason) — TPS must use TTFT from assembled content.
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":200,\"total_tokens\":210}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "openrouter-model",
+		Payload: []byte(`{"model":"openrouter-model","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var sawContent bool
+	var tps float64
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		payload := string(chunk.Payload)
+		if gjson.Get(payload, "choices.0.delta.content").String() == "hello" {
+			sawContent = true
+		}
+		if v := gjson.Get(payload, "usage.tokens_per_second"); v.Exists() {
+			tps = v.Float()
+		}
+	}
+	if !sawContent {
+		t.Fatal("expected assembled multiline content chunk")
+	}
+	if tps <= 0 {
+		t.Fatalf("expected gateway tokens_per_second on usage chunk, got %v", tps)
+	}
+	if tps > 1_000_000 {
+		t.Fatalf("tokens_per_second = %v looks like near-zero generation window from wrong TTFT", tps)
 	}
 }

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -307,29 +307,35 @@ func downstreamHeadersAfterInterceptors(baseRaw, finalRaw http.Header, passthrou
 
 // mergeGatewayTelemetryHeaders copies gateway-owned inference telemetry
 // (generation tok/s) even when passthrough-headers is false. Upstream
-// headers stay filtered.
+// headers stay filtered. Only forward TPS when the gateway marker is present
+// so an upstream-supplied X-CLIProxyAPI-Tokens-Per-Second is never trusted.
 func mergeGatewayTelemetryHeaders(dst, src http.Header) http.Header {
 	if src == nil {
 		return dst
 	}
 	const name = "X-CLIProxyAPI-Tokens-Per-Second"
-	canonical := http.CanonicalHeaderKey(name)
-	tps := src.Get(name)
-	if tps == "" {
-		for key, values := range src {
-			if http.CanonicalHeaderKey(key) == canonical && len(values) > 0 && values[0] != "" {
-				tps = values[0]
-				break
-			}
+	const marker = "X-CLIProxyAPI-Gateway-Measured-TPS"
+	markerCanonical := http.CanonicalHeaderKey(marker)
+	nameCanonical := http.CanonicalHeaderKey(name)
+	hasMarker := false
+	tps := ""
+	for key, values := range src {
+		canonical := http.CanonicalHeaderKey(key)
+		if canonical == markerCanonical && len(values) > 0 && values[0] != "" {
+			hasMarker = true
+		}
+		if canonical == nameCanonical && len(values) > 0 && values[0] != "" && tps == "" {
+			tps = values[0]
 		}
 	}
-	if tps == "" {
+	if !hasMarker || tps == "" {
 		return dst
 	}
 	if dst == nil {
 		dst = make(http.Header)
 	}
 	dst.Set(name, tps)
+	dst.Del(marker)
 	return dst
 }
 

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -287,17 +287,50 @@ func finalInterceptorHeaders(current, intercepted http.Header) http.Header {
 }
 
 func downstreamHeadersFromExecutor(headers http.Header, passthrough bool) http.Header {
-	if !passthrough {
-		return nil
+	var out http.Header
+	if passthrough {
+		out = FilterUpstreamHeaders(headers)
 	}
-	return FilterUpstreamHeaders(headers)
+	return mergeGatewayTelemetryHeaders(out, headers)
 }
 
 func downstreamHeadersAfterInterceptors(baseRaw, finalRaw http.Header, passthrough bool) http.Header {
+	var out http.Header
 	if passthrough {
-		return FilterUpstreamHeaders(finalRaw)
+		out = FilterUpstreamHeaders(finalRaw)
+	} else {
+		out = FilterUpstreamHeaders(diffHeaders(baseRaw, finalRaw))
 	}
-	return FilterUpstreamHeaders(diffHeaders(baseRaw, finalRaw))
+	out = mergeGatewayTelemetryHeaders(out, finalRaw)
+	return mergeGatewayTelemetryHeaders(out, baseRaw)
+}
+
+// mergeGatewayTelemetryHeaders copies gateway-owned inference telemetry
+// (generation tok/s) even when passthrough-headers is false. Upstream
+// headers stay filtered.
+func mergeGatewayTelemetryHeaders(dst, src http.Header) http.Header {
+	if src == nil {
+		return dst
+	}
+	const name = "X-CLIProxyAPI-Tokens-Per-Second"
+	canonical := http.CanonicalHeaderKey(name)
+	tps := src.Get(name)
+	if tps == "" {
+		for key, values := range src {
+			if http.CanonicalHeaderKey(key) == canonical && len(values) > 0 && values[0] != "" {
+				tps = values[0]
+				break
+			}
+		}
+	}
+	if tps == "" {
+		return dst
+	}
+	if dst == nil {
+		dst = make(http.Header)
+	}
+	dst.Set(name, tps)
+	return dst
 }
 
 func diffHeaders(base, next http.Header) http.Header {

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	"golang.org/x/net/context"
@@ -307,8 +308,10 @@ func downstreamHeadersAfterInterceptors(baseRaw, finalRaw http.Header, passthrou
 
 // mergeGatewayTelemetryHeaders copies gateway-owned inference telemetry
 // (generation tok/s) even when passthrough-headers is false. Upstream
-// headers stay filtered. Only forward TPS when the gateway marker is present
-// so an upstream-supplied X-CLIProxyAPI-Tokens-Per-Second is never trusted.
+// headers stay filtered. Only forward TPS when the process-local gateway
+// marker value is present so an upstream-supplied
+// X-CLIProxyAPI-Tokens-Per-Second / X-CLIProxyAPI-Gateway-Measured-TPS pair
+// is never trusted.
 func mergeGatewayTelemetryHeaders(dst, src http.Header) http.Header {
 	if src == nil {
 		return dst
@@ -321,7 +324,7 @@ func mergeGatewayTelemetryHeaders(dst, src http.Header) http.Header {
 	tps := ""
 	for key, values := range src {
 		canonical := http.CanonicalHeaderKey(key)
-		if canonical == markerCanonical && len(values) > 0 && values[0] != "" {
+		if canonical == markerCanonical && len(values) > 0 && helps.IsGatewayMeasuredTPSMarker(values[0]) {
 			hasMarker = true
 		}
 		if canonical == nameCanonical && len(values) > 0 && values[0] != "" && tps == "" {

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -1695,3 +1695,65 @@ func TestWriteModelListResponse_ExposesResponseToPluginInterceptors(t *testing.T
 		t.Fatalf("API_RESPONSE not recorded properly: %#v", apiResp)
 	}
 }
+
+func TestDownstreamHeadersFromExecutorKeepsTokensPerSecondWithoutPassthrough(t *testing.T) {
+	src := http.Header{
+		"X-Upstream":                      []string{"secret"},
+		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+	}
+	got := downstreamHeadersFromExecutor(src, false)
+	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
+		t.Fatalf("headers = %#v, want gateway TPS header without passthrough", got)
+	}
+	if got.Get("X-Upstream") != "" {
+		t.Fatalf("leaked raw upstream header with passthrough disabled: %#v", got)
+	}
+}
+
+func TestDownstreamHeadersAfterInterceptorsKeepsTokensPerSecondWithoutPassthrough(t *testing.T) {
+	base := http.Header{
+		"X-Upstream":                      []string{"raw"},
+		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+	}
+	final := http.Header{
+		"X-Upstream":                      []string{"raw"},
+		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+		"X-Plugin":                        []string{"response"},
+	}
+	got := downstreamHeadersAfterInterceptors(base, final, false)
+	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
+		t.Fatalf("headers = %#v, want gateway TPS header without passthrough", got)
+	}
+	if got.Get("X-Plugin") != "response" {
+		t.Fatalf("headers = %#v, want interceptor-added header", got)
+	}
+	if got.Get("X-Upstream") != "" {
+		t.Fatalf("leaked unchanged upstream header with passthrough disabled: %#v", got)
+	}
+}
+
+func TestHandlerForwardsTokensPerSecondWhenPassthroughDisabled(t *testing.T) {
+	model := "handler-tps-header-model"
+	executor := &interceptorCaptureExecutor{
+		execute: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+			return coreexecutor.Response{
+				Payload: []byte(`{"usage":{"completion_tokens":200}}`),
+				Headers: http.Header{
+					"X-Upstream":                      []string{"raw"},
+					"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+				},
+			}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{PassthroughHeaders: false})
+	_, headers, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if headers.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
+		t.Fatalf("headers = %#v, want gateway TPS header without passthrough", headers)
+	}
+	if headers.Get("X-Upstream") != "" {
+		t.Fatalf("leaked raw upstream header with passthrough disabled: %#v", headers)
+	}
+}

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -1700,7 +1701,7 @@ func TestDownstreamHeadersFromExecutorKeepsTokensPerSecondWithoutPassthrough(t *
 	src := http.Header{
 		"X-Upstream":                         []string{"secret"},
 		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
-		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{helps.GatewayMeasuredTPSMarkerValue()},
 	}
 	got := downstreamHeadersFromExecutor(src, false)
 	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
@@ -1715,12 +1716,12 @@ func TestDownstreamHeadersAfterInterceptorsKeepsTokensPerSecondWithoutPassthroug
 	base := http.Header{
 		"X-Upstream":                         []string{"raw"},
 		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
-		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{helps.GatewayMeasuredTPSMarkerValue()},
 	}
 	final := http.Header{
 		"X-Upstream":                         []string{"raw"},
 		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
-		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{helps.GatewayMeasuredTPSMarkerValue()},
 		"X-Plugin":                           []string{"response"},
 	}
 	got := downstreamHeadersAfterInterceptors(base, final, false)
@@ -1744,7 +1745,7 @@ func TestHandlerForwardsTokensPerSecondWhenPassthroughDisabled(t *testing.T) {
 				Headers: http.Header{
 					"X-Upstream":                         []string{"raw"},
 					"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
-					"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+					"X-CLIProxyAPI-Gateway-Measured-TPS": []string{helps.GatewayMeasuredTPSMarkerValue()},
 				},
 			}, nil
 		},
@@ -1777,5 +1778,27 @@ func TestDownstreamHeadersFromExecutorDropsUpstreamOnlyTokensPerSecond(t *testin
 	}
 	if gotPassthrough.Get("X-Upstream") != "secret" {
 		t.Fatalf("passthrough dropped unrelated header: %#v", gotPassthrough)
+	}
+}
+
+func TestDownstreamHeadersFromExecutorRejectsUpstreamForgedGatewayMarker(t *testing.T) {
+	src := http.Header{
+		"X-Upstream":                         []string{"secret"},
+		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"999.000"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+	}
+	got := downstreamHeadersFromExecutor(src, false)
+	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "" {
+		t.Fatalf("forwarded upstream-forged TPS with fake gateway marker: %#v", got)
+	}
+	gotPassthrough := downstreamHeadersFromExecutor(src, true)
+	if gotPassthrough.Get("X-CLIProxyAPI-Tokens-Per-Second") != "" {
+		t.Fatalf("passthrough forwarded upstream-forged TPS: %#v", gotPassthrough)
+	}
+	if gotPassthrough.Get("X-Upstream") != "secret" {
+		t.Fatalf("passthrough dropped unrelated header: %#v", gotPassthrough)
+	}
+	if gotPassthrough.Get("X-CLIProxyAPI-Gateway-Measured-TPS") != "" {
+		t.Fatalf("passthrough leaked forged gateway marker: %#v", gotPassthrough)
 	}
 }

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -1698,8 +1698,9 @@ func TestWriteModelListResponse_ExposesResponseToPluginInterceptors(t *testing.T
 
 func TestDownstreamHeadersFromExecutorKeepsTokensPerSecondWithoutPassthrough(t *testing.T) {
 	src := http.Header{
-		"X-Upstream":                      []string{"secret"},
-		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+		"X-Upstream":                         []string{"secret"},
+		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
 	}
 	got := downstreamHeadersFromExecutor(src, false)
 	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
@@ -1712,13 +1713,15 @@ func TestDownstreamHeadersFromExecutorKeepsTokensPerSecondWithoutPassthrough(t *
 
 func TestDownstreamHeadersAfterInterceptorsKeepsTokensPerSecondWithoutPassthrough(t *testing.T) {
 	base := http.Header{
-		"X-Upstream":                      []string{"raw"},
-		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+		"X-Upstream":                         []string{"raw"},
+		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
 	}
 	final := http.Header{
-		"X-Upstream":                      []string{"raw"},
-		"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
-		"X-Plugin":                        []string{"response"},
+		"X-Upstream":                         []string{"raw"},
+		"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
+		"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
+		"X-Plugin":                           []string{"response"},
 	}
 	got := downstreamHeadersAfterInterceptors(base, final, false)
 	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "100.000" {
@@ -1739,8 +1742,9 @@ func TestHandlerForwardsTokensPerSecondWhenPassthroughDisabled(t *testing.T) {
 			return coreexecutor.Response{
 				Payload: []byte(`{"usage":{"completion_tokens":200}}`),
 				Headers: http.Header{
-					"X-Upstream":                      []string{"raw"},
-					"X-CLIProxyAPI-Tokens-Per-Second": []string{"100.000"},
+					"X-Upstream":                         []string{"raw"},
+					"X-CLIProxyAPI-Tokens-Per-Second":    []string{"100.000"},
+					"X-CLIProxyAPI-Gateway-Measured-TPS": []string{"1"},
 				},
 			}, nil
 		},
@@ -1755,5 +1759,23 @@ func TestHandlerForwardsTokensPerSecondWhenPassthroughDisabled(t *testing.T) {
 	}
 	if headers.Get("X-Upstream") != "" {
 		t.Fatalf("leaked raw upstream header with passthrough disabled: %#v", headers)
+	}
+}
+
+func TestDownstreamHeadersFromExecutorDropsUpstreamOnlyTokensPerSecond(t *testing.T) {
+	src := http.Header{
+		"X-Upstream":                      []string{"secret"},
+		"X-CLIProxyAPI-Tokens-Per-Second": []string{"999.000"},
+	}
+	got := downstreamHeadersFromExecutor(src, false)
+	if got.Get("X-CLIProxyAPI-Tokens-Per-Second") != "" {
+		t.Fatalf("forwarded untrusted upstream TPS without gateway marker: %#v", got)
+	}
+	gotPassthrough := downstreamHeadersFromExecutor(src, true)
+	if gotPassthrough.Get("X-CLIProxyAPI-Tokens-Per-Second") != "" {
+		t.Fatalf("passthrough forwarded upstream TPS: %#v", gotPassthrough)
+	}
+	if gotPassthrough.Get("X-Upstream") != "secret" {
+		t.Fatalf("passthrough dropped unrelated header: %#v", gotPassthrough)
 	}
 }

--- a/sdk/api/handlers/header_filter.go
+++ b/sdk/api/handlers/header_filter.go
@@ -44,6 +44,9 @@ var cpaReservedResponseHeaders = map[string]struct{}{
 	"Access-Control-Expose-Headers":    {},
 	"Access-Control-Max-Age":           {},
 	"X-Cpa-Trace-Id":                   {},
+	// Gateway-managed inference telemetry — never passthrough upstream values.
+	"X-CLIProxyAPI-Tokens-Per-Second":    {},
+	"X-CLIProxyAPI-Gateway-Measured-TPS": {},
 }
 
 // IsCPAReservedResponseHeader reports whether a downstream response header is managed by CPA.

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -54,9 +54,12 @@ type Record struct {
 	RequestedAt time.Time
 	Latency     time.Duration
 	TTFT        time.Duration
-	Failed      bool
-	Fail        Failure
-	Detail      Detail
+	// TokensPerSecond is output-token generation throughput excluding TTFT.
+	// Zero means unknown (do not invent tokens/total_latency).
+	TokensPerSecond float64
+	Failed          bool
+	Fail            Failure
+	Detail          Detail
 	// ResponseHeaders stores a snapshot of upstream response headers for usage sinks.
 	ResponseHeaders http.Header
 }

--- a/sdk/cliproxy/usage/throughput.go
+++ b/sdk/cliproxy/usage/throughput.go
@@ -1,0 +1,17 @@
+package usage
+
+import "time"
+
+// TokensPerSecond is output-token generation throughput excluding TTFT.
+// Returns 0 when TTFT is unknown so callers omit the field instead of using
+// tokens / total_latency (which includes queueing and first-token wait).
+func TokensPerSecond(outputTokens int64, latency, ttft time.Duration) float64 {
+	if outputTokens <= 0 || latency <= 0 || ttft <= 0 {
+		return 0
+	}
+	generation := latency - ttft
+	if generation <= 0 {
+		return 0
+	}
+	return float64(outputTokens) / generation.Seconds()
+}

--- a/sdk/cliproxy/usage/throughput_test.go
+++ b/sdk/cliproxy/usage/throughput_test.go
@@ -1,0 +1,25 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokensPerSecondExcludesTTFT(t *testing.T) {
+	got := TokensPerSecond(200, 5*time.Second, 3*time.Second)
+	if got != 100 {
+		t.Fatalf("TokensPerSecond() = %v, want 100", got)
+	}
+}
+
+func TestTokensPerSecondOmittedWithoutTTFT(t *testing.T) {
+	if TokensPerSecond(200, 5*time.Second, 0) != 0 {
+		t.Fatal("unknown TTFT must not invent tok/s from tokens/total_latency")
+	}
+	if TokensPerSecond(0, 5*time.Second, 1*time.Second) != 0 {
+		t.Fatal("zero output tokens must omit tok/s")
+	}
+	if TokensPerSecond(200, 3*time.Second, 3*time.Second) != 0 {
+		t.Fatal("non-positive generation window must omit tok/s")
+	}
+}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1429,6 +1429,9 @@ type UsageRecord struct {
 	Latency time.Duration
 	// TTFT is the time to first token for streaming requests.
 	TTFT time.Duration
+	// TokensPerSecond is gateway-measured output-token throughput excluding TTFT.
+	// Zero means unknown and should be treated as omitted.
+	TokensPerSecond float64
 	// Failed reports whether the request failed.
 	Failed bool
 	// Failure contains failure details when Failed is true.


### PR DESCRIPTION
## Summary

Harnesses talking to CLIProxyAPI only see the OpenAI-compatible completion payload. Internal usage records already have latency + TTFT, but that never left the operator path. This PR puts **gateway-measured** generation throughput on the inference response:

- `usage.tokens_per_second` on non-stream JSON and on stream chunks that already carry `usage`
- `X-CLIProxyAPI-Tokens-Per-Second` on the executor response headers when TTFT is known

tok/s is `output_tokens / (latency - TTFT)`. If TTFT is unknown, the field is omitted. Clients must **not** invent `completion_tokens / total_latency`.

## Related

- Closes #5468
- Companion OmniRoute contract: diegosouzapw/OmniRoute#12616

## Why this shape

After Usage Keeper, dashboards are no longer the client contract. Plugins (OpenCode, Pi/OMP, OMO via OpenCode) need the number on the same response they already parse for `usage`. OpenAI-compatible extra usage keys are ignored by strict clients and still readable by harness plugins.

## Code

- `sdk/cliproxy/usage/throughput.go` — TTFT-excluding formula
- `internal/runtime/executor/helps/tokens_per_second.go` — attach onto `usage` / `response.usage` and header
- `UsageReporter.buildRecordForModel` records `Record.TokensPerSecond` for operator sinks without changing publish semantics
- OpenAI-compat executor: non-stream payload + stream data lines that already contain `usage`
- Retry-After / TPM fallback helpers are untouched

## Tests

```bash
gofmt -w .
go test ./sdk/cliproxy/usage ./internal/runtime/executor/helps -count=1
```

Local result: both packages `ok`.

- `sdk/cliproxy/usage/throughput_test.go`
- `internal/runtime/executor/helps/tokens_per_second_test.go`

## Reviewer notes

- Field is omitted when TTFT is unset (do not treat 0 as a real speed).
- Header uses `http.Header.Set` so canonical MIME casing matches `Header.Get`.
- Other executors can call the same helpers; this PR wires the OpenAI-compat path that most harness plugins use.
