### PR TITLE
fix(codex): keep template reasoning levels for budget-only thinking models

### DIFF
--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -377,6 +377,22 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 	if thinking == nil {
 		return
 	}
+	// Models that support thinking as a token budget without declaring discrete
+	// levels (for example {"min":1024,"max":64000}) still support reasoning, they
+	// just have no level list to apply. Keep the default template's reasoning
+	// metadata instead of reporting no levels at all.
+	//
+	// An entirely empty ThinkingSupport is excluded: it declares no capability at
+	// all (detectModelCapability reports CapabilityNone for it), so inheriting the
+	// template's levels would advertise reasoning the model does not support.
+	if len(thinking.Levels) == 0 {
+		if thinking.Min > 0 || thinking.Max > 0 {
+			return
+		}
+		entry["supported_reasoning_levels"] = []any{}
+		delete(entry, "default_reasoning_level")
+		return
+	}
 
 	levels := make([]any, 0, len(thinking.Levels))
 	defaultLevel := ""
@@ -398,6 +414,9 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 		})
 	}
 	if len(levels) == 0 {
+		// Every declared level was filtered out for this client version, so the
+		// template's levels do not apply either. Keep the required field as an
+		// empty array rather than dropping it.
 		entry["supported_reasoning_levels"] = levels
 		delete(entry, "default_reasoning_level")
 		return

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -591,3 +591,71 @@ func TestSanitizeCodexClientReasoningMetadataPreservesEmptyArray(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexClientModelsResponseKeepsTemplateReasoningLevelsWhenModelDeclaresNone(t *testing.T) {
+	// Models such as Antigravity's claude-sonnet-4-6 advertise thinking as a token
+	// budget ({"min":1024,"max":64000}) without a level list. They still support
+	// reasoning, so the entry keeps the default template's levels instead of
+	// reporting none. An entirely empty ThinkingSupport declares no capability at
+	// all and reports an empty array.
+	tests := []struct {
+		name       string
+		version    string
+		thinking   *registry.ThinkingSupport
+		wantLevels bool
+	}{
+		{name: "budget only modern client", version: "0.153.0", thinking: &registry.ThinkingSupport{Min: 1024, Max: 64000}, wantLevels: true},
+		{name: "budget only legacy client", version: "0.143.9", thinking: &registry.ThinkingSupport{Min: 1024, Max: 64000}, wantLevels: true},
+		{name: "max only budget", version: "0.153.0", thinking: &registry.ThinkingSupport{Max: 64000}, wantLevels: true},
+		{name: "empty thinking support", version: "0.153.0", thinking: &registry.ThinkingSupport{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := BuildResponseForClient([]map[string]any{{
+				"id":       "home-budget-thinking-model-test",
+				"thinking": tt.thinking,
+			}}, nil, false, tt.version)
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+			model := models[0]
+
+			rawLevels, ok := model["supported_reasoning_levels"].([]any)
+			if !ok {
+				t.Fatalf("supported_reasoning_levels = %#v, want an array", model["supported_reasoning_levels"])
+			}
+
+			if !tt.wantLevels {
+				// No declared capability: the required field stays present but empty,
+				// and the optional default is omitted.
+				if len(rawLevels) != 0 {
+					t.Fatalf("supported_reasoning_levels = %#v, want an empty array", rawLevels)
+				}
+				if _, exists := model["default_reasoning_level"]; exists {
+					t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
+				}
+				return
+			}
+
+			if len(rawLevels) == 0 {
+				t.Fatal("supported_reasoning_levels is empty, want the default template levels")
+			}
+			defaultLevel := stringModelValue(model, "default_reasoning_level")
+			if defaultLevel == "" {
+				t.Fatal("default_reasoning_level is empty, want the default template level")
+			}
+			for _, rawLevel := range rawLevels {
+				level, okLevel := rawLevel.(map[string]any)
+				if !okLevel {
+					t.Fatalf("supported_reasoning_levels entry = %#v, want an object", rawLevel)
+				}
+				if stringModelValue(level, "effort") == defaultLevel {
+					return
+				}
+			}
+			t.Fatalf("default_reasoning_level %q is not listed in supported_reasoning_levels %#v", defaultLevel, rawLevels)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refs #5500. Rebased onto `dev` after 5208aec landed; this now carries only the remaining piece.

## What 5208aec already fixed

Emitting `[]` instead of deleting the key keeps the catalog decodable, so Codex no longer rejects the whole response. That resolves the crash in #5500.

## What is still wrong

Budget-only models still end up with no levels. Against current `dev`:

| `thinking` | `supported_reasoning_levels` |
| --- | --- |
| `{}` | `[]` — correct, no capability declared |
| `{"levels":["max","ultra"]}` on client `0.143.9` | `[]` — correct, all levels filtered out |
| `{"min":1024,"max":64000}` | `[]` — **wrong, this model does support reasoning** |

`claude-sonnet-4-6` and `claude-opus-4-6-thinking` reach the client with no selectable effort at all. `ThinkingSupport.Levels` documents budgets and levels as two alternative modes — *"When set, the model uses level-based reasoning instead of token budgets"* — so an absent level list means "not level-based", not "no reasoning".

## Fix

Return early when the model declares a budget but no levels, keeping the default template's reasoning metadata. An entirely empty `ThinkingSupport` is excluded: `detectModelCapability` reports `CapabilityNone` when neither a budget nor levels are present, so it emits `[]` like the other no-level paths and the required field stays present.

Net effect on top of `dev`:

| `thinking` | before | after |
| --- | --- | --- |
| `{}` | `[]` | `[]` (unchanged) |
| all levels filtered out | `[]` | `[]` (unchanged) |
| `{"min":1024,"max":64000}` | `[]` | `[low medium high xhigh]`, default `medium` |

## Tests

- `TestCodexClientModelsResponseKeepsTemplateReasoningLevelsWhenModelDeclaresNone` covers a modern client (`0.153.0`), a legacy one (`0.143.9`), a `Max`-only budget, and an empty `ThinkingSupport`, asserting the empty-array shape for the last one and that `default_reasoning_level` is listed among the levels for the others.
- `TestSanitizeCodexClientReasoningMetadataPreservesEmptyArray` from 5208aec is kept as-is and still passes.
- `TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels` still passes — all of its cases declare levels, so they are unaffected by the new early return.
- `go test ./...` green; `go build ./cmd/server` clean; `gofmt` clean.

## Credit

Thanks to @Vurliy for the empty-array shape and for checking the Codex side: `supported_reasoning_levels: Vec<ReasoningEffortPreset>` is required while `default_reasoning_level: Option<ReasoningEffort>` carries `#[serde(default)]`, so omitting only the default is safe. Verified against `rust-v0.153.2`. My earlier revision was wrong to leave two delete paths in place; 5208aec covers those, and this PR is now scoped to the budget-only case alone.
