### PR TITLE
fix(claude): repair dangling tool_use to avoid Anthropic 400

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -76,6 +76,9 @@ func sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx context.Context, body 
 		logClaudeSignatureSanitizeReport(ctx, baseModel, report)
 	}
 	sanitized = helps.RepairDanglingClaudeToolUses(sanitized)
+	// Repair may move a result carrier ahead of a mid-conversation system turn.
+	// Re-evaluate cache TTL order against the finished message sequence.
+	sanitized = normalizeCacheControlTTL(sanitized)
 	return sanitizeClaudeWebSearchDomains(sanitized)
 }
 

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -75,6 +75,7 @@ func sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx context.Context, body 
 		sanitized, report = sigcompat.SanitizeClaudeMessagesForClaudeUpstream(body, baseModel, preserveEmptyThinkingBlocks...)
 		logClaudeSignatureSanitizeReport(ctx, baseModel, report)
 	}
+	sanitized = helps.RepairDanglingClaudeToolUses(sanitized)
 	return sanitizeClaudeWebSearchDomains(sanitized)
 }
 

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1633,6 +1633,49 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_BypassesUnknownModelSignatureMa
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstream_RepairsDanglingToolUse(t *testing.T) {
+	body := []byte(`{
+		"model": "claude-sonnet-4-5",
+		"messages": [
+			{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+			{"role":"user","content":"stop and look at this"}
+		]
+	}`)
+
+	t.Run("claude family", func(t *testing.T) {
+		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), body, "claude-sonnet-4-5")
+		assertSanitizedInterruptedToolResult(t, output, "t1", "stop and look at this")
+	})
+	t.Run("non-claude messages upstream", func(t *testing.T) {
+		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), body, "kimi-k2.5")
+		assertSanitizedInterruptedToolResult(t, output, "t1", "stop and look at this")
+	})
+}
+
+func assertSanitizedInterruptedToolResult(t *testing.T, output []byte, toolUseID, userText string) {
+	t.Helper()
+	messages := gjson.GetBytes(output, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %s", len(messages), output)
+	}
+	blocks := messages[1].Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("user blocks = %d, want 2: %s", len(blocks), messages[1].Raw)
+	}
+	if blocks[0].Get("type").String() != "tool_result" || blocks[0].Get("tool_use_id").String() != toolUseID {
+		t.Fatalf("expected synth tool_result for %s: %s", toolUseID, blocks[0].Raw)
+	}
+	if !blocks[0].Get("is_error").Bool() {
+		t.Fatalf("synth tool_result must set is_error: %s", blocks[0].Raw)
+	}
+	if blocks[0].Get("content").String() != "[operation interrupted by user]" {
+		t.Fatalf("synth content = %q", blocks[0].Get("content").String())
+	}
+	if blocks[1].Get("type").String() != "text" || blocks[1].Get("text").String() != userText {
+		t.Fatalf("user text not preserved: %s", blocks[1].Raw)
+	}
+}
+
 func TestClaudeExecutor_ExecuteBypassesSignatureSanitizerForUnknownModel(t *testing.T) {
 	var seenBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1650,6 +1650,27 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_RepairsDanglingToolUse(t *testi
 		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), body, "kimi-k2.5")
 		assertSanitizedInterruptedToolResult(t, output, "t1", "stop and look at this")
 	})
+	t.Run("canonical carrier compatibility fields and invalid content", func(t *testing.T) {
+		input := []byte(`{
+			"model":"claude-sonnet-4-5",
+			"messages":[
+				{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+				{"role":"user","tool_call_id":"top-alias","name":"legacy","content":[{"type":"tool_result","tool_use_id":"t1","call_id":"block-alias","content":42}]}
+			]
+		}`)
+		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), input, "claude-sonnet-4-5")
+		message := gjson.GetBytes(output, "messages.1")
+		if message.Get("tool_call_id").Exists() || message.Get("name").Exists() {
+			t.Fatalf("sanitized carrier retained top-level compatibility fields: %s", message.Raw)
+		}
+		result := message.Get("content.0")
+		if result.Get("tool_use_id").String() != "t1" || result.Get("content").Type != gjson.String || result.Get("content").String() != "42" {
+			t.Fatalf("sanitized carrier retained invalid tool result content: %s", result.Raw)
+		}
+		if result.Get("call_id").Exists() {
+			t.Fatalf("sanitized result retained a block-level compatibility field: %s", result.Raw)
+		}
+	})
 	t.Run("real result across a mid-conversation system turn renormalizes cache TTL", func(t *testing.T) {
 		midSystemBody := []byte(`{
 			"model": "claude-opus-5",

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1650,14 +1650,14 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_RepairsDanglingToolUse(t *testi
 		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), body, "kimi-k2.5")
 		assertSanitizedInterruptedToolResult(t, output, "t1", "stop and look at this")
 	})
-	t.Run("real result across a mid-conversation system turn", func(t *testing.T) {
+	t.Run("real result across a mid-conversation system turn renormalizes cache TTL", func(t *testing.T) {
 		midSystemBody := []byte(`{
 			"model": "claude-opus-5",
 			"messages": [
 				{"role":"user","content":"start"},
 				{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
-				{"role":"system","content":"new context"},
-				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"real output"}]}
+				{"role":"system","content":[{"type":"text","text":"new context","cache_control":{"type":"ephemeral","ttl":"1h"}}]},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"real output","cache_control":{"type":"ephemeral"}}]}
 			]
 		}`)
 		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), midSystemBody, "claude-opus-5")
@@ -1669,8 +1669,14 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_RepairsDanglingToolUse(t *testi
 		if result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "real output" || result.Get("is_error").Bool() {
 			t.Fatalf("real result was not preserved: %s", result.Raw)
 		}
-		if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "new context" {
+		if messages[3].Get("role").String() != "system" || messages[3].Get("content.0.text").String() != "new context" {
 			t.Fatalf("mid-conversation system turn was not replayed after the result: %s", output)
+		}
+		if got := messages[3].Get("content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("system cache_control.type = %q, want ephemeral: %s", got, output)
+		}
+		if messages[3].Get("content.0.cache_control.ttl").Exists() {
+			t.Fatalf("replayed system retained a 1h TTL after a 5m result: %s", output)
 		}
 	})
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1650,6 +1650,29 @@ func TestSanitizeClaudeMessagesForClaudeUpstream_RepairsDanglingToolUse(t *testi
 		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), body, "kimi-k2.5")
 		assertSanitizedInterruptedToolResult(t, output, "t1", "stop and look at this")
 	})
+	t.Run("real result across a mid-conversation system turn", func(t *testing.T) {
+		midSystemBody := []byte(`{
+			"model": "claude-opus-5",
+			"messages": [
+				{"role":"user","content":"start"},
+				{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]},
+				{"role":"system","content":"new context"},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"real output"}]}
+			]
+		}`)
+		output := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), midSystemBody, "claude-opus-5")
+		messages := gjson.GetBytes(output, "messages").Array()
+		if len(messages) != 4 {
+			t.Fatalf("message count = %d, want 4: %s", len(messages), output)
+		}
+		result := messages[2].Get("content.0")
+		if result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "real output" || result.Get("is_error").Bool() {
+			t.Fatalf("real result was not preserved: %s", result.Raw)
+		}
+		if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "new context" {
+			t.Fatalf("mid-conversation system turn was not replayed after the result: %s", output)
+		}
+	})
 }
 
 func assertSanitizedInterruptedToolResult(t *testing.T, output []byte, toolUseID, userText string) {

--- a/internal/runtime/executor/claude_mid_system_model_test.go
+++ b/internal/runtime/executor/claude_mid_system_model_test.go
@@ -171,6 +171,83 @@ func sendMidSystemCountTokens(t *testing.T, ex *ClaudeExecutor, ctx context.Cont
 	return err
 }
 
+// Tool-result repair can move a default-5m cache breakpoint before a 1h
+// mid-conversation system block. Every first-party path must validate TTL order
+// against that repaired sequence, not the pre-repair input.
+func TestClaudeExecutor_RepairedToolResultRenormalizesCacheTTLOnEveryUpstreamPath(t *testing.T) {
+	const model = "claude-opus-5"
+	for _, test := range []struct {
+		name string
+		send func(t *testing.T, ex *ClaudeExecutor, ctx context.Context, auth *cliproxyauth.Auth, payload []byte) error
+	}{
+		{name: "execute", send: func(t *testing.T, ex *ClaudeExecutor, ctx context.Context, auth *cliproxyauth.Auth, payload []byte) error {
+			_, err := ex.Execute(ctx, auth, cliproxyexecutor.Request{Model: model, Payload: payload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+			return err
+		}},
+		{name: "execute stream", send: func(t *testing.T, ex *ClaudeExecutor, ctx context.Context, auth *cliproxyauth.Auth, payload []byte) error {
+			result, err := ex.ExecuteStream(ctx, auth, cliproxyexecutor.Request{Model: model, Payload: payload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+			if err != nil {
+				return err
+			}
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					return chunk.Err
+				}
+			}
+			return nil
+		}},
+		{name: "count tokens", send: func(t *testing.T, ex *ClaudeExecutor, ctx context.Context, auth *cliproxyauth.Auth, payload []byte) error {
+			_, err := ex.CountTokens(ctx, auth, cliproxyexecutor.Request{Model: model, Payload: payload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			upstream := &midSystemUpstream{}
+			ex := NewClaudeExecutor(midSystemConfig())
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "never"}}
+			payload := []byte(`{"model":"claude-opus-5","max_tokens":32,"messages":[` +
+				`{"role":"user","content":[{"type":"text","text":"start"}]},` +
+				`{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]},` +
+				`{"role":"system","content":[{"type":"text","text":"constraint","cache_control":{"type":"ephemeral","ttl":"1h"}}]},` +
+				`{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"done","cache_control":{"type":"ephemeral"}}]}` +
+				`]}`)
+
+			if err := test.send(t, ex, upstream.context(t, nil), auth, payload); err != nil {
+				t.Fatalf("request error = %v", err)
+			}
+			if !upstream.called {
+				t.Fatal("expected repaired request to reach first-party upstream")
+			}
+			assertRepairedToolResultCacheTTL(t, upstream.body)
+		})
+	}
+}
+
+func assertRepairedToolResultCacheTTL(t *testing.T, payload []byte) {
+	t.Helper()
+	messages := gjson.GetBytes(payload, "messages").Array()
+	if len(messages) != 4 {
+		t.Fatalf("message count = %d, want 4: %s", len(messages), payload)
+	}
+	result := messages[2].Get("content.0")
+	if messages[2].Get("role").String() != "user" || result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "done" {
+		t.Fatalf("tool result was not moved ahead of the system turn: %s", payload)
+	}
+	if got := result.Get("cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("tool result cache_control.type = %q, want ephemeral: %s", got, payload)
+	}
+	system := messages[3]
+	if system.Get("role").String() != "system" || system.Get("content.0.text").String() != "constraint" {
+		t.Fatalf("system turn was not replayed after the result: %s", payload)
+	}
+	if got := system.Get("content.0.cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("system cache_control.type = %q, want ephemeral: %s", got, payload)
+	}
+	if system.Get("content.0.cache_control.ttl").Exists() {
+		t.Fatalf("system retained a 1h TTL after the repaired 5m result: %s", payload)
+	}
+}
+
 // Payload rules run long after translation and can rewrite model and messages,
 // so the guard has to read the finished body rather than an intermediate one.
 func TestClaudeExecutor_PayloadOverrideCannotSmuggleLegacyMidSystemMessage(t *testing.T) {

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -291,38 +291,62 @@ func claudeCarrierMessageParts(message gjson.Result, role string) []claudeCarrie
 		if id := firstClaudeStringField(message, "tool_use_id", "tool_call_id", "call_id"); id != "" {
 			result := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
 			result, _ = sjson.SetBytes(result, "tool_use_id", id)
-			if content.Exists() && content.Type != gjson.Null {
-				if content.Type == gjson.String {
-					result, _ = sjson.SetBytes(result, "content", content.String())
-				} else {
-					result, _ = sjson.SetRawBytes(result, "content", []byte(content.Raw))
-				}
+			if content.Exists() {
+				result, _ = sjson.SetRawBytes(result, "content", []byte(content.Raw))
 			}
+			result = normalizeClaudeToolResultContent(result)
 			return []claudeCarrierPart{{raw: result, isToolResult: true}}
 		}
 	}
 
 	if content.Type == gjson.String {
 		if strings.TrimSpace(content.String()) == "" {
-			return nil
+			if role == "tool" {
+				return []claudeCarrierPart{{raw: unmatchedClaudeToolDiagnostic(content)}}
+			}
+			return []claudeCarrierPart{{raw: invalidClaudeUserContentDiagnostic(content)}}
 		}
 		return []claudeCarrierPart{{raw: claudeTextPart(content.String())}}
 	}
 	if !content.IsArray() {
-		return nil
+		if role == "tool" {
+			return []claudeCarrierPart{{raw: unmatchedClaudeToolDiagnostic(content)}}
+		}
+		return []claudeCarrierPart{{raw: invalidClaudeUserContentDiagnostic(content)}}
 	}
 
 	parts := make([]claudeCarrierPart, 0, len(content.Array()))
 	content.ForEach(func(_, part gjson.Result) bool {
 		if !part.IsObject() {
+			diagnostic := invalidClaudeUserContentDiagnostic(part)
+			if role == "tool" {
+				diagnostic = unmatchedClaudeToolDiagnostic(part)
+			}
+			parts = append(parts, claudeCarrierPart{raw: diagnostic})
+			return true
+		}
+		partType := claudeStringField(part, "type")
+		if partType == "" {
+			diagnostic := invalidClaudeUserContentDiagnostic(part)
+			if role == "tool" {
+				diagnostic = unmatchedClaudeToolDiagnostic(part)
+			}
+			parts = append(parts, claudeCarrierPart{raw: diagnostic})
 			return true
 		}
 		parts = append(parts, claudeCarrierPart{
 			raw:          []byte(part.Raw),
-			isToolResult: part.Get("type").String() == "tool_result",
+			isToolResult: partType == "tool_result",
 		})
 		return true
 	})
+	if len(parts) == 0 {
+		diagnostic := invalidClaudeUserContentDiagnostic(content)
+		if role == "tool" {
+			diagnostic = unmatchedClaudeToolDiagnostic(content)
+		}
+		parts = append(parts, claudeCarrierPart{raw: diagnostic})
+	}
 	return parts
 }
 
@@ -399,6 +423,11 @@ func isCanonicalClaudeResultCarrier(message gjson.Result, toolUses []claudeClien
 	if message.Get("role").String() != "user" {
 		return false
 	}
+	for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+		if message.Get(field).Exists() {
+			return false
+		}
+	}
 	content := message.Get("content")
 	if !content.IsArray() {
 		return false
@@ -408,11 +437,16 @@ func isCanonicalClaudeResultCarrier(message gjson.Result, toolUses []claudeClien
 	extrasStarted := false
 	canonical := true
 	content.ForEach(func(_, part gjson.Result) bool {
-		if part.Get("type").String() != "tool_result" {
+		partType := claudeStringField(part, "type")
+		if partType != "tool_result" {
+			if !part.IsObject() || partType == "" {
+				canonical = false
+				return false
+			}
 			extrasStarted = true
 			return true
 		}
-		if extrasStarted || resultIndex >= len(toolUses) || part.Get("id").Exists() {
+		if extrasStarted || resultIndex >= len(toolUses) || claudeToolResultHasCompatibilityFields(part) || !isCanonicalClaudeToolResultContent(part.Get("content")) {
 			canonical = false
 			return false
 		}
@@ -441,10 +475,65 @@ func normalizeClaudeToolResult(raw []byte) ([]byte, string) {
 	// untrusted metadata and must not make a malformed result look complete.
 	id := claudeStringField(result, "tool_use_id")
 	updated := raw
-	if result.Get("id").Exists() {
-		updated, _ = sjson.DeleteBytes(updated, "id")
+	for _, field := range []string{"id", "tool_call_id", "call_id", "name"} {
+		updated, _ = sjson.DeleteBytes(updated, field)
 	}
+	updated = normalizeClaudeToolResultContent(updated)
 	return updated, id
+}
+
+func claudeToolResultHasCompatibilityFields(result gjson.Result) bool {
+	for _, field := range []string{"id", "tool_call_id", "call_id", "name"} {
+		if result.Get(field).Exists() {
+			return true
+		}
+	}
+	return false
+}
+
+func isCanonicalClaudeToolResultContent(content gjson.Result) bool {
+	if content.Type == gjson.String {
+		return true
+	}
+	if !content.IsArray() || len(content.Array()) == 0 {
+		return false
+	}
+	canonical := true
+	content.ForEach(func(_, part gjson.Result) bool {
+		if !part.IsObject() || claudeStringField(part, "type") == "" {
+			canonical = false
+			return false
+		}
+		return true
+	})
+	return canonical
+}
+
+func normalizeClaudeToolResultContent(result []byte) []byte {
+	content := gjson.GetBytes(result, "content")
+	if content.Type == gjson.String {
+		return result
+	}
+	if content.IsArray() && len(content.Array()) > 0 {
+		parts := make([][]byte, 0, len(content.Array()))
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.IsObject() && claudeStringField(part, "type") != "" {
+				parts = append(parts, []byte(part.Raw))
+			} else {
+				parts = append(parts, invalidClaudeToolResultContentDiagnostic(part))
+			}
+			return true
+		})
+		updated, _ := sjson.SetRawBytes(result, "content", translatorcommon.JoinRawArray(parts))
+		return updated
+	}
+
+	text := ""
+	if content.Exists() && content.Type != gjson.Null {
+		text = claudeToolResultText(content)
+	}
+	updated, _ := sjson.SetBytes(result, "content", text)
+	return updated
 }
 
 func alignClaudeToolResultToolset(result []byte, toolsetName string) []byte {
@@ -547,7 +636,19 @@ func repairStandaloneClaudeToolResults(message gjson.Result) ([]byte, bool) {
 }
 
 func unmatchedClaudeToolDiagnostic(content gjson.Result) []byte {
-	text := "[unmatched tool result]"
+	return claudeDiagnosticTextPart("[unmatched tool result]", content)
+}
+
+func invalidClaudeUserContentDiagnostic(content gjson.Result) []byte {
+	return claudeDiagnosticTextPart("[invalid user content]", content)
+}
+
+func invalidClaudeToolResultContentDiagnostic(content gjson.Result) []byte {
+	return claudeDiagnosticTextPart("[invalid tool result content]", content)
+}
+
+func claudeDiagnosticTextPart(label string, content gjson.Result) []byte {
+	text := label
 	if diagnostic := strings.TrimSpace(claudeToolResultText(content)); diagnostic != "" {
 		text += "\n" + diagnostic
 	}

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -157,12 +157,16 @@ func collectClaudeResultCarrierRun(messages []gjson.Result, start int, toolUses 
 				run.base = message
 			}
 			run.parts = append(run.parts, parts...)
-			if claudeCarrierPartsContainInterrupt(parts, outstanding) {
+			interrupt := claudeCarrierPartsContainInterrupt(parts, outstanding)
+			if interrupt {
 				run.followingInterrupt = true
 			}
 			consumeClaudeOutstandingToolResults(outstanding, parts)
 			run.count++
 			run.end++
+			if interrupt {
+				break
+			}
 			continue
 		}
 
@@ -268,14 +272,7 @@ func buildDeferredClaudeCarrier(base gjson.Result, parts []claudeCarrierPart) []
 		content = append(content, downgradeClaudeToolResult(normalized, id))
 	}
 
-	message := []byte(`{"role":"user","content":[]}`)
-	if base.IsObject() {
-		message = []byte(base.Raw)
-		message, _ = sjson.SetBytes(message, "role", "user")
-		for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
-			message, _ = sjson.DeleteBytes(message, field)
-		}
-	}
+	message := claudeUserCarrierEnvelope(base)
 	message, _ = sjson.SetRawBytes(message, "content", translatorcommon.JoinRawArray(content))
 	return message
 }
@@ -381,15 +378,20 @@ func buildCanonicalClaudeResultCarrier(base gjson.Result, toolUses []claudeClien
 	}
 	content = append(content, extras...)
 
+	message := claudeUserCarrierEnvelope(base)
+	message, _ = sjson.SetRawBytes(message, "content", translatorcommon.JoinRawArray(content))
+	return message
+}
+
+func claudeUserCarrierEnvelope(base gjson.Result) []byte {
 	message := []byte(`{"role":"user","content":[]}`)
 	if base.IsObject() {
 		message = []byte(base.Raw)
-		message, _ = sjson.SetBytes(message, "role", "user")
-		for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
-			message, _ = sjson.DeleteBytes(message, field)
-		}
 	}
-	message, _ = sjson.SetRawBytes(message, "content", translatorcommon.JoinRawArray(content))
+	message, _ = sjson.SetBytes(message, "role", "user")
+	for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+		message, _ = sjson.DeleteBytes(message, field)
+	}
 	return message
 }
 
@@ -506,35 +508,24 @@ func repairStandaloneClaudeToolResults(message gjson.Result) ([]byte, bool) {
 		return []byte(message.Raw), false
 	}
 	content := message.Get("content")
-	if content.Type == gjson.String {
-		if role != "tool" {
-			return []byte(message.Raw), false
-		}
-		text := "[unmatched tool result]"
-		if strings.TrimSpace(content.String()) != "" {
-			text += "\n" + content.String()
-		}
-		updated := []byte(message.Raw)
-		updated, _ = sjson.SetBytes(updated, "role", "user")
-		updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray([][]byte{claudeTextPart(text)}))
-		return updated, true
-	}
 	if !content.IsArray() {
 		if role != "tool" {
 			return []byte(message.Raw), false
 		}
-		updated := []byte(message.Raw)
-		updated, _ = sjson.SetBytes(updated, "role", "user")
+		updated := claudeUserCarrierEnvelope(message)
+		updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray([][]byte{unmatchedClaudeToolDiagnostic(content)}))
 		return updated, true
 	}
 
 	parts := make([][]byte, 0, len(content.Array()))
 	hasToolResult := false
 	content.ForEach(func(_, part gjson.Result) bool {
-		if !part.IsObject() {
+		partType := part.Get("type")
+		if !part.IsObject() || partType.Type != gjson.String || strings.TrimSpace(partType.String()) == "" {
+			parts = append(parts, unmatchedClaudeToolDiagnostic(part))
 			return true
 		}
-		if part.Get("type").String() == "tool_result" {
+		if partType.String() == "tool_result" {
 			hasToolResult = true
 			normalized, id := normalizeClaudeToolResult([]byte(part.Raw))
 			parts = append(parts, downgradeClaudeToolResult(normalized, id))
@@ -546,14 +537,21 @@ func repairStandaloneClaudeToolResults(message gjson.Result) ([]byte, bool) {
 	if !hasToolResult && role != "tool" {
 		return []byte(message.Raw), false
 	}
-
-	updated := []byte(message.Raw)
-	updated, _ = sjson.SetBytes(updated, "role", "user")
-	for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
-		updated, _ = sjson.DeleteBytes(updated, field)
+	if len(parts) == 0 {
+		parts = append(parts, unmatchedClaudeToolDiagnostic(gjson.Result{}))
 	}
+
+	updated := claudeUserCarrierEnvelope(message)
 	updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray(parts))
 	return updated, true
+}
+
+func unmatchedClaudeToolDiagnostic(content gjson.Result) []byte {
+	text := "[unmatched tool result]"
+	if diagnostic := strings.TrimSpace(claudeToolResultText(content)); diagnostic != "" {
+		text += "\n" + diagnostic
+	}
+	return claudeTextPart(text)
 }
 
 func dropUnresolvedClaudeServerToolUses(message gjson.Result) ([]byte, bool) {

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -1,0 +1,488 @@
+package helps
+
+import (
+	"strings"
+
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const interruptedClaudeToolResultContent = "[operation interrupted by user]"
+
+type claudeClientToolUse struct {
+	id          string
+	toolsetName string
+}
+
+type claudeCarrierPart struct {
+	raw          []byte
+	isToolResult bool
+}
+
+// RepairDanglingClaudeToolUses closes client tool calls left incomplete by an
+// interrupted agent turn. It also canonicalizes adjacent result carriers so the
+// final Claude Messages payload contains one ordered user turn with exactly one
+// result for every client tool call.
+func RepairDanglingClaudeToolUses(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+
+	messageResults := messages.Array()
+	out := make([][]byte, 0, len(messageResults)+2)
+	changed := false
+
+	for i := 0; i < len(messageResults); i++ {
+		message := messageResults[i]
+		toolUses := claudeAssistantClientToolUses(message)
+		if len(toolUses) == 0 {
+			repaired, repairedMessage := repairStandaloneClaudeToolResults(message)
+			out = append(out, repaired)
+			changed = changed || repairedMessage
+			continue
+		}
+
+		runEnd, runCount, carrierParts := collectClaudeResultCarrierRun(messageResults, i+1)
+		var carrierBase gjson.Result
+		if runCount > 0 {
+			carrierBase = messageResults[i+1]
+		}
+		carrier := buildCanonicalClaudeResultCarrier(carrierBase, toolUses, carrierParts)
+		hasExtras := claudeContentHasNonToolResults(gjson.GetBytes(carrier, "content"))
+		assistantRaw := []byte(message.Raw)
+		droppedServerTool := false
+		if hasExtras {
+			// A pending server tool may only be resumed by a user turn containing
+			// client tool results. Interrupt text ends that turn, so abandon only
+			// unresolved server calls before preserving the user's new instruction.
+			assistantRaw, droppedServerTool = dropUnresolvedClaudeServerToolUses(message)
+			changed = changed || droppedServerTool
+		}
+		out = append(out, assistantRaw)
+
+		if runCount == 1 && !droppedServerTool && isCanonicalClaudeResultCarrier(messageResults[i+1], toolUses) {
+			out = append(out, []byte(messageResults[i+1].Raw))
+			i = runEnd - 1
+			continue
+		}
+
+		out = append(out, carrier)
+		changed = true
+		if runCount > 0 {
+			i = runEnd - 1
+		}
+	}
+
+	if !changed {
+		return payload
+	}
+	updated, errSet := sjson.SetRawBytes(payload, "messages", translatorcommon.JoinRawArray(out))
+	if errSet != nil {
+		return payload
+	}
+	return updated
+}
+
+func claudeAssistantClientToolUses(message gjson.Result) []claudeClientToolUse {
+	if message.Get("role").String() != "assistant" {
+		return nil
+	}
+	content := message.Get("content")
+	if !content.IsArray() {
+		return nil
+	}
+	toolUses := make([]claudeClientToolUse, 0)
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "tool_use" {
+			return true
+		}
+		id := claudeStringField(part, "id")
+		if id == "" {
+			return true
+		}
+		toolUses = append(toolUses, claudeClientToolUse{
+			id:          id,
+			toolsetName: claudeStringField(part, "toolset_name"),
+		})
+		return true
+	})
+	return toolUses
+}
+
+func collectClaudeResultCarrierRun(messages []gjson.Result, start int) (end, count int, parts []claudeCarrierPart) {
+	end = start
+	for end < len(messages) {
+		message := messages[end]
+		role := message.Get("role").String()
+		if role != "user" && role != "tool" {
+			break
+		}
+		content := message.Get("content")
+		if claudeContentContainsType(content, "tool_use") {
+			break
+		}
+
+		messageParts := claudeCarrierMessageParts(message, role)
+		parts = append(parts, messageParts...)
+		count++
+		end++
+	}
+	return end, count, parts
+}
+
+func claudeCarrierMessageParts(message gjson.Result, role string) []claudeCarrierPart {
+	content := message.Get("content")
+	if role == "tool" && !claudeContentContainsType(content, "tool_result") {
+		if id := firstClaudeStringField(message, "tool_use_id", "tool_call_id", "call_id"); id != "" {
+			result := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+			result, _ = sjson.SetBytes(result, "tool_use_id", id)
+			if content.Exists() && content.Type != gjson.Null {
+				if content.Type == gjson.String {
+					result, _ = sjson.SetBytes(result, "content", content.String())
+				} else {
+					result, _ = sjson.SetRawBytes(result, "content", []byte(content.Raw))
+				}
+			}
+			return []claudeCarrierPart{{raw: result, isToolResult: true}}
+		}
+	}
+
+	if content.Type == gjson.String {
+		if strings.TrimSpace(content.String()) == "" {
+			return nil
+		}
+		return []claudeCarrierPart{{raw: claudeTextPart(content.String())}}
+	}
+	if !content.IsArray() {
+		return nil
+	}
+
+	parts := make([]claudeCarrierPart, 0, len(content.Array()))
+	content.ForEach(func(_, part gjson.Result) bool {
+		if !part.IsObject() {
+			return true
+		}
+		parts = append(parts, claudeCarrierPart{
+			raw:          []byte(part.Raw),
+			isToolResult: part.Get("type").String() == "tool_result",
+		})
+		return true
+	})
+	return parts
+}
+
+func claudeContentHasNonToolResults(content gjson.Result) bool {
+	if !content.IsArray() {
+		return false
+	}
+	hasExtras := false
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "tool_result" {
+			hasExtras = true
+			return false
+		}
+		return true
+	})
+	return hasExtras
+}
+
+func buildCanonicalClaudeResultCarrier(base gjson.Result, toolUses []claudeClientToolUse, carrierParts []claudeCarrierPart) []byte {
+	wanted := make(map[string]int, len(toolUses))
+	for index, toolUse := range toolUses {
+		if _, exists := wanted[toolUse.id]; !exists {
+			wanted[toolUse.id] = index
+		}
+	}
+
+	results := make([][]byte, len(toolUses))
+	extras := make([][]byte, 0, len(carrierParts))
+	for _, part := range carrierParts {
+		if !part.isToolResult {
+			extras = append(extras, part.raw)
+			continue
+		}
+
+		normalized, id := normalizeClaudeToolResult(part.raw)
+		index, expected := wanted[id]
+		if !expected || results[index] != nil {
+			// Orphan and duplicate result blocks are invalid at protocol level.
+			// Keep their diagnostic payload as ordinary user text instead.
+			extras = append(extras, downgradeClaudeToolResult(normalized, id))
+			continue
+		}
+		results[index] = alignClaudeToolResultToolset(normalized, toolUses[index].toolsetName)
+	}
+
+	content := make([][]byte, 0, len(toolUses)+len(extras))
+	for index, toolUse := range toolUses {
+		result := results[index]
+		if result == nil {
+			result = interruptedClaudeToolResult(toolUse)
+		}
+		content = append(content, result)
+	}
+	content = append(content, extras...)
+
+	message := []byte(`{"role":"user","content":[]}`)
+	if base.IsObject() {
+		message = []byte(base.Raw)
+		message, _ = sjson.SetBytes(message, "role", "user")
+		for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+			message, _ = sjson.DeleteBytes(message, field)
+		}
+	}
+	message, _ = sjson.SetRawBytes(message, "content", translatorcommon.JoinRawArray(content))
+	return message
+}
+
+func isCanonicalClaudeResultCarrier(message gjson.Result, toolUses []claudeClientToolUse) bool {
+	if message.Get("role").String() != "user" {
+		return false
+	}
+	content := message.Get("content")
+	if !content.IsArray() {
+		return false
+	}
+
+	resultIndex := 0
+	extrasStarted := false
+	canonical := true
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "tool_result" {
+			extrasStarted = true
+			return true
+		}
+		if extrasStarted || resultIndex >= len(toolUses) || part.Get("id").Exists() {
+			canonical = false
+			return false
+		}
+		if claudeStringField(part, "tool_use_id") != toolUses[resultIndex].id {
+			canonical = false
+			return false
+		}
+		toolsetName := part.Get("toolset_name")
+		if toolUses[resultIndex].toolsetName == "" && toolsetName.Exists() {
+			canonical = false
+			return false
+		}
+		if toolUses[resultIndex].toolsetName != "" && claudeStringField(part, "toolset_name") != toolUses[resultIndex].toolsetName {
+			canonical = false
+			return false
+		}
+		resultIndex++
+		return true
+	})
+	return canonical && resultIndex == len(toolUses)
+}
+
+func normalizeClaudeToolResult(raw []byte) ([]byte, string) {
+	result := gjson.ParseBytes(raw)
+	id := claudeStringField(result, "tool_use_id")
+	aliasID := claudeStringField(result, "id")
+	updated := raw
+	if id == "" && aliasID != "" {
+		id = aliasID
+		updated, _ = sjson.SetBytes(updated, "tool_use_id", id)
+	}
+	if result.Get("id").Exists() {
+		updated, _ = sjson.DeleteBytes(updated, "id")
+	}
+	return updated, id
+}
+
+func alignClaudeToolResultToolset(result []byte, toolsetName string) []byte {
+	if toolsetName == "" {
+		updated, _ := sjson.DeleteBytes(result, "toolset_name")
+		return updated
+	}
+	updated, _ := sjson.SetBytes(result, "toolset_name", toolsetName)
+	return updated
+}
+
+func interruptedClaudeToolResult(toolUse claudeClientToolUse) []byte {
+	result := []byte(`{"type":"tool_result","tool_use_id":"","content":"","is_error":true}`)
+	result, _ = sjson.SetBytes(result, "tool_use_id", toolUse.id)
+	if toolUse.toolsetName != "" {
+		result, _ = sjson.SetBytes(result, "toolset_name", toolUse.toolsetName)
+		result, _ = sjson.SetRawBytes(result, "content", translatorcommon.JoinRawArray([][]byte{claudeTextPart(interruptedClaudeToolResultContent)}))
+	} else {
+		result, _ = sjson.SetBytes(result, "content", interruptedClaudeToolResultContent)
+	}
+	return result
+}
+
+func downgradeClaudeToolResult(result []byte, id string) []byte {
+	label := "[unmatched tool result"
+	if id != "" {
+		label += " " + id
+	}
+	label += "]"
+	if text := strings.TrimSpace(claudeToolResultText(gjson.GetBytes(result, "content"))); text != "" {
+		label += "\n" + text
+	}
+	return claudeTextPart(label)
+}
+
+func claudeToolResultText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if content.IsArray() {
+		text := make([]string, 0, len(content.Array()))
+		content.ForEach(func(_, part gjson.Result) bool {
+			if value := part.Get("text"); value.Type == gjson.String && value.String() != "" {
+				text = append(text, value.String())
+			}
+			return true
+		})
+		if len(text) > 0 {
+			return strings.Join(text, "\n")
+		}
+	}
+	if content.Exists() && content.Type != gjson.Null {
+		return content.Raw
+	}
+	return ""
+}
+
+func repairStandaloneClaudeToolResults(message gjson.Result) ([]byte, bool) {
+	role := message.Get("role").String()
+	if role != "user" && role != "tool" {
+		return []byte(message.Raw), false
+	}
+	content := message.Get("content")
+	if content.Type == gjson.String {
+		if role != "tool" {
+			return []byte(message.Raw), false
+		}
+		text := "[unmatched tool result]"
+		if strings.TrimSpace(content.String()) != "" {
+			text += "\n" + content.String()
+		}
+		updated := []byte(message.Raw)
+		updated, _ = sjson.SetBytes(updated, "role", "user")
+		updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray([][]byte{claudeTextPart(text)}))
+		return updated, true
+	}
+	if !content.IsArray() {
+		if role != "tool" {
+			return []byte(message.Raw), false
+		}
+		updated := []byte(message.Raw)
+		updated, _ = sjson.SetBytes(updated, "role", "user")
+		return updated, true
+	}
+
+	parts := make([][]byte, 0, len(content.Array()))
+	hasToolResult := false
+	content.ForEach(func(_, part gjson.Result) bool {
+		if !part.IsObject() {
+			return true
+		}
+		if part.Get("type").String() == "tool_result" {
+			hasToolResult = true
+			normalized, id := normalizeClaudeToolResult([]byte(part.Raw))
+			parts = append(parts, downgradeClaudeToolResult(normalized, id))
+			return true
+		}
+		parts = append(parts, []byte(part.Raw))
+		return true
+	})
+	if !hasToolResult && role != "tool" {
+		return []byte(message.Raw), false
+	}
+
+	updated := []byte(message.Raw)
+	updated, _ = sjson.SetBytes(updated, "role", "user")
+	for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+		updated, _ = sjson.DeleteBytes(updated, field)
+	}
+	updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray(parts))
+	return updated, true
+}
+
+func dropUnresolvedClaudeServerToolUses(message gjson.Result) ([]byte, bool) {
+	content := message.Get("content")
+	if !content.IsArray() {
+		return []byte(message.Raw), false
+	}
+
+	unresolved := make(map[string]struct{})
+	content.ForEach(func(_, part gjson.Result) bool {
+		switch part.Get("type").String() {
+		case "server_tool_use", "mcp_tool_use":
+			if id := claudeStringField(part, "id"); id != "" {
+				unresolved[id] = struct{}{}
+			}
+		}
+		return true
+	})
+	if len(unresolved) == 0 {
+		return []byte(message.Raw), false
+	}
+	content.ForEach(func(_, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		if partType != "tool_result" && strings.Contains(partType, "tool_result") {
+			delete(unresolved, claudeStringField(part, "tool_use_id"))
+		}
+		return true
+	})
+	if len(unresolved) == 0 {
+		return []byte(message.Raw), false
+	}
+
+	parts := make([][]byte, 0, len(content.Array()))
+	content.ForEach(func(_, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		if partType == "server_tool_use" || partType == "mcp_tool_use" {
+			if _, drop := unresolved[claudeStringField(part, "id")]; drop {
+				return true
+			}
+		}
+		parts = append(parts, []byte(part.Raw))
+		return true
+	})
+	updated := []byte(message.Raw)
+	updated, _ = sjson.SetRawBytes(updated, "content", translatorcommon.JoinRawArray(parts))
+	return updated, true
+}
+
+func claudeContentContainsType(content gjson.Result, partType string) bool {
+	if !content.IsArray() {
+		return false
+	}
+	found := false
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() == partType {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func claudeTextPart(text string) []byte {
+	part := []byte(`{"type":"text","text":""}`)
+	part, _ = sjson.SetBytes(part, "text", text)
+	return part
+}
+
+func firstClaudeStringField(result gjson.Result, fields ...string) string {
+	for _, field := range fields {
+		if value := claudeStringField(result, field); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func claudeStringField(result gjson.Result, field string) string {
+	value := result.Get(field)
+	if value.Type != gjson.String {
+		return ""
+	}
+	return value.String()
+}

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -20,6 +20,14 @@ type claudeCarrierPart struct {
 	isToolResult bool
 }
 
+type claudeResultCarrierRun struct {
+	end                int
+	count              int
+	base               gjson.Result
+	parts              []claudeCarrierPart
+	interveningSystems [][]byte
+}
+
 // RepairDanglingClaudeToolUses closes client tool calls left incomplete by an
 // interrupted agent turn. It also canonicalizes adjacent result carriers so the
 // final Claude Messages payload contains one ordered user turn with exactly one
@@ -44,12 +52,8 @@ func RepairDanglingClaudeToolUses(payload []byte) []byte {
 			continue
 		}
 
-		runEnd, runCount, carrierParts := collectClaudeResultCarrierRun(messageResults, i+1)
-		var carrierBase gjson.Result
-		if runCount > 0 {
-			carrierBase = messageResults[i+1]
-		}
-		carrier := buildCanonicalClaudeResultCarrier(carrierBase, toolUses, carrierParts)
+		run := collectClaudeResultCarrierRun(messageResults, i+1)
+		carrier := buildCanonicalClaudeResultCarrier(run.base, toolUses, run.parts)
 		hasExtras := claudeContentHasNonToolResults(gjson.GetBytes(carrier, "content"))
 		assistantRaw := []byte(message.Raw)
 		droppedServerTool := false
@@ -62,16 +66,19 @@ func RepairDanglingClaudeToolUses(payload []byte) []byte {
 		}
 		out = append(out, assistantRaw)
 
-		if runCount == 1 && !droppedServerTool && isCanonicalClaudeResultCarrier(messageResults[i+1], toolUses) {
-			out = append(out, []byte(messageResults[i+1].Raw))
-			i = runEnd - 1
+		if run.count == 1 && !droppedServerTool && isCanonicalClaudeResultCarrier(run.base, toolUses) {
+			out = append(out, []byte(run.base.Raw))
+			out = append(out, run.interveningSystems...)
+			changed = changed || len(run.interveningSystems) > 0
+			i = run.end - 1
 			continue
 		}
 
 		out = append(out, carrier)
+		out = append(out, run.interveningSystems...)
 		changed = true
-		if runCount > 0 {
-			i = runEnd - 1
+		if run.count > 0 {
+			i = run.end - 1
 		}
 	}
 
@@ -111,25 +118,50 @@ func claudeAssistantClientToolUses(message gjson.Result) []claudeClientToolUse {
 	return toolUses
 }
 
-func collectClaudeResultCarrierRun(messages []gjson.Result, start int) (end, count int, parts []claudeCarrierPart) {
-	end = start
-	for end < len(messages) {
-		message := messages[end]
-		role := message.Get("role").String()
-		if role != "user" && role != "tool" {
+func collectClaudeResultCarrierRun(messages []gjson.Result, start int) claudeResultCarrierRun {
+	run := claudeResultCarrierRun{end: start}
+	for run.end < len(messages) {
+		message := messages[run.end]
+		if isClaudeResultCarrierMessage(message) {
+			if run.count == 0 {
+				run.base = message
+			}
+			run.parts = append(run.parts, claudeCarrierMessageParts(message, message.Get("role").String())...)
+			run.count++
+			run.end++
+			continue
+		}
+
+		if message.Get("role").String() != "system" {
 			break
 		}
-		content := message.Get("content")
-		if claudeContentContainsType(content, "tool_use") {
+		systemEnd := run.end
+		for systemEnd < len(messages) && messages[systemEnd].Get("role").String() == "system" {
+			systemEnd++
+		}
+		if systemEnd == len(messages) || !isClaudeResultCarrierMessage(messages[systemEnd]) {
 			break
 		}
 
-		messageParts := claudeCarrierMessageParts(message, role)
-		parts = append(parts, messageParts...)
-		count++
-		end++
+		// Anthropic requires the user result carrier immediately after an
+		// assistant tool_use, while a mid-conversation system turn must follow a
+		// user turn. Defer only system runs that lead to another carrier, then
+		// replay them after the canonical carrier. This keeps their relative order
+		// while satisfying both placement rules.
+		for index := run.end; index < systemEnd; index++ {
+			run.interveningSystems = append(run.interveningSystems, []byte(messages[index].Raw))
+		}
+		run.end = systemEnd
 	}
-	return end, count, parts
+	return run
+}
+
+func isClaudeResultCarrierMessage(message gjson.Result) bool {
+	role := message.Get("role").String()
+	if role != "user" && role != "tool" {
+		return false
+	}
+	return !claudeContentContainsType(message.Get("content"), "tool_use")
 }
 
 func claudeCarrierMessageParts(message gjson.Result, role string) []claudeCarrierPart {

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -279,13 +279,10 @@ func isCanonicalClaudeResultCarrier(message gjson.Result, toolUses []claudeClien
 
 func normalizeClaudeToolResult(raw []byte) ([]byte, string) {
 	result := gjson.ParseBytes(raw)
+	// Only tool_use_id links an Anthropic result to a call. A generic id is
+	// untrusted metadata and must not make a malformed result look complete.
 	id := claudeStringField(result, "tool_use_id")
-	aliasID := claudeStringField(result, "id")
 	updated := raw
-	if id == "" && aliasID != "" {
-		id = aliasID
-		updated, _ = sjson.SetBytes(updated, "tool_use_id", id)
-	}
 	if result.Get("id").Exists() {
 		updated, _ = sjson.DeleteBytes(updated, "id")
 	}

--- a/internal/runtime/executor/helps/claude_tool_turns.go
+++ b/internal/runtime/executor/helps/claude_tool_turns.go
@@ -25,7 +25,9 @@ type claudeResultCarrierRun struct {
 	count              int
 	base               gjson.Result
 	parts              []claudeCarrierPart
-	interveningSystems [][]byte
+	replayAfterCarrier [][]byte
+	followingInterrupt bool
+	bridgedSystem      bool
 }
 
 // RepairDanglingClaudeToolUses closes client tool calls left incomplete by an
@@ -52,9 +54,9 @@ func RepairDanglingClaudeToolUses(payload []byte) []byte {
 			continue
 		}
 
-		run := collectClaudeResultCarrierRun(messageResults, i+1)
+		run := collectClaudeResultCarrierRun(messageResults, i+1, toolUses)
 		carrier := buildCanonicalClaudeResultCarrier(run.base, toolUses, run.parts)
-		hasExtras := claudeContentHasNonToolResults(gjson.GetBytes(carrier, "content"))
+		hasExtras := claudeContentHasNonToolResults(gjson.GetBytes(carrier, "content")) || run.followingInterrupt
 		assistantRaw := []byte(message.Raw)
 		droppedServerTool := false
 		if hasExtras {
@@ -68,14 +70,14 @@ func RepairDanglingClaudeToolUses(payload []byte) []byte {
 
 		if run.count == 1 && !droppedServerTool && isCanonicalClaudeResultCarrier(run.base, toolUses) {
 			out = append(out, []byte(run.base.Raw))
-			out = append(out, run.interveningSystems...)
-			changed = changed || len(run.interveningSystems) > 0
+			out = append(out, run.replayAfterCarrier...)
+			changed = changed || len(run.replayAfterCarrier) > 0
 			i = run.end - 1
 			continue
 		}
 
 		out = append(out, carrier)
-		out = append(out, run.interveningSystems...)
+		out = append(out, run.replayAfterCarrier...)
 		changed = true
 		if run.count > 0 {
 			i = run.end - 1
@@ -118,21 +120,56 @@ func claudeAssistantClientToolUses(message gjson.Result) []claudeClientToolUse {
 	return toolUses
 }
 
-func collectClaudeResultCarrierRun(messages []gjson.Result, start int) claudeResultCarrierRun {
+func collectClaudeResultCarrierRun(messages []gjson.Result, start int, toolUses []claudeClientToolUse) claudeResultCarrierRun {
 	run := claudeResultCarrierRun{end: start}
+	outstanding := make(map[string]struct{}, len(toolUses))
+	for _, toolUse := range toolUses {
+		outstanding[toolUse.id] = struct{}{}
+	}
 	for run.end < len(messages) {
 		message := messages[run.end]
 		if isClaudeResultCarrierMessage(message) {
+			parts := claudeCarrierMessageParts(message, message.Get("role").String())
+			if run.bridgedSystem {
+				if !claudeCarrierPartsContainOutstandingResult(parts, outstanding) {
+					run.followingInterrupt = true
+					break
+				}
+				matched, remaining := extractClaudeOutstandingToolResults(outstanding, parts)
+				run.parts = append(run.parts, matched...)
+				if len(remaining) > 0 {
+					run.replayAfterCarrier = append(run.replayAfterCarrier, buildDeferredClaudeCarrier(message, remaining))
+					run.followingInterrupt = true
+				}
+				if run.count == 0 && len(remaining) == 0 {
+					run.base = message
+				}
+				run.count++
+				run.end++
+				if len(remaining) > 0 {
+					// Remaining user content ends the tool-result bridge. A later result
+					// must not be hoisted across that instruction or diagnostic text.
+					break
+				}
+				continue
+			}
 			if run.count == 0 {
 				run.base = message
 			}
-			run.parts = append(run.parts, claudeCarrierMessageParts(message, message.Get("role").String())...)
+			run.parts = append(run.parts, parts...)
+			if claudeCarrierPartsContainInterrupt(parts, outstanding) {
+				run.followingInterrupt = true
+			}
+			consumeClaudeOutstandingToolResults(outstanding, parts)
 			run.count++
 			run.end++
 			continue
 		}
 
 		if message.Get("role").String() != "system" {
+			break
+		}
+		if run.followingInterrupt {
 			break
 		}
 		systemEnd := run.end
@@ -142,18 +179,105 @@ func collectClaudeResultCarrierRun(messages []gjson.Result, start int) claudeRes
 		if systemEnd == len(messages) || !isClaudeResultCarrierMessage(messages[systemEnd]) {
 			break
 		}
+		nextCarrier := messages[systemEnd]
+		nextParts := claudeCarrierMessageParts(nextCarrier, nextCarrier.Get("role").String())
+		if len(outstanding) == 0 || !claudeCarrierPartsContainOutstandingResult(nextParts, outstanding) {
+			run.followingInterrupt = true
+			break
+		}
 
 		// Anthropic requires the user result carrier immediately after an
 		// assistant tool_use, while a mid-conversation system turn must follow a
-		// user turn. Defer only system runs that lead to another carrier, then
-		// replay them after the canonical carrier. This keeps their relative order
-		// while satisfying both placement rules.
+		// user turn. Defer only system runs whose next carrier satisfies an
+		// outstanding call, then replay them after the canonical carrier. This
+		// keeps completed tool turns from absorbing a later ordinary user request.
 		for index := run.end; index < systemEnd; index++ {
-			run.interveningSystems = append(run.interveningSystems, []byte(messages[index].Raw))
+			run.replayAfterCarrier = append(run.replayAfterCarrier, []byte(messages[index].Raw))
 		}
 		run.end = systemEnd
+		run.bridgedSystem = true
 	}
 	return run
+}
+
+func claudeCarrierPartsContainInterrupt(parts []claudeCarrierPart, outstanding map[string]struct{}) bool {
+	matched := make(map[string]struct{})
+	for _, part := range parts {
+		if !part.isToolResult {
+			return true
+		}
+		id := claudeStringField(gjson.ParseBytes(part.raw), "tool_use_id")
+		if _, exists := outstanding[id]; !exists {
+			return true
+		}
+		if _, duplicate := matched[id]; duplicate {
+			return true
+		}
+		matched[id] = struct{}{}
+	}
+	return false
+}
+
+func claudeCarrierPartsContainOutstandingResult(parts []claudeCarrierPart, outstanding map[string]struct{}) bool {
+	for _, part := range parts {
+		if !part.isToolResult {
+			continue
+		}
+		id := claudeStringField(gjson.ParseBytes(part.raw), "tool_use_id")
+		if _, exists := outstanding[id]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+func consumeClaudeOutstandingToolResults(outstanding map[string]struct{}, parts []claudeCarrierPart) {
+	for _, part := range parts {
+		if !part.isToolResult {
+			continue
+		}
+		delete(outstanding, claudeStringField(gjson.ParseBytes(part.raw), "tool_use_id"))
+	}
+}
+
+func extractClaudeOutstandingToolResults(outstanding map[string]struct{}, parts []claudeCarrierPart) (matched, remaining []claudeCarrierPart) {
+	matched = make([]claudeCarrierPart, 0, len(parts))
+	remaining = make([]claudeCarrierPart, 0, len(parts))
+	for _, part := range parts {
+		if part.isToolResult {
+			id := claudeStringField(gjson.ParseBytes(part.raw), "tool_use_id")
+			if _, exists := outstanding[id]; exists {
+				matched = append(matched, part)
+				delete(outstanding, id)
+				continue
+			}
+		}
+		remaining = append(remaining, part)
+	}
+	return matched, remaining
+}
+
+func buildDeferredClaudeCarrier(base gjson.Result, parts []claudeCarrierPart) []byte {
+	content := make([][]byte, 0, len(parts))
+	for _, part := range parts {
+		if !part.isToolResult {
+			content = append(content, part.raw)
+			continue
+		}
+		normalized, id := normalizeClaudeToolResult(part.raw)
+		content = append(content, downgradeClaudeToolResult(normalized, id))
+	}
+
+	message := []byte(`{"role":"user","content":[]}`)
+	if base.IsObject() {
+		message = []byte(base.Raw)
+		message, _ = sjson.SetBytes(message, "role", "user")
+		for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+			message, _ = sjson.DeleteBytes(message, field)
+		}
+	}
+	message, _ = sjson.SetRawBytes(message, "content", translatorcommon.JoinRawArray(content))
+	return message
 }
 
 func isClaudeResultCarrierMessage(message gjson.Result) bool {

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -1,0 +1,254 @@
+package helps
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestRepairDanglingClaudeToolUses(t *testing.T) {
+	t.Run("merges an interrupting user prompt after an error result", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"cmd":"curl"}}]},{"role":"user","content":"fix the regression"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		blocks := messages[1].Get("content").Array()
+		if len(blocks) != 2 {
+			t.Fatalf("user blocks = %d, want 2: %s", len(blocks), messages[1].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
+		if blocks[1].Get("type").String() != "text" || blocks[1].Get("text").String() != "fix the regression" {
+			t.Fatalf("user text not preserved: %s", blocks[1].Raw)
+		}
+	})
+
+	t.Run("adds a user result after a trailing assistant", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t_last","name":"Read","input":{}}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		if messages[1].Get("role").String() != "user" {
+			t.Fatalf("inserted role = %q, want user", messages[1].Get("role").String())
+		}
+		assertInterruptedClaudeToolResult(t, messages[1].Get("content.0"), "t_last", "")
+	})
+
+	t.Run("leaves a canonical pairing byte-identical", func(t *testing.T) {
+		input := []byte(`{ "messages": [ {"role":"assistant","content":[{"type":"tool_use","id":"done1","name":"Bash"}]}, {"role":"user","content":[{"type":"tool_result","tool_use_id":"done1","content":"success"},{"type":"text","text":"continue"}]} ], "max_tokens": 42 }`)
+		got := RepairDanglingClaudeToolUses(input)
+		if !bytes.Equal(got, input) {
+			t.Fatalf("canonical pairing mutated:\n got %s\nwant %s", got, input)
+		}
+	})
+
+	t.Run("orders partial parallel results by tool use", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"Bash"},{"type":"tool_use","id":"p2","name":"Bash"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"p1 done"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		blocks := messages[1].Get("content").Array()
+		if len(blocks) != 2 {
+			t.Fatalf("user blocks = %d, want 2: %s", len(blocks), messages[1].Raw)
+		}
+		if blocks[0].Get("tool_use_id").String() != "p1" || blocks[0].Get("content").String() != "p1 done" {
+			t.Fatalf("existing p1 result was not kept first: %s", blocks[0].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+	})
+
+	t.Run("inserts a result between consecutive assistants", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"mid","name":"Bash"}]},{"role":"assistant","content":[{"type":"text","text":"continue"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 3)
+		assertInterruptedClaudeToolResult(t, messages[1].Get("content.0"), "mid", "")
+		if messages[2].Get("role").String() != "assistant" || messages[2].Get("content.0.text").String() != "continue" {
+			t.Fatalf("trailing assistant mutated: %s", messages[2].Raw)
+		}
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"user","content":"stop"}]}`)
+		once := RepairDanglingClaudeToolUses(input)
+		twice := RepairDanglingClaudeToolUses(once)
+		if !bytes.Equal(twice, once) {
+			t.Fatalf("second repair mutated:\n once %s\n twice %s", once, twice)
+		}
+	})
+}
+
+func TestRepairDanglingClaudeToolUsesCanonicalizesResultCarriers(t *testing.T) {
+	t.Run("normalizes tool role and top level call id", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"tool","tool_call_id":"t1","content":"real output"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		if messages[1].Get("role").String() != "user" || messages[1].Get("tool_call_id").Exists() {
+			t.Fatalf("tool message not normalized: %s", messages[1].Raw)
+		}
+		result := messages[1].Get("content.0")
+		if result.Get("type").String() != "tool_result" || result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "real output" {
+			t.Fatalf("tool result not preserved: %s", result.Raw)
+		}
+		if result.Get("is_error").Bool() {
+			t.Fatalf("real tool output was marked as an error: %s", result.Raw)
+		}
+	})
+
+	t.Run("normalizes an id alias inside a result block", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"tool","content":[{"type":"tool_result","id":"t1","content":"real output"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		result := messages[1].Get("content.0")
+		if messages[1].Get("role").String() != "user" || result.Get("tool_use_id").String() != "t1" || result.Get("id").Exists() {
+			t.Fatalf("id alias not normalized: %s", messages[1].Raw)
+		}
+		if result.Get("content").String() != "real output" || result.Get("is_error").Bool() {
+			t.Fatalf("normalized real output changed semantics: %s", result.Raw)
+		}
+	})
+
+	t.Run("does not treat a generic top level id as a tool result id", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"tool","id":"t1","content":"untrusted alias"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		blocks := messages[1].Get("content").Array()
+		if len(blocks) != 2 {
+			t.Fatalf("user blocks = %d, want 2: %s", len(blocks), messages[1].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
+		if blocks[1].Get("type").String() != "text" || blocks[1].Get("text").String() != "untrusted alias" {
+			t.Fatalf("generic id payload was not downgraded safely: %s", messages[1].Raw)
+		}
+	})
+
+	t.Run("merges split parallel carriers without inventing errors", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"two"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		blocks := messages[1].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("tool_use_id").String() != "p1" || blocks[1].Get("tool_use_id").String() != "p2" {
+			t.Fatalf("split results not merged in call order: %s", messages[1].Raw)
+		}
+		for _, block := range blocks {
+			if block.Get("is_error").Bool() {
+				t.Fatalf("real result replaced by an error: %s", block.Raw)
+			}
+		}
+	})
+
+	t.Run("downgrades duplicate orphan and malformed results", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"one"}]},{"role":"tool","content":[{"type":"tool_result","tool_use_id":"t1","content":"first"},{"type":"tool_result","tool_use_id":"t1","content":"duplicate"},{"type":"tool_result","tool_use_id":"ghost","content":"orphan"},{"type":"tool_result","content":"missing id"},{"type":"text","text":"keep me"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		blocks := messages[1].Get("content").Array()
+		toolResultCount := 0
+		var text strings.Builder
+		for _, block := range blocks {
+			if block.Get("type").String() == "tool_result" {
+				toolResultCount++
+				if block.Get("tool_use_id").String() != "t1" {
+					t.Fatalf("unexpected protocol result survived: %s", block.Raw)
+				}
+			}
+			if block.Get("type").String() == "text" {
+				text.WriteString(block.Get("text").String())
+			}
+		}
+		if toolResultCount != 1 {
+			t.Fatalf("tool result count = %d, want 1: %s", toolResultCount, messages[1].Raw)
+		}
+		for _, want := range []string{"duplicate", "orphan", "missing id", "keep me"} {
+			if !strings.Contains(text.String(), want) {
+				t.Fatalf("downgraded text lost %q: %s", want, messages[1].Raw)
+			}
+		}
+	})
+
+	t.Run("downgrades a standalone orphan result", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"ghost","content":"diagnostic"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 1)
+		block := messages[0].Get("content.0")
+		if block.Get("type").String() != "text" || !strings.Contains(block.Get("text").String(), "diagnostic") {
+			t.Fatalf("standalone orphan not downgraded: %s", messages[0].Raw)
+		}
+	})
+}
+
+func TestRepairDanglingClaudeToolUsesPreservesToolsetAndServerToolRules(t *testing.T) {
+	t.Run("copies toolset name onto a synthetic result", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"browser1","toolset_name":"browser","name":"navigate","input":{}}]},{"role":"user","content":"stop"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		result := messages[1].Get("content.0")
+		assertInterruptedClaudeToolResult(t, result, "browser1", "browser")
+		if !result.Get("content").IsArray() || result.Get("content.0.type").String() != "text" {
+			t.Fatalf("toolset result must use typed content blocks: %s", result.Raw)
+		}
+	})
+
+	t.Run("copies toolset name onto a real result", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"browser1","toolset_name":"browser","name":"navigate","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"browser1","content":[{"type":"text","text":"done"}]}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		result := messages[1].Get("content.0")
+		if result.Get("toolset_name").String() != "browser" || result.Get("content.0.text").String() != "done" || result.Get("is_error").Bool() {
+			t.Fatalf("real toolset result was not aligned: %s", result.Raw)
+		}
+	})
+
+	t.Run("drops an unresolved server call before preserving interrupt text", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"server_tool_use","id":"srv1","name":"web_search","input":{}},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"user","content":"change direction"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		assistantBlocks := messages[0].Get("content").Array()
+		if len(assistantBlocks) != 1 || assistantBlocks[0].Get("type").String() != "tool_use" {
+			t.Fatalf("unresolved server call was not removed safely: %s", messages[0].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, messages[1].Get("content.0"), "client1", "")
+		if messages[1].Get("content.1.text").String() != "change direction" {
+			t.Fatalf("interrupt text was not preserved: %s", messages[1].Raw)
+		}
+	})
+
+	t.Run("keeps a completed server call", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"server_tool_use","id":"srv1","name":"web_search","input":{}},{"type":"web_search_tool_result","tool_use_id":"srv1","content":[]},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"user","content":"change direction"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		if messages[0].Get("content.0.type").String() != "server_tool_use" || messages[0].Get("content.1.type").String() != "web_search_tool_result" {
+			t.Fatalf("completed server call was removed: %s", messages[0].Raw)
+		}
+	})
+
+	t.Run("keeps an unresolved server call when the user turn has only results", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"server_tool_use","id":"srv1","name":"web_search","input":{}},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"client1","content":"done"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		if !bytes.Equal(got, input) {
+			t.Fatalf("valid server resume history mutated:\n got %s\nwant %s", got, input)
+		}
+	})
+}
+
+func claudeMessagesForTest(t *testing.T, payload []byte, want int) []gjson.Result {
+	t.Helper()
+	messages := gjson.GetBytes(payload, "messages").Array()
+	if len(messages) != want {
+		t.Fatalf("message count = %d, want %d: %s", len(messages), want, payload)
+	}
+	return messages
+}
+
+func assertInterruptedClaudeToolResult(t *testing.T, block gjson.Result, toolUseID, toolsetName string) {
+	t.Helper()
+	if block.Get("type").String() != "tool_result" || block.Get("tool_use_id").String() != toolUseID {
+		t.Fatalf("expected interrupted result for %s: %s", toolUseID, block.Raw)
+	}
+	content := block.Get("content").String()
+	if block.Get("content").IsArray() {
+		content = block.Get("content.0.text").String()
+	}
+	if content != interruptedClaudeToolResultContent || !block.Get("is_error").Bool() {
+		t.Fatalf("synthetic result is not an error: %s", block.Raw)
+	}
+	if block.Get("toolset_name").String() != toolsetName {
+		t.Fatalf("toolset_name = %q, want %q: %s", block.Get("toolset_name").String(), toolsetName, block.Raw)
+	}
+}

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -265,6 +265,125 @@ func TestRepairDanglingClaudeToolUsesCanonicalizesResultCarriers(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("sanitizes compatibility fields on a canonical result carrier", func(t *testing.T) {
+		input := []byte(`{"messages":[` +
+			`{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},` +
+			`{"role":"user","tool_use_id":"top-tool-use","tool_call_id":"top-tool-call","call_id":"top-call","id":"top-id","name":"top-name","content":[` +
+			`{"type":"tool_result","tool_use_id":"t1","tool_call_id":"block-tool-call","call_id":"block-call","id":"block-id","name":"block-name","content":"done"}` +
+			`]}` +
+			`]}`)
+
+		once := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, once, 2)
+		assertClaudeUserCarrierEnvelope(t, messages[1])
+		result := messages[1].Get("content.0")
+		if result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "done" || result.Get("is_error").Bool() {
+			t.Fatalf("canonical result was not preserved: %s", result.Raw)
+		}
+		for _, field := range []string{"tool_call_id", "call_id", "id", "name"} {
+			if result.Get(field).Exists() {
+				t.Fatalf("canonical result retained block-level %s: %s", field, result.Raw)
+			}
+		}
+		if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+			t.Fatalf("canonical compatibility cleanup is not idempotent:\n once %s\n twice %s", once, twice)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name            string
+		carrier         string
+		wantDiagnostics []string
+	}{
+		{
+			name:            "legacy tool number",
+			carrier:         `{"role":"tool","tool_call_id":"t1","id":"legacy","name":"tool","content":42}`,
+			wantDiagnostics: []string{"42"},
+		},
+		{
+			name:            "legacy tool boolean",
+			carrier:         `{"role":"tool","tool_call_id":"t1","content":false}`,
+			wantDiagnostics: []string{"false"},
+		},
+		{
+			name:    "legacy tool null",
+			carrier: `{"role":"tool","tool_call_id":"t1","content":null}`,
+		},
+		{
+			name:            "result object",
+			carrier:         `{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":{"raw":"object output"}}]}`,
+			wantDiagnostics: []string{"object output"},
+		},
+		{
+			name:            "legacy tool primitive array",
+			carrier:         `{"role":"tool","call_id":"t1","content":["raw output",17,{"raw":"untyped output"},{"type":"text","text":"typed output"}]}`,
+			wantDiagnostics: []string{"raw output", "17", "untyped output", "typed output"},
+		},
+		{
+			name:            "result empty array",
+			carrier:         `{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[]}]}`,
+			wantDiagnostics: []string{"[]"},
+		},
+		{
+			name:    "result missing content",
+			carrier: `{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1"}]}`,
+		},
+	} {
+		t.Run("normalizes adopted "+testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},` + testCase.carrier + `]}`)
+			once := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, once, 2)
+			assertClaudeUserCarrierEnvelope(t, messages[1])
+			result := messages[1].Get("content.0")
+			if result.Get("type").String() != "tool_result" || result.Get("tool_use_id").String() != "t1" || result.Get("is_error").Bool() {
+				t.Fatalf("adopted result was not preserved: %s", result.Raw)
+			}
+			if !isCanonicalClaudeToolResultContent(result.Get("content")) {
+				t.Fatalf("adopted result retained invalid content: %s", result.Raw)
+			}
+			diagnostic := claudeToolResultText(result.Get("content"))
+			for _, want := range testCase.wantDiagnostics {
+				if !strings.Contains(diagnostic, want) {
+					t.Fatalf("adopted result lost %q: %s", want, result.Raw)
+				}
+			}
+			if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+				t.Fatalf("adopted %s cleanup is not idempotent:\n once %s\n twice %s", testCase.name, once, twice)
+			}
+		})
+	}
+
+	for _, testCase := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "whole number", content: `42`, want: "42"},
+		{name: "primitive array", content: `[17,{"raw":"untyped"}]`, want: "untyped"},
+		{name: "empty array", content: `[]`, want: "[invalid user content]"},
+	} {
+		t.Run("preserves invalid interrupting user content "+testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"user","content":` + testCase.content + `}]}`)
+			once := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, once, 2)
+			blocks := messages[1].Get("content").Array()
+			if len(blocks) < 2 {
+				t.Fatalf("invalid user content was dropped: %s", messages[1].Raw)
+			}
+			assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
+			var diagnostic strings.Builder
+			for _, block := range blocks[1:] {
+				diagnostic.WriteString(block.Get("text").String())
+			}
+			if !strings.Contains(diagnostic.String(), testCase.want) {
+				t.Fatalf("invalid user diagnostic lost %q: %s", testCase.want, messages[1].Raw)
+			}
+			if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+				t.Fatalf("invalid user %s repair is not idempotent:\n once %s\n twice %s", testCase.name, once, twice)
+			}
+		})
+	}
 }
 
 func TestRepairDanglingClaudeToolUsesStopsAtFirstInterruptingCarrier(t *testing.T) {

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -174,6 +174,85 @@ func TestRepairDanglingClaudeToolUsesCanonicalizesResultCarriers(t *testing.T) {
 	})
 }
 
+func TestRepairDanglingClaudeToolUsesRelocatesInterveningSystemTurns(t *testing.T) {
+	t.Run("adopts a real result across a system turn", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"system","content":"new context","clear_at":"next_user_message"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"real output"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 4)
+		result := messages[2].Get("content.0")
+		if messages[2].Get("role").String() != "user" || result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "real output" {
+			t.Fatalf("real result was not adopted: %s", messages[2].Raw)
+		}
+		if result.Get("is_error").Bool() {
+			t.Fatalf("real result was replaced by an interruption: %s", result.Raw)
+		}
+		if messages[3].Raw != `{"role":"system","content":"new context","clear_at":"next_user_message"}` {
+			t.Fatalf("system turn was not replayed intact after the result: %s", messages[3].Raw)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("real-result relocation is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	t.Run("merges split results before replaying systems in source order", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"system","content":"first"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"two"}]},{"role":"system","content":[{"type":"text","text":"second"}],"clear_at":"next_user_message"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"}]},{"role":"system","content":"third"},{"role":"assistant","content":"continue"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 7)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("tool_use_id").String() != "p1" || blocks[1].Get("tool_use_id").String() != "p2" {
+			t.Fatalf("split real results were not merged in call order: %s", messages[2].Raw)
+		}
+		for _, block := range blocks {
+			if block.Get("is_error").Bool() {
+				t.Fatalf("real result was replaced by an interruption: %s", block.Raw)
+			}
+		}
+		if messages[3].Get("content").String() != "first" || messages[4].Get("content.0.text").String() != "second" || messages[5].Get("content").String() != "third" {
+			t.Fatalf("system turn order changed: %s", got)
+		}
+		if messages[4].Get("clear_at").String() != "next_user_message" {
+			t.Fatalf("system metadata was not preserved: %s", messages[4].Raw)
+		}
+		if messages[6].Get("role").String() != "assistant" || messages[6].Get("content").String() != "continue" {
+			t.Fatalf("following assistant turn changed: %s", messages[6].Raw)
+		}
+	})
+
+	t.Run("places an interrupt and its synthetic result before the system turn", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"system","content":"new constraint"},{"role":"user","content":"change direction"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 4)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 2 {
+			t.Fatalf("canonical user blocks = %d, want 2: %s", len(blocks), messages[2].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
+		if blocks[1].Get("type").String() != "text" || blocks[1].Get("text").String() != "change direction" {
+			t.Fatalf("interrupt text was not preserved: %s", messages[2].Raw)
+		}
+		if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "new constraint" {
+			t.Fatalf("system turn was not moved after the canonical user turn: %s", messages[3].Raw)
+		}
+	})
+
+	t.Run("inserts a fallback before terminal systems without duplication", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"system","content":"first"},{"role":"system","content":"second"},{"role":"assistant","content":"continue"}]}`)
+		once := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, once, 6)
+		assertInterruptedClaudeToolResult(t, messages[2].Get("content.0"), "t1", "")
+		if messages[3].Get("content").String() != "first" || messages[4].Get("content").String() != "second" {
+			t.Fatalf("terminal systems were lost or reordered: %s", once)
+		}
+		if messages[5].Get("role").String() != "assistant" {
+			t.Fatalf("following assistant turn changed: %s", messages[5].Raw)
+		}
+		twice := RepairDanglingClaudeToolUses(once)
+		if !bytes.Equal(twice, once) {
+			t.Fatalf("system relocation is not idempotent:\n once %s\n twice %s", once, twice)
+		}
+	})
+}
+
 func TestRepairDanglingClaudeToolUsesPreservesToolsetAndServerToolRules(t *testing.T) {
 	t.Run("copies toolset name onto a synthetic result", func(t *testing.T) {
 		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"browser1","toolset_name":"browser","name":"navigate","input":{}}]},{"role":"user","content":"stop"}]}`)

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -194,6 +194,136 @@ func TestRepairDanglingClaudeToolUsesRelocatesInterveningSystemTurns(t *testing.
 		}
 	})
 
+	t.Run("keeps a completed result before a system and later user request", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"done"}]},{"role":"system","content":"apply this constraint"},{"role":"user","content":"next request"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		if !bytes.Equal(got, input) {
+			t.Fatalf("completed turn absorbed a later request:\n got %s\nwant %s", got, input)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("completed result boundary is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	t.Run("hoists only an outstanding result across a system turn", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"system","content":"apply before the request"},{"role":"user","content":[{"type":"text","text":"next request"},{"type":"tool_result","tool_use_id":"t1","content":"done"},{"type":"tool_result","tool_use_id":"ghost","content":"orphan output"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 5)
+		result := messages[2].Get("content.0")
+		if result.Get("tool_use_id").String() != "t1" || result.Get("content").String() != "done" || result.Get("is_error").Bool() {
+			t.Fatalf("outstanding result was not hoisted intact: %s", messages[2].Raw)
+		}
+		if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "apply before the request" {
+			t.Fatalf("system constraint moved after the ordinary request: %s", got)
+		}
+		deferred := messages[4].Get("content").Array()
+		if messages[4].Get("role").String() != "user" || len(deferred) != 2 || deferred[0].Get("text").String() != "next request" || !strings.Contains(deferred[1].Get("text").String(), "orphan output") {
+			t.Fatalf("ordinary request was not preserved after the system constraint: %s", got)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("split result carrier is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	t.Run("fills a partial parallel result before a system without absorbing the next request", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"}]},{"role":"system","content":"constraint"},{"role":"user","content":"next request"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 5)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("tool_use_id").String() != "p1" || blocks[0].Get("content").String() != "one" {
+			t.Fatalf("partial real result changed: %s", got)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+		if messages[3].Get("role").String() != "system" || messages[4].Get("content").String() != "next request" {
+			t.Fatalf("later request crossed the system boundary: %s", got)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("partial-result fallback is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	t.Run("stops after a bridged result carrier leaves user content", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"system","content":"first constraint"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"},{"type":"text","text":"change direction"}]},{"role":"system","content":"second constraint"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"late two"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 7)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("tool_use_id").String() != "p1" || blocks[0].Get("content").String() != "one" {
+			t.Fatalf("first bridged result changed: %s", got)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+		if messages[3].Get("content").String() != "first constraint" || messages[4].Get("content.0.text").String() != "change direction" || messages[5].Get("content").String() != "second constraint" {
+			t.Fatalf("system and user content order changed: %s", got)
+		}
+		if messages[6].Get("content.0.type").String() != "text" || !strings.Contains(messages[6].Get("content.0.text").String(), "late two") {
+			t.Fatalf("late result crossed the user interruption: %s", got)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("bridged interruption boundary is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	t.Run("does not bridge after immediate result carrier user content", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"},{"type":"text","text":"change direction"}]},{"role":"system","content":"constraint"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"late two"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 5)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 3 || blocks[0].Get("tool_use_id").String() != "p1" {
+			t.Fatalf("immediate carrier changed unexpectedly: %s", got)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+		if blocks[2].Get("text").String() != "change direction" || messages[3].Get("role").String() != "system" {
+			t.Fatalf("user content or system order changed: %s", got)
+		}
+		if messages[4].Get("content.0.type").String() != "text" || !strings.Contains(messages[4].Get("content.0.text").String(), "late two") {
+			t.Fatalf("late result crossed the immediate user content: %s", got)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("immediate interruption boundary is not idempotent:\n once %s\n twice %s", got, twice)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name       string
+		laterBlock string
+		wantText   string
+	}{
+		{name: "orphan", laterBlock: `{"type":"tool_result","tool_use_id":"ghost","content":"orphan output"}`, wantText: "orphan output"},
+		{name: "malformed", laterBlock: `{"type":"tool_result","id":"t1","content":"malformed output"}`, wantText: "malformed output"},
+	} {
+		t.Run("does not bridge a completed result to a later "+testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"done"}]},{"role":"system","content":"constraint"},{"role":"user","content":[` + testCase.laterBlock + `]}]}`)
+			got := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, got, 5)
+			if messages[2].Get("content.0.tool_use_id").String() != "t1" || messages[2].Get("content.0.content").String() != "done" {
+				t.Fatalf("completed result changed: %s", got)
+			}
+			if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "constraint" {
+				t.Fatalf("system moved across later %s: %s", testCase.name, got)
+			}
+			later := messages[4].Get("content.0")
+			if later.Get("type").String() != "text" || !strings.Contains(later.Get("text").String(), testCase.wantText) {
+				t.Fatalf("later %s was not downgraded in place: %s", testCase.name, got)
+			}
+			if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+				t.Fatalf("%s boundary is not idempotent:\n once %s\n twice %s", testCase.name, got, twice)
+			}
+		})
+	}
+
+	t.Run("does not bridge a duplicate while another result is outstanding", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"}]},{"role":"system","content":"constraint"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"duplicate"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 5)
+		blocks := messages[2].Get("content").Array()
+		if len(blocks) != 2 || blocks[0].Get("tool_use_id").String() != "p1" {
+			t.Fatalf("first result carrier changed unexpectedly: %s", got)
+		}
+		assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+		if messages[3].Get("role").String() != "system" || messages[4].Get("content.0.type").String() != "text" || !strings.Contains(messages[4].Get("content.0.text").String(), "duplicate") {
+			t.Fatalf("duplicate crossed the system boundary: %s", got)
+		}
+	})
+
 	t.Run("merges split results before replaying systems in source order", func(t *testing.T) {
 		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},{"role":"system","content":"first"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"two"}]},{"role":"system","content":[{"type":"text","text":"second"}],"clear_at":"next_user_message"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"}]},{"role":"system","content":"third"},{"role":"assistant","content":"continue"}]}`)
 		got := RepairDanglingClaudeToolUses(input)
@@ -216,24 +346,51 @@ func TestRepairDanglingClaudeToolUsesRelocatesInterveningSystemTurns(t *testing.
 		if messages[6].Get("role").String() != "assistant" || messages[6].Get("content").String() != "continue" {
 			t.Fatalf("following assistant turn changed: %s", messages[6].Raw)
 		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("multi-system result bridging is not idempotent:\n once %s\n twice %s", got, twice)
+		}
 	})
 
-	t.Run("places an interrupt and its synthetic result before the system turn", func(t *testing.T) {
+	t.Run("does not bridge a plain request across a system turn", func(t *testing.T) {
 		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"system","content":"new constraint"},{"role":"user","content":"change direction"}]}`)
 		got := RepairDanglingClaudeToolUses(input)
-		messages := claudeMessagesForTest(t, got, 4)
+		messages := claudeMessagesForTest(t, got, 5)
 		blocks := messages[2].Get("content").Array()
-		if len(blocks) != 2 {
-			t.Fatalf("canonical user blocks = %d, want 2: %s", len(blocks), messages[2].Raw)
+		if len(blocks) != 1 {
+			t.Fatalf("synthetic result blocks = %d, want 1: %s", len(blocks), messages[2].Raw)
 		}
 		assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
-		if blocks[1].Get("type").String() != "text" || blocks[1].Get("text").String() != "change direction" {
-			t.Fatalf("interrupt text was not preserved: %s", messages[2].Raw)
-		}
 		if messages[3].Get("role").String() != "system" || messages[3].Get("content").String() != "new constraint" {
-			t.Fatalf("system turn was not moved after the canonical user turn: %s", messages[3].Raw)
+			t.Fatalf("system turn moved across the user request: %s", got)
+		}
+		if messages[4].Get("role").String() != "user" || messages[4].Get("content").String() != "change direction" {
+			t.Fatalf("ordinary user request was not preserved after the system turn: %s", got)
+		}
+		if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+			t.Fatalf("plain-request fallback is not idempotent:\n once %s\n twice %s", got, twice)
 		}
 	})
+
+	for _, testCase := range []struct {
+		name  string
+		block string
+	}{
+		{name: "orphan", block: `{"type":"tool_result","tool_use_id":"ghost","content":"orphan"}`},
+		{name: "malformed", block: `{"type":"tool_result","id":"t1","content":"malformed"}`},
+	} {
+		t.Run("does not bridge an "+testCase.name+" result for an outstanding call", func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read"}]},{"role":"system","content":"constraint"},{"role":"user","content":[` + testCase.block + `]}]}`)
+			got := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, got, 5)
+			assertInterruptedClaudeToolResult(t, messages[2].Get("content.0"), "t1", "")
+			if messages[3].Get("role").String() != "system" || messages[4].Get("content.0.type").String() != "text" {
+				t.Fatalf("%s result crossed the system boundary: %s", testCase.name, got)
+			}
+			if twice := RepairDanglingClaudeToolUses(got); !bytes.Equal(twice, got) {
+				t.Fatalf("outstanding %s fallback is not idempotent:\n once %s\n twice %s", testCase.name, got, twice)
+			}
+		})
+	}
 
 	t.Run("inserts a fallback before terminal systems without duplication", func(t *testing.T) {
 		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"system","content":"first"},{"role":"system","content":"second"},{"role":"assistant","content":"continue"}]}`)
@@ -319,6 +476,33 @@ func TestRepairDanglingClaudeToolUsesPreservesToolsetAndServerToolRules(t *testi
 			t.Fatalf("valid server resume history mutated:\n got %s\nwant %s", got, input)
 		}
 	})
+
+	t.Run("keeps an unresolved server call when a real client result crosses a system", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"server_tool_use","id":"srv1","name":"web_search","input":{}},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"system","content":"context"},{"role":"user","content":[{"type":"tool_result","tool_use_id":"client1","content":"done"}]}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 4)
+		if messages[1].Get("content.0.type").String() != "server_tool_use" {
+			t.Fatalf("resumable server call was removed: %s", got)
+		}
+		if messages[2].Get("content.0.tool_use_id").String() != "client1" || messages[3].Get("role").String() != "system" {
+			t.Fatalf("client result and system were not normalized: %s", got)
+		}
+	})
+
+	for _, serverType := range []string{"server_tool_use", "mcp_tool_use"} {
+		t.Run("drops an unresolved "+serverType+" before a post-system request", func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"` + serverType + `","id":"srv1","name":"lookup","input":{}},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"client1","content":"done"}]},{"role":"system","content":"constraint"},{"role":"user","content":"next request"}]}`)
+			got := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, got, 5)
+			assistantBlocks := messages[1].Get("content").Array()
+			if len(assistantBlocks) != 1 || assistantBlocks[0].Get("type").String() != "tool_use" {
+				t.Fatalf("unresolved %s was not removed before the later request: %s", serverType, got)
+			}
+			if messages[2].Get("content.0.tool_use_id").String() != "client1" || messages[3].Get("role").String() != "system" || messages[4].Get("content").String() != "next request" {
+				t.Fatalf("completed client turn or later request was reordered: %s", got)
+			}
+		})
+	}
 }
 
 func claudeMessagesForTest(t *testing.T, payload []byte, want int) []gjson.Result {

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -92,16 +92,17 @@ func TestRepairDanglingClaudeToolUsesCanonicalizesResultCarriers(t *testing.T) {
 		}
 	})
 
-	t.Run("normalizes an id alias inside a result block", func(t *testing.T) {
-		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"tool","content":[{"type":"tool_result","id":"t1","content":"real output"}]}]}`)
+	t.Run("does not accept an id alias inside a result block", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash"}]},{"role":"user","content":[{"type":"tool_result","id":"t1","content":"real output"}]}]}`)
 		got := RepairDanglingClaudeToolUses(input)
 		messages := claudeMessagesForTest(t, got, 2)
-		result := messages[1].Get("content.0")
-		if messages[1].Get("role").String() != "user" || result.Get("tool_use_id").String() != "t1" || result.Get("id").Exists() {
-			t.Fatalf("id alias not normalized: %s", messages[1].Raw)
+		blocks := messages[1].Get("content").Array()
+		if messages[1].Get("role").String() != "user" || len(blocks) != 2 {
+			t.Fatalf("malformed result carrier not normalized: %s", messages[1].Raw)
 		}
-		if result.Get("content").String() != "real output" || result.Get("is_error").Bool() {
-			t.Fatalf("normalized real output changed semantics: %s", result.Raw)
+		assertInterruptedClaudeToolResult(t, blocks[0], "t1", "")
+		if blocks[1].Get("type").String() != "text" || !strings.Contains(blocks[1].Get("text").String(), "real output") {
+			t.Fatalf("id alias was treated as a valid result or lost: %s", messages[1].Raw)
 		}
 	})
 
@@ -202,6 +203,20 @@ func TestRepairDanglingClaudeToolUsesPreservesToolsetAndServerToolRules(t *testi
 		assistantBlocks := messages[0].Get("content").Array()
 		if len(assistantBlocks) != 1 || assistantBlocks[0].Get("type").String() != "tool_use" {
 			t.Fatalf("unresolved server call was not removed safely: %s", messages[0].Raw)
+		}
+		assertInterruptedClaudeToolResult(t, messages[1].Get("content.0"), "client1", "")
+		if messages[1].Get("content.1.text").String() != "change direction" {
+			t.Fatalf("interrupt text was not preserved: %s", messages[1].Raw)
+		}
+	})
+
+	t.Run("drops an unresolved MCP call before preserving interrupt text", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"mcp_tool_use","id":"mcp1","server_name":"example","name":"lookup","input":{}},{"type":"tool_use","id":"client1","name":"Read","input":{}}]},{"role":"user","content":"change direction"}]}`)
+		got := RepairDanglingClaudeToolUses(input)
+		messages := claudeMessagesForTest(t, got, 2)
+		assistantBlocks := messages[0].Get("content").Array()
+		if len(assistantBlocks) != 1 || assistantBlocks[0].Get("type").String() != "tool_use" {
+			t.Fatalf("unresolved MCP call was not removed safely: %s", messages[0].Raw)
 		}
 		assertInterruptedClaudeToolResult(t, messages[1].Get("content.0"), "client1", "")
 		if messages[1].Get("content.1.text").String() != "change direction" {

--- a/internal/runtime/executor/helps/claude_tool_turns_test.go
+++ b/internal/runtime/executor/helps/claude_tool_turns_test.go
@@ -172,6 +172,137 @@ func TestRepairDanglingClaudeToolUsesCanonicalizesResultCarriers(t *testing.T) {
 			t.Fatalf("standalone orphan not downgraded: %s", messages[0].Raw)
 		}
 	})
+
+	t.Run("cleans compatibility fields from a standalone tool string", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"tool","tool_use_id":"tool-use","tool_call_id":"tool-call","call_id":"call","id":"generic","name":"legacy","content":"diagnostic"}]}`)
+		once := RepairDanglingClaudeToolUses(input)
+		message := claudeMessagesForTest(t, once, 1)[0]
+		assertClaudeUserCarrierEnvelope(t, message)
+		if message.Get("content.0.type").String() != "text" || !strings.Contains(message.Get("content.0.text").String(), "diagnostic") {
+			t.Fatalf("standalone tool string was not preserved as diagnostic text: %s", message.Raw)
+		}
+		if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+			t.Fatalf("standalone tool string cleanup is not idempotent:\n once %s\n twice %s", once, twice)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name           string
+		content        string
+		wantDiagnostic string
+	}{
+		{name: "null", content: `null`},
+		{name: "object", content: `{"raw":"diagnostic"}`, wantDiagnostic: `{"raw":"diagnostic"}`},
+		{name: "number", content: `42`, wantDiagnostic: `42`},
+		{name: "boolean", content: `true`, wantDiagnostic: `true`},
+	} {
+		t.Run("cleans compatibility fields from standalone tool content "+testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"tool","tool_use_id":"tool-use","tool_call_id":"tool-call","call_id":"call","id":"generic","name":"legacy","content":` + testCase.content + `}]}`)
+			once := RepairDanglingClaudeToolUses(input)
+			message := claudeMessagesForTest(t, once, 1)[0]
+			assertClaudeUserCarrierEnvelope(t, message)
+			text := message.Get("content.0.text")
+			if !message.Get("content").IsArray() || message.Get("content.0.type").String() != "text" || !strings.Contains(text.String(), "[unmatched tool result]") {
+				t.Fatalf("standalone %s content was not converted to diagnostic text: %s", testCase.name, message.Raw)
+			}
+			if testCase.wantDiagnostic != "" && !strings.Contains(text.String(), testCase.wantDiagnostic) {
+				t.Fatalf("standalone %s diagnostic was lost: %s", testCase.name, message.Raw)
+			}
+			if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+				t.Fatalf("standalone %s content cleanup is not idempotent:\n once %s\n twice %s", testCase.name, once, twice)
+			}
+		})
+	}
+
+	t.Run("cleans compatibility fields when standalone tool content is missing", func(t *testing.T) {
+		input := []byte(`{"messages":[{"role":"tool","tool_use_id":"tool-use","tool_call_id":"tool-call","call_id":"call","id":"generic","name":"legacy"}]}`)
+		once := RepairDanglingClaudeToolUses(input)
+		message := claudeMessagesForTest(t, once, 1)[0]
+		assertClaudeUserCarrierEnvelope(t, message)
+		if !message.Get("content").IsArray() || message.Get("content.0.type").String() != "text" || !strings.Contains(message.Get("content.0.text").String(), "[unmatched tool result]") {
+			t.Fatalf("missing standalone tool content was not converted to diagnostic text: %s", message.Raw)
+		}
+		if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+			t.Fatalf("missing standalone tool content cleanup is not idempotent:\n once %s\n twice %s", once, twice)
+		}
+	})
+
+	for _, testCase := range []struct {
+		name            string
+		content         string
+		wantDiagnostics []string
+	}{
+		{name: "empty array", content: `[]`},
+		{name: "primitive array", content: `["raw diagnostic",17,true,null]`, wantDiagnostics: []string{"raw diagnostic", "17", "true"}},
+		{name: "untyped object array", content: `[{"raw":"object diagnostic"},{"type":"","raw":"empty type"}]`, wantDiagnostics: []string{"object diagnostic", "empty type"}},
+	} {
+		t.Run("repairs standalone tool "+testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[{"role":"tool","tool_use_id":"tool-use","tool_call_id":"tool-call","call_id":"call","id":"generic","name":"legacy","content":` + testCase.content + `}]}`)
+			once := RepairDanglingClaudeToolUses(input)
+			message := claudeMessagesForTest(t, once, 1)[0]
+			assertClaudeUserCarrierEnvelope(t, message)
+			blocks := message.Get("content").Array()
+			if len(blocks) == 0 {
+				t.Fatalf("standalone tool %s produced empty user content: %s", testCase.name, message.Raw)
+			}
+			var diagnostic strings.Builder
+			for _, block := range blocks {
+				if block.Get("type").String() != "text" {
+					t.Fatalf("standalone tool %s retained a non-text primitive: %s", testCase.name, message.Raw)
+				}
+				diagnostic.WriteString(block.Get("text").String())
+			}
+			if !strings.Contains(diagnostic.String(), "[unmatched tool result]") {
+				t.Fatalf("standalone tool %s lost its diagnostic label: %s", testCase.name, message.Raw)
+			}
+			for _, want := range testCase.wantDiagnostics {
+				if !strings.Contains(diagnostic.String(), want) {
+					t.Fatalf("standalone tool %s lost diagnostic %q: %s", testCase.name, want, message.Raw)
+				}
+			}
+			if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+				t.Fatalf("standalone tool %s cleanup is not idempotent:\n once %s\n twice %s", testCase.name, once, twice)
+			}
+		})
+	}
+}
+
+func TestRepairDanglingClaudeToolUsesStopsAtFirstInterruptingCarrier(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		extra     string
+		wantExtra string
+	}{
+		{name: "text", extra: `{"type":"text","text":"change direction"}`, wantExtra: "change direction"},
+		{name: "duplicate", extra: `{"type":"tool_result","tool_use_id":"p1","content":"duplicate one"}`, wantExtra: "duplicate one"},
+		{name: "orphan", extra: `{"type":"tool_result","tool_use_id":"ghost","content":"orphan output"}`, wantExtra: "orphan output"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			input := []byte(`{"messages":[` +
+				`{"role":"assistant","content":[{"type":"tool_use","id":"p1","name":"one"},{"type":"tool_use","id":"p2","name":"two"}]},` +
+				`{"role":"user","content":[{"type":"tool_result","tool_use_id":"p1","content":"one"},` + testCase.extra + `]},` +
+				`{"role":"user","content":[{"type":"tool_result","tool_use_id":"p2","content":"late two"}]}` +
+				`]}`)
+
+			once := RepairDanglingClaudeToolUses(input)
+			messages := claudeMessagesForTest(t, once, 3)
+			blocks := messages[1].Get("content").Array()
+			if len(blocks) != 3 || blocks[0].Get("tool_use_id").String() != "p1" || blocks[0].Get("content").String() != "one" || blocks[0].Get("is_error").Bool() {
+				t.Fatalf("first result carrier changed unexpectedly: %s", messages[1].Raw)
+			}
+			assertInterruptedClaudeToolResult(t, blocks[1], "p2", "")
+			if blocks[2].Get("type").String() != "text" || !strings.Contains(blocks[2].Get("text").String(), testCase.wantExtra) {
+				t.Fatalf("interrupting %s content was not preserved: %s", testCase.name, messages[1].Raw)
+			}
+			late := messages[2].Get("content.0")
+			if late.Get("type").String() != "text" || !strings.Contains(late.Get("text").String(), "late two") {
+				t.Fatalf("late p2 result crossed the interrupting carrier: %s", once)
+			}
+			if twice := RepairDanglingClaudeToolUses(once); !bytes.Equal(twice, once) {
+				t.Fatalf("%s carrier boundary is not idempotent:\n once %s\n twice %s", testCase.name, once, twice)
+			}
+		})
+	}
 }
 
 func TestRepairDanglingClaudeToolUsesRelocatesInterveningSystemTurns(t *testing.T) {
@@ -512,6 +643,18 @@ func claudeMessagesForTest(t *testing.T, payload []byte, want int) []gjson.Resul
 		t.Fatalf("message count = %d, want %d: %s", len(messages), want, payload)
 	}
 	return messages
+}
+
+func assertClaudeUserCarrierEnvelope(t *testing.T, message gjson.Result) {
+	t.Helper()
+	if message.Get("role").String() != "user" {
+		t.Fatalf("carrier role = %q, want user: %s", message.Get("role").String(), message.Raw)
+	}
+	for _, field := range []string{"tool_use_id", "tool_call_id", "call_id", "id", "name"} {
+		if message.Get(field).Exists() {
+			t.Fatalf("carrier retained top-level %s: %s", field, message.Raw)
+		}
+	}
 }
 
 func assertInterruptedClaudeToolResult(t *testing.T, block gjson.Result, toolUseID, toolsetName string) {


### PR DESCRIPTION
## Problem

An interrupted client tool call can leave an assistant `tool_use` without a matching user `tool_result`. Anthropic-compatible Messages endpoints reject the next request with HTTP 400 instead of accepting the user interruption.

## Fix

Repair the final Messages payload in the runtime executor sanitizer:

- merge adjacent user/tool result carriers into one canonical `role: user` turn until an actual user/diagnostic interruption boundary
- accept only `tool_use_id` as a valid result link
- synthesize missing results as `is_error: true` with `[operation interrupted by user]`
- order results by the preceding client `tool_use` calls and keep all result blocks before interruption text
- downgrade duplicate, orphan, malformed, or standalone tool results to valid diagnostic user text
- sanitize adopted and canonical carriers by removing incompatible message/block compatibility IDs and normalizing primitive, object, null, empty, or untyped result content without silently dropping diagnostic data
- preserve and echo `toolset_name` for toolset member results
- move only outstanding real results ahead of intervening mid-conversation system turns; keep ordinary user text after the system constraint and stop collecting later results across it
- renormalize cache-control TTLs after relocation so the final 5m/1h evaluation order remains valid
- for mixed client/server tool turns, preserve pending server tools when the user turn contains results only; when a later request ends the turn, remove only unresolved server/MCP calls and keep completed pairs

The helper lives under `internal/runtime/executor/helps`; this PR has no `internal/translator/**` diff. Execute, stream, and token-count paths share the sanitizer.

## Validation

- `go test ./internal/runtime/executor/... -count=1`
- targeted race tests for the helper and executor sanitizer
- `go vet ./internal/runtime/executor/...`
- server build
- full suite passes apart from unchanged intermittent tests outside this diff; isolated reruns passed

Anthropic placement rules:
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
