### PR TITLE
fix(codex): preserve required empty reasoning levels

### DIFF
--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -398,7 +398,7 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 		})
 	}
 	if len(levels) == 0 {
-		delete(entry, "supported_reasoning_levels")
+		entry["supported_reasoning_levels"] = []any{}
 		delete(entry, "default_reasoning_level")
 		return
 	}
@@ -434,7 +434,7 @@ func sanitizeCodexClientReasoningMetadata(entry map[string]any, clientVersion st
 	}
 
 	if len(levels) == 0 {
-		delete(entry, "supported_reasoning_levels")
+		entry["supported_reasoning_levels"] = []any{}
 		delete(entry, "default_reasoning_level")
 		return
 	}

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -377,6 +377,11 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 	if thinking == nil {
 		return
 	}
+	// Budget-based thinking has no discrete registry levels. Keep the validated
+	// template levels so Codex clients retain their effort selector.
+	if len(thinking.Levels) == 0 && (thinking.Min > 0 || thinking.Max > 0) {
+		return
+	}
 
 	levels := make([]any, 0, len(thinking.Levels))
 	defaultLevel := ""

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -549,7 +549,7 @@ func TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels(t *te
 	}
 }
 
-func TestCodexClientModelsResponseKeepsRequiredEmptyReasoningLevels(t *testing.T) {
+func TestCodexClientModelsResponseKeepsTemplateReasoningLevelsForBudgetThinking(t *testing.T) {
 	for _, modelID := range []string{"claude-opus-4-20250514", "claude-opus-4-6-thinking"} {
 		t.Run(modelID, func(t *testing.T) {
 			resp := BuildResponse([]map[string]any{{"id": modelID}}, nil, false)
@@ -560,20 +560,48 @@ func TestCodexClientModelsResponseKeepsRequiredEmptyReasoningLevels(t *testing.T
 
 			model := models[0]
 			rawLevels, ok := model["supported_reasoning_levels"].([]any)
-			if !ok || len(rawLevels) != 0 {
-				t.Fatalf("supported_reasoning_levels = %#v, want empty array", model["supported_reasoning_levels"])
+			if !ok || len(rawLevels) == 0 {
+				t.Fatalf("supported_reasoning_levels = %#v, want template levels", model["supported_reasoning_levels"])
 			}
-			if _, exists := model["default_reasoning_level"]; exists {
-				t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
+			defaultLevel := stringModelValue(model, "default_reasoning_level")
+			if defaultLevel == "" {
+				t.Fatal("default_reasoning_level is empty, want a template default")
 			}
-
-			encodedLevels, err := json.Marshal(rawLevels)
-			if err != nil {
-				t.Fatalf("marshal supported_reasoning_levels: %v", err)
+			for _, rawLevel := range rawLevels {
+				level, okLevel := rawLevel.(map[string]any)
+				if okLevel && stringModelValue(level, "effort") == defaultLevel {
+					return
+				}
 			}
-			if string(encodedLevels) != "[]" {
-				t.Fatalf("supported_reasoning_levels JSON = %s, want []", encodedLevels)
-			}
+			t.Fatalf("default_reasoning_level %q is not listed in supported_reasoning_levels %#v", defaultLevel, rawLevels)
 		})
+	}
+}
+
+func TestCodexClientModelsResponseKeepsRequiredEmptyReasoningLevels(t *testing.T) {
+	resp := BuildResponse([]map[string]any{{
+		"id":       "home-empty-thinking-model-test",
+		"thinking": &registry.ThinkingSupport{},
+	}}, nil, false)
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+
+	model := models[0]
+	rawLevels, ok := model["supported_reasoning_levels"].([]any)
+	if !ok || len(rawLevels) != 0 {
+		t.Fatalf("supported_reasoning_levels = %#v, want empty array", model["supported_reasoning_levels"])
+	}
+	if _, exists := model["default_reasoning_level"]; exists {
+		t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
+	}
+
+	encodedLevels, err := json.Marshal(rawLevels)
+	if err != nil {
+		t.Fatalf("marshal supported_reasoning_levels: %v", err)
+	}
+	if string(encodedLevels) != "[]" {
+		t.Fatalf("supported_reasoning_levels JSON = %s, want []", encodedLevels)
 	}
 }

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -521,8 +522,9 @@ func TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels(t *te
 			}
 			model := models[0]
 			if len(tt.wantEfforts) == 0 {
-				if _, exists := model["supported_reasoning_levels"]; exists {
-					t.Fatalf("supported_reasoning_levels = %#v, want absent", model["supported_reasoning_levels"])
+				rawLevels, ok := model["supported_reasoning_levels"].([]any)
+				if !ok || len(rawLevels) != 0 {
+					t.Fatalf("supported_reasoning_levels = %#v, want empty array", model["supported_reasoning_levels"])
 				}
 				if _, exists := model["default_reasoning_level"]; exists {
 					t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
@@ -542,6 +544,35 @@ func TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels(t *te
 			}
 			if got := stringModelValue(model, "default_reasoning_level"); got != tt.wantDefault {
 				t.Fatalf("default_reasoning_level = %q, want %q", got, tt.wantDefault)
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponseKeepsRequiredEmptyReasoningLevels(t *testing.T) {
+	for _, modelID := range []string{"claude-opus-4-20250514", "claude-opus-4-6-thinking"} {
+		t.Run(modelID, func(t *testing.T) {
+			resp := BuildResponse([]map[string]any{{"id": modelID}}, nil, false)
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+
+			model := models[0]
+			rawLevels, ok := model["supported_reasoning_levels"].([]any)
+			if !ok || len(rawLevels) != 0 {
+				t.Fatalf("supported_reasoning_levels = %#v, want empty array", model["supported_reasoning_levels"])
+			}
+			if _, exists := model["default_reasoning_level"]; exists {
+				t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
+			}
+
+			encodedLevels, err := json.Marshal(rawLevels)
+			if err != nil {
+				t.Fatalf("marshal supported_reasoning_levels: %v", err)
+			}
+			if string(encodedLevels) != "[]" {
+				t.Fatalf("supported_reasoning_levels JSON = %s, want []", encodedLevels)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- keep validated template reasoning levels for models that declare budget-based thinking without discrete levels
- emit `supported_reasoning_levels: []` when a model declares no reasoning capability or client-version filtering removes every level
- omit `default_reasoning_level` whenever the resulting level list is empty
- cover Claude OAuth, Antigravity, explicit empty capability, and legacy-client filtering paths

## Background

Codex deserializes `supported_reasoning_levels` as a required field. Since `cdda333c` (`fix(codex): clear unsupported reasoning levels`), CLIProxyAPI deletes this field when a model has no explicit reasoning levels or when client-version filtering removes all levels.

A single affected model then causes Codex to reject the entire remote model catalog and fall back to its bundled catalog.

The two zero-level cases have different semantics. A model with a nonzero thinking budget still supports reasoning, so it keeps the validated default template levels and selector. A model with no declared capability, or whose levels are all incompatible with the requesting client, must not inherit unsupported choices; it receives an empty array instead. This preserves Codex's required response shape without advertising unsupported levels.

`default_reasoning_level` remains omitted whenever no selectable level exists.

Fixes #5500

## Testing

- `go test ./internal/client/codex/models`
- `go test ./...`
- `go build ./cmd/server`

---

## 中文翻译

### 摘要

- 对于使用 token budget、但没有离散推理等级的模型，保留经过验证的模板推理等级
- 当模型没有声明推理能力，或客户端版本过滤掉所有等级时，返回 `supported_reasoning_levels: []`
- 结果等级列表为空时，不返回 `default_reasoning_level`
- 覆盖 Claude OAuth、Antigravity、显式空能力以及旧客户端等级过滤路径

### 背景

Codex 在反序列化时将 `supported_reasoning_levels` 视为必填字段。自提交 `cdda333c`（`fix(codex): clear unsupported reasoning levels`）以来，当模型没有明确的推理等级，或客户端版本过滤后没有剩余等级时，CLIProxyAPI 会删除该字段。

只要模型目录中有一个模型受到影响，Codex 就会拒绝整个远程模型目录，并回退到内置模型目录。

两种“零等级”情况的语义并不相同。具有非零 thinking budget 的模型仍支持推理，因此保留经过验证的默认模板等级和选择器。没有声明推理能力的模型，或其等级与请求客户端全部不兼容的模型，不应继承不受支持的选项；这两种情况改为返回空数组。这样既能满足 Codex 要求的响应结构，也不会声明模型不支持的等级。

没有可选等级时，`default_reasoning_level` 仍保持不返回。

对应问题：#5500

### 测试

- `go test ./internal/client/codex/models`
- `go test ./...`
- `go build ./cmd/server`