### PR TITLE
fix(thinking): pass xhigh effort through to Claude models that support it

### DIFF
--- a/internal/thinking/claude_xhigh_effort_test.go
+++ b/internal/thinking/claude_xhigh_effort_test.go
@@ -1,0 +1,48 @@
+package thinking_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	responsesclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/openai/responses"
+	"github.com/tidwall/gjson"
+)
+
+// Codex sends reasoning.effort on the Responses API; the translator emits
+// output_config.effort and ApplyThinking then validates it against the
+// registered Claude model, so this covers the full request path.
+func TestResponsesEffortReachesClaudeAfterApplyThinking(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		effort     string
+		wantEffort string
+	}{
+		{"xhigh passes through on opus-4-8", "claude-opus-4-8", "xhigh", "xhigh"},
+		{"xhigh passes through on sonnet-5", "claude-sonnet-5", "xhigh", "xhigh"},
+		{"xhigh passes through on opus-5", "claude-opus-5", "xhigh", "xhigh"},
+		{"max passes through on opus-4-8", "claude-opus-4-8", "max", "max"},
+		{"xhigh clamps to max on opus-4-6", "claude-opus-4-6", "xhigh", "max"},
+		{"xhigh clamps to max on sonnet-4-6", "claude-sonnet-4-6", "xhigh", "max"},
+		{"high passes through on opus-4-6", "claude-opus-4-6", "high", "high"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := fmt.Sprintf(`{"model":%q,"reasoning":{"effort":%q},"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]}`, tt.model, tt.effort)
+			translated := responsesclaude.ConvertOpenAIResponsesRequestToClaude(tt.model, []byte(raw), false)
+			out, err := thinking.ApplyThinking(translated, tt.model, "openai-response", "claude", "claude")
+			if err != nil {
+				t.Fatalf("ApplyThinking() error = %v; translated=%s", err, translated)
+			}
+			root := gjson.ParseBytes(out)
+			if got := root.Get("thinking.type").String(); got != "adaptive" {
+				t.Fatalf("thinking.type = %q, want adaptive. Output: %s", got, out)
+			}
+			if got := root.Get("output_config.effort").String(); got != tt.wantEffort {
+				t.Fatalf("output_config.effort = %q, want %q. Output: %s", got, tt.wantEffort, out)
+			}
+		})
+	}
+}

--- a/internal/thinking/convert.go
+++ b/internal/thinking/convert.go
@@ -108,10 +108,13 @@ func HasLevel(levels []string, target string) bool {
 }
 
 // MapToClaudeEffort maps a generic thinking level string to a Claude adaptive
-// thinking effort value (low/medium/high/max).
+// thinking effort value (low/medium/high/xhigh/max).
 //
-// supportsMax indicates whether the target model supports "max" effort.
-// Returns the mapped effort and true if the level is valid, or ("", false) otherwise.
+// supportsMax indicates whether the target model supports "max" effort, which
+// every Claude model with xhigh also supports. xhigh is passed through on such
+// models; when the exact model lacks xhigh (Opus 4.6, Sonnet 4.6), ApplyThinking
+// clamps it to max after translation. Returns the mapped effort and true if the
+// level is valid, or ("", false) otherwise.
 func MapToClaudeEffort(level string, supportsMax bool) (string, bool) {
 	level = strings.ToLower(strings.TrimSpace(level))
 	switch level {
@@ -123,7 +126,7 @@ func MapToClaudeEffort(level string, supportsMax bool) (string, bool) {
 		return level, true
 	case "xhigh", "max":
 		if supportsMax {
-			return "max", true
+			return level, true
 		}
 		return "high", true
 	case "auto":

--- a/internal/thinking/convert_test.go
+++ b/internal/thinking/convert_test.go
@@ -1,0 +1,60 @@
+package thinking
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestMapToClaudeEffort(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       string
+		supportsMax bool
+		want        string
+		ok          bool
+	}{
+		{"xhigh passes through when max is supported", "xhigh", true, "xhigh", true},
+		{"max passes through when max is supported", "max", true, "max", true},
+		{"xhigh clamps to high without max", "xhigh", false, "high", true},
+		{"max clamps to high without max", "max", false, "high", true},
+		{"minimal maps to low", "minimal", true, "low", true},
+		{"medium passes through", "medium", true, "medium", true},
+		{"auto maps to high", "auto", true, "high", true},
+		{"case and whitespace normalized", " XHigh ", true, "xhigh", true},
+		{"unknown level rejected", "ultra", true, "", false},
+		{"empty level rejected", "", true, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := MapToClaudeEffort(tt.level, tt.supportsMax)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("MapToClaudeEffort(%q, %v) = (%q, %v), want (%q, %v)", tt.level, tt.supportsMax, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestClampLevelPrefersHighIntentFallbacks(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     ThinkingLevel
+		supported []string
+		want      ThinkingLevel
+	}{
+		{"xhigh stays xhigh", LevelXHigh, []string{"low", "medium", "high", "xhigh", "max"}, LevelXHigh},
+		{"xhigh prefers max over high", LevelXHigh, []string{"low", "medium", "high", "max"}, LevelMax},
+		{"xhigh falls back to high", LevelXHigh, []string{"low", "medium", "high"}, LevelHigh},
+		{"max prefers xhigh over high", LevelMax, []string{"low", "medium", "high", "xhigh"}, LevelXHigh},
+		{"max falls back to high", LevelMax, []string{"low", "medium", "high"}, LevelHigh},
+		{"other levels keep nearest-lower tie break", LevelMedium, []string{"low", "high"}, LevelLow},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{ID: "claude-test", Thinking: &registry.ThinkingSupport{Levels: tt.supported}}
+			if got := clampLevel(tt.level, modelInfo, "claude"); got != tt.want {
+				t.Fatalf("clampLevel(%q, %v) = %q, want %q", tt.level, tt.supported, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -239,8 +239,17 @@ func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupp
 // standardLevelOrder defines the canonical ordering of thinking levels from lowest to highest.
 var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax}
 
+// highIntentClampOrder lists the preferred fallbacks for the two top levels,
+// matching mapConfiguredHighIntent: a request for more than high should keep
+// as much of that intent as the model allows before degrading to high.
+var highIntentClampOrder = map[ThinkingLevel][]ThinkingLevel{
+	LevelXHigh: {LevelXHigh, LevelMax, LevelHigh},
+	LevelMax:   {LevelMax, LevelXHigh, LevelHigh},
+}
+
 // clampLevel clamps the given level to the nearest supported level.
-// On tie, prefers the lower level.
+// xhigh and max follow highIntentClampOrder; other levels pick the nearest
+// supported level and prefer the lower one on tie.
 func clampLevel(level ThinkingLevel, modelInfo *registry.ModelInfo, provider string) ThinkingLevel {
 	model := "unknown"
 	var supported []string
@@ -255,6 +264,13 @@ func clampLevel(level ThinkingLevel, modelInfo *registry.ModelInfo, provider str
 
 	if len(supported) == 0 || isLevelSupported(string(level), supported) {
 		return level
+	}
+
+	for _, candidate := range highIntentClampOrder[ThinkingLevel(strings.ToLower(strings.TrimSpace(string(level))))] {
+		if isLevelSupported(string(candidate), supported) {
+			logLevelClamp(provider, model, level, candidate)
+			return candidate
+		}
 	}
 
 	pos := levelIndex(string(level))
@@ -273,15 +289,19 @@ func clampLevel(level ThinkingLevel, modelInfo *registry.ModelInfo, provider str
 
 	if bestIdx >= 0 {
 		clamped := standardLevelOrder[bestIdx]
-		log.WithFields(log.Fields{
-			"provider":       provider,
-			"model":          model,
-			"original_value": string(level),
-			"clamped_to":     string(clamped),
-		}).Debug("thinking: level clamped |")
+		logLevelClamp(provider, model, level, clamped)
 		return clamped
 	}
 	return level
+}
+
+func logLevelClamp(provider, model string, original, clamped ThinkingLevel) {
+	log.WithFields(log.Fields{
+		"provider":       provider,
+		"model":          model,
+		"original_value": string(original),
+		"clamped_to":     string(clamped),
+	}).Debug("thinking: level clamped |")
 }
 
 // clampBudget clamps a budget value to the model's supported range.


### PR DESCRIPTION
## Summary

`MapToClaudeEffort` was written in March 2026 (#1805), when Claude adaptive effort had only `low/medium/high/max`, so it folded `xhigh` into `max`. Opus 4.7 introduced `xhigh` and the embedded registry has listed it for Opus 4.7/4.8, Opus 5, Sonnet 5 and Fable 5/5.1 since 5dcca69e, but the OpenAI Chat, OpenAI Responses and Gemini → Claude translators still rewrote a requested `xhigh` to `max`.

Reproduced on v7.2.146 with a Claude OAuth credential: a Codex `/v1/responses` request with `reasoning.effort: "xhigh"` for `claude-opus-4-8` reaches Anthropic as `"output_config":{"effort":"max"}` (visible in the proxy error log body). The same `xhigh` sent directly on `/v1/messages` is forwarded unchanged and Anthropic accepts it, so the clamp is the only thing in the way.

## Changes

Only `internal/thinking` is touched (the translator path guard is respected; the translator call sites keep their `supportsMax` signature).

- `MapToClaudeEffort`: `xhigh` passes through whenever the model supports `max` (every Claude model with `xhigh` also has `max`). `ApplyThinking` runs after translation and validates against the exact model, so models without `xhigh` are clamped there.
- `clampLevel`: `xhigh` now degrades to `max` before `high`, and `max` to `xhigh` before `high`, matching the order `mapConfiguredHighIntent` already uses. Without this the nearest-lower tie break would send Opus 4.6 / Sonnet 4.6 `high` instead of today's `max`. Other levels keep the existing nearest-lower behavior.
- Tests: `TestMapToClaudeEffort`, `TestClampLevelPrefersHighIntentFallbacks`, and `TestResponsesEffortReachesClaudeAfterApplyThinking`, which runs the Responses → Claude translator followed by `ApplyThinking` for Opus 4.8 / Opus 5 / Sonnet 5 (`xhigh` kept) and Opus 4.6 / Sonnet 4.6 (`xhigh` → `max`).

Net behavior change: `xhigh` reaches Opus 4.7/4.8, Opus 5, Sonnet 5 and Fable 5/5.1 as `xhigh`. Everything else is unchanged.

## Test Plan

- [x] `go build ./...`, `go vet ./internal/thinking/...`, `go test ./internal/thinking/... ./internal/runtime/... ./internal/translator/... ./sdk/...` pass (Go 1.26)
- [x] The three new tests fail on `dev` for the `xhigh` cases (`output_config.effort = "max"`, `clampLevel = "high"`) and pass with this change

## Related

- #5409 and #4796 cover the same symptom for third-party / user-defined models; this PR is about built-in Claude models with `xhigh` in the registry.

https://claude.ai/code/session_01SeMV6JBq4HvTyXPMuf6njW