### PR TITLE
fix(signature): accept decimal Claude CAIS context ids

### DIFF
--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -316,6 +316,49 @@ func TestClaudeCAISSignature_DetectSignatureProvider(t *testing.T) {
 	}
 }
 
+func TestIsClaudeCAISContextID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"1047401152336", true},
+		{observedContextID, true},
+		{"D9743975-4BB0-4936-9E28-D5B0D21BDC48", true},
+		{"1", true},
+		{"18446744073709551615", true},
+		{"", false},
+		{"0", false},
+		{"01", false},
+		{"-1", false},
+		{"+1", false},
+		{"not-a-canonical-uuid-value-000000000", false},
+		{"18446744073709551616", false},
+	}
+	for _, tc := range cases {
+		if got := isClaudeCAISContextID(tc.in); got != tc.want {
+			t.Errorf("isClaudeCAISContextID(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClaudeCAISSignature_AcceptsDecimalContextID(t *testing.T) {
+	const decimalContextID = "1047401152336"
+	p := defaultClaudeCAISParts("claude-opus-5")
+	p.contextID = decimalContextID
+	sig := p.encode()
+
+	info, err := InspectClaudeCAISSignature(sig)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+	if info.ContextID != decimalContextID {
+		t.Fatalf("ContextID = %q, want %q", info.ContextID, decimalContextID)
+	}
+	if !IsValidClaudeCAISSignature(sig) {
+		t.Fatal("IsValidClaudeCAISSignature = false, want true")
+	}
+}
+
 func TestClaudeCAISSignature_ObservedOpus5Layout(t *testing.T) {
 	signature := testClaudeCAISSignature("claude-opus-5")
 	info, err := InspectClaudeCAISSignature(signature)
@@ -567,9 +610,24 @@ func TestClaudeCAISSignature_RejectsMalformedPayloads(t *testing.T) {
 			p.modelText = []byte{'c', 'l', 'a', 'u', 'd', 'e', '-', 0xff, 0xfe}
 			return p.encode()
 		}()},
-		{"non-uuid context id", func() string {
+		{"garbage context id", func() string {
 			p := defaultClaudeCAISParts("claude-opus-5")
 			p.contextID = "not-a-canonical-uuid-value-000000000"
+			return p.encode()
+		}()},
+		{"signed decimal context id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = "-1047401152336"
+			return p.encode()
+		}()},
+		{"leading-zero decimal context id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = "01047401152336"
+			return p.encode()
+		}()},
+		{"overflow decimal context id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = "18446744073709551616"
 			return p.encode()
 		}()},
 	}

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -74,7 +74,7 @@
 //	|     |- Field 6  (bytes):  model_text [required, "claude-" prefixed]
 //	|     |- Field 7  (varint): unknown [optional, observed as 1]
 //	|     |- Field 8  (bytes):  block kind [optional, observed as "thinking"]
-//	|     `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	|     `- Field 11 (bytes):  context id [optional, canonical UUID or positive uint64 decimal]
 //	`- Field 3 (varint): trailer [optional, observed as 1]
 //
 // CAIS validation is structural rather than an exact replay of the observed
@@ -112,6 +112,7 @@ package signature
 import (
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -733,8 +734,8 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 			if errField != nil {
 				return errField
 			}
-			if !isCanonicalUUID(value) {
-				return fmt.Errorf("invalid Claude CAIS signature: channel field 11 context id must be a canonical UUID, got %q", value)
+			if !isClaudeCAISContextID(value) {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 11 context id must be a canonical UUID or a positive uint64 decimal string, got %q", value)
 			}
 			info.ContextID = value
 		}
@@ -778,6 +779,20 @@ func decodeClaudeCAISUTF8(raw []byte, typ protowire.Type, label string) (string,
 		return "", fmt.Errorf("invalid Claude CAIS signature: %s must be valid UTF-8", label)
 	}
 	return string(value), nil
+}
+
+// isClaudeCAISContextID reports whether s is a CAIS channel field 11 context
+// id: a canonical UUID, or a positive uint64 decimal string with no sign and
+// no leading zero. Observed Opus-5 / model_hub traffic emits both forms.
+func isClaudeCAISContextID(s string) bool {
+	if isCanonicalUUID(s) {
+		return true
+	}
+	if s == "" || s[0] < '1' || s[0] > '9' {
+		return false
+	}
+	_, err := strconv.ParseUint(s, 10, 64)
+	return err == nil
 }
 
 func isCanonicalUUID(s string) bool {


### PR DESCRIPTION
## Summary

Claude CAIS channel field 11 is currently required to be a canonical UUID. Observed Opus-5 / model_hub signatures also put a positive uint64 decimal string there (e.g. `1047401152336`). UUID-only validation rejects those payloads, so sanitizers strip the signature and the thinking block is replayed unsigned. Upstream then returns `-4003`.

This PR accepts either form:

- canonical UUID (existing `isCanonicalUUID`)
- positive uint64 decimal string: first digit `1-9`, `strconv.ParseUint(s, 10, 64)`; reject empty, sign, leading zero, and overflow

Independent of #5422, which still UUID-only-validates field 11.

## Test plan

- [x] `go test ./internal/signature/ -count=1`
- Synthetic CAIS with context id `1047401152336` now passes `InspectClaudeCAISSignature` / `IsValidClaudeCAISSignature`
- UUID context ids still accepted
- Garbage, signed, leading-zero, and overflow context ids still rejected