### PR TITLE
fix(thinking): forward requested reasoning effort verbatim for assumed default levels

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -116,6 +116,11 @@ type ThinkingSupport struct {
 	// Levels defines discrete reasoning effort levels (e.g., "low", "medium", "high").
 	// When set, the model uses level-based reasoning instead of token budgets.
 	Levels []string `json:"levels,omitempty" yaml:"levels,omitempty"`
+	// LevelsAssumed marks Levels as a proxy default fabricated for models whose
+	// configuration declares no thinking support at all. The declared set cannot
+	// be trusted, so requested effort levels must be forwarded verbatim for the
+	// upstream to validate instead of being mapped or clamped against them.
+	LevelsAssumed bool `json:"levels_assumed,omitempty" yaml:"levels-assumed,omitempty"`
 }
 
 // ModelRegistration tracks a model's availability

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -365,7 +365,7 @@ func shouldMapConfiguredHighIntent(fromFormat, toFormat string, modelInfo *regis
 }
 
 func mapConfiguredHighIntent(level ThinkingLevel, modelInfo *registry.ModelInfo) ThinkingLevel {
-	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 {
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 || modelInfo.Thinking.LevelsAssumed {
 		return level
 	}
 	level = ThinkingLevel(strings.ToLower(strings.TrimSpace(string(level))))

--- a/internal/thinking/apply_configured_api_key_test.go
+++ b/internal/thinking/apply_configured_api_key_test.go
@@ -62,6 +62,40 @@ func TestApplyThinkingWithModelInfoMapsOpenAICompatibilityHighIntent(t *testing.
 	}
 }
 
+// A model whose configuration declares no thinking support gets proxy-fabricated
+// default levels; those must not remap an explicitly requested effort (#5499).
+func TestApplyThinkingWithModelInfoKeepsAssumedLevelRequestsVerbatim(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "xhigh stays xhigh", source: "xhigh", want: "xhigh"},
+		{name: "high stays high", source: "high", want: "high"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{
+				ID:   "compat-upstream",
+				Type: "openai-compatibility",
+				Thinking: &registry.ThinkingSupport{
+					Levels:        []string{"low", "medium", "high"},
+					LevelsAssumed: true,
+				},
+			}
+			body := []byte(`{"reasoning_effort":"` + tc.source + `"}`)
+			source := []byte(`{"reasoning":{"effort":"` + tc.source + `"}}`)
+			out, err := thinking.ApplyThinkingWithModelInfo(body, source, "compat-upstream", "openai-response", "openai", "compat-provider", modelInfo)
+			if err != nil {
+				t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+			}
+			if got := gjson.GetBytes(out, "reasoning_effort").String(); got != tc.want {
+				t.Fatalf("reasoning_effort = %q, want %q; body=%s", got, tc.want, out)
+			}
+		})
+	}
+}
+
 func TestApplyThinkingWithModelInfoMapsResponsesToCodexHighIntent(t *testing.T) {
 	modelInfo := &registry.ModelInfo{
 		ID:       "codex-upstream",

--- a/internal/thinking/apply_configured_api_key_test.go
+++ b/internal/thinking/apply_configured_api_key_test.go
@@ -96,6 +96,51 @@ func TestApplyThinkingWithModelInfoKeepsAssumedLevelRequestsVerbatim(t *testing.
 	}
 }
 
+// Sentinel requests on assumed level sets reach the upstream unchanged:
+// an explicit disable must not become "low" and auto must be serialized as
+// "auto" rather than a fixed level or dropped (#5499 review).
+func TestApplyThinkingWithModelInfoKeepsAssumedSentinelsVerbatim(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:   "compat-upstream",
+		Type: "openai-compatibility",
+		Thinking: &registry.ThinkingSupport{
+			Levels:        []string{"low", "medium", "high"},
+			LevelsAssumed: true,
+		},
+	}
+
+	noneBody := []byte(`{}`)
+	noneSource := []byte(`{"reasoning":{"effort":"none"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(noneBody, noneSource, "compat-upstream", "openai-response", "openai", "compat-provider", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo(none) error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "none" {
+		t.Fatalf("reasoning_effort = %q, want none; body=%s", got, out)
+	}
+
+	autoBody := []byte(`{}`)
+	autoSource := []byte(`{"reasoning":{"effort":"auto"}}`)
+	out, err = thinking.ApplyThinkingWithModelInfo(autoBody, autoSource, "compat-upstream", "openai-response", "openai", "compat-provider", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo(auto) error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "auto" {
+		t.Fatalf("reasoning_effort = %q, want auto; body=%s", got, out)
+	}
+
+	// The (auto) model suffix carries no body field to preserve; the request
+	// must still be serialized as an explicit auto effort.
+	suffixBody := []byte(`{}`)
+	out, err = thinking.ApplyThinkingWithModelInfo(suffixBody, suffixBody, "compat-upstream(auto)", "openai", "openai", "compat-provider", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo(suffix auto) error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "auto" {
+		t.Fatalf("suffix auto reasoning_effort = %q, want auto; body=%s", got, out)
+	}
+}
+
 func TestApplyThinkingWithModelInfoMapsResponsesToCodexHighIntent(t *testing.T) {
 	modelInfo := &registry.ModelInfo{
 		ID:       "codex-upstream",

--- a/internal/thinking/provider/openai/apply.go
+++ b/internal/thinking/provider/openai/apply.go
@@ -47,7 +47,11 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 	}
 
 	// Only handle ModeLevel and ModeNone; other modes pass through unchanged.
-	if config.Mode != thinking.ModeLevel && config.Mode != thinking.ModeNone {
+	// Assumed level sets carry no real model contract, so an explicitly
+	// requested auto is serialized as "auto" for the upstream to interpret —
+	// otherwise a suffix-based auto request (no body field to preserve) would
+	// be silently dropped.
+	if config.Mode != thinking.ModeLevel && config.Mode != thinking.ModeNone && !(config.Mode == thinking.ModeAuto && modelInfo.Thinking.LevelsAssumed) {
 		return body, nil
 	}
 
@@ -63,9 +67,14 @@ func (a *Applier) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *
 	effort := ""
 	support := modelInfo.Thinking
 	if config.Budget == 0 {
-		if support.ZeroAllowed || thinking.HasLevel(support.Levels, string(thinking.LevelNone)) {
+		// Assumed default levels carry no real contract: an explicit disable
+		// request is forwarded as "none" for the upstream to honor or reject.
+		if support.ZeroAllowed || support.LevelsAssumed || thinking.HasLevel(support.Levels, string(thinking.LevelNone)) {
 			effort = string(thinking.LevelNone)
 		}
+	}
+	if effort == "" && config.Mode == thinking.ModeAuto && support.LevelsAssumed {
+		effort = string(thinking.LevelAuto)
 	}
 	if effort == "" && config.Level != "" {
 		effort = string(config.Level)

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -129,7 +129,9 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		config.Level = ""
 	}
 
-	if len(support.Levels) > 0 && config.Mode == ModeLevel {
+	// Assumed default levels carry no real model contract, so an explicitly
+	// requested level is forwarded for the upstream to accept or reject.
+	if len(support.Levels) > 0 && config.Mode == ModeLevel && !support.LevelsAssumed {
 		if !isLevelSupported(string(config.Level), support.Levels) {
 			if allowClampUnsupported {
 				config.Level = clampLevel(config.Level, modelInfo, toFormat)

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -156,8 +156,10 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		}
 	}
 
-	// Convert ModeAuto to mid-range if dynamic not allowed
-	if config.Mode == ModeAuto && !support.DynamicAllowed {
+	// Convert ModeAuto to mid-range if dynamic not allowed. Assumed default
+	// levels carry no real model contract, so the requested sentinel is
+	// forwarded for the upstream to interpret instead of being rewritten.
+	if config.Mode == ModeAuto && !support.DynamicAllowed && !support.LevelsAssumed {
 		config = convertAutoToMidRange(config, support, toFormat, model)
 		// The canonical mid-range level may not be present in a model's discrete
 		// level subset (for example, Levels=[low, high]). Clamp the generated
@@ -182,9 +184,10 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		// ModeNone for a model that cannot be disabled falls back to the lowest
 		// supported level. Budget-capable models reach this path with Budget > 0;
 		// level-only models need the capability flags checked explicitly because
-		// their Min/Max range is zero.
+		// their Min/Max range is zero. Assumed level sets skip the fallback so an
+		// explicit disable request is forwarded instead of becoming "low".
 		cannotDisableLevelModel := !support.ZeroAllowed && !isLevelSupported(string(LevelNone), support.Levels)
-		if config.Mode == ModeNone && len(support.Levels) > 0 && (config.Budget > 0 || cannotDisableLevelModel) {
+		if config.Mode == ModeNone && !support.LevelsAssumed && len(support.Levels) > 0 && (config.Budget > 0 || cannotDisableLevelModel) {
 			config.Level = ThinkingLevel(support.Levels[0])
 		}
 	}

--- a/sdk/cliproxy/auth/api_key_model_assumed_levels_test.go
+++ b/sdk/cliproxy/auth/api_key_model_assumed_levels_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/openai"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// End to end: an openai-compatibility model without a thinking block gets the
+// fabricated default levels at the capability route, and a requested effort
+// must survive both resolution and application verbatim (#5499). The openai
+// provider applier is blank-imported so the assertion covers the real write,
+// not an unapplied passthrough body.
+func TestAttachResolvedAPIKeyModelInfoForwardsEffortForAssumedLevels(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name:    "sglang",
+		BaseURL: "http://127.0.0.1:12345/v1",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{Name: "qwen3.8-27b", Alias: "qwen3.8-27b-sglang"},
+		},
+	}}})
+	auth := &Auth{
+		ID:       "auth-assumed-levels",
+		Provider: "openai-compatibility:sglang",
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   "sk-test",
+			AttributeSource:   "config:openai-compatibility[0]",
+			"compat_name":     "sglang",
+			"provider_key":    "openai-compatibility:sglang",
+		},
+	}
+	registerCapabilityTestAuth(t, manager, auth)
+
+	req := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "qwen3.8-27b-sglang", "qwen3.8-27b")
+	modelInfo, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || modelInfo == nil || modelInfo.Thinking == nil {
+		t.Fatalf("resolved model info missing thinking support: %+v", modelInfo)
+	}
+	if !modelInfo.Thinking.LevelsAssumed {
+		t.Fatalf("fabricated levels lost the assumed marker through resolution: %+v", modelInfo.Thinking)
+	}
+
+	body := []byte(`{"reasoning_effort":"xhigh"}`)
+	source := []byte(`{"reasoning":{"effort":"xhigh"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, modelInfo.ID, "openai-response", "openai", auth.Provider, modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want verbatim xhigh; body=%s", got, out)
+	}
+}

--- a/sdk/cliproxy/auth/api_key_model_capabilities.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities.go
@@ -236,7 +236,7 @@ func compileOpenAICompatibleModelCapabilities(out map[string][]apiKeyModelCapabi
 	for i := range models {
 		support := models[i].Thinking
 		if support == nil && !models[i].Image {
-			support = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			support = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}, LevelsAssumed: true}
 		}
 		addConfiguredModelCapability(out, models[i].Name, models[i].Alias, "openai-compatibility", support, models[i].IsCompat)
 	}

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -741,7 +741,7 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		}
 		thinkingSupport := model.Thinking
 		if thinkingSupport == nil && !model.Image {
-			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}, LevelsAssumed: true}
 		}
 		if model.Thinking != nil {
 			info.ExplicitThinking = true


### PR DESCRIPTION
## Summary

OpenAI-compatibility models whose configuration declares no `thinking` block get a proxy-fabricated default level set `["low", "medium", "high"]` (`buildOpenAICompatibilityConfigModels` / `compileOpenAICompatibleModelCapabilities`). `mapConfiguredHighIntent` treated that fabricated set as a real model contract and remapped a requested `reasoning_effort: "xhigh"` down to `high`, which upstreams that accept `xhigh` but not `high` (e.g. SGLang chat templates with `xhigh/medium/low`) then reject with a 400 reporting the wrong level.

This marks the fabricated level sets with a new `ThinkingSupport.LevelsAssumed` flag and skips the high-intent remap plus the level-support enforcement for them, so the explicitly requested effort is forwarded verbatim for the upstream to accept or reject. Explicitly configured `thinking.levels` keep the existing remap/clamp behavior (including `TestApplyThinkingWithModelInfoKeepsSameFamilyValidationStrict`).

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Requested `xhigh` no longer downgraded for assumed-level models (fails before: got `high`) | `go test ./internal/thinking/ -run TestApplyThinkingWithModelInfoKeepsAssumedLevelRequestsVerbatim -v` | red before fix, green after |
| Explicit levels keep remap/validation behavior | `go test ./internal/thinking/` | ok (incl. locked strict-validation and remap cases) |
| Dependent packages | `go test -p 2 ./sdk/cliproxy/... ./internal/...` | ok; `internal/runtime/executor` xai Images/Videos flaky in combined runs on this machine (pre-existing, single-run green, documented in prior PRs) |
| Build | `go build -o test-output ./cmd/server` | ok |
| Format | `gofmt -l` on changed files | clean |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
- [ ] Behavior change to existing flags/endpoints: default-level fabrication no longer clamps requested effort (see Summary)
