### PR TITLE
perf(antigravity): batch reasoning replay mutations

### DIFF
--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -326,7 +326,53 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 func applyAntigravityReasoningReplayItems(payload []byte, items [][]byte, toolSchemas map[string]any) ([]byte, bool) {
 	updated := payload
 	changed := false
-	index := newAntigravityReplayRequestIndex(updated)
+	index := newAntigravityReplayRequestIndex(payload)
+	for len(items) > 0 {
+		batch := newAntigravityReplayBatch(index)
+		handled := 0
+		for handled < len(items) && batch.apply(items[handled], toolSchemas) {
+			handled++
+		}
+		if handled > 0 {
+			next, ok := batch.build(updated)
+			if !ok {
+				// A malformed or non-addressable part offset makes splicing unsafe.
+				// Nothing has been committed yet, so retain the exact legacy behavior
+				// for all remaining items.
+				next, sequentialChanged := applyAntigravityReasoningReplayItemsSequential(index, updated, items, toolSchemas)
+				return next, changed || sequentialChanged
+			}
+			updated = next
+			changed = batch.applied || changed
+			items = items[handled:]
+			if len(items) == 0 {
+				break
+			}
+			index = newAntigravityReplayRequestIndex(updated)
+			// Retry the first unhandled item against the freshly flushed payload.
+			// It may only have rejected the batch because a prior stable-ID restore
+			// made the old context index stale.
+			continue
+		}
+
+		// Apply one structural or context-dependent item with the original
+		// sequential implementation, then start another safe batch. A rare
+		// fallback therefore cannot make every preceding signature rewrite the
+		// entire request again.
+		next, itemChanged := applyAntigravityReasoningReplayItemsSequential(index, updated, items[:1], toolSchemas)
+		updated = next
+		changed = itemChanged || changed
+		items = items[1:]
+		if len(items) > 0 && itemChanged {
+			index = newAntigravityReplayRequestIndex(updated)
+		}
+	}
+	return updated, changed
+}
+
+func applyAntigravityReasoningReplayItemsSequential(index *antigravityReplayRequestIndex, payload []byte, items [][]byte, toolSchemas map[string]any) ([]byte, bool) {
+	updated := payload
+	changed := false
 	for itemIndex, item := range items {
 		eligible := filterAntigravityReasoningReplayItemsForRequestWithIndex(index, [][]byte{item}, toolSchemas)
 		if len(eligible) != 1 {
@@ -346,6 +392,367 @@ func applyAntigravityReasoningReplayItems(payload []byte, items [][]byte, toolSc
 		}
 	}
 	return updated, changed
+}
+
+type antigravityReplayPartKey struct {
+	contentIndex int
+	partIndex    int
+}
+
+// antigravityReplayBatch applies replay items to small part fragments
+// and splices them into the full request once. Stable provenance IDs can be
+// restored on this path because their identity does not depend on context. If
+// that restore would make a later item depend on stale context, the current
+// segment ends and the caller retries that item against the flushed payload.
+type antigravityReplayBatch struct {
+	index                     *antigravityReplayRequestIndex
+	replacements              map[antigravityReplayPartKey][]byte
+	functionResponsePartsByID map[string][]antigravityReplayPartKey
+	applied                   bool
+	identityChanged           bool
+}
+
+func newAntigravityReplayBatch(index *antigravityReplayRequestIndex) *antigravityReplayBatch {
+	batch := &antigravityReplayBatch{
+		index:                     index,
+		replacements:              make(map[antigravityReplayPartKey][]byte),
+		functionResponsePartsByID: make(map[string][]antigravityReplayPartKey),
+	}
+	if index != nil {
+		for callID, keys := range index.functionResponsePartsByID {
+			batch.functionResponsePartsByID[callID] = append([]antigravityReplayPartKey(nil), keys...)
+		}
+	}
+	return batch
+}
+
+func applyAntigravityReplayItemsBatch(
+	index *antigravityReplayRequestIndex,
+	payload []byte,
+	items [][]byte,
+	toolSchemas map[string]any,
+) ([]byte, bool, bool) {
+	batch := newAntigravityReplayBatch(index)
+	for _, item := range items {
+		if !batch.apply(item, toolSchemas) {
+			return nil, false, false
+		}
+	}
+	updated, ok := batch.build(payload)
+	if !ok {
+		return nil, false, false
+	}
+	return updated, batch.applied, true
+}
+
+func (b *antigravityReplayBatch) apply(item []byte, toolSchemas map[string]any) bool {
+	itemResult := gjson.ParseBytes(item)
+	switch strings.TrimSpace(itemResult.Get("type").String()) {
+	case "thought_signature":
+		return b.applyThoughtSignature(itemResult)
+	case "function_call_part":
+		return b.applyFunctionCallSignature(itemResult, toolSchemas)
+	default:
+		return true
+	}
+}
+
+func (b *antigravityReplayBatch) part(key antigravityReplayPartKey) (gjson.Result, bool) {
+	if b == nil || b.index == nil || key.contentIndex < 0 || key.contentIndex >= len(b.index.contents) {
+		return gjson.Result{}, false
+	}
+	parts := b.index.contents[key.contentIndex].parts
+	if key.partIndex < 0 || key.partIndex >= len(parts) {
+		return gjson.Result{}, false
+	}
+	if replacement, ok := b.replacements[key]; ok {
+		return gjson.ParseBytes(replacement), true
+	}
+	return parts[key.partIndex], true
+}
+
+func (b *antigravityReplayBatch) setPart(key antigravityReplayPartKey, part []byte) bool {
+	current, ok := b.part(key)
+	changed := !ok || !bytes.Equal([]byte(current.Raw), part)
+	b.replacements[key] = part
+	return changed
+}
+
+func (b *antigravityReplayBatch) removeThoughtSignatureFromOtherParts(contentIndex int, signature string, keep antigravityReplayPartKey) bool {
+	signature = strings.TrimSpace(signature)
+	if signature == "" || b == nil || b.index == nil || contentIndex < 0 || contentIndex >= len(b.index.contents) {
+		return false
+	}
+	changed := false
+	for partIndex := range b.index.contents[contentIndex].parts {
+		key := antigravityReplayPartKey{contentIndex: contentIndex, partIndex: partIndex}
+		if key == keep {
+			continue
+		}
+		part, ok := b.part(key)
+		if !ok || antigravityNativePartThoughtSignature(part) != signature {
+			continue
+		}
+		updated := []byte(part.Raw)
+		for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+			updated, _ = sjson.DeleteBytes(updated, field)
+		}
+		changed = b.setPart(key, updated) || changed
+	}
+	return changed
+}
+
+func (b *antigravityReplayBatch) applyThoughtSignature(itemResult gjson.Result) bool {
+	signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String())
+	if signature == "" {
+		return true
+	}
+	// Legacy positional items rely on the context fingerprint. Restoring a
+	// stable function-call ID changes that fingerprint, while the immutable
+	// batch index still describes the original payload.
+	if b.identityChanged && strings.TrimSpace(itemResult.Get("targetHash").String()) == "" {
+		return false
+	}
+	contentIndex, partIndex, ok := b.index.thoughtSignaturePartIndex(itemResult)
+	if !ok {
+		return true
+	}
+	key := antigravityReplayPartKey{contentIndex: contentIndex, partIndex: partIndex}
+	part, ok := b.part(key)
+	if !ok {
+		return false
+	}
+	if antigravityHasNativeThoughtSignature(part.Get("thoughtSignature").String()) {
+		return true
+	}
+	updated, errSet := sjson.SetBytes([]byte(part.Raw), "thoughtSignature", signature)
+	if errSet != nil {
+		return false
+	}
+	b.removeThoughtSignatureFromOtherParts(contentIndex, signature, key)
+	b.setPart(key, updated)
+	// The sequential thought-signature path treats any successful Set as an
+	// applied replay, even when a later item restores the original bytes.
+	b.applied = true
+	return true
+}
+
+func (b *antigravityReplayBatch) applyFunctionCallSignature(itemResult gjson.Result, toolSchemas map[string]any) bool {
+	location, found := b.index.functionCallPartLocationForReplayWithSchemas(itemResult, toolSchemas)
+	if !found {
+		location, found = b.index.functionCallProvenanceLocation(itemResult, toolSchemas)
+		if !found {
+			return false
+		}
+	}
+	key := antigravityReplayPartKey{contentIndex: location.contentIndex, partIndex: location.partIndex}
+	part, ok := b.part(key)
+	if !ok {
+		return false
+	}
+	functionCall := part.Get("functionCall")
+	nativeID := strings.TrimSpace(itemResult.Get("call_id").String())
+	name := strings.TrimSpace(itemResult.Get("name").String())
+	currentID := strings.TrimSpace(functionCall.Get("id").String())
+	nativeCall, okCall := antigravityNativeFunctionCallJSON(itemResult, nativeID)
+	if !okCall {
+		return false
+	}
+	sameNativeCall := currentID == nativeID && bytes.Equal(
+		antigravityCanonicalReplayJSON([]byte(functionCall.Raw)),
+		antigravityCanonicalReplayJSON(nativeCall),
+	)
+	stableID := util.GeminiClaudeToolUseID(nativeID, name, itemResult.Get("args").Raw)
+	restoreStableID := currentID != nativeID && currentID == stableID
+	if !sameNativeCall && !restoreStableID {
+		return false
+	}
+	// The immutable lookup keeps the first location for an ID. If a malformed
+	// history reuses a stable ID, sequential replay must rebuild after restoring
+	// each occurrence so the next one becomes addressable.
+	if restoreStableID && b.index.functionCallCountsByID[currentID] != 1 {
+		return false
+	}
+	signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String())
+	if sameNativeCall && (signature == "" || antigravityHasNativeThoughtSignature(part.Get("thoughtSignature").String())) {
+		return true
+	}
+	// A native-ID item needs context to authorize a signature mutation. After
+	// an earlier stable-ID restore that decision must be made against a rebuilt
+	// index, so conservatively fall back to sequential replay.
+	if b.identityChanged && currentID == nativeID {
+		return false
+	}
+	if restoreStableID && !b.functionResponsesCanRestoreID(currentID, name) {
+		return true
+	}
+	updated, errSet := sjson.SetRawBytes([]byte(part.Raw), "functionCall", nativeCall)
+	if errSet != nil {
+		return false
+	}
+	for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+		updated, _ = sjson.DeleteBytes(updated, field)
+	}
+	if signature != "" {
+		updated, errSet = sjson.SetBytes(updated, "thoughtSignature", signature)
+		if errSet != nil {
+			return false
+		}
+	}
+
+	// Stage every fragment before committing any of them. A function replay can
+	// touch the call, matching responses, and duplicate signatures; a failed
+	// staging attempt must not leak partial work into the preceding safe batch.
+	pending := map[antigravityReplayPartKey][]byte{key: updated}
+	if signature != "" {
+		for partIndex := range b.index.contents[location.contentIndex].parts {
+			otherKey := antigravityReplayPartKey{contentIndex: location.contentIndex, partIndex: partIndex}
+			if otherKey == key {
+				continue
+			}
+			otherPart, okPart := b.part(otherKey)
+			if !okPart || antigravityNativePartThoughtSignature(otherPart) != signature {
+				continue
+			}
+			otherUpdated := []byte(otherPart.Raw)
+			for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+				otherUpdated, _ = sjson.DeleteBytes(otherUpdated, field)
+			}
+			pending[otherKey] = otherUpdated
+		}
+	}
+	if restoreStableID {
+		if !b.stageFunctionResponseIDRestores(pending, currentID, nativeID, name) {
+			return false
+		}
+	}
+	itemChanged := false
+	for pendingKey, pendingPart := range pending {
+		itemChanged = b.setPart(pendingKey, pendingPart) || itemChanged
+	}
+	if restoreStableID {
+		keys := b.functionResponsePartsByID[currentID]
+		if len(keys) > 0 {
+			delete(b.functionResponsePartsByID, currentID)
+			b.functionResponsePartsByID[nativeID] = append(b.functionResponsePartsByID[nativeID], keys...)
+		}
+		b.identityChanged = true
+	}
+	b.applied = itemChanged || b.applied
+	return true
+}
+
+func (b *antigravityReplayBatch) functionResponsesCanRestoreID(currentID, nativeName string) bool {
+	if currentID == "" {
+		return true
+	}
+	for _, key := range b.functionResponsePartsByID[currentID] {
+		part, ok := b.part(key)
+		if !ok {
+			return false
+		}
+		response := part.Get("functionResponse")
+		if !response.Exists() || strings.TrimSpace(response.Get("id").String()) != currentID {
+			return false
+		}
+		name := strings.TrimSpace(response.Get("name").String())
+		if name != "" && name != "unknown" && name != nativeName {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *antigravityReplayBatch) stageFunctionResponseIDRestores(
+	pending map[antigravityReplayPartKey][]byte,
+	currentID, nativeID, nativeName string,
+) bool {
+	if currentID == "" || nativeID == "" || nativeName == "" || currentID == nativeID {
+		return true
+	}
+	for _, key := range b.functionResponsePartsByID[currentID] {
+		part, ok := b.part(key)
+		if replacement, exists := pending[key]; exists {
+			part = gjson.ParseBytes(replacement)
+			ok = true
+		}
+		if !ok {
+			return false
+		}
+		response := part.Get("functionResponse")
+		if !response.Exists() || strings.TrimSpace(response.Get("id").String()) != currentID {
+			return false
+		}
+		updated, errSet := sjson.SetBytes([]byte(part.Raw), "functionResponse.id", nativeID)
+		if errSet != nil {
+			return false
+		}
+		updated, errSet = sjson.SetBytes(updated, "functionResponse.name", nativeName)
+		if errSet != nil {
+			return false
+		}
+		pending[key] = updated
+	}
+	return true
+}
+
+func (b *antigravityReplayBatch) build(payload []byte) ([]byte, bool) {
+	if b == nil || b.index == nil || len(b.replacements) == 0 {
+		return payload, true
+	}
+	outputSize := len(payload)
+	replacementCount := 0
+	for key, replacement := range b.replacements {
+		original, ok := b.indexedPart(key)
+		if !ok {
+			return nil, false
+		}
+		if bytes.Equal(replacement, []byte(original.Raw)) {
+			continue
+		}
+		outputSize += len(replacement) - len(original.Raw)
+		replacementCount++
+	}
+	if replacementCount == 0 || outputSize < 0 {
+		return payload, true
+	}
+	out := make([]byte, 0, outputSize)
+	last := 0
+	applied := 0
+	for contentIndex, content := range b.index.contents {
+		for partIndex, part := range content.parts {
+			key := antigravityReplayPartKey{contentIndex: contentIndex, partIndex: partIndex}
+			replacement, ok := b.replacements[key]
+			if !ok || bytes.Equal(replacement, []byte(part.Raw)) {
+				continue
+			}
+			start := part.Index
+			end := start + len(part.Raw)
+			if start <= last || start < 0 || end < start || end > len(payload) {
+				return nil, false
+			}
+			out = append(out, payload[last:start]...)
+			out = append(out, replacement...)
+			last = end
+			applied++
+		}
+	}
+	if applied != replacementCount {
+		return nil, false
+	}
+	out = append(out, payload[last:]...)
+	return out, true
+}
+
+func (b *antigravityReplayBatch) indexedPart(key antigravityReplayPartKey) (gjson.Result, bool) {
+	if b == nil || b.index == nil || key.contentIndex < 0 || key.contentIndex >= len(b.index.contents) {
+		return gjson.Result{}, false
+	}
+	parts := b.index.contents[key.contentIndex].parts
+	if key.partIndex < 0 || key.partIndex >= len(parts) {
+		return gjson.Result{}, false
+	}
+	return parts[key.partIndex], true
 }
 
 func filterAntigravityReasoningReplayItemsForRequestWithSchemas(payload []byte, items [][]byte, toolSchemas map[string]any) [][]byte {
@@ -882,14 +1289,18 @@ type antigravityReplayRequestIndex struct {
 	validContents               bool
 	contents                    []antigravityReplayIndexedContent
 	functionCallsByID           map[string]antigravityReplayIndexedPart
+	functionCallCountsByID      map[string]int
 	functionResponseContentByID map[string]int
+	functionResponsePartsByID   map[string][]antigravityReplayPartKey
 	contextFingerprints         *antigravityReplayContextFingerprints
 }
 
 func newAntigravityReplayRequestIndex(payload []byte) *antigravityReplayRequestIndex {
 	index := &antigravityReplayRequestIndex{
 		functionCallsByID:           make(map[string]antigravityReplayIndexedPart),
+		functionCallCountsByID:      make(map[string]int),
 		functionResponseContentByID: make(map[string]int),
+		functionResponsePartsByID:   make(map[string][]antigravityReplayPartKey),
 	}
 	contentsResult := util.GetGJSONBytesNoCopy(payload, "request.contents")
 	index.validContents = contentsResult.IsArray()
@@ -906,6 +1317,9 @@ func newAntigravityReplayRequestIndex(payload []byte) *antigravityReplayRequestI
 			for partIndex, part := range indexedContent.parts {
 				if functionCall := part.Get("functionCall"); functionCall.Exists() {
 					callID := strings.TrimSpace(functionCall.Get("id").String())
+					if callID != "" {
+						index.functionCallCountsByID[callID]++
+					}
 					if _, exists := index.functionCallsByID[callID]; callID != "" && !exists {
 						index.functionCallsByID[callID] = antigravityReplayIndexedPart{
 							contentIndex: contentIndex,
@@ -919,6 +1333,10 @@ func newAntigravityReplayRequestIndex(payload []byte) *antigravityReplayRequestI
 					callID := strings.TrimSpace(functionResponse.Get("id").String())
 					if _, exists := index.functionResponseContentByID[callID]; callID != "" && !exists {
 						index.functionResponseContentByID[callID] = contentIndex
+					}
+					if callID != "" {
+						key := antigravityReplayPartKey{contentIndex: contentIndex, partIndex: partIndex}
+						index.functionResponsePartsByID[callID] = append(index.functionResponsePartsByID[callID], key)
 					}
 				}
 			}

--- a/internal/runtime/executor/antigravity_reasoning_replay_index_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_index_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -391,6 +392,230 @@ func TestApplyAntigravityReasoningReplayItemsRebuildsIndexAfterMutation(t *testi
 	}
 }
 
+func TestApplyAntigravityReasoningReplayItemsBatchesSignatureOnlyMutations(t *testing.T) {
+	const turns = 4
+	base := syntheticAntigravityReplayBenchmarkPayload(1<<10, turns)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithoutSignatures(1<<10, turns)
+
+	got, gotChanged, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload),
+		payload,
+		items,
+		nil,
+	)
+	if !handled {
+		t.Fatal("signature-only replay did not use the batch path")
+	}
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if gotChanged != wantChanged {
+		t.Fatalf("changed = %t, want %t", gotChanged, wantChanged)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("payload differs\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsBatchPreservesSignatureMoveOrder(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"ask"}]},{"role":"model","parts":[{"text":"first"},{"text":"second"}]}]}}`)
+	const signature = "shared-native-signature-123456789"
+	items := make([][]byte, 0, 2)
+	for partIndex, text := range []string{"first", "second"} {
+		kind, fingerprint := antigravityReplayPartFingerprint(gjson.Parse(`{"text":"` + text + `"}`))
+		item := buildAntigravityThoughtSignatureItem(1, partIndex, signature, kind, fingerprint)
+		items = append(items, antigravityReplayItemContextHashForTest(item, payload, 1))
+	}
+
+	got, gotChanged, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload),
+		payload,
+		items,
+		nil,
+	)
+	if !handled {
+		t.Fatal("signature move did not use the batch path")
+	}
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if gotChanged != wantChanged || !bytes.Equal(got, want) {
+		t.Fatalf("batch differs from sequential replay\n got: %s\nwant: %s", got, want)
+	}
+	if first := gjson.GetBytes(got, "request.contents.1.parts.0.thoughtSignature"); first.Exists() {
+		t.Fatalf("signature remained on the first part: %s", got)
+	}
+	if second := gjson.GetBytes(got, "request.contents.1.parts.1.thoughtSignature").String(); second != signature {
+		t.Fatalf("second signature = %q, want %q", second, signature)
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsBatchPreservesStickyChangedResult(t *testing.T) {
+	const signature = "shared-native-signature-123456789"
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"ask"}]},{"role":"model","parts":[{"text":"first","thoughtSignature":"` + signature + `"},{"text":"second"}]}]}}`)
+	items := make([][]byte, 0, 2)
+	for _, target := range []struct {
+		partIndex int
+		text      string
+	}{{partIndex: 1, text: "second"}, {partIndex: 0, text: "first"}} {
+		kind, fingerprint := antigravityReplayPartFingerprint(gjson.Parse(`{"text":"` + target.text + `"}`))
+		item := buildAntigravityThoughtSignatureItem(1, target.partIndex, signature, kind, fingerprint)
+		items = append(items, antigravityReplayItemContextHashForTest(item, payload, 1))
+	}
+
+	got, gotChanged, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload),
+		payload,
+		items,
+		nil,
+	)
+	if !handled {
+		t.Fatal("signature round trip did not use the batch path")
+	}
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if !gotChanged || gotChanged != wantChanged {
+		t.Fatalf("changed = %t, want sticky %t", gotChanged, wantChanged)
+	}
+	if !bytes.Equal(got, want) || !bytes.Equal(got, payload) {
+		t.Fatalf("signature round trip did not restore the original payload\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsBatchesStableProvenanceIDs(t *testing.T) {
+	const turns = 4
+	base := syntheticAntigravityReplayBenchmarkPayload(1<<10, turns)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithProvenanceIDs(1<<10, turns)
+
+	got, gotChanged, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload),
+		payload,
+		items,
+		nil,
+	)
+	if !handled {
+		t.Fatal("stable provenance replay did not use the batch path")
+	}
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if gotChanged != wantChanged || !bytes.Equal(got, want) {
+		t.Fatalf("batch differs from sequential stable-ID replay\n got: %s\nwant: %s", got, want)
+	}
+	for turn := range turns {
+		callContentIndex := 1 + turn*2
+		responseContentIndex := callContentIndex + 1
+		wantID := fmt.Sprintf("call-%d", turn)
+		if gotID := gjson.GetBytes(got, fmt.Sprintf("request.contents.%d.parts.0.functionCall.id", callContentIndex)).String(); gotID != wantID {
+			t.Fatalf("call %d ID = %q, want %q", turn, gotID, wantID)
+		}
+		if gotID := gjson.GetBytes(got, fmt.Sprintf("request.contents.%d.parts.0.functionResponse.id", responseContentIndex)).String(); gotID != wantID {
+			t.Fatalf("response %d ID = %q, want %q", turn, gotID, wantID)
+		}
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsSegmentsDuplicateStableProvenanceIDs(t *testing.T) {
+	const (
+		nativeID = "reused-native-call"
+		name     = "lookup"
+		argsRaw  = `{"turn":0}`
+	)
+	stableID := util.GeminiClaudeToolUseID(nativeID, name, argsRaw)
+	base := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"start"}]},{"role":"model","parts":[{"functionCall":{"id":"` + nativeID + `","name":"` + name + `","args":` + argsRaw + `},"thoughtSignature":"sig-a"}]},{"role":"user","parts":[{"functionResponse":{"id":"` + nativeID + `","name":"` + name + `","response":{"result":"a"}}}]},{"role":"model","parts":[{"functionCall":{"id":"` + nativeID + `","name":"` + name + `","args":` + argsRaw + `},"thoughtSignature":"sig-b"}]},{"role":"user","parts":[{"functionResponse":{"id":"` + nativeID + `","name":"` + name + `","response":{"result":"b"}}}]}]}}`)
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"start"}]},{"role":"model","parts":[{"functionCall":{"id":"` + stableID + `","name":"` + name + `","args":` + argsRaw + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + stableID + `","name":"` + name + `","response":{"result":"a"}}}]},{"role":"model","parts":[{"functionCall":{"id":"` + stableID + `","name":"` + name + `","args":` + argsRaw + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + stableID + `","name":"` + name + `","response":{"result":"b"}}}]}]}}`)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	if _, _, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload), payload, items, nil,
+	); handled {
+		t.Fatal("single batch accepted a non-unique stable provenance ID")
+	}
+
+	got, gotChanged := applyAntigravityReasoningReplayItems(payload, items, nil)
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if gotChanged != wantChanged || !bytes.Equal(got, want) {
+		t.Fatalf("duplicate-ID segmentation differs from sequential replay\n got: %s\nwant: %s", got, want)
+	}
+	for _, contentIndex := range []int{1, 3} {
+		path := fmt.Sprintf("request.contents.%d.parts.0.functionCall.id", contentIndex)
+		if gotID := gjson.GetBytes(got, path).String(); gotID != nativeID {
+			t.Fatalf("call at contents[%d] ID = %q, want %q", contentIndex, gotID, nativeID)
+		}
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsFallsBackAfterIdentityChangesContext(t *testing.T) {
+	const (
+		nativeID  = "call-0"
+		name      = "lookup"
+		argsRaw   = `{"turn":0}`
+		signature = "native-call-signature"
+	)
+	base := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"start"}]},{"role":"model","parts":[{"functionCall":{"id":"` + nativeID + `","name":"` + name + `","args":` + argsRaw + `},"thoughtSignature":"` + signature + `"}]},{"role":"user","parts":[{"functionResponse":{"id":"` + nativeID + `","name":"` + name + `","response":{"result":"ok"}}}]},{"role":"model","parts":[{"text":"later"}]}]}}`)
+	callItems := antigravityReasoningReplayItemsFromRequest(base)
+	if len(callItems) != 1 {
+		t.Fatalf("call items = %d, want 1", len(callItems))
+	}
+	stableID := util.GeminiClaudeToolUseID(nativeID, name, argsRaw)
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"text":"start"}]},{"role":"model","parts":[{"functionCall":{"id":"` + stableID + `","name":"` + name + `","args":` + argsRaw + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + stableID + `","name":"` + name + `","response":{"result":"ok"}}}]},{"role":"model","parts":[{"text":"later"}]}]}}`)
+	legacyThoughtItem := buildAntigravityThoughtSignatureItem(3, 0, "later-signature", "", "")
+	legacyThoughtItem = antigravityReplayItemContextHashForTest(legacyThoughtItem, payload, 3)
+	items := append(callItems, legacyThoughtItem)
+
+	if _, _, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload), payload, items, nil,
+	); handled {
+		t.Fatal("batch path reused a context fingerprint after restoring a stable ID")
+	}
+	got, gotChanged := applyAntigravityReasoningReplayItems(payload, items, nil)
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, nil)
+	if gotChanged != wantChanged || !bytes.Equal(got, want) {
+		t.Fatalf("fallback differs from sequential replay\n got: %s\nwant: %s", got, want)
+	}
+	if signature := gjson.GetBytes(got, "request.contents.3.parts.0.thoughtSignature"); signature.Exists() {
+		t.Fatalf("stale-context signature was applied: %s", got)
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsSegmentsLateStructuralFallback(t *testing.T) {
+	const turns = 16
+	base := syntheticAntigravityReplayBenchmarkPayload(1<<10, turns)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithoutSignatures(1<<10, turns)
+	lastCallPath := fmt.Sprintf("request.contents.%d.parts.0.functionCall.id", 1+(turns-1)*2)
+	var errSet error
+	payload, errSet = sjson.SetBytes(payload, lastCallPath, "lookup-legacy-client-id")
+	if errSet != nil {
+		t.Fatalf("set legacy call ID: %v", errSet)
+	}
+	toolSchemas := map[string]any{"lookup": map[string]any{"type": "object"}}
+
+	if _, _, handled := applyAntigravityReplayItemsBatch(
+		newAntigravityReplayRequestIndex(payload), payload, items, toolSchemas,
+	); handled {
+		t.Fatal("all-or-nothing batch unexpectedly handled a legacy identity restore")
+	}
+	got, gotChanged := applyAntigravityReasoningReplayItems(payload, items, toolSchemas)
+	want, wantChanged := legacyApplyAntigravityReasoningReplayItems(payload, items, toolSchemas)
+	if gotChanged != wantChanged || !bytes.Equal(got, want) {
+		t.Fatalf("segmented fallback differs from sequential replay\n got: %s\nwant: %s", got, want)
+	}
+	wantLastID := fmt.Sprintf("call-%d", turns-1)
+	if gotLastID := gjson.GetBytes(got, lastCallPath).String(); gotLastID != wantLastID {
+		t.Fatalf("last call ID = %q, want %q", gotLastID, wantLastID)
+	}
+}
+
+func TestApplyAntigravityReasoningReplayItemsBatchRejectsUnknownPartOffset(t *testing.T) {
+	base := syntheticAntigravityReplayBenchmarkPayload(1<<10, 1)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithoutSignatures(1<<10, 1)
+	index := newAntigravityReplayRequestIndex(payload)
+	index.contents[1].parts[0].Index = 0
+
+	if _, _, handled := applyAntigravityReplayItemsBatch(index, payload, items, nil); handled {
+		t.Fatal("batch path accepted an unknown zero part offset")
+	}
+}
+
 var antigravityReplayBenchmarkItems [][]byte
 
 func BenchmarkAntigravityReasoningReplayItemsFromRequest(b *testing.B) {
@@ -449,6 +674,55 @@ func syntheticAntigravityReplayBenchmarkPayload(inlineBytes, turns int) []byte {
 			&payload,
 			`,{"role":"model","parts":[{"functionResponse":{"id":"call-%d","name":"lookup","response":{"result":"ok"}}}]}`,
 			turn,
+		)
+	}
+	payload.WriteString(`]}}`)
+	return []byte(payload.String())
+}
+
+func syntheticAntigravityReplayBenchmarkPayloadWithoutSignatures(inlineBytes, turns int) []byte {
+	var payload strings.Builder
+	payload.Grow(inlineBytes + turns*256)
+	payload.WriteString(`{"request":{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"application/octet-stream","data":"`)
+	payload.WriteString(strings.Repeat("a", inlineBytes))
+	payload.WriteString(`"}}]}`)
+	for turn := range turns {
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"model","parts":[{"functionCall":{"id":"call-%d","name":"lookup","args":{"turn":%d}}}]}`,
+			turn,
+			turn,
+		)
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"model","parts":[{"functionResponse":{"id":"call-%d","name":"lookup","response":{"result":"ok"}}}]}`,
+			turn,
+		)
+	}
+	payload.WriteString(`]}}`)
+	return []byte(payload.String())
+}
+
+func syntheticAntigravityReplayBenchmarkPayloadWithProvenanceIDs(inlineBytes, turns int) []byte {
+	var payload strings.Builder
+	payload.Grow(inlineBytes + turns*320)
+	payload.WriteString(`{"request":{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"application/octet-stream","data":"`)
+	payload.WriteString(strings.Repeat("a", inlineBytes))
+	payload.WriteString(`"}}]}`)
+	for turn := range turns {
+		nativeID := fmt.Sprintf("call-%d", turn)
+		argsRaw := fmt.Sprintf(`{"turn":%d}`, turn)
+		stableID := util.GeminiClaudeToolUseID(nativeID, "lookup", argsRaw)
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"model","parts":[{"functionCall":{"id":%q,"name":"lookup","args":%s}}]}`,
+			stableID,
+			argsRaw,
+		)
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"model","parts":[{"functionResponse":{"id":%q,"name":"lookup","response":{"result":"ok"}}}]}`,
+			stableID,
 		)
 	}
 	payload.WriteString(`]}}`)
@@ -663,4 +937,54 @@ func BenchmarkApplyAntigravityReasoningReplayItems(b *testing.B) {
 			_, _ = applyAntigravityReasoningReplayItems(payload, items, nil)
 		}
 	})
+}
+
+func BenchmarkApplyAntigravityReasoningReplayItemsLargeBatch(b *testing.B) {
+	const (
+		inlineBytes = 10 << 20
+		turns       = 161
+	)
+	base := syntheticAntigravityReplayBenchmarkPayload(inlineBytes, turns)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	if len(items) != turns {
+		b.Fatalf("items = %d, want %d", len(items), turns)
+	}
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithProvenanceIDs(inlineBytes, turns)
+	if _, changed := applyAntigravityReasoningReplayItems(payload, items, nil); !changed {
+		b.Fatal("benchmark payload applies nothing")
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = applyAntigravityReasoningReplayItems(payload, items, nil)
+	}
+}
+
+func BenchmarkApplyAntigravityReasoningReplayItemsLargeSegmentedFallback(b *testing.B) {
+	const (
+		inlineBytes = 10 << 20
+		turns       = 161
+	)
+	base := syntheticAntigravityReplayBenchmarkPayload(inlineBytes, turns)
+	items := antigravityReasoningReplayItemsFromRequest(base)
+	payload := syntheticAntigravityReplayBenchmarkPayloadWithoutSignatures(inlineBytes, turns)
+	lastCallPath := fmt.Sprintf("request.contents.%d.parts.0.functionCall.id", 1+(turns-1)*2)
+	var errSet error
+	payload, errSet = sjson.SetBytes(payload, lastCallPath, "lookup-legacy-client-id")
+	if errSet != nil {
+		b.Fatalf("set legacy call ID: %v", errSet)
+	}
+	toolSchemas := map[string]any{"lookup": map[string]any{"type": "object"}}
+	if _, changed := applyAntigravityReasoningReplayItems(payload, items, toolSchemas); !changed {
+		b.Fatal("benchmark payload applies nothing")
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = applyAntigravityReasoningReplayItems(payload, items, toolSchemas)
+	}
 }


### PR DESCRIPTION
## Summary

- batch replay-safe thought-signature and native function-call restorations on small part fragments, then splice the full request once
- index function-response locations so stable provenance ID restoration does not rescan a large inline payload for every ledger item
- flush maximal safe segments around structural/context-dependent items, preserving the existing sequential implementation as a compatibility fallback
- retain exact sequential semantics for context drift, duplicate stable IDs, signature moves, and sticky changed results

## Motivation

A roughly 10 MiB Antigravity request with a long replay ledger could rewrite and re-index the complete JSON payload for every replay hit. On a 512 MiB deployment this created multi-gigabyte allocation churn and could trigger an OOM restart.

The request index introduced previously reduced the cost, but mutation remained O(payload size × replay hits). This change makes the common replay path approximately O(payload size + replay items).

## Benchmarks

Linux/amd64, GOMAXPROCS=1:

| Fixture | Before | After |
| --- | ---: | ---: |
| 1 MiB / 32 items, indexed | ~517 ms, ~536 MB/op | ~12 ms, ~9.1 MB/op |
| 10 MiB / 161 real stable provenance IDs | ~29.7 s, ~29.0 GB/op worst case | ~0.11–0.12 s, ~76–92 MB/op |
| 10 MiB / 161 items with a late legacy structural fallback | ~2.6 s, ~3.0 GB/op | ~0.29–0.32 s, ~245–251 MB/op |

The isolated 10 MiB benchmark process peaked around 134 MiB RSS.

## Safety

- Unsupported or context-dependent mutations continue through the original sequential path.
- A failed batch stages no partial changes.
- Stable ID restoration is batched only for unique opaque provenance IDs.
- Later items are retried against a fresh index whenever an identity restore changes context.
- Final payloads are compared byte-for-byte with the legacy implementation in deterministic and randomized differential tests.

## Validation

- `go test ./internal/runtime/executor -count=1`
- targeted `go test -race`
- randomized legacy differential tests
- stable-ID, duplicate-ID, context-drift, signature-move, malformed-offset, and segmented-fallback tests
- `go build ./cmd/server`
- `go test ./... -count=1` passed all relevant packages; the existing timing-sensitive `TestPionMediaRelayBridgesAudioAndDataChannel` failed once and passed when rerun alone