### PR TITLE
fix(codex): keep WebSocket handshake 404 request-scoped

### DIFF
--- a/internal/runtime/executor/codex_websockets_errors.go
+++ b/internal/runtime/executor/codex_websockets_errors.go
@@ -19,6 +19,22 @@ type statusErrWithHeaders struct {
 	headers http.Header
 }
 
+type codexWebsocketHandshakeNotFoundError struct {
+	statusErr
+}
+
+func (codexWebsocketHandshakeNotFoundError) IsRequestScoped() bool {
+	return true
+}
+
+func newCodexWebsocketHandshakeStatusErr(statusCode int, body []byte) error {
+	statusError := newCodexStatusErr(statusCode, body)
+	if statusCode == http.StatusNotFound {
+		return codexWebsocketHandshakeNotFoundError{statusErr: statusError}
+	}
+	return statusError
+}
+
 func (e statusErrWithHeaders) Headers() http.Header {
 	if e.headers == nil {
 		return nil

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -158,7 +158,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			cliproxyexecutor.MarkUpstreamAttempt(ctx)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
-			return resp, newCodexStatusErr(respHS.StatusCode, bodyErr)
+			return resp, newCodexWebsocketHandshakeStatusErr(respHS.StatusCode, bodyErr)
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
 		return resp, errDial
@@ -251,9 +251,16 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 					return resp, errSendRetry
 				}
 			} else {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				return resp, errDialRetry
+				retryErr := errDialRetry
+				if respHSRetry != nil && respHSRetry.StatusCode > 0 {
+					bodyErr := websocketHandshakeBody(respHSRetry)
+					helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHSRetry.StatusCode, respHSRetry.Header.Clone(), bodyErr)
+					retryErr = newCodexWebsocketHandshakeStatusErr(respHSRetry.StatusCode, bodyErr)
+				} else {
+					closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", retryErr)
+				return resp, retryErr
 			}
 		} else {
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -482,12 +483,235 @@ func TestCodexWebsocketsExecuteStreamHandshakeErrorReturnsWithoutLockingSession(
 			if !ok || statusErr.StatusCode() != http.StatusUnauthorized {
 				t.Fatalf("attempt %d error = %T %v, want status 401", i+1, errExecute, errExecute)
 			}
+			if requestError, ok := errExecute.(cliproxyexecutor.RequestScopedError); ok && requestError.IsRequestScoped() {
+				t.Fatalf("attempt %d error = %T, credential 401 must not be request-scoped", i+1, errExecute)
+			}
 			if !cliproxyexecutor.UpstreamAttempted(attemptCtx) {
 				t.Fatalf("attempt %d websocket handshake was not marked as upstream", i+1)
 			}
 		case <-time.After(5 * time.Second):
 			t.Fatalf("attempt %d timed out; execution session remained locked", i+1)
 		}
+	}
+}
+
+func TestCodexWebsocketsHandshakeNotFoundIsRequestScoped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{
+		ID:       "codex-test",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "sk-test",
+			"base_url": server.URL,
+		},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+
+	t.Run("execute", func(t *testing.T) {
+		_, errExecute := exec.Execute(context.Background(), auth, req, opts)
+		if errExecute == nil {
+			t.Fatal("Execute() error = nil, want websocket handshake error")
+		}
+		statusError, ok := errExecute.(interface{ StatusCode() int })
+		if !ok || statusError.StatusCode() != http.StatusNotFound {
+			t.Fatalf("Execute() error = %T %v, want status 404", errExecute, errExecute)
+		}
+		requestError, ok := errExecute.(cliproxyexecutor.RequestScopedError)
+		if !ok || !requestError.IsRequestScoped() {
+			t.Fatalf("Execute() error = %T, want request-scoped handshake failure", errExecute)
+		}
+	})
+
+	t.Run("execute_stream", func(t *testing.T) {
+		_, errExecute := exec.ExecuteStream(context.Background(), auth, req, opts)
+		if errExecute == nil {
+			t.Fatal("ExecuteStream() error = nil, want websocket handshake error")
+		}
+		statusError, ok := errExecute.(interface{ StatusCode() int })
+		if !ok || statusError.StatusCode() != http.StatusNotFound {
+			t.Fatalf("ExecuteStream() error = %T %v, want status 404", errExecute, errExecute)
+		}
+		requestError, ok := errExecute.(cliproxyexecutor.RequestScopedError)
+		if !ok || !requestError.IsRequestScoped() {
+			t.Fatalf("ExecuteStream() error = %T, want request-scoped handshake failure", errExecute)
+		}
+	})
+}
+
+func TestCodexWebsocketsHandshakeNotFoundDoesNotChangeAuthAvailability(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	for _, disableCooling := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable_cooling_%t", disableCooling), func(t *testing.T) {
+			manager := cliproxyauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}}))
+
+			const authID = "codex-websocket-404-auth"
+			const model = "gpt-5.4"
+			auth := &cliproxyauth.Auth{
+				ID:       authID,
+				Provider: "codex",
+				Status:   cliproxyauth.StatusActive,
+				Attributes: map[string]string{
+					"api_key":    "sk-test",
+					"base_url":   server.URL,
+					"websockets": "true",
+				},
+				Metadata: map[string]any{"disable_cooling": disableCooling},
+			}
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+			ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+			_, errExecute := manager.ExecuteStream(ctx, []string{"codex"}, cliproxyexecutor.Request{
+				Model:   model,
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","id":"msg-1"}]}`),
+			}, cliproxyexecutor.Options{
+				Stream:         true,
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+			})
+			if errExecute == nil {
+				t.Fatal("ExecuteStream() error = nil, want websocket handshake error")
+			}
+			statusError, ok := errExecute.(interface{ StatusCode() int })
+			if !ok || statusError.StatusCode() != http.StatusNotFound {
+				t.Fatalf("ExecuteStream() error = %T %v, want status 404", errExecute, errExecute)
+			}
+
+			updated, ok := manager.GetByID(authID)
+			if !ok || updated == nil {
+				t.Fatal("auth missing after request-scoped websocket failure")
+			}
+			if updated.Status != cliproxyauth.StatusActive || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+				t.Fatalf("auth availability changed after request-scoped websocket 404: status=%s unavailable=%t retry=%v", updated.Status, updated.Unavailable, updated.NextRetryAfter)
+			}
+			if len(updated.ModelStates) != 0 {
+				t.Fatalf("websocket handshake 404 created model cooldown state: %#v", updated.ModelStates)
+			}
+			if reg.IsModelSuspendedForClient(authID, model) {
+				t.Fatal("websocket handshake 404 suspended the model registry entry")
+			}
+		})
+	}
+}
+
+func TestCodexWebsocketsReconnectHandshakeNotFoundIsRequestScoped(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	staleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, errUpgrade := upgrader.Upgrade(w, r, nil)
+		if errUpgrade != nil {
+			t.Errorf("upgrade stale websocket: %v", errUpgrade)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer staleServer.Close()
+
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"temporary websocket route miss"}}`))
+	}))
+	defer targetServer.Close()
+
+	tests := []struct {
+		name string
+		run  func(*CodexWebsocketsExecutor, context.Context, *cliproxyauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) error
+	}{
+		{
+			name: "execute",
+			run: func(exec *CodexWebsocketsExecutor, ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, errExecute := exec.Execute(ctx, auth, req, opts)
+				return errExecute
+			},
+		},
+		{
+			name: "execute_stream",
+			run: func(exec *CodexWebsocketsExecutor, ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) error {
+				_, errExecute := exec.ExecuteStream(ctx, auth, req, opts)
+				return errExecute
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			staleURL := "ws" + strings.TrimPrefix(staleServer.URL, "http")
+			staleConn, _, errDial := websocket.DefaultDialer.Dial(staleURL, nil)
+			if errDial != nil {
+				t.Fatalf("dial stale websocket: %v", errDial)
+			}
+			if errClose := staleConn.Close(); errClose != nil {
+				t.Fatalf("close stale websocket: %v", errClose)
+			}
+
+			exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			exec.store = &codexWebsocketSessionStore{sessions: make(map[string]*codexWebsocketSession)}
+			sessionID := "reconnect-404-" + tt.name
+			auth := &cliproxyauth.Auth{
+				ID:       "codex-reconnect-test",
+				Provider: "codex",
+				Attributes: map[string]string{
+					"api_key":  "sk-test",
+					"base_url": targetServer.URL,
+				},
+			}
+			wsURL := "ws" + strings.TrimPrefix(targetServer.URL, "http") + "/responses"
+			sess := exec.getOrCreateSession(sessionID)
+			sess.connMu.Lock()
+			sess.conn = staleConn
+			sess.connCloser = newWebsocketConnectionCloser(staleConn)
+			sess.wsURL = wsURL
+			sess.authID = auth.ID
+			sess.readerConn = staleConn
+			sess.connMu.Unlock()
+			sess.resetUpstreamDisconnectError(staleConn)
+
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.4",
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","id":"msg-1"}]}`),
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FromString("openai-response"),
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+				},
+			}
+
+			errExecute := tt.run(exec, context.Background(), auth, req, opts)
+			if errExecute == nil {
+				t.Fatal("reconnect error = nil, want websocket handshake error")
+			}
+			statusError, ok := errExecute.(interface{ StatusCode() int })
+			if !ok || statusError.StatusCode() != http.StatusNotFound {
+				t.Fatalf("reconnect error = %T %v, want status 404", errExecute, errExecute)
+			}
+			requestError, ok := errExecute.(cliproxyexecutor.RequestScopedError)
+			if !ok || !requestError.IsRequestScoped() {
+				t.Fatalf("reconnect error = %T, want request-scoped handshake failure", errExecute)
+			}
+			if !strings.Contains(errExecute.Error(), "temporary websocket route miss") {
+				t.Fatalf("reconnect error did not preserve response body: %v", errExecute)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -166,7 +166,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			if sess != nil {
 				sess.reqMu.Unlock()
 			}
-			return nil, newCodexStatusErr(respHS.StatusCode, bodyErr)
+			return nil, newCodexWebsocketHandshakeStatusErr(respHS.StatusCode, bodyErr)
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
 		if sess != nil {
@@ -218,11 +218,18 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			// Retry once with a new websocket connection for the same execution session.
 			connRetry, closerRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, wsHeaders)
 			if errDialRetry != nil || connRetry == nil {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
+				retryErr := errDialRetry
+				if respHSRetry != nil && respHSRetry.StatusCode > 0 {
+					bodyErr := websocketHandshakeBody(respHSRetry)
+					helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHSRetry.StatusCode, respHSRetry.Header.Clone(), bodyErr)
+					retryErr = newCodexWebsocketHandshakeStatusErr(respHSRetry.StatusCode, bodyErr)
+				} else {
+					closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", retryErr)
 				sess.clearActive(conn, readCh)
 				sess.reqMu.Unlock()
-				return nil, errDialRetry
+				return nil, retryErr
 			}
 			previousConn, previousReadCh := conn, readCh
 			conn = connRetry


### PR DESCRIPTION
## Summary

- treat an HTTP 404 returned during the upstream Codex WebSocket upgrade as request-scoped
- apply the same classification to initial and reconnect handshakes in streaming and non-streaming execution
- preserve the upstream status and safe response body for downstream reporting
- leave credential 401/403, quota 429, transient 5xx, normal HTTP/model 404, and in-band WebSocket errors unchanged

## Why

The WebSocket upgrade happens before any `response.create` payload is sent. A temporary 404 at this boundary indicates that the WebSocket route is unavailable; it does not show that the selected OAuth credential or model is invalid.

Previously the plain status error reached the auth conductor as credential/model-affecting. A route-wide temporary 404 could therefore cool each credential and leave later requests returning `auth_unavailable` after the route recovered.

The dedicated error implements the existing request-scoped contract, so failure telemetry is retained while auth/model availability remains unchanged. A later connection can try WebSockets again normally.

## Tests

- initial `Execute` and `ExecuteStream` handshake 404 classification
- reconnect `Execute` and `ExecuteStream` handshake 404 classification and body preservation
- auth-manager state with cooling enabled and disabled
- no model state or model-registry suspension after handshake 404
- session-lock release after handshake errors
- negative controls for credential 401 and quota 429
- `go test -count=1 ./sdk/cliproxy/auth`
- `go test -count=1 ./...`
