### PR TITLE
fix(claude): disable thinking after foreign thinking strip

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -74,8 +74,90 @@ func sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx context.Context, body 
 		var report sigcompat.SignatureSanitizeReport
 		sanitized, report = sigcompat.SanitizeClaudeMessagesForClaudeUpstream(body, baseModel, preserveEmptyThinkingBlocks...)
 		logClaudeSignatureSanitizeReport(ctx, baseModel, report)
+		if report.DroppedForeignProviderThinking {
+			sanitized = disableClaudeThinkingAfterForeignProviderStrip(sanitized)
+		}
 	}
 	return sanitizeClaudeWebSearchDomains(sanitized)
+}
+
+// disableClaudeThinkingAfterForeignProviderStrip request-scopes thinking off
+// after Claude Messages sanitize dropped foreign/substantive thinking. Claude-
+// compatible upstreams (e.g. SuperRelay) reject -4003 when thinking stays
+// enabled, and leftover legal thinking/redacted_thinking blocks also fail once
+// type is disabled.
+func disableClaudeThinkingAfterForeignProviderStrip(body []byte) []byte {
+	if !claudeThinkingConfigIsActive(body) {
+		return body
+	}
+	body, _ = sjson.SetBytes(body, "thinking.type", "disabled")
+	for _, path := range []string{"thinking.budget_tokens", "thinking.budgetTokens"} {
+		if gjson.GetBytes(body, path).Exists() {
+			body, _ = sjson.DeleteBytes(body, path)
+		}
+	}
+	if gjson.GetBytes(body, "output_config.effort").Exists() {
+		body, _ = sjson.DeleteBytes(body, "output_config.effort")
+	}
+	if oc := gjson.GetBytes(body, "output_config"); oc.Exists() && oc.IsObject() && len(oc.Map()) == 0 {
+		body, _ = sjson.DeleteBytes(body, "output_config")
+	}
+	return stripClaudeThinkingContentBlocksAndEmptyMessages(body)
+}
+
+func claudeThinkingConfigIsActive(body []byte) bool {
+	switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String())) {
+	case "enabled", "adaptive", "auto":
+		return true
+	}
+	if gjson.GetBytes(body, "thinking.budget_tokens").Int() > 0 || gjson.GetBytes(body, "thinking.budgetTokens").Int() > 0 {
+		return true
+	}
+	effort := gjson.GetBytes(body, "output_config.effort")
+	return effort.Exists() && strings.TrimSpace(effort.String()) != ""
+}
+
+func stripClaudeThinkingContentBlocksAndEmptyMessages(body []byte) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body
+	}
+	messageResults := messages.Array()
+	keptMessages := make([]string, 0, len(messageResults))
+	modified := false
+	for _, message := range messageResults {
+		content := message.Get("content")
+		if !content.IsArray() {
+			keptMessages = append(keptMessages, message.Raw)
+			continue
+		}
+		contentResults := content.Array()
+		keptParts := make([]string, 0, len(contentResults))
+		messageModified := false
+		for _, part := range contentResults {
+			switch part.Get("type").String() {
+			case "thinking", "redacted_thinking":
+				messageModified = true
+				continue
+			}
+			keptParts = append(keptParts, part.Raw)
+		}
+		if !messageModified {
+			keptMessages = append(keptMessages, message.Raw)
+			continue
+		}
+		modified = true
+		if len(keptParts) == 0 {
+			continue
+		}
+		updated, _ := sjson.SetRaw(message.Raw, "content", "["+strings.Join(keptParts, ",")+"]")
+		keptMessages = append(keptMessages, updated)
+	}
+	if !modified {
+		return body
+	}
+	output, _ := sjson.SetRawBytes(body, "messages", []byte("["+strings.Join(keptMessages, ",")+"]"))
+	return output
 }
 
 // sanitizeClaudeWebSearchDomains removes empty allowed_domains/blocked_domains
@@ -112,15 +194,16 @@ func logClaudeSignatureSanitizeReport(ctx context.Context, baseModel string, rep
 	}
 
 	fields := log.Fields{
-		"component":           "signature_sanitizer",
-		"executor":            "claude",
-		"action":              "sanitize_claude_messages",
-		"target_provider":     string(report.TargetProvider),
-		"target_model":        baseModel,
-		"preserved":           report.Preserved,
-		"dropped_blocks":      report.DroppedBlocks,
-		"dropped_signatures":  report.DroppedSignatures,
-		"replaced_signatures": report.ReplacedSignatures,
+		"component":                         "signature_sanitizer",
+		"executor":                          "claude",
+		"action":                            "sanitize_claude_messages",
+		"target_provider":                   string(report.TargetProvider),
+		"target_model":                      baseModel,
+		"preserved":                         report.Preserved,
+		"dropped_blocks":                    report.DroppedBlocks,
+		"dropped_signatures":                report.DroppedSignatures,
+		"replaced_signatures":               report.ReplacedSignatures,
+		"dropped_foreign_provider_thinking": report.DroppedForeignProviderThinking,
 	}
 	if len(report.Decisions) > 0 {
 		decision := report.Decisions[0]

--- a/internal/runtime/executor/claude_executor_foreign_thinking_disable_test.go
+++ b/internal/runtime/executor/claude_executor_foreign_thinking_disable_test.go
@@ -1,0 +1,192 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const foreignStripClaudeCAIS = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamWithDebug_DisablesThinkingAfterForeignStrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("foreign unsigned non-empty thinking", func(t *testing.T) {
+		body := []byte(`{
+			"thinking":{"type":"adaptive","budget_tokens":2048},
+			"output_config":{"effort":"high","format":{"type":"json"}},
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"foreign reasoning"},
+					{"type":"text","text":"answer"}
+				]},
+				{"role":"user","content":[{"type":"text","text":"next"}]}
+			]
+		}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "claude-sonnet-4-5")
+		assertThinkingDisabledAndBlocksStripped(t, out)
+		if got := gjson.GetBytes(out, "output_config.format.type").String(); got != "json" {
+			t.Fatalf("output_config.format should be preserved, got %q: %s", got, out)
+		}
+		if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "answer" {
+			t.Fatalf("non-thinking content should be preserved, got %q: %s", got, out)
+		}
+	})
+
+	t.Run("incompatible gemini-carrier signature", func(t *testing.T) {
+		body := []byte(`{
+			"thinking":{"type":"adaptive"},
+			"output_config":{"effort":"high"},
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"gemini thought","signature":"skip_thought_signature_validator"},
+					{"type":"redacted_thinking","data":"keep-until-downgrade"},
+					{"type":"text","text":"answer"}
+				]}
+			]
+		}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "claude-sonnet-4-5")
+		assertThinkingDisabledAndBlocksStripped(t, out)
+		if gjson.GetBytes(out, "output_config").Exists() {
+			t.Fatalf("empty output_config should be deleted: %s", out)
+		}
+		if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "answer" {
+			t.Fatalf("remaining text = %q, want answer: %s", got, out)
+		}
+	})
+
+	t.Run("empty placeholder drop only does not downgrade", func(t *testing.T) {
+		body := []byte(`{
+			"thinking":{"type":"adaptive"},
+			"output_config":{"effort":"high"},
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"","signature":""},
+					{"type":"text","text":"answer"}
+				]}
+			]
+		}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "claude-sonnet-4-5")
+		assertThinkingStillActive(t, out, "adaptive", "high")
+		if gjson.GetBytes(out, "messages.0.content.#(type==thinking)").Exists() {
+			t.Fatalf("empty placeholder should still be dropped: %s", out)
+		}
+		if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "answer" {
+			t.Fatalf("remaining text = %q, want answer: %s", got, out)
+		}
+	})
+
+	t.Run("legal Claude CAIS only does not downgrade", func(t *testing.T) {
+		body := []byte(`{
+			"thinking":{"type":"adaptive"},
+			"output_config":{"effort":"high"},
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"keep","signature":"` + foreignStripClaudeCAIS + `"},
+					{"type":"text","text":"answer"}
+				]}
+			]
+		}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "claude-fable-5")
+		assertThinkingStillActive(t, out, "adaptive", "high")
+		thinking := gjson.GetBytes(out, "messages.0.content.0")
+		if thinking.Get("type").String() != "thinking" {
+			t.Fatalf("legal CAIS thinking block should be preserved: %s", out)
+		}
+		if got := thinking.Get("signature").String(); got != foreignStripClaudeCAIS {
+			t.Fatalf("CAIS signature = %q, want preserved", got)
+		}
+	})
+
+	t.Run("kimi model skips sanitize and leaves body unchanged", func(t *testing.T) {
+		body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"skip_thought_signature_validator"},{"type":"text","text":"hello"}]}]}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "kimi-k2.5")
+		if string(out) != string(body) {
+			t.Fatalf("kimi body should be unchanged\n got: %s\nwant: %s", out, body)
+		}
+	})
+
+	t.Run("foreign drop strips leftover legal thinking so disabled thinking is not mixed with CAIS", func(t *testing.T) {
+		body := []byte(`{
+			"thinking":{"type":"adaptive"},
+			"output_config":{"effort":"high"},
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"foreign reasoning"},
+					{"type":"thinking","thinking":"keep","signature":"` + foreignStripClaudeCAIS + `"},
+					{"type":"text","text":"answer"}
+				]}
+			]
+		}`)
+		out := sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, body, "claude-fable-5")
+		assertThinkingDisabledAndBlocksStripped(t, out)
+		if gjson.GetBytes(out, "messages.0.content.#(type==thinking)").Exists() {
+			t.Fatalf("leftover legal CAIS must be stripped after foreign drop: %s", out)
+		}
+	})
+}
+
+func TestDisableThinkingIfToolChoiceForced_StillRemovesThinkingBeforeSanitize(t *testing.T) {
+	payload := []byte(`{
+		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"high"},
+		"tool_choice":{"type":"any"},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"foreign reasoning"},
+				{"type":"text","text":"answer"}
+			]}
+		]
+	}`)
+	out := disableThinkingIfToolChoiceForced(payload)
+	out = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(context.Background(), out, "claude-sonnet-4-5")
+	if gjson.GetBytes(out, "thinking").Exists() {
+		t.Fatalf("thinking should remain removed after forced tool_choice, got %s", gjson.GetBytes(out, "thinking").Raw)
+	}
+	if gjson.GetBytes(out, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should remain removed after forced tool_choice: %s", out)
+	}
+	if gjson.GetBytes(out, "messages.0.content.#(type==thinking)").Exists() {
+		t.Fatalf("foreign thinking block should still be stripped: %s", out)
+	}
+}
+
+func assertThinkingDisabledAndBlocksStripped(t *testing.T, body []byte) {
+	t.Helper()
+	if got := gjson.GetBytes(body, "thinking.type").String(); got != "disabled" {
+		t.Fatalf("thinking.type = %q, want disabled: %s", got, body)
+	}
+	if gjson.GetBytes(body, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should be cleared: %s", body)
+	}
+	if gjson.GetBytes(body, "output_config.effort").Exists() {
+		t.Fatalf("output_config.effort should be cleared: %s", body)
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return
+	}
+	for i, message := range messages.Array() {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for j, part := range content.Array() {
+			switch part.Get("type").String() {
+			case "thinking", "redacted_thinking":
+				t.Fatalf("messages[%d].content[%d] still has %s: %s", i, j, part.Get("type").String(), body)
+			}
+		}
+	}
+}
+
+func assertThinkingStillActive(t *testing.T, body []byte, wantType, wantEffort string) {
+	t.Helper()
+	if got := gjson.GetBytes(body, "thinking.type").String(); got != wantType {
+		t.Fatalf("thinking.type = %q, want %q: %s", got, wantType, body)
+	}
+	if got := gjson.GetBytes(body, "output_config.effort").String(); got != wantEffort {
+		t.Fatalf("output_config.effort = %q, want %q: %s", got, wantEffort, body)
+	}
+}

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -25,7 +25,11 @@ type SignatureSanitizeReport struct {
 	DroppedBlocks      int
 	DroppedSignatures  int
 	ReplacedSignatures int
-	Decisions          []SignatureCompatibilityDecision
+	// DroppedForeignProviderThinking is set when a thinking block with
+	// substantive provider state was dropped because it is not a legal Claude
+	// keep. Empty placeholders increment DroppedBlocks but do not set this flag.
+	DroppedForeignProviderThinking bool
+	Decisions                      []SignatureCompatibilityDecision
 }
 
 // SanitizeClaudeMessagesSignaturesForModel removes or preserves Claude
@@ -161,6 +165,9 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 				messageModified = true
 			default:
 				report.DroppedBlocks++
+				if targetProvider == SignatureProviderClaude && thinkingBlockHasSubstantiveProviderState(part) {
+					report.DroppedForeignProviderThinking = true
+				}
 				messageModified = true
 			}
 		}
@@ -265,6 +272,18 @@ func claudeToolUseSignaturePaths() []string {
 
 func claudeToolUseProvenancePaths() []string {
 	return append(claudeToolUseSignaturePaths(), "model")
+}
+
+func thinkingBlockHasSubstantiveProviderState(part gjson.Result) bool {
+	if strings.TrimSpace(claudeThinkingBlockText(part)) != "" {
+		return true
+	}
+	for _, path := range []string{"signature", "thoughtSignature", "thought_signature", "encrypted_content", "data"} {
+		if strings.TrimSpace(part.Get(path).String()) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {

--- a/internal/signature/claude_messages_sanitize_foreign_thinking_test.go
+++ b/internal/signature/claude_messages_sanitize_foreign_thinking_test.go
@@ -1,0 +1,106 @@
+package signature
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeClaudeMessagesForClaudeUpstream_DroppedForeignProviderThinking(t *testing.T) {
+	geminiCarrier := testGeminiThoughtSignatureEnvelope()
+	cais := testClaudeCAISSignature("claude-fable-5")
+
+	cases := []struct {
+		name     string
+		input    []byte
+		wantFlag bool
+		wantDrop int
+		wantKeep int
+	}{
+		{
+			name: "foreign unsigned non-empty thinking",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"foreign reasoning"},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: true,
+			wantDrop: 1,
+		},
+		{
+			name: "gemini-carrier incompatible signature",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"gemini thought","signature":"` + geminiCarrier + `"},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: true,
+			wantDrop: 1,
+		},
+		{
+			name: "empty placeholder drop only",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","signature":""},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: false,
+			wantDrop: 1,
+		},
+		{
+			name: "legal Claude CAIS only",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"keep","signature":"` + cais + `"},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: false,
+			wantKeep: 1,
+		},
+		{
+			name: "empty placeholder plus legal CAIS does not count as foreign",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","signature":""},
+				{"type":"thinking","thinking":"keep","signature":"` + cais + `"},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: false,
+			wantDrop: 1,
+			wantKeep: 1,
+		},
+		{
+			name: "unsigned empty text with thoughtSignature is foreign",
+			input: []byte(`{"messages":[{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","thoughtSignature":"skip_thought_signature_validator"},
+				{"type":"text","text":"answer"}
+			]}]}`),
+			wantFlag: true,
+			wantDrop: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, report := SanitizeClaudeMessagesForClaudeUpstream(tc.input, "claude-sonnet-4-5")
+			if report.DroppedForeignProviderThinking != tc.wantFlag {
+				t.Fatalf("DroppedForeignProviderThinking = %v, want %v; report=%+v", report.DroppedForeignProviderThinking, tc.wantFlag, report)
+			}
+			if report.DroppedBlocks != tc.wantDrop {
+				t.Fatalf("DroppedBlocks = %d, want %d; report=%+v", report.DroppedBlocks, tc.wantDrop, report)
+			}
+			if report.Preserved != tc.wantKeep {
+				t.Fatalf("Preserved = %d, want %d; report=%+v", report.Preserved, tc.wantKeep, report)
+			}
+		})
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstream_DroppedForeignDoesNotMutateThinkingConfig(t *testing.T) {
+	input := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"foreign reasoning"},{"type":"text","text":"answer"}]}]}`)
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-5")
+	if !report.DroppedForeignProviderThinking {
+		t.Fatalf("expected DroppedForeignProviderThinking; report=%+v", report)
+	}
+	if got := gjson.GetBytes(output, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("signature sanitizer must not rewrite thinking.type, got %q", got)
+	}
+	if got := gjson.GetBytes(output, "output_config.effort").String(); got != "high" {
+		t.Fatalf("signature sanitizer must not rewrite output_config.effort, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Claude Messages sanitize already drops foreign/incompatible thinking blocks before Claude-compatible upstreams. The sanitize report was then discarded, so `thinking.type` (and `output_config.effort`) could stay enabled. SuperRelay-style upstreams reject that mix with `-4003`.

This PR:

- Records `DroppedForeignProviderThinking` when a dropped thinking block has substantive provider state (non-empty text or signature-like fields). Empty placeholders still increment `DroppedBlocks` but do not trigger a downgrade.
- After Claude Messages sanitize, if that flag is set and top-level thinking is active, set `thinking.type=disabled`, clear budget/effort, strip leftover `thinking` / `redacted_thinking` blocks, and compact empty messages.
- Leaves legal Claude CAIS-only history, empty-placeholder-only drops, Kimi/non-Claude models, and the forced `tool_choice` path unchanged.

Inspired by cross-family thinking history hygiene: after foreign thinking is stripped, the request-scoped thinking config has to match the remaining history.

## Test plan

- [x] `go test ./internal/signature/ ./internal/runtime/executor/ -count=1`
- Foreign unsigned thinking and Gemini-carrier signatures with `thinking.type=adaptive` + `output_config.effort=high` now disable thinking and strip leftover thinking blocks
- Empty placeholder drop only does not downgrade
- Legal Claude CAIS only preserves thinking config and the block
- Kimi/non-Claude models skip sanitize
- Forced `tool_choice` still removes thinking rather than re-enabling it