### PR TITLE
feat: opt-in per-key model discovery filtering via auth metadata

### DIFF
--- a/docs/sdk-access.md
+++ b/docs/sdk-access.md
@@ -152,3 +152,35 @@ accessManager.SetProviders(sdkaccess.RegisteredProviders())
 ```
 
 This mirrors the behaviour in `internal/access.ApplyAccessProviders`, enabling runtime updates without restarting the process.
+
+### Authenticated model-list visibility
+
+Authentication providers and frontend authentication plugins can optionally return
+the metadata entry `model_list_allowed_ids` (SDK constant
+`pluginapi.ModelListAllowedIDsMetadataKey`). Its value is a JSON array of exact IDs:
+
+```go
+Metadata: map[string]string{
+    pluginapi.ModelListAllowedIDsMetadataKey: `["model-a", "model-b"]`,
+},
+```
+
+Only metadata produced by successful authentication is consulted. Request headers
+and query parameters cannot set this policy. Existing native keys and plugins
+that omit the entry retain their current behavior. An empty array hides every
+model; invalid policy data fails closed with a generic server error. Restricted
+responses use `Cache-Control: private, no-store`.
+
+Filtering is applied to the final OpenAI, Claude, Gemini, Codex-client and Grok
+model lists, including Home-backed lists. IDs are case-sensitive and there is no
+wildcard matching. OpenAI/Claude/Grok use the returned `id`; Codex uses `slug`;
+Gemini uses `name` and also accepts its value without the `models/` prefix.
+For Claude cloaking, supply the final displayed ID, or disable model-list
+cloaking using the existing configuration. The policy only removes entries: it
+does not register aliases or add models absent from the underlying catalog.
+Retained entries keep their fields, and Claude boundary IDs are recomputed.
+
+This is discovery filtering, **not execution authorization**. Plugins must still
+enforce allowed models when handling inference requests. Individual Gemini model
+detail requests and fields within retained entries are not filtered by this
+list-only policy. No Docker configuration changes or custom endpoints are needed.

--- a/internal/api/server_model_list_policy_test.go
+++ b/internal/api/server_model_list_policy_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/gemini"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type catalogTestAuth struct{}
+
+func (catalogTestAuth) Identifier() string { return "catalog-test" }
+func (catalogTestAuth) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.Result, *sdkaccess.AuthError) {
+	key := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	result := &sdkaccess.Result{Principal: key, Provider: "catalog-test"}
+	var policy string
+	switch key {
+	case "native":
+		return result, nil
+	case "empty":
+		policy = `[]`
+	case "allowed":
+		policy = `["catalog-visible"]`
+	case "invalid-policy":
+		policy = `null`
+	default:
+		return nil, sdkaccess.NewInvalidCredentialError()
+	}
+	result.Metadata = map[string]string{pluginapi.ModelListAllowedIDsMetadataKey: policy}
+	return result, nil
+}
+
+func TestAuthenticatedModelListPolicyRoutes(t *testing.T) {
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("catalog-policy-client", "openai", []*registry.ModelInfo{
+		{ID: "catalog-visible", Object: "model", OwnedBy: "test"},
+		{ID: "catalog-hidden", Object: "model", OwnedBy: "test"},
+	})
+	t.Cleanup(func() { registryRef.UnregisterClient("catalog-policy-client") })
+	manager := sdkaccess.NewManager()
+	manager.SetProviders([]sdkaccess.Provider{catalogTestAuth{}})
+	base := &handlers.BaseAPIHandler{}
+	server := &Server{}
+	router := gin.New()
+	router.Use(AuthMiddleware(manager))
+	router.GET("/v1/models", server.unifiedModelsHandler(openai.NewOpenAIAPIHandler(base), claude.NewClaudeCodeAPIHandler(base)))
+	router.GET("/v1beta/models", gemini.NewGeminiAPIHandler(base).GeminiModels)
+	for _, route := range []struct{ name, path, ua string }{
+		{"openai", "/v1/models", ""},
+		{"claude", "/v1/models", "claude-cli"},
+		{"codex", "/v1/models?client_version=0.100.0", ""},
+		{"grok", "/v1/models", "grok-shell/0.2"},
+		{"gemini", "/v1beta/models", ""},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			for _, key := range []string{"empty", "invalid-policy", "bad-key"} {
+				r := httptest.NewRequest("GET", route.path, nil)
+				r.Header.Set("Authorization", "Bearer "+key)
+				r.Header.Set("User-Agent", route.ua)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+				wantStatus := 200
+				if key == "invalid-policy" {
+					wantStatus = 500
+				}
+				if key == "bad-key" {
+					wantStatus = 401
+				}
+				if w.Code != wantStatus {
+					t.Fatalf("%s: %d %s", key, w.Code, w.Body)
+				}
+				if key == "empty" {
+					var response map[string]json.RawMessage
+					if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+						t.Fatal(err)
+					}
+					rows, exists := response["data"]
+					if !exists {
+						rows = response["models"]
+					}
+					if string(rows) != "[]" {
+						t.Fatalf("unfiltered %s: %s", route.name, w.Body)
+					}
+				}
+			}
+		})
+	}
+	for _, key := range []string{"allowed", "native"} {
+		r := httptest.NewRequest("GET", "/v1/models?model_list_allowed_ids=[]", nil)
+		r.Header.Set("Authorization", "Bearer "+key)
+		r.Header.Set("model_list_allowed_ids", "[]")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		if w.Code != 200 || !strings.Contains(w.Body.String(), "catalog-visible") {
+			t.Fatalf("%s: %d %s", key, w.Code, w.Body)
+		}
+		if strings.Contains(w.Body.String(), "catalog-hidden") != (key == "native") {
+			t.Fatalf("wrong catalog for %s: %s", key, w.Body)
+		}
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -624,7 +624,7 @@ func (s *Server) handleGrokModels(c *gin.Context) {
 	} else {
 		models = grokModelsFromRegistryInfos(registry.GetGlobalRegistry().GetAvailableModelInfos())
 	}
-	c.JSON(http.StatusOK, grokbuild.BuildResponse(models))
+	handlers.WriteModelList(c, grokbuild.BuildResponse(models))
 }
 
 // handleHomeCodexClientModels builds the Codex client catalog from Home model IDs.
@@ -640,7 +640,7 @@ func (s *Server) handleHomeCodexClientModels(c *gin.Context, clientVersion strin
 		models = append(models, formatHomeCodexModel(entry))
 	}
 
-	c.JSON(http.StatusOK, codexmodels.BuildResponseForClient(models, nil, s.cfg.Codex.OptimizeMultiAgentV2, clientVersion))
+	handlers.WriteModelList(c, codexmodels.BuildResponseForClient(models, nil, s.cfg.Codex.OptimizeMultiAgentV2, clientVersion))
 }
 
 func formatHomeCodexModel(entry homeModelEntry) map[string]any {
@@ -712,7 +712,7 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 
 	if isClaude {
 		disableCloaking := s.cfg != nil && s.cfg.ClaudeCode.DisableCloakingModelList
-		c.JSON(http.StatusOK, claudemodels.BuildResponse(formatHomeClaudeModels(entries), disableCloaking))
+		handlers.WriteModelList(c, claudemodels.BuildResponse(formatHomeClaudeModels(entries), disableCloaking))
 		return
 	}
 
@@ -730,7 +730,7 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 		}
 		filtered = append(filtered, model)
 	}
-	c.JSON(http.StatusOK, gin.H{
+	handlers.WriteModelList(c, gin.H{
 		"object": "list",
 		"data":   filtered,
 	})
@@ -778,7 +778,7 @@ func (s *Server) handleHomeGeminiModels(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	handlers.WriteModelList(c, gin.H{
 		"models": formatHomeGeminiModels(entries),
 	})
 }

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -156,7 +156,7 @@ func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
 	disableCloaking := h.Cfg != nil && h.Cfg.ClaudeCode.DisableCloakingModelList
-	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models(), disableCloaking))
+	handlers.WriteModelList(c, claudemodels.BuildResponse(h.Models(), disableCloaking))
 }
 
 // handleNonStreamingResponse handles non-streaming content generation requests for Claude models.

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -72,7 +72,7 @@ func (h *GeminiAPIHandler) GeminiModels(c *gin.Context) {
 		}
 		normalizedModels = append(normalizedModels, normalizedModel)
 	}
-	c.JSON(http.StatusOK, gin.H{
+	handlers.WriteModelList(c, gin.H{
 		"models": normalizedModels,
 	})
 }

--- a/sdk/api/handlers/model_list_policy.go
+++ b/sdk/api/handlers/model_list_policy.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+// WriteModelList applies an optional authenticated catalog policy before writing
+// a successful model-list response. Execution authorization remains independent.
+func WriteModelList(c *gin.Context, payload any) {
+	metadata, _ := c.Get("accessMetadata")
+	attributes, _ := metadata.(map[string]string)
+	rawPolicy, restricted := attributes[pluginapi.ModelListAllowedIDsMetadataKey]
+	if !restricted {
+		c.JSON(http.StatusOK, payload)
+		return
+	}
+	// Catalogs vary by authenticated identity and must not enter shared caches.
+	c.Header("Cache-Control", "private, no-store")
+	filtered, errFilter := filterModelList(payload, rawPolicy)
+	if errFilter != nil {
+		// Do not disclose policy contents, model identifiers, or credentials.
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": gin.H{
+			"type": "server_error", "message": "Invalid authenticated model-list policy or catalog",
+		}})
+		return
+	}
+	c.JSON(http.StatusOK, filtered)
+}
+
+func filterModelList(payload any, rawPolicy string) (map[string]json.RawMessage, error) {
+	var ids []string
+	if errDecode := json.Unmarshal([]byte(rawPolicy), &ids); errDecode != nil || ids == nil {
+		return nil, fmt.Errorf("policy must be a JSON string array")
+	}
+	allowed := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" || strings.TrimSpace(id) != id {
+			return nil, fmt.Errorf("policy contains an invalid model ID")
+		}
+		allowed[id] = struct{}{}
+	}
+	raw, errEncode := json.Marshal(payload)
+	if errEncode != nil {
+		return nil, errEncode
+	}
+	var catalog map[string]json.RawMessage
+	if errDecode := json.Unmarshal(raw, &catalog); errDecode != nil {
+		return nil, errDecode
+	}
+	field := "data"
+	if _, exists := catalog[field]; !exists {
+		field = "models"
+	}
+	var rows []json.RawMessage
+	if rawRows, exists := catalog[field]; !exists {
+		return nil, fmt.Errorf("missing model list")
+	} else if errDecode := json.Unmarshal(rawRows, &rows); errDecode != nil {
+		return nil, errDecode
+	}
+	kept := make([]json.RawMessage, 0, len(rows))
+	keptIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		var model struct {
+			ID   string `json:"id"`
+			Slug string `json:"slug"`
+			Name string `json:"name"`
+		}
+		if errDecode := json.Unmarshal(row, &model); errDecode != nil {
+			return nil, errDecode
+		}
+		id := model.ID
+		if id == "" {
+			id = model.Slug
+		}
+		if id == "" {
+			id = model.Name
+		}
+		_, match := allowed[id]
+		// Gemini resource names use models/<id>, whereas calls commonly use <id>.
+		if !match && model.ID == "" && model.Slug == "" && strings.HasPrefix(model.Name, "models/") {
+			_, match = allowed[strings.TrimPrefix(model.Name, "models/")]
+		}
+		if id != "" && match {
+			kept = append(kept, row)
+			keptIDs = append(keptIDs, id)
+		}
+	}
+	catalog[field], errEncode = json.Marshal(kept)
+	if errEncode != nil {
+		return nil, errEncode
+	}
+	// Claude catalogs carry boundary IDs; never leave a removed ID in them.
+	for _, boundary := range []string{"first_id", "last_id"} {
+		if _, exists := catalog[boundary]; !exists {
+			continue
+		}
+		var value any
+		if len(keptIDs) > 0 {
+			value = keptIDs[0]
+			if boundary == "last_id" {
+				value = keptIDs[len(keptIDs)-1]
+			}
+		}
+		catalog[boundary], _ = json.Marshal(value)
+	}
+	return catalog, nil
+}

--- a/sdk/api/handlers/model_list_policy_test.go
+++ b/sdk/api/handlers/model_list_policy_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func TestModelListPolicyFormats(t *testing.T) {
+	for _, tc := range []struct{ name, payload, policy, want string }{
+		{"openai", `{"object":"list","data":[{"id":"a","created":9007199254740993},{"id":"b"}]}`, `["a"]`, `{"object":"list","data":[{"id":"a","created":9007199254740993}]}`},
+		{"codex", `{"models":[{"slug":"a","extra":{"x":true}},{"slug":"b"}]}`, `["a"]`, `{"models":[{"slug":"a","extra":{"x":true}}]}`},
+		{"gemini", `{"models":[{"name":"models/a"},{"name":"models/b"}]}`, `["a"]`, `{"models":[{"name":"models/a"}]}`},
+		{"gemini-resource", `{"models":[{"name":"models/a"}]}`, `["models/a"]`, `{"models":[{"name":"models/a"}]}`},
+		{"claude-boundaries", `{"data":[{"id":"a"},{"id":"b"},{"id":"c"}],"first_id":"a","last_id":"c","has_more":false}`, `["b"]`, `{"data":[{"id":"b"}],"first_id":"b","last_id":"b","has_more":false}`},
+		{"empty", `{"data":[{"id":"a"}],"first_id":"a","last_id":"a"}`, `[]`, `{"data":[],"first_id":null,"last_id":null}`},
+		{"exact-no-wildcard", `{"data":[{"id":"abc"},{"id":"A"}]}`, `["a","*"]`, `{"data":[]}`},
+		{"duplicates", `{"data":[{"id":"a"},{"id":"b"}]}`, `["a","a"]`, `{"data":[{"id":"a"}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := filterModelList(json.RawMessage(tc.payload), tc.policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var expected map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tc.want), &expected); err != nil {
+				t.Fatal(err)
+			}
+			want, _ := json.Marshal(expected)
+			if string(raw) != string(want) {
+				t.Fatalf("got %s, want %s", raw, want)
+			}
+		})
+	}
+}
+
+func TestModelListPolicyFailClosed(t *testing.T) {
+	for _, policy := range []string{"", "null", "{}", `[1]`, `[null]`, `[""]`, `[" a"]`, `["a"] trailing`} {
+		t.Run(policy, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Set("accessMetadata", map[string]string{pluginapi.ModelListAllowedIDsMetadataKey: policy})
+			WriteModelList(c, gin.H{"data": []gin.H{{"id": "private-model"}}})
+			if w.Code != 500 || strings.Contains(w.Body.String(), "private-model") {
+				t.Fatalf("unexpected response: %d %s", w.Code, w.Body)
+			}
+		})
+	}
+}
+
+func TestModelListPolicyIdentityIsolation(t *testing.T) {
+	payload := gin.H{"data": []gin.H{{"id": "a"}, {"id": "b"}}}
+	for _, policy := range []string{`["a"]`, `["b"]`, ""} {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/v1/models?model_list_allowed_ids=[]", nil)
+		c.Request.Header.Set("model_list_allowed_ids", "[]")
+		if policy != "" {
+			c.Set("accessMetadata", map[string]string{pluginapi.ModelListAllowedIDsMetadataKey: policy})
+		}
+		WriteModelList(c, payload)
+		if w.Code != 200 {
+			t.Fatal(w.Code)
+		}
+		var response struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		if policy == "" {
+			if len(response.Data) != 2 {
+				t.Fatal("client headers/query changed unrestricted catalog")
+			}
+		} else {
+			if len(response.Data) != 1 || !strings.Contains(policy, `"`+response.Data[0].ID+`"`) {
+				t.Fatalf("cross-identity response: %s", w.Body)
+			}
+			if w.Header().Get("Cache-Control") != "private, no-store" {
+				t.Fatal("missing cache protection")
+			}
+		}
+	}
+}
+
+func TestModelListPolicyInvalidCatalog(t *testing.T) {
+	for _, raw := range []string{`null`, `{}`, `{"data":{}}`, `{"data":[1]}`} {
+		if _, err := filterModelList(json.RawMessage(raw), `["a"]`); err == nil {
+			t.Fatalf("accepted invalid catalog %s", raw)
+		}
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -61,7 +61,7 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	if _, ok := c.Request.URL.Query()["client_version"]; ok {
 		clientVersion := c.Query("client_version")
-		c.JSON(http.StatusOK, h.codexClientModelsResponse(clientVersion))
+		handlers.WriteModelList(c, h.codexClientModelsResponse(clientVersion))
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 		filteredModels[i] = filteredModel
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	handlers.WriteModelList(c, gin.H{
 		"object": "list",
 		"data":   filteredModels,
 	})

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -448,6 +448,11 @@ type FrontendAuthRequest struct {
 	Body []byte
 }
 
+// ModelListAllowedIDsMetadataKey optionally restricts discovery to exact model IDs.
+// The value is a JSON string array; absent means unrestricted and [] means empty.
+// It affects model-list responses only, not execution authorization.
+const ModelListAllowedIDsMetadataKey = "model_list_allowed_ids"
+
 // FrontendAuthResponse reports the authentication decision and identity metadata.
 type FrontendAuthResponse struct {
 	// Authenticated reports whether the request was accepted.


### PR DESCRIPTION
## Motivation

Implements a narrow version of option B from https://github.com/router-for-me/CLIProxyAPI/discussions/4968 (originally issue #4949).

Frontend-auth plugins can enforce inference permissions today, but standard model discovery still exposes the global catalog. This lets authenticated providers supply an optional discovery allowlist without custom deployments, endpoints, or replacing native authentication. I maintain a virtual-key plugin and would like clients to keep using the ordinary base URL.

## Changes

- Add `pluginapi.ModelListAllowedIDsMetadataKey` (`model_list_allowed_ids`): a JSON array carried in successful authentication metadata.
- Apply a shared final-response filter to OpenAI, Claude, Gemini, Codex-client and Grok lists, including Home-backed list responses.
- Omitted metadata preserves existing behavior; `[]` returns an empty catalog; malformed policies fail closed without exposing policy values.
- Preserve retained model fields and recompute Claude boundary IDs. Prevent shared caching of restricted responses.
- Document the opt-in contract in `docs/sdk-access.md`.

## Scope and compatibility

This is **discovery filtering only**, not an inference authorization mechanism. Plugins must continue enforcing execution permissions. No native-key configuration, plugin wire schema, Docker settings or existing-key behavior changes are required.

The initial contract intentionally uses exact, case-sensitive IDs (no wildcards/deny rules). Gemini also accepts names without its resource prefix. Claude cloaking requires the final displayed ID. Individual Gemini model detail requests and references inside retained model fields are outside this list-only scope. The contract name/design is open to maintainer feedback.

## Validation

Tested against upstream `2a6b87a` with Go 1.27.1 on Linux:

- `go build -o /tmp/cpa-model-list-contribution-server ./cmd/server`
- `go test ./...`
- `go test -race ./sdk/api/handlers ./internal/api`
- `go vet ./sdk/api/handlers/... ./internal/api/...`
- `git diff --check`

Added unit coverage for supported payload shapes, exact matching, empty/invalid policies, numeric precision, boundary IDs, and identity isolation. Added real authentication-middleware/handler tests for OpenAI, Claude, Gemini, Codex-client and Grok routes, including invalid credentials, fail-closed behavior, and unchanged native catalogs. Home list call sites use the same writer; no new live Home-backend integration test is claimed.

No production deployment was changed for this contribution.
