### PR TITLE
fix(translator): preserve Gemini prompt cache by demoting mid-session developer messages (#5490)

### DIFF
--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -294,7 +294,7 @@ func ValidateGeminiFunctionCallPairing(inputRawJSON []byte) error {
 	contents.ForEach(func(contentIndex, content gjson.Result) bool {
 		i := int(contentIndex.Int())
 		parts := content.Get("parts")
-		if !parts.IsArray() {
+		if !parts.IsArray() || parts.Raw == "[]" || !parts.Get("0").Exists() {
 			if len(pending) > 0 {
 				validationErr = fmt.Errorf(
 					"%s[%d]: content appears before %d pending functionResponse part(s)",
@@ -352,12 +352,19 @@ func ValidateGeminiFunctionCallPairing(inputRawJSON []byte) error {
 			pending = calls
 			return true
 		case len(responses) == 0 && len(pending) > 0:
-			validationErr = fmt.Errorf(
-				"%s[%d]: content appears before %d pending functionResponse part(s)",
-				contentsPath,
-				i,
-				len(pending),
-			)
+			// Allow intervening user content (such as system reminders, mid-session developer notices, or user turns)
+			// to appear before the pending functionResponse turn. Upstream Antigravity accepts this natively.
+			// Reject only if it is a model turn without responses, which breaks turn ownership.
+			role := strings.ToLower(strings.TrimSpace(content.Get("role").String()))
+			if role == "model" {
+				validationErr = fmt.Errorf(
+					"%s[%d]: model content appears before %d pending functionResponse part(s)",
+					contentsPath,
+					i,
+					len(pending),
+				)
+			}
+			return validationErr == nil
 		case len(responses) == 0:
 			return true
 		case len(pending) == 0:

--- a/internal/signature/gemini_validation_test.go
+++ b/internal/signature/gemini_validation_test.go
@@ -365,10 +365,17 @@ func TestValidateGeminiFunctionCallPairing_ValidParallelGroup(t *testing.T) {
 	}
 }
 
-func TestValidateGeminiFunctionCallPairing_RejectsUserBoundaryBeforeResponse(t *testing.T) {
-	payload := []byte(`{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"run","args":{}}}]},{"role":"user","parts":[{"text":"boundary"}]},{"role":"model","parts":[{"functionResponse":{"id":"call-1","name":"run","response":{"result":"ok"}}}]}]}`)
+func TestValidateGeminiFunctionCallPairing_AllowsUserBoundaryBeforeResponse(t *testing.T) {
+	payload := []byte(`{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"run","args":{}}}]},{"role":"user","parts":[{"text":"boundary"}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"run","response":{"result":"ok"}}}]}]}`)
+	if err := ValidateGeminiFunctionCallPairing(payload); err != nil {
+		t.Fatalf("user boundary before function response should be accepted: %v", err)
+	}
+}
+
+func TestValidateGeminiFunctionCallPairing_RejectsModelBoundaryBeforeResponse(t *testing.T) {
+	payload := []byte(`{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"run","args":{}}}]},{"role":"model","parts":[{"text":"boundary"}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"run","response":{"result":"ok"}}}]}]}`)
 	if err := ValidateGeminiFunctionCallPairing(payload); err == nil {
-		t.Fatal("user boundary before function response was accepted")
+		t.Fatal("model boundary before function response should be rejected")
 	}
 }
 

--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -359,14 +359,14 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			}
 			originalRole := roleResult.String()
 			var precedingToolUseIDs []string
-			if originalRole != "system" {
+			if originalRole != "system" && originalRole != "developer" {
 				precedingToolUseIDs = pendingToolUseIDs
 				pendingToolUseIDs = nil
 			}
 			role := originalRole
 			if role == "assistant" {
 				role = "model"
-			} else if role == "system" {
+			} else if role == "system" || role == "developer" {
 				role = "user"
 			}
 			partItems := make([][]byte, 0, 4)
@@ -389,7 +389,7 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 				pendingDetachedTargetKind = targetKind
 			}
 			contentsResult := messageResult.Get("content")
-			if originalRole == "system" {
+			if originalRole == "system" || originalRole == "developer" {
 				if reminderText, ok := translatorcommon.ClaudeMessageSystemReminderText(contentsResult); ok {
 					partJSON := []byte(`{}`)
 					partJSON, _ = sjson.SetBytes(partJSON, "text", reminderText)

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -183,6 +183,54 @@ func TestConvertClaudeRequestToAntigravity_ConvertsMessageSystemRoleToUserConten
 	}
 }
 
+func TestConvertClaudeRequestToAntigravity_MessageLevelDeveloperInstructionsBecomeMergedUserReminder(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gemini-3.5-flash",
+		"system": "Top-level rules",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+			{"role": "developer", "content": "String mid-conversation developer rule"},
+			{"role": "developer", "content": [{"type": "text", "text": "Array mid-conversation developer rule"}]}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("gemini-3.5-flash", inputJSON, false)
+	outputStr := string(output)
+
+	if devContent := gjson.Get(outputStr, `request.contents.#(role=="developer")`); devContent.Exists() {
+		t.Fatalf("developer role should not be emitted in request.contents: %s", devContent.Raw)
+	}
+
+	contents := gjson.Get(outputStr, "request.contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("Expected consecutive user and developer turns to be merged into a single user turn, got %d: %s", len(contents), gjson.Get(outputStr, "request.contents").Raw)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("Expected first content role user, got %q", got)
+	}
+	parts := contents[0].Get("parts").Array()
+	if len(parts) != 3 {
+		t.Fatalf("Expected 3 parts in merged user content, got %d: %s", len(parts), contents[0].Get("parts").Raw)
+	}
+	if got := parts[0].Get("text").String(); got != "Hello" {
+		t.Fatalf("Unexpected initial user prompt text: %q", got)
+	}
+	if got := parts[1].Get("text").String(); got != "<system-reminder>\nString mid-conversation developer rule\n</system-reminder>" {
+		t.Fatalf("Unexpected string developer content text: %q", got)
+	}
+	if got := parts[2].Get("text").String(); got != "<system-reminder>\nArray mid-conversation developer rule\n</system-reminder>" {
+		t.Fatalf("Unexpected array developer content text: %q", got)
+	}
+
+	systemInstructionParts := gjson.Get(outputStr, "request.systemInstruction.parts").Array()
+	if len(systemInstructionParts) != 1 {
+		t.Fatalf("Expected only top-level system parts, got %d: %s", len(systemInstructionParts), gjson.Get(outputStr, "request.systemInstruction.parts").Raw)
+	}
+	if got := systemInstructionParts[0].Get("text").String(); got != "Top-level rules" {
+		t.Fatalf("Unexpected first system part: %q", got)
+	}
+}
+
 func TestConvertClaudeRequestToAntigravity_PreservesToolPairingWithInterveningSystemMessage(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "gemini-3.5-flash",

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -69,7 +69,7 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			role := value.Get("role").String()
 			content := []byte(value.Raw)
 			if role != "user" && role != "model" {
-				if value.Get("parts.#.functionResponse").Exists() || value.Get("parts.#.function_response").Exists() {
+				if translatorcommon.ContentHasGeminiFunctionResponse([]byte(value.Raw)) {
 					role = "user"
 				} else if previousRole == "" || previousRole == "model" {
 					role = "user"

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -69,7 +69,9 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			role := value.Get("role").String()
 			content := []byte(value.Raw)
 			if role != "user" && role != "model" {
-				if previousRole == "" || previousRole == "model" {
+				if value.Get("parts.#.functionResponse").Exists() || value.Get("parts.#.function_response").Exists() {
+					role = "user"
+				} else if previousRole == "" || previousRole == "model" {
 					role = "user"
 				} else {
 					role = "model"

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -1141,3 +1141,39 @@ func TestConvertGeminiRequestToAntigravity_PreservesSiblingToolImageOnUserRole(t
 		t.Fatalf("sibling inline data should be absorbed into functionResponse.parts. Output: %s", out)
 	}
 }
+
+func TestNormalizeRoles_InvalidRoleWithoutFunctionResponseAlternates(t *testing.T) {
+	inputJSON := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "first"}]},
+			{"role": "invalid", "parts": [{"text": "second"}]}
+		]
+	}`)
+	out := ConvertGeminiRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 contents, got %d", len(contents))
+	}
+	if got := contents[1].Get("role").String(); got != "model" {
+		t.Fatalf("text-only invalid role following user should normalize to model, got %q", got)
+	}
+}
+
+func TestNormalizeRoles_InvalidRoleWithFunctionResponseNormalizesToUser(t *testing.T) {
+	inputJSON := []byte(`{
+		"contents": [
+			{"role": "model", "parts": [{"functionCall": {"name": "test", "args": {}}}]},
+			{"role": "user", "parts": [{"text": "intervening user message"}]},
+			{"role": "invalid", "parts": [{"functionResponse": {"name": "test", "response": {}}}]}
+		]
+	}`)
+	out := ConvertGeminiRequestToAntigravity("gemini-3-flash", inputJSON, false)
+	// Role functionResponse should NEVER be normalized to model
+	for _, content := range gjson.GetBytes(out, "request.contents").Array() {
+		if content.Get("parts.0.functionResponse").Exists() {
+			if got := content.Get("role").String(); got != "user" && got != "function" {
+				t.Fatalf("functionResponse role should be user or function, got %q", got)
+			}
+		}
+	}
+}

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -165,12 +165,13 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 			}
 		}
 
+		hasEncounteredConversation := false
 		for i := 0; i < len(arr); i++ {
 			m := arr[i]
 			role := m.Get("role").String()
 			content := m.Get("content")
 
-			if (role == "system" || role == "developer") && len(arr) > 1 {
+			if (role == "system" || role == "developer") && len(arr) > 1 && !hasEncounteredConversation {
 				// system -> request.systemInstruction as a user message style
 				if content.Type == gjson.String {
 					systemParts = append(systemParts, antigravityOpenAITextPart(content.String()))
@@ -181,10 +182,13 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						systemParts = append(systemParts, antigravityOpenAITextPart(contentPart.Get("text").String()))
 					}
 				}
-			} else if role == "user" || ((role == "system" || role == "developer") && len(arr) == 1) {
+			} else if role == "user" || role == "system" || role == "developer" {
+				hasEncounteredConversation = true
 				partItems := make([][]byte, 0, 4)
 				if content.Type == gjson.String {
 					partItems = append(partItems, antigravityOpenAITextPart(content.String()))
+				} else if content.IsObject() && content.Get("type").String() == "text" {
+					partItems = append(partItems, antigravityOpenAITextPart(content.Get("text").String()))
 				} else if content.IsArray() {
 					for _, item := range content.Array() {
 						switch item.Get("type").String() {
@@ -227,8 +231,11 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 						}
 					}
 				}
-				contentItems = append(contentItems, antigravityOpenAIContent("user", partItems))
+				if len(partItems) > 0 {
+					contentItems = append(contentItems, antigravityOpenAIContent("user", partItems))
+				}
 			} else if role == "assistant" {
+				hasEncounteredConversation = true
 				partItems := make([][]byte, 0, 4)
 				if reasoningContent := m.Get("reasoning_content"); reasoningContent.Type == gjson.String && reasoningContent.String() != "" {
 					part := antigravityOpenAITextPart(reasoningContent.String())

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -189,6 +189,49 @@ func TestConvertOpenAIRequestToAntigravitySkipsEmptyAssistantMessages(t *testing
 	}
 }
 
+func TestConvertOpenAIRequestToAntigravity_MidSessionDeveloperMessageDoesNotMutateSystemInstruction(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"messages": [
+			{"role": "system", "content": "You are a helpful assistant"},
+			{"role": "user", "content": "Turn 1 user"},
+			{"role": "assistant", "content": "Turn 1 assistant"},
+			{"role": "developer", "content": "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>"},
+			{"role": "user", "content": "Turn 2 user"}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	output := gjson.ParseBytes(result)
+
+	// request.systemInstruction must contain only original system prompt
+	sysParts := output.Get("request.systemInstruction.parts").Array()
+	if len(sysParts) != 1 {
+		t.Fatalf("request.systemInstruction parts = %d, want 1. Output: %s", len(sysParts), result)
+	}
+	if got := sysParts[0].Get("text").String(); got != "You are a helpful assistant" {
+		t.Fatalf("systemInstruction text = %q, want %q", got, "You are a helpful assistant")
+	}
+
+	// contents must contain user, model, user (demoted dev message), user
+	contents := output.Get("request.contents").Array()
+	if len(contents) != 4 {
+		t.Fatalf("contents length = %d, want 4. Output: %s", len(contents), result)
+	}
+	if contents[0].Get("role").String() != "user" || contents[0].Get("parts.0.text").String() != "Turn 1 user" {
+		t.Fatalf("turn 0 mismatch: %s", contents[0].Raw)
+	}
+	if contents[1].Get("role").String() != "model" || contents[1].Get("parts.0.text").String() != "Turn 1 assistant" {
+		t.Fatalf("turn 1 mismatch: %s", contents[1].Raw)
+	}
+	if contents[2].Get("role").String() != "user" || contents[2].Get("parts.0.text").String() != "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>" {
+		t.Fatalf("turn 2 mismatch: %s", contents[2].Raw)
+	}
+	if contents[3].Get("role").String() != "user" || contents[3].Get("parts.0.text").String() != "Turn 2 user" {
+		t.Fatalf("turn 3 mismatch: %s", contents[3].Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToAntigravityThinkingAliases(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -401,3 +401,112 @@ func TestConvertOpenAIResponsesRequestToAntigravity_PreservesAdditionalToolsAndT
 		t.Fatalf("allowedFunctionNames.0 = %q, want functions__continuity_probe", allowed)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_MidSessionDeveloperMessageDoesNotMutateSystemInstruction(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Turn 1 user"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "output_text", "text": "Turn 1 assistant"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>"
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Turn 2 user"}
+				]
+			}
+		]
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("invalid JSON output: %s", out)
+	}
+
+	// In Antigravity envelope, systemInstruction is at request.systemInstruction
+	sysParts := gjson.GetBytes(out, "request.systemInstruction.parts").Array()
+	if len(sysParts) != 1 {
+		t.Fatalf("request.systemInstruction parts count = %d, want 1; output=%s", len(sysParts), out)
+	}
+	if got := sysParts[0].Get("text").String(); got != "Be a helpful assistant" {
+		t.Fatalf("systemInstruction part = %q, want %q; output=%s", got, "Be a helpful assistant", out)
+	}
+
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("request.contents count = %d, want 3; output=%s", len(contents), out)
+	}
+	if contents[2].Get("role").String() != "user" {
+		t.Fatalf("turn 2 role = %q, want user; output=%s", contents[2].Get("role").String(), out)
+	}
+	turn2Parts := contents[2].Get("parts").Array()
+	if len(turn2Parts) != 2 {
+		t.Fatalf("turn 2 parts count = %d, want 2; output=%s", len(turn2Parts), out)
+	}
+	if got := turn2Parts[0].Get("text").String(); got != "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>" {
+		t.Fatalf("turn 2 part 0 = %q, want image_resize_notice; output=%s", got, out)
+	}
+	if got := turn2Parts[1].Get("text").String(); got != "Turn 2 user" {
+		t.Fatalf("turn 2 part 1 = %q, want Turn 2 user; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_InterveningDeveloperMessagePreservesToolPairing(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Run tool"}
+				]
+			},
+			{
+				"type": "function_call",
+				"call_id": "call-1",
+				"name": "run_command",
+				"arguments": "{\"command\":\"echo test\"}"
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": "<permissions instructions>\nApproved: echo\n</permissions instructions>"
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call-1",
+				"output": "test"
+			}
+		]
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("invalid JSON output: %s", out)
+	}
+
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity request: %v; output=%s", errPair, out)
+	}
+}

--- a/internal/translator/common/gemini.go
+++ b/internal/translator/common/gemini.go
@@ -54,3 +54,58 @@ func MergeAdjacentGeminiContents(contents [][]byte) [][]byte {
 	}
 	return merged
 }
+
+// ContentHasGeminiFunctionResponse reports whether a Gemini content turn contains any functionResponse part.
+func ContentHasGeminiFunctionResponse(content []byte) bool {
+	hasFR := false
+	gjson.GetBytes(content, "parts").ForEach(func(_, part gjson.Result) bool {
+		if part.Get("functionResponse").Exists() || part.Get("function_response").Exists() {
+			hasFR = true
+			return false
+		}
+		return true
+	})
+	return hasFR
+}
+
+// MergeAdjacentGeminiUserContents merges consecutive user Content turns,
+// but leaves turns containing functionResponse unmerged to preserve tool-call/response boundaries.
+func MergeAdjacentGeminiUserContents(contents [][]byte) [][]byte {
+	if len(contents) <= 1 {
+		return contents
+	}
+	merged := make([][]byte, 0, len(contents))
+	for _, content := range contents {
+		if len(content) == 0 {
+			continue
+		}
+		role := gjson.GetBytes(content, "role").String()
+		partsResult := gjson.GetBytes(content, "parts")
+		if !partsResult.IsArray() || partsResult.Raw == "[]" || !partsResult.Get("0").Exists() {
+			continue
+		}
+		if len(merged) > 0 {
+			lastIndex := len(merged) - 1
+			lastJSON := merged[lastIndex]
+			lastRole := gjson.GetBytes(lastJSON, "role").String()
+			if lastRole == "user" && role == "user" && !ContentHasGeminiFunctionResponse(lastJSON) && !ContentHasGeminiFunctionResponse(content) {
+				lastParts := gjson.GetBytes(lastJSON, "parts").Array()
+				currentParts := partsResult.Array()
+				combinedParts := make([][]byte, 0, len(lastParts)+len(currentParts))
+				for _, p := range lastParts {
+					combinedParts = append(combinedParts, []byte(p.Raw))
+				}
+				for _, p := range currentParts {
+					combinedParts = append(combinedParts, []byte(p.Raw))
+				}
+				updated, err := sjson.SetRawBytes(lastJSON, "parts", JoinRawArray(combinedParts))
+				if err == nil {
+					merged[lastIndex] = updated
+					continue
+				}
+			}
+		}
+		merged = append(merged, content)
+	}
+	return merged
+}

--- a/internal/translator/common/gemini_test.go
+++ b/internal/translator/common/gemini_test.go
@@ -84,3 +84,32 @@ func TestMergeAdjacentGeminiContents(t *testing.T) {
 		}
 	})
 }
+
+func TestMergeAdjacentGeminiUserContents(t *testing.T) {
+	t.Run("merges consecutive pure text user turns", func(t *testing.T) {
+		contents := [][]byte{
+			[]byte(`{"role":"user","parts":[{"text":"prompt 1"}]}`),
+			[]byte(`{"role":"user","parts":[{"text":"prompt 2"}]}`),
+		}
+		merged := MergeAdjacentGeminiUserContents(contents)
+		if len(merged) != 1 {
+			t.Fatalf("expected 1 merged user turn, got %d", len(merged))
+		}
+		parts := gjson.GetBytes(merged[0], "parts").Array()
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(parts))
+		}
+	})
+
+	t.Run("does not merge across functionResponse boundaries", func(t *testing.T) {
+		contents := [][]byte{
+			[]byte(`{"role":"user","parts":[{"functionResponse":{"name":"test","response":{"result":"ok"}}}]}`),
+			[]byte(`{"role":"user","parts":[{"text":"user note"}]}`),
+			[]byte(`{"role":"user","parts":[{"function_response":{"name":"test2","response":{"result":"ok2"}}}]}`),
+		}
+		merged := MergeAdjacentGeminiUserContents(contents)
+		if len(merged) != 3 {
+			t.Fatalf("expected 3 separate turns preserving functionResponse, got %d", len(merged))
+		}
+	})
+}

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -88,20 +88,20 @@ func convertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool,
 			}
 			originalRole := roleResult.String()
 			var precedingToolUseIDs []string
-			if originalRole != "system" {
+			if originalRole != "system" && originalRole != "developer" {
 				precedingToolUseIDs = pendingToolUseIDs
 				pendingToolUseIDs = nil
 			}
 			role := originalRole
 			if role == "assistant" {
 				role = "model"
-			} else if role == "system" {
+			} else if role == "system" || role == "developer" {
 				role = "user"
 			}
 
 			partItems := make([][]byte, 0, 4)
 			contentsResult := messageResult.Get("content")
-			if roleResult.String() == "system" {
+			if roleResult.String() == "system" || roleResult.String() == "developer" {
 				if reminderText, ok := translatorcommon.ClaudeMessageSystemReminderText(contentsResult); ok {
 					part := []byte(`{"text":""}`)
 					part, _ = sjson.SetBytes(part, "text", reminderText)

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -175,6 +175,53 @@ func TestConvertClaudeRequestToGemini_ConvertsMessageSystemRoleToUserContent(t *
 	}
 }
 
+func TestConvertClaudeRequestToGemini_MessageLevelDeveloperInstructionsBecomeMergedUserReminder(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gemini-3-flash-preview",
+		"system": "Top-level rules",
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+			{"role": "developer", "content": "String mid-conversation developer rule"},
+			{"role": "developer", "content": [{"type": "text", "text": "Array mid-conversation developer rule"}]}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToGemini("gemini-3-flash-preview", inputJSON, false)
+
+	if devContent := gjson.GetBytes(output, `contents.#(role=="developer")`); devContent.Exists() {
+		t.Fatalf("developer role should not be emitted in contents: %s", devContent.Raw)
+	}
+
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("Expected consecutive user and developer turns to be merged into a single user turn, got %d: %s", len(contents), gjson.GetBytes(output, "contents").Raw)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("Expected first content role user, got %q", got)
+	}
+	parts := contents[0].Get("parts").Array()
+	if len(parts) != 3 {
+		t.Fatalf("Expected 3 parts in merged user content, got %d: %s", len(parts), contents[0].Get("parts").Raw)
+	}
+	if got := parts[0].Get("text").String(); got != "Hello" {
+		t.Fatalf("Unexpected initial user prompt text: %q", got)
+	}
+	if got := parts[1].Get("text").String(); got != "<system-reminder>\nString mid-conversation developer rule\n</system-reminder>" {
+		t.Fatalf("Unexpected string developer content text: %q", got)
+	}
+	if got := parts[2].Get("text").String(); got != "<system-reminder>\nArray mid-conversation developer rule\n</system-reminder>" {
+		t.Fatalf("Unexpected array developer content text: %q", got)
+	}
+
+	systemInstructionParts := gjson.GetBytes(output, "systemInstruction.parts").Array()
+	if len(systemInstructionParts) != 1 {
+		t.Fatalf("Expected only top-level system parts, got %d: %s", len(systemInstructionParts), gjson.GetBytes(output, "systemInstruction.parts").Raw)
+	}
+	if got := systemInstructionParts[0].Get("text").String(); got != "Top-level rules" {
+		t.Fatalf("Unexpected first system part: %q", got)
+	}
+}
+
 func TestConvertClaudeRequestToGemini_PreservesToolPairingWithInterveningSystemMessage(t *testing.T) {
 	inputJSON := []byte(`{
 		"model": "gemini-3-flash-preview",

--- a/internal/translator/gemini/gemini/gemini_gemini_request.go
+++ b/internal/translator/gemini/gemini/gemini_gemini_request.go
@@ -78,7 +78,11 @@ func ConvertGeminiRequestToGemini(_ string, inputRawJSON []byte, _ bool) []byte 
 		contents.ForEach(func(_, value gjson.Result) bool {
 			role := value.Get("role").String()
 			if role != "user" && role != "model" {
-				role = nextGeminiRole(prevRole)
+				if translatorcommon.ContentHasGeminiFunctionResponse([]byte(value.Raw)) {
+					role = "user"
+				} else {
+					role = nextGeminiRole(prevRole)
+				}
 				rolesChanged = true
 			}
 			prevRole = role
@@ -91,7 +95,11 @@ func ConvertGeminiRequestToGemini(_ string, inputRawJSON []byte, _ bool) []byte 
 				role := value.Get("role").String()
 				item := []byte(value.Raw)
 				if role != "user" && role != "model" {
-					role = nextGeminiRole(prevRole)
+					if translatorcommon.ContentHasGeminiFunctionResponse([]byte(value.Raw)) {
+						role = "user"
+					} else {
+						role = nextGeminiRole(prevRole)
+					}
 					item, _ = sjson.SetBytes(item, "role", role)
 				}
 				prevRole = role
@@ -105,7 +113,11 @@ func ConvertGeminiRequestToGemini(_ string, inputRawJSON []byte, _ bool) []byte 
 		contents.ForEach(func(_ gjson.Result, value gjson.Result) bool {
 			role := value.Get("role").String()
 			if role != "user" && role != "model" {
-				role = nextGeminiRole(prevRole)
+				if translatorcommon.ContentHasGeminiFunctionResponse([]byte(value.Raw)) {
+					role = "user"
+				} else {
+					role = nextGeminiRole(prevRole)
+				}
 				out, _ = sjson.SetBytes(out, fmt.Sprintf("contents.%d.role", idx), role)
 			}
 			prevRole = role

--- a/internal/translator/gemini/gemini/gemini_gemini_request_test.go
+++ b/internal/translator/gemini/gemini/gemini_gemini_request_test.go
@@ -253,3 +253,20 @@ func TestBackfillEmptyFunctionResponseNames_MultipleGroups(t *testing.T) {
 		t.Errorf("Expected second group name 'Grep', got '%s'", name1)
 	}
 }
+
+func TestConvertGeminiRequestToGemini_FunctionResponseWithInvalidRoleNormalizesToUser(t *testing.T) {
+	inputJSON := []byte(`{
+		"contents": [
+			{"role": "user", "parts": [{"text": "reminder"}]},
+			{"role": "invalid", "parts": [{"functionResponse": {"name": "lookup", "response": {}}}]}
+		]
+	}`)
+	out := ConvertGeminiRequestToGemini("gemini-3-flash", inputJSON, false)
+	contents := gjson.GetBytes(out, "contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 contents, got %d", len(contents))
+	}
+	if got := contents[1].Get("role").String(); got != "user" {
+		t.Fatalf("functionResponse invalid role should normalize to user, got %q", got)
+	}
+}

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request.go
@@ -150,12 +150,13 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 			}
 		}
 
+		hasEncounteredConversation := false
 		for i := 0; i < len(arr); i++ {
 			m := arr[i]
 			role := m.Get("role").String()
 			content := m.Get("content")
 
-			if (role == "system" || role == "developer") && len(arr) > 1 {
+			if (role == "system" || role == "developer") && len(arr) > 1 && !hasEncounteredConversation {
 				// system -> systemInstruction as a user message style
 				if content.Type == gjson.String {
 					systemParts = append(systemParts, geminiTextPart(content.String()))
@@ -167,11 +168,14 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						systemParts = append(systemParts, geminiTextPart(contents[j].Get("text").String()))
 					}
 				}
-			} else if role == "user" || ((role == "system" || role == "developer") && len(arr) == 1) {
+			} else if role == "user" || role == "system" || role == "developer" {
+				hasEncounteredConversation = true
 				// Build single user content node to avoid splitting into multiple contents.
 				partItems := make([][]byte, 0, 4)
 				if content.Type == gjson.String {
 					partItems = append(partItems, geminiTextPart(content.String()))
+				} else if content.IsObject() && content.Get("type").String() == "text" {
+					partItems = append(partItems, geminiTextPart(content.Get("text").String()))
 				} else if content.IsArray() {
 					for _, item := range content.Array() {
 						switch item.Get("type").String() {
@@ -212,8 +216,11 @@ func ConvertOpenAIRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						}
 					}
 				}
-				contentItems = append(contentItems, geminiContentNode("user", partItems))
+				if len(partItems) > 0 {
+					contentItems = append(contentItems, geminiContentNode("user", partItems))
+				}
 			} else if role == "assistant" {
+				hasEncounteredConversation = true
 				partItems := make([][]byte, 0, 4)
 				if reasoningContent := m.Get("reasoning_content"); reasoningContent.Type == gjson.String && reasoningContent.String() != "" {
 					part := geminiTextPart(reasoningContent.String())

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_request_test.go
@@ -224,6 +224,49 @@ func TestConvertOpenAIRequestToGeminiSkipsEmptyAssistantMessages(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIRequestToGemini_MidSessionDeveloperMessageDoesNotMutateSystemInstruction(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"messages": [
+			{"role": "system", "content": "You are a helpful assistant"},
+			{"role": "user", "content": "Turn 1 user"},
+			{"role": "assistant", "content": "Turn 1 assistant"},
+			{"role": "developer", "content": "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>"},
+			{"role": "user", "content": "Turn 2 user"}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToGemini("gemini-3-flash", []byte(inputJSON), false)
+	output := gjson.ParseBytes(result)
+
+	// systemInstruction must contain only original system prompt
+	sysParts := output.Get("systemInstruction.parts").Array()
+	if len(sysParts) != 1 {
+		t.Fatalf("systemInstruction parts = %d, want 1. Output: %s", len(sysParts), result)
+	}
+	if got := sysParts[0].Get("text").String(); got != "You are a helpful assistant" {
+		t.Fatalf("systemInstruction text = %q, want %q", got, "You are a helpful assistant")
+	}
+
+	// contents must contain user, model, user (demoted dev message), user
+	contents := output.Get("contents").Array()
+	if len(contents) != 4 {
+		t.Fatalf("contents length = %d, want 4. Output: %s", len(contents), result)
+	}
+	if contents[0].Get("role").String() != "user" || contents[0].Get("parts.0.text").String() != "Turn 1 user" {
+		t.Fatalf("turn 0 mismatch: %s", contents[0].Raw)
+	}
+	if contents[1].Get("role").String() != "model" || contents[1].Get("parts.0.text").String() != "Turn 1 assistant" {
+		t.Fatalf("turn 1 mismatch: %s", contents[1].Raw)
+	}
+	if contents[2].Get("role").String() != "user" || contents[2].Get("parts.0.text").String() != "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>" {
+		t.Fatalf("turn 2 mismatch: %s", contents[2].Raw)
+	}
+	if contents[3].Get("role").String() != "user" || contents[3].Get("parts.0.text").String() != "Turn 2 user" {
+		t.Fatalf("turn 3 mismatch: %s", contents[3].Raw)
+	}
+}
+
 func TestConvertOpenAIRequestToGeminiMapsMaxTokens(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -142,6 +142,10 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 				hasEncounteredConversation = true
 				if _, isAssistantOutput := openAIResponsesAssistantVisibleText(item); !isAssistantOutput {
+					if len(pendingDeveloperParts) > 0 {
+						contentItems = append(contentItems, geminiContent("user", pendingDeveloperParts))
+						pendingDeveloperParts = nil
+					}
 					pendingFunctionCallIDs = nil
 				}
 

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -77,6 +77,8 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			normalized = reorderOpenAIResponsesDetachedReasoning(normalized)
 		}
 		consumedFunctionOutputIndexes := make(map[int]bool)
+		hasEncounteredConversation := false
+		var pendingDeveloperParts [][]byte
 		for i := 0; i < len(normalized); i++ {
 			if consumedFunctionOutputIndexes[i] {
 				continue
@@ -91,24 +93,54 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 			switch itemType {
 			case "message":
 				if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
-					pendingFunctionCallIDs = nil
+					if !hasEncounteredConversation {
+						pendingFunctionCallIDs = nil
+						if contentArray := item.Get("content"); contentArray.Exists() {
+							if contentArray.IsArray() {
+								contentArray.ForEach(func(_, contentItem gjson.Result) bool {
+									part := []byte(`{"text":""}`)
+									part, _ = sjson.SetBytes(part, "text", contentItem.Get("text").String())
+									systemParts = append(systemParts, part)
+									return true
+								})
+							} else if contentArray.Type == gjson.String {
+								part := []byte(`{"text":""}`)
+								part, _ = sjson.SetBytes(part, "text", contentArray.String())
+								systemParts = append(systemParts, part)
+							}
+						}
+						continue
+					}
+
+					var devParts [][]byte
 					if contentArray := item.Get("content"); contentArray.Exists() {
 						if contentArray.IsArray() {
 							contentArray.ForEach(func(_, contentItem gjson.Result) bool {
-								part := []byte(`{"text":""}`)
-								part, _ = sjson.SetBytes(part, "text", contentItem.Get("text").String())
-								systemParts = append(systemParts, part)
+								text := contentItem.Get("text").String()
+								if text != "" {
+									part := []byte(`{"text":""}`)
+									part, _ = sjson.SetBytes(part, "text", text)
+									devParts = append(devParts, part)
+								}
 								return true
 							})
-						} else if contentArray.Type == gjson.String {
+						} else if contentArray.Type == gjson.String && contentArray.String() != "" {
 							part := []byte(`{"text":""}`)
 							part, _ = sjson.SetBytes(part, "text", contentArray.String())
-							systemParts = append(systemParts, part)
+							devParts = append(devParts, part)
+						}
+					}
+					if len(devParts) > 0 {
+						if len(pendingFunctionCallIDs) > 0 {
+							pendingDeveloperParts = append(pendingDeveloperParts, devParts...)
+						} else {
+							contentItems = append(contentItems, geminiContent("user", devParts))
 						}
 					}
 					continue
 				}
 
+				hasEncounteredConversation = true
 				if _, isAssistantOutput := openAIResponsesAssistantVisibleText(item); !isAssistantOutput {
 					pendingFunctionCallIDs = nil
 				}
@@ -231,6 +263,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				}
 
 			case "function_call", "custom_tool_call":
+				hasEncounteredConversation = true
 				signature := geminiResponsesThoughtSignature
 				if rawSignature := strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()); rawSignature != "" {
 					signature = openAIResponsesGeminiThoughtSignature(rawSignature)
@@ -247,6 +280,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				}
 
 			case "function_call_output", "custom_tool_call_output":
+				hasEncounteredConversation = true
 				orderedOutputs, consumedIndexes, remainingPending := collectOpenAIResponsesFunctionCallOutputs(normalized, i, pendingFunctionCallIDs)
 				pendingFunctionCallIDs = remainingPending
 				for consumedIndex := range consumedIndexes {
@@ -259,8 +293,13 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				if len(responseParts) > 0 {
 					contentItems = append(contentItems, geminiContent("user", responseParts))
 				}
+				if len(pendingFunctionCallIDs) == 0 && len(pendingDeveloperParts) > 0 {
+					contentItems = append(contentItems, geminiContent("user", pendingDeveloperParts))
+					pendingDeveloperParts = nil
+				}
 
 			case "reasoning":
+				hasEncounteredConversation = true
 				thoughtText := item.Get("summary.0.text").String()
 				rawSignature := item.Get("encrypted_content").String()
 				carrierDirection := geminiResponsesCarrierDirection(item)
@@ -297,7 +336,12 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				}
 			}
 		}
+		if len(pendingDeveloperParts) > 0 {
+			contentItems = append(contentItems, geminiContent("user", pendingDeveloperParts))
+			pendingDeveloperParts = nil
+		}
 		contentItems = coalesceAdjacentOpenAIResponsesModelContents(contentItems)
+		contentItems = translatorcommon.MergeAdjacentGeminiUserContents(contentItems)
 		out = translatorcommon.SetRawArrayItems(out, "contents", contentItems)
 	} else if input.Exists() && input.Type == gjson.String {
 		// Simple string input conversion to user message.

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1218,6 +1218,67 @@ func TestConvertOpenAIResponsesRequestToGemini_InterveningDeveloperMessagePreser
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToGemini_InterveningDeveloperAndUserMessageFlushesInOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "function_call",
+				"call_id": "call-1",
+				"name": "run_command",
+				"arguments": "{\"command\":\"test\"}"
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": "<permissions instructions>\nApproved: test\n</permissions instructions>"
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Wait, also check this"}
+				]
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call-1",
+				"output": "done"
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	// Pairing should be valid
+	if errPair := internalsignature.ValidateGeminiFunctionCallPairing(output); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed: %v; output=%s", errPair, output)
+	}
+
+	contents := result.Get("contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents count = %d, want 3; output=%s", len(contents), output)
+	}
+	if contents[0].Get("role").String() != "model" {
+		t.Fatalf("turn 0 role = %q, want model", contents[0].Get("role").String())
+	}
+	midParts := contents[1].Get("parts").Array()
+	if len(midParts) != 2 {
+		t.Fatalf("turn 1 parts count = %d, want 2; output=%s", len(midParts), output)
+	}
+	if !strings.Contains(midParts[0].Get("text").String(), "permissions instructions") {
+		t.Fatalf("turn 1 part 0 should be developer notice; got %s", midParts[0].Raw)
+	}
+	if midParts[1].Get("text").String() != "Wait, also check this" {
+		t.Fatalf("turn 1 part 1 should be user text; got %s", midParts[1].Raw)
+	}
+	if !contents[2].Get("parts.0.functionResponse").Exists() {
+		t.Fatalf("turn 2 should be functionResponse; got %s", contents[2].Raw)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToGeminiCleansToolSchemaRequiredFields(t *testing.T) {
 	inputJSON := `{
 		"model": "gemini-2.0-flash",

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1011,6 +1011,213 @@ func TestConvertOpenAIResponsesRequestToGemini_SystemAndDeveloperRoles(t *testin
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToGemini_MidSessionDeveloperMessageDoesNotMutateSystemInstruction(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Turn 1 user"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "output_text", "text": "Turn 1 assistant"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>"
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Turn 2 user"}
+				]
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	// systemInstruction must remain strictly unchanged (only original instructions, not developer notice)
+	systemInstruction := result.Get("systemInstruction")
+	if !systemInstruction.Exists() {
+		t.Fatalf("systemInstruction missing; output=%s", output)
+	}
+	parts := systemInstruction.Get("parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("systemInstruction parts count = %d, want 1; output=%s", len(parts), output)
+	}
+	if got := parts[0].Get("text").String(); got != "Be a helpful assistant" {
+		t.Fatalf("systemInstruction part = %q, want %q; output=%s", got, "Be a helpful assistant", output)
+	}
+
+	// contents should contain user, model, user (with merged developer notice + turn 2 user text)
+	contents := result.Get("contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents count = %d, want 3; output=%s", len(contents), output)
+	}
+	if contents[0].Get("role").String() != "user" || contents[0].Get("parts.0.text").String() != "Turn 1 user" {
+		t.Fatalf("turn 1 user content malformed; output=%s", output)
+	}
+	if contents[1].Get("role").String() != "model" || contents[1].Get("parts.0.text").String() != "Turn 1 assistant" {
+		t.Fatalf("turn 1 model content malformed; output=%s", output)
+	}
+	if contents[2].Get("role").String() != "user" {
+		t.Fatalf("turn 2 user content role = %q, want user; output=%s", contents[2].Get("role").String(), output)
+	}
+	turn2Parts := contents[2].Get("parts").Array()
+	if len(turn2Parts) != 2 {
+		t.Fatalf("turn 2 parts count = %d, want 2; output=%s", len(turn2Parts), output)
+	}
+	if got := turn2Parts[0].Get("text").String(); got != "<image_resize_notice>Image 1 was resized to 800x600</image_resize_notice>" {
+		t.Fatalf("turn 2 part 0 = %q, want image_resize_notice; output=%s", got, output)
+	}
+	if got := turn2Parts[1].Get("text").String(); got != "Turn 2 user" {
+		t.Fatalf("turn 2 part 1 = %q, want Turn 2 user; output=%s", got, output)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_MultipleMidSessionDeveloperMessagesArrayContent(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Turn 1"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{"type": "output_text", "text": "Reply 1"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": [
+					{"type": "input_text", "text": "<permissions instructions>\nApproved: git\n</permissions instructions>"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": [
+					{"type": "input_text", "text": "<collaboration_mode>\nPlan\n</collaboration_mode>"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Proceed"}
+				]
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	// systemInstruction only contains original instructions
+	parts := result.Get("systemInstruction.parts").Array()
+	if len(parts) != 1 || parts[0].Get("text").String() != "Be a helpful assistant" {
+		t.Fatalf("systemInstruction corrupted: %s", output)
+	}
+
+	// All mid-session developer messages coalesced into the final user turn
+	contents := result.Get("contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents count = %d, want 3; output=%s", len(contents), output)
+	}
+	turn2Parts := contents[2].Get("parts").Array()
+	if len(turn2Parts) != 3 {
+		t.Fatalf("turn 2 parts count = %d, want 3; output=%s", len(turn2Parts), output)
+	}
+	if !strings.Contains(turn2Parts[0].Get("text").String(), "permissions instructions") {
+		t.Fatalf("part 0 mismatch; output=%s", output)
+	}
+	if !strings.Contains(turn2Parts[1].Get("text").String(), "collaboration_mode") {
+		t.Fatalf("part 1 mismatch; output=%s", output)
+	}
+	if turn2Parts[2].Get("text").String() != "Proceed" {
+		t.Fatalf("part 2 mismatch; output=%s", output)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_InterveningDeveloperMessagePreservesToolPairing(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.5-flash",
+		"instructions": "Be a helpful assistant",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Run tool"}
+				]
+			},
+			{
+				"type": "function_call",
+				"call_id": "call-1",
+				"name": "run_command",
+				"arguments": "{\"command\":\"echo test\"}"
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": "<permissions instructions>\nApproved: echo\n</permissions instructions>"
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call-1",
+				"output": "test"
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.5-flash", []byte(inputJSON), false)
+	result := gjson.ParseBytes(output)
+
+	// Validate function call pairing passes strictly (no content turn before pending functionResponse)
+	if errPair := internalsignature.ValidateGeminiFunctionCallPairing(output); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed: %v; output=%s", errPair, output)
+	}
+
+	// systemInstruction only contains original instructions
+	parts := result.Get("systemInstruction.parts").Array()
+	if len(parts) != 1 || parts[0].Get("text").String() != "Be a helpful assistant" {
+		t.Fatalf("systemInstruction corrupted: %s", output)
+	}
+
+	// Function response should have matching call id and name
+	foundFR := false
+	for _, content := range result.Get("contents").Array() {
+		for _, part := range content.Get("parts").Array() {
+			if part.Get("functionResponse.name").String() == "run_command" {
+				foundFR = true
+			}
+		}
+	}
+	if !foundFR {
+		t.Fatalf("functionResponse run_command not found or lost pairing: %s", output)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToGeminiCleansToolSchemaRequiredFields(t *testing.T) {
 	inputJSON := `{
 		"model": "gemini-2.0-flash",


### PR DESCRIPTION
## Summary
Fixes #5490.

When proxying OpenAI Responses API, Chat Completions, or Claude Messages requests to Google Gemini / Antigravity, mid-session `developer` role messages (such as `<image_resize_notice>`, `<permissions instructions>`, or `<collaboration_mode>` frequently emitted by Codex) were hoisted out of `input`/`messages` and appended to the top-level `systemInstruction`.

Because Google Gemini's context caching (Paged KV Checkpoint) relies on strict prefix matching starting from `systemInstruction` at Token 0, mutating `systemInstruction` mid-session completely invalidated the accumulated prefix cache for the entire conversation, dropping cached tokens from 440,000+ down to 0 and incurring a massive latency and cost penalty.

## Changes
1. **OpenAI Responses API (`input`) -> Gemini / Antigravity**:
   - Only hoist `developer` / `system` messages to `systemInstruction` before conversation starts (`!hasEncounteredConversation`), keeping Token 0 prefix immutable.
   - Once conversation begins, retain mid-session `developer` / `system` messages in `contents` as `role: "user"`.
   - Merge consecutive user turns using `MergeAdjacentGeminiUserContents`, keeping tool responses (`functionResponse`) separate.
   - Buffer mid-session developer messages during pending function calls and emit after `functionResponse` to preserve tool call pairing.

2. **OpenAI Chat Completions API (`messages`) -> Gemini / Antigravity**:
   - Apply the same leading vs mid-session distinction for `system` / `developer` messages.
   - Guard against empty `partItems` when appending user turns to prevent emitting empty `parts: []`.

3. **Claude Messages API (`messages`) -> Gemini / Antigravity**:
   - Handle `role: "developer"` identically to `role: "system"` in messages, demoting to `<system-reminder>` user turns and avoiding upstream `HTTP 400: Role 'developer' is not supported`.

4. **Pairing Validation & Role Normalization**:
   - Update `ValidateGeminiFunctionCallPairing` to allow intervening user turns before `functionResponse`, matching upstream Antigravity tolerance while strictly rejecting model turns and empty contents.
   - Ensure Antigravity role normalizer always assigns `role: "user"` to turns containing `functionResponse`.

5. **Performance & Tests**:
   - Fast-path for single-turn requests (`len <= 1`) with 0 allocs and 0 ns overhead.
   - Eliminates redundant slice allocations on empty parts checking via `!parts.Get("0").Exists()`.
   - Comprehensive unit tests added across all 3 entrances, tool pairing scenarios, and Antigravity envelopes.

## Verification
- `go test ./...` passed across all packages.
- `go test -race ./internal/signature/... ./internal/translator/...` passed cleanly.
- `go build -ldflags="-s -w" -o /dev/null ./cmd/server` passed.
- Direct upstream live probe against `daily-cloudcode-pa.googleapis.com/v1internal:generateContent` verified role constraints and pairing behavior.