### PR TITLE
pluginhost: let stream-chunk interceptors opt out of the history window

### DIFF
--- a/internal/pluginhost/adapters_interceptors.go
+++ b/internal/pluginhost/adapters_interceptors.go
@@ -277,7 +277,14 @@ func (h *Host) InterceptStreamChunkExcept(ctx context.Context, req pluginapi.Str
 			nextReq.RequestBody = bytes.Clone(req.RequestBody)
 		}
 		nextReq.Body = bytes.Clone(current.Body)
-		nextReq.HistoryChunks = cloneByteSlices(req.HistoryChunks)
+		// Plugins that opt out via StreamChunkOmitHistory never receive the delivered-chunk
+		// history window: no interceptor consumes it, and cloning/marshaling up to 1 MiB of
+		// it per frame is near O(n^2) on long streams. Others still get it unchanged.
+		if record.plugin.Capabilities.StreamChunkOmitHistory {
+			nextReq.HistoryChunks = nil
+		} else {
+			nextReq.HistoryChunks = cloneByteSlices(req.HistoryChunks)
+		}
 		nextReq.Metadata = cloneInterceptorMetadata(req.Metadata)
 		if resp, ok := h.callStreamChunkInterceptor(ctx, record, interceptor, nextReq); ok {
 			current.Headers = mergeHeaders(current.Headers, resp.Headers, resp.ClearHeaders)
@@ -327,6 +334,25 @@ func (h *Host) StreamChunkPayloadIncludesRequestBody() bool {
 
 func streamChunkOmitsRequestBodies(schemaVersion uint32) bool {
 	return schemaVersion >= pluginabi.SchemaVersionStreamChunkOmitRequestBody
+}
+
+// StreamChunkPayloadIncludesHistory reports whether any active stream chunk interceptor
+// still consumes the HistoryChunks window (i.e. has not opted out via
+// StreamChunkOmitHistory). When false, the host can skip accumulating the history window
+// entirely, not just skip sending it.
+func (h *Host) StreamChunkPayloadIncludesHistory() bool {
+	if h == nil {
+		return false
+	}
+	for _, record := range h.activeRecords() {
+		if h.isPluginFused(record.id) || record.plugin.Capabilities.StreamChunkInterceptor == nil {
+			continue
+		}
+		if !record.plugin.Capabilities.StreamChunkOmitHistory {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Host) HasRequestInterceptors() bool {

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -1770,6 +1770,146 @@ func TestStreamChunkRequestBodyPolicyBySchemaVersion(t *testing.T) {
 	}
 }
 
+type omitHistoryRegisterClient struct{}
+
+func (omitHistoryRegisterClient) Call(_ context.Context, method string, _ []byte) ([]byte, error) {
+	if method != pluginabi.MethodPluginRegister {
+		return nil, fmt.Errorf("unexpected method %q", method)
+	}
+	return marshalRPCResult(rpcRegistration{
+		SchemaVersion: pluginabi.SchemaVersion,
+		Capabilities:  rpcCapabilities{StreamChunkInterceptor: true, StreamChunkOmitHistory: true},
+	})
+}
+
+func (omitHistoryRegisterClient) Shutdown() {}
+
+// TestRegisterRPCPluginParsesStreamChunkOmitHistory proves the registration JSON's
+// stream_chunk_omit_history flag propagates through the real RPC decode into
+// plugin.Capabilities.StreamChunkOmitHistory (not a hand-built Capabilities struct).
+// Removing the rpc_client.go assignment makes this RED.
+func TestRegisterRPCPluginParsesStreamChunkOmitHistory(t *testing.T) {
+	plugin, err := registerRPCPlugin(context.Background(), nil, "omit", omitHistoryRegisterClient{}, pluginabi.MethodPluginRegister, nil)
+	if err != nil {
+		t.Fatalf("registerRPCPlugin: %v", err)
+	}
+	if plugin.Capabilities.StreamChunkInterceptor == nil {
+		t.Fatal("StreamChunkInterceptor not wired from registration")
+	}
+	if !plugin.Capabilities.StreamChunkOmitHistory {
+		t.Fatal("StreamChunkOmitHistory=false: registration JSON capability did not propagate through the RPC decode (rpc_client parse missing)")
+	}
+}
+
+func TestStreamChunkHistoryPolicyByCapability(t *testing.T) {
+	var legacyGot, modernGot pluginapi.StreamChunkInterceptRequest
+	host := newHostWithRecords(
+		capabilityRecord{
+			id: "legacy",
+			plugin: pluginapi.Plugin{
+				Capabilities: pluginapi.Capabilities{
+					StreamChunkInterceptor: responseInterceptorFunc{
+						interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+							legacyGot = req
+							return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+						},
+					},
+					// StreamChunkOmitHistory unset: legacy plugin still receives history.
+				},
+			},
+		},
+		capabilityRecord{
+			id: "modern",
+			plugin: pluginapi.Plugin{
+				Capabilities: pluginapi.Capabilities{
+					StreamChunkOmitHistory: true,
+					StreamChunkInterceptor: responseInterceptorFunc{
+						interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+							modernGot = req
+							return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+						},
+					},
+				},
+			},
+		},
+	)
+	// A legacy consumer keeps the accumulation policy on.
+	if !host.StreamChunkPayloadIncludesHistory() {
+		t.Fatal("StreamChunkPayloadIncludesHistory() = false, want true when a legacy stream interceptor is active")
+	}
+
+	_ = host.InterceptStreamChunk(context.Background(), pluginapi.StreamChunkInterceptRequest{
+		Body:          []byte("chunk"),
+		HistoryChunks: [][]byte{[]byte("h0"), []byte("h1")},
+		ChunkIndex:    0,
+	})
+	if len(legacyGot.HistoryChunks) != 2 || string(legacyGot.HistoryChunks[0]) != "h0" {
+		t.Fatalf("legacy history = %#v, want preserved", legacyGot.HistoryChunks)
+	}
+	if len(modernGot.HistoryChunks) != 0 {
+		t.Fatalf("modern history = %#v, want omitted for StreamChunkOmitHistory plugin", modernGot.HistoryChunks)
+	}
+
+	// When every active interceptor opts out, the accumulation policy turns off so the
+	// host stops retaining the history window entirely.
+	modernOnly := newHostWithRecords(capabilityRecord{
+		id: "modern-only",
+		plugin: pluginapi.Plugin{
+			Capabilities: pluginapi.Capabilities{
+				StreamChunkOmitHistory: true,
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						return pluginapi.StreamChunkInterceptResponse{}, nil
+					},
+				},
+			},
+		},
+	})
+	if modernOnly.StreamChunkPayloadIncludesHistory() {
+		t.Fatal("StreamChunkPayloadIncludesHistory() = true, want false when every stream interceptor opted out")
+	}
+}
+
+// benchInterceptStreamChunkHistory measures the host-side per-frame cost of delivering
+// a chunk to a stream interceptor with a 1 MiB / 64-chunk history window. With
+// omitHistory the host skips cloneByteSlices of that window; without it, the legacy
+// deep-clone dominates.
+func benchInterceptStreamChunkHistory(b *testing.B, omitHistory bool) {
+	const chunks = 64
+	const per = (1 << 20) / chunks
+	history := make([][]byte, chunks)
+	for i := range history {
+		frag := make([]byte, per)
+		for j := range frag {
+			frag[j] = byte('a' + (i+j)%26)
+		}
+		history[i] = frag
+	}
+	host := newHostWithRecords(capabilityRecord{
+		id: "p",
+		plugin: pluginapi.Plugin{
+			Capabilities: pluginapi.Capabilities{
+				StreamChunkOmitHistory: omitHistory,
+				StreamChunkInterceptor: responseInterceptorFunc{
+					interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+					},
+				},
+			},
+		},
+	})
+	req := pluginapi.StreamChunkInterceptRequest{Body: []byte("data: {}\n\n"), HistoryChunks: history, ChunkIndex: 0}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = host.InterceptStreamChunk(ctx, req)
+	}
+}
+
+func BenchmarkInterceptStreamChunkHistoryLegacy(b *testing.B) { benchInterceptStreamChunkHistory(b, false) }
+func BenchmarkInterceptStreamChunkHistoryOmit(b *testing.B)   { benchInterceptStreamChunkHistory(b, true) }
+
 func TestHasRequestInterceptorsReflectsActiveRequestInterceptors(t *testing.T) {
 	responseOnly := newHostWithRecords(capabilityRecord{
 		id: "response",

--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -133,6 +133,7 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 	if resp.Capabilities.StreamChunkInterceptor {
 		plugin.Capabilities.StreamChunkInterceptor = adapter
 	}
+	plugin.Capabilities.StreamChunkOmitHistory = resp.Capabilities.StreamChunkOmitHistory
 	if resp.Capabilities.WebSocketResponseObserver {
 		plugin.Capabilities.WebSocketResponseObserver = adapter
 	}

--- a/internal/pluginhost/rpc_schema.go
+++ b/internal/pluginhost/rpc_schema.go
@@ -39,6 +39,7 @@ type rpcCapabilities struct {
 	ResponseAfterTranslator       bool                         `json:"response_after_translator"`
 	ResponseInterceptor           bool                         `json:"response_interceptor"`
 	StreamChunkInterceptor        bool                         `json:"response_stream_interceptor"`
+	StreamChunkOmitHistory        bool                         `json:"stream_chunk_omit_history"`
 	WebSocketResponseObserver     bool                         `json:"websocket_response_observer"`
 	ThinkingApplier               bool                         `json:"thinking_applier"`
 	UsagePlugin                   bool                         `json:"usage_plugin"`
@@ -156,6 +157,7 @@ func rpcCapabilitiesFromPlugin(plugin pluginapi.Plugin) rpcCapabilities {
 		ResponseAfterTranslator:       caps.ResponseAfterTranslator != nil,
 		ResponseInterceptor:           caps.ResponseInterceptor != nil,
 		StreamChunkInterceptor:        caps.StreamChunkInterceptor != nil,
+		StreamChunkOmitHistory:        caps.StreamChunkOmitHistory,
 		WebSocketResponseObserver:     caps.WebSocketResponseObserver != nil,
 		ThinkingApplier:               caps.ThinkingApplier != nil,
 		UsagePlugin:                   caps.UsagePlugin != nil,

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -51,6 +51,26 @@ func streamChunkPayloadIncludesRequestBody(host PluginInterceptorHost) bool {
 	return true
 }
 
+// streamChunkHistoryPolicy reports whether payload stream-chunk interceptors still
+// consume the HistoryChunks window (any plugin that has not opted out via
+// StreamChunkOmitHistory).
+type streamChunkHistoryPolicy interface {
+	StreamChunkPayloadIncludesHistory() bool
+}
+
+// streamChunkPayloadIncludesHistory returns true when at least one active stream
+// interceptor still needs the delivered-chunk history window. Evaluated per call so
+// mid-stream plugin reloads stay correct. Unknown hosts default to true.
+func streamChunkPayloadIncludesHistory(host PluginInterceptorHost) bool {
+	if host == nil {
+		return false
+	}
+	if policy, ok := host.(streamChunkHistoryPolicy); ok {
+		return policy.StreamChunkPayloadIncludesHistory()
+	}
+	return true
+}
+
 type requestInterceptorDetector interface {
 	HasRequestInterceptors() bool
 }

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -29,6 +29,11 @@ type handlerInterceptorTestHost struct {
 	completeRequest               func(context.Context, pluginapi.RequestCompletion)
 	// includeStreamChunkRequestBodies simulates legacy schema_version < 3 plugins.
 	includeStreamChunkRequestBodies bool
+	// omitStreamChunkHistory simulates a plugin that declared StreamChunkOmitHistory.
+	omitStreamChunkHistory bool
+	// streamChunkHistoryPolicy, when set, overrides omitStreamChunkHistory and is invoked
+	// once per chunk so a test can simulate a mid-stream reload flipping the policy.
+	streamChunkHistoryPolicy func() bool
 }
 
 type handlerInterceptorNoStreamTestHost struct {
@@ -106,6 +111,19 @@ func (h *handlerInterceptorTestHost) StreamChunkPayloadIncludesRequestBody() boo
 		return false
 	}
 	return h.includeStreamChunkRequestBodies
+}
+
+// StreamChunkPayloadIncludesHistory implements streamChunkHistoryPolicy. Default true
+// (a legacy history consumer); set omitStreamChunkHistory to simulate a plugin that
+// declared StreamChunkOmitHistory so the handler stops accumulating the window.
+func (h *handlerInterceptorTestHost) StreamChunkPayloadIncludesHistory() bool {
+	if h == nil {
+		return false
+	}
+	if h.streamChunkHistoryPolicy != nil {
+		return h.streamChunkHistoryPolicy()
+	}
+	return !h.omitStreamChunkHistory
 }
 
 type interceptorCaptureExecutor struct {
@@ -485,6 +503,147 @@ func TestHandlerLifecycleCompletesSuccessfulStreamOnce(t *testing.T) {
 	case duplicate := <-completions:
 		t.Fatalf("duplicate stream completion = %#v", duplicate)
 	default:
+	}
+}
+
+func drainInterceptorStream(t *testing.T, dataChan <-chan []byte, errChan <-chan *interfaces.ErrorMessage) {
+	t.Helper()
+	for dataChan != nil || errChan != nil {
+		select {
+		case _, ok := <-dataChan:
+			if !ok {
+				dataChan = nil
+			}
+		case errMsg, ok := <-errChan:
+			if ok && errMsg != nil {
+				t.Fatalf("stream error = %#v", errMsg)
+			}
+			if !ok {
+				errChan = nil
+			}
+		}
+	}
+}
+
+// streamHistoryChunkPayloads are the three payload frames used by the accumulation teeth.
+var streamHistoryChunkPayloads = [][]byte{[]byte("c0"), []byte("c1"), []byte("c2")}
+
+func newStreamHistoryChunks() chan coreexecutor.StreamChunk {
+	chunks := make(chan coreexecutor.StreamChunk, len(streamHistoryChunkPayloads))
+	for _, p := range streamHistoryChunkPayloads {
+		chunks <- coreexecutor.StreamChunk{Payload: append([]byte(nil), p...)}
+	}
+	close(chunks)
+	return chunks
+}
+
+// runHistoryAuthManagerStream exercises the auth-manager stream route (handlers_stream.go
+// executeStreamWithAuthManager), which the model resolves to when it is not routed to a
+// plugin executor.
+func runHistoryAuthManagerStream(t *testing.T, host *handlerInterceptorTestHost) {
+	t.Helper()
+	model := "history-accum-auth-manager"
+	executor := &interceptorCaptureExecutor{
+		stream: func(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			return &coreexecutor.StreamResult{Chunks: newStreamHistoryChunks()}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{})
+	handler.SetPluginHost(host)
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(`{"model":"`+model+`","stream":true}`), "")
+	drainInterceptorStream(t, dataChan, errChan)
+}
+
+// runHistoryPluginExecutorStream exercises the plugin-executor stream route
+// (handlers_stream.go streamWithPluginExecutor), reached when the model router targets a
+// plugin executor.
+func runHistoryPluginExecutorStream(t *testing.T, host *handlerInterceptorTestHost) {
+	t.Helper()
+	const targetPluginID = "history-accum-plugin"
+	mockHost := &mockPluginUsageHost{streamResult: &coreexecutor.StreamResult{Chunks: newStreamHistoryChunks()}}
+	mockHost.hasRouters = true
+	mockHost.route = func(context.Context, pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+	handler.SetPluginHost(host)
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "history-accum-plugin-executor", []byte(`{"model":"history-accum-plugin-executor","stream":true}`), "")
+	drainInterceptorStream(t, dataChan, errChan)
+}
+
+// TestExecuteStreamHistoryAccumulationAcrossRoutesAndReloads drives BOTH real streaming
+// routes (auth-manager and plugin-executor) through BOTH mid-stream policy transitions and
+// asserts the history the interceptor receives on the third frame. The policy flips after
+// the first chunk, so a startup snapshot of the policy produces a different third-frame
+// history than the correct per-chunk evaluation, and a route whose guard ignores the
+// policy over-accumulates — each mutation turns a case RED.
+func TestExecuteStreamHistoryAccumulationAcrossRoutesAndReloads(t *testing.T) {
+	routes := []struct {
+		name string
+		run  func(*testing.T, *handlerInterceptorTestHost)
+	}{
+		{"auth_manager", runHistoryAuthManagerStream},
+		{"plugin_executor", runHistoryPluginExecutorStream},
+	}
+	cases := []struct {
+		name      string
+		policy    []bool // per-chunk StreamChunkPayloadIncludesHistory result
+		wantThird []string
+	}{
+		// opt-out first, then a consumer activates: accumulation starts at activation, so
+		// the third frame carries only the second chunk (not the discarded first).
+		{"optout_then_legacy", []bool{false, true, true}, []string{"c1"}},
+		// legacy first, then the last consumer opts out: accumulation stops, so the third
+		// frame still carries only the first chunk (not the second).
+		{"legacy_then_optout", []bool{true, false, false}, []string{"c0"}},
+	}
+	for _, route := range routes {
+		for _, tc := range cases {
+			t.Run(route.name+"/"+tc.name, func(t *testing.T) {
+				var mu sync.Mutex
+				var seen [][][]byte
+				var calls int
+				host := &handlerInterceptorTestHost{
+					streamChunkHistoryPolicy: func() bool {
+						mu.Lock()
+						defer mu.Unlock()
+						i := calls
+						calls++
+						if i < len(tc.policy) {
+							return tc.policy[i]
+						}
+						return tc.policy[len(tc.policy)-1]
+					},
+					interceptStreamChunk: func(_ context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+						if req.ChunkIndex >= 0 { // payload chunks only; skip header-init (-1)
+							mu.Lock()
+							seen = append(seen, req.HistoryChunks)
+							mu.Unlock()
+						}
+						return pluginapi.StreamChunkInterceptResponse{Body: req.Body}
+					},
+				}
+				route.run(t, host)
+				mu.Lock()
+				defer mu.Unlock()
+				if len(seen) < 3 {
+					t.Fatalf("expected 3 payload interceptions, got %d", len(seen))
+				}
+				got := make([]string, len(seen[2]))
+				for i, b := range seen[2] {
+					got[i] = string(b)
+				}
+				if len(got) != len(tc.wantThird) {
+					t.Fatalf("third-frame history = %v, want %v (per-chunk policy not honored on this route)", got, tc.wantThird)
+				}
+				for i := range got {
+					if got[i] != tc.wantThird[i] {
+						t.Fatalf("third-frame history = %v, want %v", got, tc.wantThird)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -93,6 +93,15 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
 	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	// Retain the delivered-chunk history window only while some active interceptor still
+	// consumes it. Evaluated per chunk (not snapshotted) so a mid-stream plugin reload that
+	// flips the last history consumer takes effect immediately: once every active stream
+	// interceptor has opted out (StreamChunkOmitHistory) accumulation stops, and a legacy
+	// consumer activated mid-stream begins receiving history from that chunk on (history is
+	// not reconstructed retroactively).
+	streamHistoryNeeded := func() bool {
+		return streamInterceptorsActive && streamChunkPayloadIncludesHistory(interceptorHost)
+	}
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
 	baseStreamHeaders := cloneHeader(streamResult.Headers)
 	// Request headers and request bodies are stream-invariant. Keep a private snapshot
@@ -270,7 +279,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			}
 			select {
 			case dataChan <- payload:
-				if streamInterceptorsActive {
+				if streamHistoryNeeded() {
 					historyChunks = appendStreamInterceptorHistory(historyChunks, payload)
 				}
 			case <-done:
@@ -376,6 +385,11 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()
 	streamInterceptorsActive := streamInterceptorsEnabled(interceptorHost)
+	// History retention is re-evaluated per chunk (see the sibling stream handler) so a
+	// mid-stream reload flipping the last history consumer takes effect immediately.
+	streamHistoryNeeded := func() bool {
+		return streamInterceptorsActive && streamChunkPayloadIncludesHistory(interceptorHost)
+	}
 	// Resolve bootstrap retries and header initialization before returning so the
 	// returned header snapshot is never modified by the stream goroutine.
 	rawStreamHeaders := cloneHeader(streamResult.Headers)
@@ -658,7 +672,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				}
 				return
 			}
-			if streamInterceptorsActive {
+			if streamHistoryNeeded() {
 				historyChunks = appendStreamInterceptorHistory(historyChunks, bootstrapPayload)
 			}
 		}
@@ -722,7 +736,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				}
 				return
 			}
-			if streamInterceptorsActive {
+			if streamHistoryNeeded() {
 				historyChunks = appendStreamInterceptorHistory(historyChunks, payload)
 			}
 		}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -112,6 +112,11 @@ type Capabilities struct {
 	ResponseInterceptor ResponseInterceptor
 	// StreamChunkInterceptor rewrites successful HTTP stream chunks before downstream delivery.
 	StreamChunkInterceptor StreamChunkInterceptor
+	// StreamChunkOmitHistory declares that this stream chunk interceptor does not consume
+	// StreamChunkInterceptRequest.HistoryChunks. When set, the host stops cloning/sending
+	// the history window to this plugin, and stops accumulating it entirely when no active
+	// interceptor needs it. Pure opt-in hint: unset preserves the legacy full-history payload.
+	StreamChunkOmitHistory bool
 	// WebSocketResponseObserver receives upstream WebSocket response events during execution.
 	WebSocketResponseObserver WebSocketResponseObserver
 	// ThinkingApplier applies validated thinking configuration to provider payloads.


### PR DESCRIPTION
## Problem

The host retains a bounded history window (up to 64 chunks / 1 MiB) of already-delivered stream chunks and deep-clones it into `StreamChunkInterceptRequest.HistoryChunks` for **every** stream-chunk interceptor on **every** payload frame (and JSON-marshals it again for RPC plugins). Interceptors that never read `HistoryChunks` still pay that cost on both sides, and because the window grows with the stream, the total cost approaches O(n²) over a long stream.

This is not theoretical: we run a capture/observability interceptor in production that only consumes the current chunk. On long streams the per-frame history clone/marshal/decode dominated CPU (a mostly-idle gateway climbed to several fully busy cores; profiles attributed the majority of time to this path).

## Change

Add an explicit **opt-out capability** — feature detection rather than a schema-version ratchet, so it stays orthogonal to future contract versions:

- A plugin that declares `stream_chunk_omit_history: true` in its registration capabilities no longer receives `HistoryChunks` on payload stream-chunk calls (per-plugin gate in `InterceptStreamChunk*`).
- `Host.StreamChunkPayloadIncludesHistory()` reports whether any active stream-chunk interceptor still consumes the window. Both streaming handlers consult it **per chunk** (not snapshotted), so a mid-stream plugin reload takes effect immediately: accumulation stops once the last consumer opts out, and a consumer activated mid-stream receives history from that chunk on (the window is not reconstructed retroactively).
- Plugins that do not declare the capability see byte-identical behavior; hosts that don't know the flag simply ignore it, so plugins can declare it unconditionally.

If you'd rather evolve this as a schema-version step (like `schema_version >= 3` omitting per-chunk request bodies), the change converts directly — happy to rework to that form.

## Benchmarks

Per delivered frame against a 64-chunk / 1 MiB history window (`BenchmarkInterceptStreamChunkHistory*`):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| legacy | ~256,266 | 1,051,176 | 70 |
| opt-out | ~739 | 800 | 5 |

## Tests

- `TestStreamChunkHistoryPolicyByCapability`: per-plugin omission (a legacy plugin keeps receiving history alongside an opted-out plugin that doesn't) and the host-level accumulation policy flip.
- `TestRegisterRPCPluginParsesStreamChunkOmitHistory`: the registration JSON capability propagates through the real RPC decode.
- `TestExecuteStreamHistoryAccumulationAcrossRoutesAndReloads`: drives both real streaming routes (auth-manager and plugin-executor) through both mid-stream policy transitions and asserts the exact history the interceptor sees on the third frame.

## Field experience

This exact capability form has been running in our production deployment for a while with the expected CPU reduction and no capture/data regressions.
