### PR TITLE
fix(aistudio): send uppercase thinkingLevel enum to the AI Studio upstream

### DIFF
--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -488,7 +488,28 @@ func (e *AIStudioExecutor) translateRequest(ctx context.Context, req cliproxyexe
 	}
 	payload, _ = sjson.DeleteBytes(payload, "session_id")
 	payload = helps.EnsureGeminiLeadingUserContent(payload, "contents")
+	payload = normalizeAIStudioThinkingLevel(payload)
 	return payload, translatedPayload{payload: payload, action: action, toFormat: to}, nil
+}
+
+// normalizeAIStudioThinkingLevel uppercases generationConfig.thinkingConfig.thinkingLevel.
+// The AI Studio upstream validates the value as an uppercase enum and rejects the
+// lowercase canonical levels used elsewhere with "400 Request contains an invalid
+// argument" (https://github.com/router-for-me/CLIProxyAPI/issues/5481).
+func normalizeAIStudioThinkingLevel(payload []byte) []byte {
+	level := gjson.GetBytes(payload, "generationConfig.thinkingConfig.thinkingLevel").String()
+	if level == "" {
+		return payload
+	}
+	upper := strings.ToUpper(level)
+	if upper == level {
+		return payload
+	}
+	out, err := sjson.SetBytes(payload, "generationConfig.thinkingConfig.thinkingLevel", upper)
+	if err != nil {
+		return payload
+	}
+	return out
 }
 
 func (e *AIStudioExecutor) buildEndpoint(model, action, alt string) string {

--- a/internal/runtime/executor/aistudio_executor_test.go
+++ b/internal/runtime/executor/aistudio_executor_test.go
@@ -51,6 +51,24 @@ func TestAIStudioTranslateRequestPrependsLeadingUserForIssue4959ResponsesHistory
 	assertIssue4959LeadingUserContents(t, gjson.GetBytes(body.payload, "contents").Array())
 }
 
+// The AI Studio upstream rejects lowercase thinking levels with 400 (#5481);
+// the executor must emit the uppercase enum (HIGH/LOW/MEDIUM) on this channel.
+func TestAIStudioTranslateRequestUppercasesThinkingLevel(t *testing.T) {
+	executor := NewAIStudioExecutor(&config.Config{}, "aistudio", nil)
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"thinkingConfig":{"thinkingLevel":"high","includeThoughts":true}}}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}
+	payload, _, err := executor.translateRequest(context.Background(), req, opts, false)
+	if err != nil {
+		t.Fatalf("translateRequest() error = %v", err)
+	}
+	if got := gjson.GetBytes(payload, "generationConfig.thinkingConfig.thinkingLevel").String(); got != "HIGH" {
+		t.Fatalf("thinkingLevel = %q, want HIGH; body=%s", got, payload)
+	}
+}
+
 func TestAIStudioExecutorWithoutRelaySessionDoesNotMarkUpstreamAttempt(t *testing.T) {
 	const authID = "aistudio-not-connected"
 	relay := wsrelay.NewManager(wsrelay.Options{})


### PR DESCRIPTION
## Summary

The AI Studio upstream validates `generationConfig.thinkingConfig.thinkingLevel` as an uppercase enum and rejects the lowercase canonical levels used on other Gemini-protocol channels: `high` returns `400 Request contains an invalid argument` while `HIGH` succeeds (same for `LOW`/`MEDIUM`, per the issue).

The AI Studio executor now normalizes the level to uppercase at its request-translation exit (`normalizeAIStudioThinkingLevel`), so every path that sets the field on this channel (Gemini-native passthrough, the thinking pipeline, payload rules) reaches the upstream in the only accepted form. Other Gemini-protocol channels are untouched.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Lowercase `high` becomes `HIGH` on the aistudio channel (fails before: stayed `high`) | `go test ./internal/runtime/executor/ -run TestAIStudioTranslateRequestUppercasesThinkingLevel -v -count=1` | red before fix, green after |
| No regression in existing AI Studio executor tests | `go test -p 1 ./internal/runtime/executor/ -run "TestAIStudio" -v -count=1` | all pass |
| Executor package | `go test -p 1 ./internal/runtime/executor/ -count=1` | only the pre-existing xai Images/Videos combined-run flaky fails on this machine (single-run green, documented in prior PRs) |
| Build | `go build -o test-output ./cmd/server` | ok |
| Format | `gofmt -l` on changed files | clean |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
