### PR TITLE
fix(auth): cool single upstream 404s for minutes instead of 12 hours

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -50,6 +50,10 @@ type Result struct {
 	Provider string
 	// Model is the upstream model identifier used for the request.
 	Model string
+	// UpstreamModel is the alias-resolved upstream name the provider actually
+	// received when it differs from Model. Structured not-found errors name
+	// this identifier, so 404 classification matches against both.
+	UpstreamModel string
 	// RouteModel is the requested logical route model before alias resolution.
 	RouteModel string
 	// Success marks whether the execution succeeded.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -859,9 +859,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 404:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
-							} else if isExplicitModelNotFoundError(result.Error, thinking.ParseSuffix(modelKey).ModelName) {
+							} else if isExplicitModelNotFoundForState(result.Error, modelKey, result.UpstreamModel) {
 								// A 404 that explicitly names this model as unsupported is
-								// demonstrably persistent and keeps the long cooldown.
+								// demonstrably persistent and keeps the long cooldown. The
+								// structured message names the upstream identifier, which
+								// differs from the route alias under alias mapping.
 								state.NextRetryAfter = now.Add(modelSupportCooldown)
 							} else {
 								// Concurrent in-flight failures complete in any order: a
@@ -1482,6 +1484,24 @@ func resultErrorFromError(err error) *Error {
 		}
 	}
 	return resultErr
+}
+
+// isExplicitModelNotFoundForState reports whether a 404 result explicitly
+// names the attempted model — by route key or by the alias-resolved upstream
+// identifier, since structured provider errors quote the upstream name — as
+// unsupported (#5476 review).
+func isExplicitModelNotFoundForState(err *Error, modelKey, upstreamModel string) bool {
+	if err == nil {
+		return false
+	}
+	if isExplicitModelNotFoundError(err, thinking.ParseSuffix(modelKey).ModelName) {
+		return true
+	}
+	upstream := strings.TrimSpace(upstreamModel)
+	if upstream == "" || strings.EqualFold(upstream, modelKey) {
+		return false
+	}
+	return isExplicitModelNotFoundError(err, thinking.ParseSuffix(upstream).ModelName)
 }
 
 // shouldSkipCredentialCooldown reports failures that must not mark auth/model cooling.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -825,7 +825,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						if disableCooling {
 							state.NextRetryAfter = time.Time{}
 						} else {
-							next := now.Add(12 * time.Hour)
+							next := now.Add(modelSupportCooldown)
 							state.NextRetryAfter = next
 						}
 					} else if isCloudflareChallengeResultError(result.Error) {
@@ -859,8 +859,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 404:
 							if disableCooling {
 								state.NextRetryAfter = time.Time{}
+							} else if isExplicitModelNotFoundError(result.Error, thinking.ParseSuffix(modelKey).ModelName) {
+								// A 404 that explicitly names this model as unsupported is
+								// demonstrably persistent and keeps the long cooldown.
+								state.NextRetryAfter = now.Add(modelSupportCooldown)
 							} else {
-								next := now.Add(12 * time.Hour)
+								// Concurrent in-flight failures complete in any order: a
+								// transient 404 must not shorten a still-live longer
+								// deadline recorded by an earlier result.
+								next := now.Add(notFoundCooldown)
+								if state.NextRetryAfter.After(next) && state.NextRetryAfter.After(now) {
+									next = state.NextRetryAfter
+								}
 								state.NextRetryAfter = next
 							}
 						case 429:
@@ -2112,7 +2122,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			if disableCooling {
 				auth.NextRetryAfter = time.Time{}
 			} else {
-				auth.NextRetryAfter = now.Add(12 * time.Hour)
+				auth.NextRetryAfter = now.Add(notFoundCooldown)
 			}
 		case 429:
 			auth.StatusMessage = "quota exhausted"

--- a/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
@@ -87,10 +87,14 @@ func TestManager_MarkResult_CredentialScope_DoesNotPromoteSiblingDeadlineToQuota
 
 	m, auth := newCooldownMonotonicManager(t, "model-a", "model-b")
 
-	// 1. Model B gets a 404 (12h deadline).
+	// 1. Model B gets an explicit model-not-found 404 (12h deadline).
 	m.MarkResult(context.Background(), Result{
 		AuthID: auth.ID, Provider: auth.Provider, Model: "model-b",
-		Success: false, Error: &Error{HTTPStatus: http.StatusNotFound, Message: "model not found"},
+		Success: false, Error: &Error{
+			Code:       "model_not_found",
+			HTTPStatus: http.StatusNotFound,
+			Message:    "model model-b was not found",
+		},
 	})
 	before := time.Now()
 
@@ -259,15 +263,15 @@ func TestManager_ApplyAuthFailureState_PreservesLongerCredentialDeadline(t *test
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m, auth := newCooldownMonotonicManager(t, "model-a")
-			// Credential-wide 404 (12h deadline).
+			// Credential-wide 404 (10-minute transient deadline).
 			m.MarkResult(context.Background(), Result{
 				AuthID: auth.ID, Provider: auth.Provider, Model: "",
 				Success: false, Error: &Error{HTTPStatus: http.StatusNotFound, Message: "credential not found"},
 			})
 			before := time.Now()
 			snap, _ := m.GetByID(auth.ID)
-			if !snap.Unavailable || snap.NextRetryAfter.Before(before.Add(11*time.Hour)) {
-				t.Fatalf("precondition failed: expected ~12h deadline, got: %v", snap.NextRetryAfter.Sub(before))
+			if !snap.Unavailable || snap.NextRetryAfter.Before(before.Add(9*time.Minute)) {
+				t.Fatalf("precondition failed: expected ~10m deadline, got: %v", snap.NextRetryAfter.Sub(before))
 			}
 
 			// Follow up with a shorter credential failure.
@@ -277,7 +281,7 @@ func TestManager_ApplyAuthFailureState_PreservesLongerCredentialDeadline(t *test
 			})
 
 			updated, _ := m.GetByID(auth.ID)
-			if updated.NextRetryAfter.Before(before.Add(11 * time.Hour)) {
+			if updated.NextRetryAfter.Before(before.Add(9 * time.Minute)) {
 				t.Fatalf("shorter failure shortened credential-level deadline to %v", updated.NextRetryAfter.Sub(before))
 			}
 		})

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -604,7 +604,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -817,7 +817,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: execOpts, SkipQuotaObservation: true}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1403,7 +1403,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			execReq.Model = upstreamModel
 			creditsCtx = syncMetadataSessionToContext(creditsCtx, creditsOpts.Metadata)
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
-			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
+			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -253,7 +253,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 			}
-			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
+			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, UpstreamModel: upstreamModel, RouteModel: routeModel, Success: errExecute == nil, Options: execOpts}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -7,6 +7,75 @@ import (
 	"time"
 )
 
+// Alias-mapped models: the provider's structured 404 names the alias-resolved
+// upstream identifier, not the public route model. Classification must match
+// either name before falling back to the short transient window (#5476 review).
+func TestManager_MarkResult_ExplicitNotFoundMatchesUpstreamModel(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-alias-404", Provider: "codex"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "public-model",
+		UpstreamModel: "upstream-name",
+		Success:       false,
+		Error: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"type":"not_found_error","message":"model upstream-name was not found"}`,
+		},
+	})
+
+	before := time.Now()
+	updated, _ := m.GetByID(auth.ID)
+	state := existingModelState(updated, canonicalModelKey("public-model"))
+	if state == nil {
+		t.Fatal("model state missing")
+	}
+	if state.NextRetryAfter.Before(before.Add(6 * time.Hour)) {
+		t.Fatalf("upstream-named 404 fell into the transient branch: %v", state.NextRetryAfter.Sub(before))
+	}
+}
+
+// The credential-level clamp inherited from the merged #5501 work keeps a live
+// 401 deadline when a later generic 404 proposes a shorter window (#5476 review).
+func TestManager_MarkResult_Transient404KeepsLongerCredentialDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-cred-404-order", Provider: "codex"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "",
+		Success: false, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+	before := time.Now()
+	snap, _ := m.GetByID(auth.ID)
+	if snap.NextRetryAfter.Before(before.Add(25 * time.Minute)) {
+		t.Fatalf("precondition failed: expected ~30m 401 deadline, got %v", snap.NextRetryAfter.Sub(before))
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "",
+		Success: false, Error: &Error{HTTPStatus: http.StatusNotFound, Message: "upstream stream failed"},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated.NextRetryAfter.Before(before.Add(25 * time.Minute)) {
+		t.Fatalf("transient 404 shortened the live credential deadline to %v", updated.NextRetryAfter.Sub(before))
+	}
+}
+
 // Concurrent in-flight 404s complete in any order: a generic transient 404
 // landing after an explicit model-not-found result must not shorten the model's
 // still-live long cooldown (#5476 review).

--- a/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_not_found_cooldown_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// Concurrent in-flight 404s complete in any order: a generic transient 404
+// landing after an explicit model-not-found result must not shorten the model's
+// still-live long cooldown (#5476 review).
+func TestManager_MarkResult_Transient404KeepsLongerModelDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-404-order", Provider: "codex"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	model := "gpt-5.6-sol"
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Success: false,
+		Error: &Error{
+			Code:       "model_not_found",
+			HTTPStatus: http.StatusNotFound,
+			Message:    `model gpt-5.6-sol was not found`,
+		},
+	})
+	before := time.Now()
+	snap, _ := m.GetByID(auth.ID)
+	state := existingModelState(snap, canonicalModelKey(model))
+	if state == nil || state.NextRetryAfter.Before(before.Add(6*time.Hour)) {
+		t.Fatalf("precondition failed: expected long model-not-found deadline, got %+v", state)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: model,
+		Success: false,
+		Error:   &Error{HTTPStatus: http.StatusNotFound, Message: `upstream stream failed`},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	stateAfter := existingModelState(updated, canonicalModelKey(model))
+	if stateAfter == nil || stateAfter.NextRetryAfter.Before(before.Add(6*time.Hour)) {
+		t.Fatalf("transient 404 shortened the model's long deadline to %v", stateAfter.NextRetryAfter.Sub(before))
+	}
+}
+
+// A single upstream 404 is frequently transient on Codex routes (streamed
+// response.failed events map to 404), so it must cool the credential for
+// minutes instead of the 12h fixed window (#5476). Structured model-support
+// errors keep their own long cooldown path.
+func TestManager_MarkResult_SingleNotFoundCooldownsMinutes(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	notFoundErr := &Error{
+		HTTPStatus: http.StatusNotFound,
+		Message:    `{"error":{"type":"response_failed","message":"upstream stream failed"}}`,
+	}
+
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{name: "credential level", model: ""},
+		{name: "model level", model: "gpt-5.6-sol"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "auth-not-found-" + tc.name, Provider: "codex"}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			before := time.Now()
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    tc.model,
+				Success:  false,
+				Error:    notFoundErr,
+			})
+
+			updated, ok := m.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatalf("expected auth to be present")
+			}
+			cooldown := updated.NextRetryAfter.Sub(before)
+			if cooldown <= 0 || cooldown > 15*time.Minute {
+				t.Fatalf("single 404 cooldown = %v, want a short window (minutes)", cooldown)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -35,6 +35,16 @@ const (
 	quotaBackoffMax           = 30 * time.Minute
 	minQuotaCooldownFloor     = 10 * time.Second
 	transientErrorCooldown    = time.Minute
+	// notFoundCooldown covers raw HTTP 404s that carry no model-support
+	// classification. They are frequently transient on Codex routes (streamed
+	// response.failed events map to 404), so a single occurrence only cools the
+	// credential for minutes.
+	notFoundCooldown = 10 * time.Minute
+	// modelSupportCooldown is the long cooldown for demonstrably persistent
+	// model-availability failures: structured model-not-found errors and
+	// model-support messages that name this credential as unable to serve the
+	// model.
+	modelSupportCooldown = 12 * time.Hour
 )
 
 // StartAutoRefresh launches a background loop that evaluates auth freshness

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -290,7 +290,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true
@@ -376,7 +376,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, bootstrapErr, m.runtimeConfigSnapshot())
 			if okAction {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -396,7 +396,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -407,7 +407,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
@@ -422,7 +422,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true
@@ -440,7 +440,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				upstreamErr = currentErr
 			}
 			warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), emptyErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
+			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, UpstreamModel: execModel, RouteModel: routeModel, Success: false, Error: resultErrorFromError(emptyErr), Options: execOpts}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr


### PR DESCRIPTION
## Summary

A single upstream HTTP 404 set `NextRetryAfter = now + 12h`, taking a Codex credential out of rotation for half a day. 404s on these routes are frequently transient (streamed `response.failed` events map to 404 via `codexTerminalFailureStatus`, upstream blips, model rollouts), and transient 5xx errors only cool for ~1 minute. With a single credential configured, every subsequent request returned `503 auth_unavailable` without reaching the upstream until a manual disable/enable toggle or restart.

This splits the 404 handling:

- raw 404s that do not explicitly identify the requested model as unsupported cool for **10 minutes** (new `notFoundCooldown`);
- 404s that explicitly name the model (existing `isExplicitModelNotFoundError` classification, e.g. `Code: model_not_found`) keep the **12h** model-support cooldown, now named `modelSupportCooldown` alongside the existing 400/422 model-support path.

The credential-level path (`applyAuthFailureState`) has no model context, so its 404s use the short cooldown; model-specific persistence is enforced on the model-state path where the model is known.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Single 404 (no model identification) cools minutes at both credential and model level (fails before: `12h0m0s`) | `go test ./sdk/cliproxy/auth/ -run TestManager_MarkResult_SingleNotFoundCooldownsMinutes -v -count=1` | red before fix, green after |
| Explicit model-not-found 404 keeps ~12h | `go test ./sdk/cliproxy/auth/ -run TestManager_ExecuteCount_ExplicitModelNotFoundSuspendsModel -count=1` | pass (existing locked behavior) |
| auth package | `go test -p 1 ./sdk/cliproxy/auth/ -count=1` | ok |
| Build | `go build -o test-output ./cmd/server` | ok |
| Format | `gofmt -l` on changed files | clean |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
- [ ] Behavior change: single raw 404 cooldown 12h -> 10min (see Summary)
