### PR TITLE
fix(codex): recognize codex_exec user agent for multi-agent v2 optimization

### DIFF
--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -193,7 +193,8 @@ func IsCodexClientUserAgent(userAgent string) bool {
 	return strings.HasPrefix(userAgent, "Codex Desktop/") ||
 		strings.HasPrefix(userAgent, "codex-tui/") ||
 		userAgent == "codex_cli_rs" ||
-		strings.HasPrefix(userAgent, "codex_cli_rs/")
+		strings.HasPrefix(userAgent, "codex_cli_rs/") ||
+		strings.HasPrefix(userAgent, "codex_exec/")
 }
 
 func isCodexMultiAgentClient(userAgent string) bool {

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -44,6 +44,11 @@ func TestIsCodexMultiAgentClient(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "codex exec",
+			userAgent: "codex_exec/0.153.2 (Mac OS 26.6.2; arm64) unknown (codex_exec; 0.153.2)",
+			want:      true,
+		},
+		{
 			name:      "other client",
 			userAgent: "curl/8.7.1",
 			want:      false,


### PR DESCRIPTION
## Problem

`codex exec` sends the User-Agent `codex_exec/<version> (...)`. `IsCodexClientUserAgent` only recognizes `Codex Desktop/`, `codex-tui/` and `codex_cli_rs`, so with `codex.optimize-multi-agent-v2: true` the spawn_agent / send_message tool schemas are left untouched for `codex exec` sessions. The upstream then encrypts the delegated task (`message.encrypted` stays in the schema), and any subagent routed to a non-Codex upstream (Claude, Antigravity/Gemini, xAI) receives only the `NEW_TASK` header with an opaque `encrypted_content` token and cannot see its task.

Observed on v7.2.149 with Codex CLI 0.153.2 (`codex exec --profile <cliproxy>` + a custom agent on `claude-fable-5-1`): the subagent answered "no task in the message, only context". Adding the prefix made the same run return the expected result; the `Codex Desktop/0.153.1` client was already handled.

## Change

- `IsCodexClientUserAgent`: accept the `codex_exec/` prefix.
- Test: add a `codex exec` case to `TestIsCodexMultiAgentClient` with a real UA string.

## Verification

```
gofmt -l internal/client/codex/optimize-multi-agent-v2/   # clean
go build -o test-output ./cmd/server && rm -f test-output  # ok
go test ./internal/client/codex/optimize-multi-agent-v2/   # ok
go test ./internal/runtime/executor/ -run 'Codex|MultiAgent'  # ok
```

Live check on macOS: `codex exec` root on `gpt-5.6-sol` spawning a custom agent on `claude-fable-5-1` through the proxy now delivers the task text (proxy log shows `spawnTools=1 messageTools=3 encryptedFlags=3` on the first turn and the subagent reply contains the requested token).

Other Codex originators seen in the 0.153 binary (`codex_desktop`, `codex-app-server`, `codex_vscode`) are not included here because I could not observe their wire User-Agent; happy to add them if you know the exact strings.
