### PR TITLE
feat(executor): synthesize Codex compaction for Claude, Antigravity and Gemini upstreams

### DIFF
--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -27,6 +27,9 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompaction(ctx, e, auth, req, opts)
+	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	if !antigravityCoolingDisabled(auth, e.cfg) {
 		if inCooldown, remaining, errCooldown := antigravityIsInShortCooldownRequired(ctx, auth, baseModel, time.Now()); errCooldown != nil {

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -24,6 +24,9 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompactionStream(ctx, e, auth, req, opts)
+	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 
 	ctx = context.WithValue(ctx, "alt", "")

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -21,6 +21,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompaction(ctx, e, auth, req, opts)
+	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)
 

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -23,6 +23,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompactionStream(ctx, e, auth, req, opts)
+	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
 	upstreamModel := e.upstreamModel(baseModel)
 

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -130,6 +130,9 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if opts.Alt == "responses/compact" {
 		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
 	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompaction(ctx, e, auth, req, opts)
+	}
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractions(ctx, auth, req, opts)
 	}
@@ -248,6 +251,9 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	}
+	if helps.SyntheticCompactionSupported(req.Payload, opts) {
+		return helps.ExecuteSyntheticCompactionStream(ctx, e, auth, req, opts)
 	}
 	if shouldExecuteNativeInteractions(auth, opts) {
 		return e.executeInteractionsStream(ctx, auth, req, opts)

--- a/internal/runtime/executor/helps/codex_compaction_fallback.go
+++ b/internal/runtime/executor/helps/codex_compaction_fallback.go
@@ -1,0 +1,312 @@
+package helps
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Codex "remote compaction v2" sends a normal Responses request whose input
+// ends with a {"type":"compaction_trigger"} item and expects exactly one
+// output item of type "compaction" back. Only OpenAI/Codex upstreams can
+// produce the opaque encrypted_content blob. For every other upstream this
+// file synthesizes the compaction: it asks the upstream model for a handoff
+// summary, wraps the summary into a compaction item with a proxy-owned
+// marker, and on replay turns that item back into a plain user message so
+// the model keeps the conversation state instead of losing it.
+
+const (
+	codexCompactionTriggerType = "compaction_trigger"
+	codexCompactionItemType    = "compaction"
+	// syntheticCompactionPrefix marks encrypted_content values produced by this
+	// proxy. Native OpenAI blobs start with "gAAAA" and never match it.
+	syntheticCompactionPrefix = "cpa-compaction-v1:"
+
+	syntheticCompactionPrompt = "The context window is being compacted. Do not continue the task. " +
+		"Write a handoff summary for a model that will continue this conversation without seeing the earlier messages. " +
+		"Include, in this order: the user's goal and constraints; decisions made and why; what has been done so far " +
+		"(files read or changed, commands run, results, errors); the current state of any tool interaction; " +
+		"open questions or approvals still pending from the user; and the exact next steps. " +
+		"Be precise: keep file paths, identifiers, numbers, error text and user quotes verbatim. " +
+		"Output plain text only, no preamble."
+
+	syntheticCompactionReplayPrefix = "The conversation so far was compacted. The following summary, written by the previous model window, " +
+		"is the authoritative state of the task. Continue from it without repeating completed work:\n\n"
+)
+
+type compactionExecutor interface {
+	Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error)
+}
+
+// IsCodexCompactionTriggerRequest reports whether a Responses payload asks for
+// remote compaction v2 (its input carries a compaction_trigger item).
+func IsCodexCompactionTriggerRequest(payload []byte) bool {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == codexCompactionTriggerType {
+			return true
+		}
+	}
+	return false
+}
+
+// SyntheticCompactionSupported reports whether the fallback applies: the
+// request is a compaction trigger coming from the Responses API.
+func SyntheticCompactionSupported(payload []byte, opts cliproxyexecutor.Options) bool {
+	if opts.Alt == "responses/compact" {
+		return false
+	}
+	if opts.SourceFormat != sdktranslator.FormatOpenAIResponse {
+		return false
+	}
+	return IsCodexCompactionTriggerRequest(payload)
+}
+
+// ExecuteSyntheticCompaction runs the summary turn and returns a non-streaming
+// Responses payload whose only output item is a compaction item.
+func ExecuteSyntheticCompaction(ctx context.Context, exec compactionExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	responseJSON, headers, err := runSyntheticCompaction(ctx, exec, auth, req, opts)
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: responseJSON, Headers: headers}, nil
+}
+
+// ExecuteSyntheticCompactionStream runs the summary turn and replays the
+// result as a minimal Responses SSE stream.
+func ExecuteSyntheticCompactionStream(ctx context.Context, exec compactionExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	responseJSON, headers, err := runSyntheticCompaction(ctx, exec, auth, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	chunks := SyntheticCompactionStreamChunks(responseJSON)
+	out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+	for _, chunk := range chunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	close(out)
+	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}, nil
+}
+
+func runSyntheticCompaction(ctx context.Context, exec compactionExecutor, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) ([]byte, map[string][]string, error) {
+	if exec == nil {
+		return nil, nil, errors.New("synthetic compaction: executor is nil")
+	}
+	summaryPayload := BuildSyntheticCompactionSummaryPayload(req.Payload)
+	summaryReq := req
+	summaryReq.Payload = summaryPayload
+	summaryOpts := opts
+	summaryOpts.Stream = false
+	summaryOpts.Alt = ""
+	summaryOpts.OriginalRequest = summaryPayload
+	summaryOpts.ResponseFormat = sdktranslator.FormatOpenAIResponse
+	summaryOpts.WebSocketResponseObserver = nil
+
+	resp, err := exec.Execute(ctx, auth, summaryReq, summaryOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("synthetic compaction: summary request failed: %w", err)
+	}
+	summary := strings.TrimSpace(responsesOutputText(resp.Payload))
+	if summary == "" {
+		return nil, nil, errors.New("synthetic compaction: upstream returned an empty summary")
+	}
+	model := strings.TrimSpace(gjson.GetBytes(req.Payload, "model").String())
+	if model == "" {
+		model = req.Model
+	}
+	item := SyntheticCompactionItem(summary)
+	responseJSON := syntheticCompactionResponse(model, item, gjson.GetBytes(resp.Payload, "usage"))
+	log.Infof("synthetic compaction: produced compaction item model=%s summary_chars=%d", model, len(summary))
+	return responseJSON, resp.Headers, nil
+}
+
+// BuildSyntheticCompactionSummaryPayload turns a compaction trigger request
+// into a plain, tool-free summary request for the same upstream model.
+func BuildSyntheticCompactionSummaryPayload(payload []byte) []byte {
+	out := removeInputItemsByType(payload, codexCompactionTriggerType)
+	for _, field := range []string{"tools", "tool_choice", "parallel_tool_calls", "include", "stream", "text.format", "max_output_tokens"} {
+		out, _ = sjson.DeleteBytes(out, field)
+	}
+	message := []byte(`{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}`)
+	message, _ = sjson.SetBytes(message, "content.0.text", syntheticCompactionPrompt)
+	out, _ = sjson.SetRawBytes(out, "input.-1", message)
+	out, _ = sjson.SetBytes(out, "stream", false)
+	return out
+}
+
+// SyntheticCompactionItem builds the compaction output item carrying the
+// summary under the proxy marker.
+func SyntheticCompactionItem(summary string) []byte {
+	item := []byte(`{"type":"compaction","id":"","encrypted_content":""}`)
+	item, _ = sjson.SetBytes(item, "id", "cmp_"+strings.ReplaceAll(uuid.NewString(), "-", ""))
+	item, _ = sjson.SetBytes(item, "encrypted_content", syntheticCompactionPrefix+base64.RawURLEncoding.EncodeToString([]byte(summary)))
+	return item
+}
+
+// DecodeSyntheticCompaction returns the summary carried by a proxy-produced
+// compaction item, or false for foreign (natively encrypted) items.
+func DecodeSyntheticCompaction(encryptedContent string) (string, bool) {
+	if !strings.HasPrefix(encryptedContent, syntheticCompactionPrefix) {
+		return "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(encryptedContent, syntheticCompactionPrefix))
+	if err != nil {
+		return "", false
+	}
+	return string(raw), true
+}
+
+// InputHasSyntheticCompaction reports whether a Responses input array carries
+// a proxy-produced compaction item.
+func InputHasSyntheticCompaction(inputRaw []byte) bool {
+	input := gjson.ParseBytes(inputRaw)
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) != codexCompactionItemType {
+			continue
+		}
+		if _, ok := DecodeSyntheticCompaction(item.Get("encrypted_content").String()); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// RewriteSyntheticCompactionInput prepares a Responses payload for a
+// non-Codex upstream: proxy-produced compaction items become user messages
+// carrying the summary, foreign compaction items and stray triggers are
+// dropped with a warning because no other upstream can read them.
+func RewriteSyntheticCompactionInput(payload []byte) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return payload
+	}
+	items := make([][]byte, 0, len(input.Array()))
+	changed := false
+	for _, item := range input.Array() {
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case codexCompactionTriggerType:
+			changed = true
+			continue
+		case codexCompactionItemType:
+			changed = true
+			summary, ok := DecodeSyntheticCompaction(item.Get("encrypted_content").String())
+			if !ok {
+				log.Warnf("synthetic compaction: dropping compaction item %s encrypted by another provider; earlier context is not recoverable for this upstream", item.Get("id").String())
+				continue
+			}
+			message := []byte(`{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}`)
+			message, _ = sjson.SetBytes(message, "content.0.text", syntheticCompactionReplayPrefix+summary)
+			items = append(items, message)
+			continue
+		}
+		items = append(items, []byte(item.Raw))
+	}
+	if !changed {
+		return payload
+	}
+	out, err := sjson.SetRawBytes(payload, "input", translatorcommon.JoinRawArray(items))
+	if err != nil {
+		return payload
+	}
+	return out
+}
+
+// SyntheticCompactionStreamChunks renders a completed Responses payload as
+// the minimal SSE sequence Codex expects for a compaction turn.
+func SyntheticCompactionStreamChunks(responseJSON []byte) [][]byte {
+	seq := 0
+	next := func() int { seq++; return seq }
+	inProgress, _ := sjson.SetBytes(responseJSON, "status", "in_progress")
+	inProgress, _ = sjson.SetRawBytes(inProgress, "output", []byte(`[]`))
+	inProgress, _ = sjson.DeleteBytes(inProgress, "usage")
+	item := gjson.GetBytes(responseJSON, "output.0").Raw
+
+	event := func(name string, body string) []byte {
+		payload := []byte(body)
+		payload, _ = sjson.SetBytes(payload, "sequence_number", next())
+		return translatorcommon.SSEEventData(name, payload)
+	}
+	created, _ := sjson.SetRawBytes([]byte(`{"type":"response.created","sequence_number":0,"response":{}}`), "response", inProgress)
+	progress, _ := sjson.SetRawBytes([]byte(`{"type":"response.in_progress","sequence_number":0,"response":{}}`), "response", inProgress)
+	added, _ := sjson.SetRawBytes([]byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{}}`), "item", []byte(item))
+	done, _ := sjson.SetRawBytes([]byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{}}`), "item", []byte(item))
+	completed, _ := sjson.SetRawBytes([]byte(`{"type":"response.completed","sequence_number":0,"response":{}}`), "response", responseJSON)
+	return [][]byte{
+		event("response.created", string(created)),
+		event("response.in_progress", string(progress)),
+		event("response.output_item.added", string(added)),
+		event("response.output_item.done", string(done)),
+		event("response.completed", string(completed)),
+	}
+}
+
+func syntheticCompactionResponse(model string, item []byte, usage gjson.Result) []byte {
+	out := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"model":"","output":[]}`)
+	out, _ = sjson.SetBytes(out, "id", "resp_"+strings.ReplaceAll(uuid.NewString(), "-", ""))
+	out, _ = sjson.SetBytes(out, "created_at", time.Now().Unix())
+	out, _ = sjson.SetBytes(out, "model", model)
+	out, _ = sjson.SetRawBytes(out, "output.-1", item)
+	if usage.Exists() && usage.IsObject() {
+		out, _ = sjson.SetRawBytes(out, "usage", []byte(usage.Raw))
+	} else {
+		out, _ = sjson.SetRawBytes(out, "usage", []byte(`{"input_tokens":0,"output_tokens":0,"total_tokens":0}`))
+	}
+	return EnsureResponsesUsageDetails(out)
+}
+
+func responsesOutputText(payload []byte) string {
+	var text strings.Builder
+	for _, item := range gjson.GetBytes(payload, "output").Array() {
+		if strings.TrimSpace(item.Get("type").String()) != "message" {
+			continue
+		}
+		for _, part := range item.Get("content").Array() {
+			if strings.TrimSpace(part.Get("type").String()) == "output_text" {
+				text.WriteString(part.Get("text").String())
+			}
+		}
+	}
+	return text.String()
+}
+
+func removeInputItemsByType(payload []byte, itemType string) []byte {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return payload
+	}
+	items := make([][]byte, 0, len(input.Array()))
+	changed := false
+	for _, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) == itemType {
+			changed = true
+			continue
+		}
+		items = append(items, []byte(item.Raw))
+	}
+	if !changed {
+		return payload
+	}
+	out, err := sjson.SetRawBytes(payload, "input", translatorcommon.JoinRawArray(items))
+	if err != nil {
+		return payload
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/codex_compaction_fallback.go
+++ b/internal/runtime/executor/helps/codex_compaction_fallback.go
@@ -34,13 +34,7 @@ const (
 	// proxy. Native OpenAI blobs start with "gAAAA" and never match it.
 	syntheticCompactionPrefix = "cpa-compaction-v1:"
 
-	syntheticCompactionPrompt = "The context window is being compacted. Do not continue the task. " +
-		"Write a handoff summary for a model that will continue this conversation without seeing the earlier messages. " +
-		"Include, in this order: the user's goal and constraints; decisions made and why; what has been done so far " +
-		"(files read or changed, commands run, results, errors); the current state of any tool interaction; " +
-		"open questions or approvals still pending from the user; and the exact next steps. " +
-		"Be precise: keep file paths, identifiers, numbers, error text and user quotes verbatim. " +
-		"Output plain text only, no preamble."
+	syntheticCompactionPrompt = "Summarize the transcript inside <summary></summary> tags. Include relevant information in the summary such that this conversation will be continued by a new context window without needing to redo work or be reprovided with relevant constraints or context. Be sure to preserve: (1) any difficulties or problems that came up, and how they were handled or resolved; (2) any possibilities, options, or approaches that were considered but ruled out, and why; (3) the user's goal and explicit constraints, quoted verbatim where possible; (4) decisions made and their rationale; (5) what has been completed, with file paths, identifiers, commands, results and error text kept verbatim; (6) the current state of any tool interaction and anything still pending from the user; (7) the exact next steps. Do not continue the task; write only the summary."
 
 	syntheticCompactionReplayPrefix = "The conversation so far was compacted. The following summary, written by the previous model window, " +
 		"is the authoritative state of the task. Continue from it without repeating completed work:\n\n"
@@ -121,7 +115,7 @@ func runSyntheticCompaction(ctx context.Context, exec compactionExecutor, auth *
 	if err != nil {
 		return nil, nil, fmt.Errorf("synthetic compaction: summary request failed: %w", err)
 	}
-	summary := strings.TrimSpace(responsesOutputText(resp.Payload))
+	summary := extractSummaryTag(strings.TrimSpace(responsesOutputText(resp.Payload)))
 	if summary == "" {
 		return nil, nil, errors.New("synthetic compaction: upstream returned an empty summary")
 	}
@@ -309,4 +303,15 @@ func removeInputItemsByType(payload []byte, itemType string) []byte {
 		return payload
 	}
 	return out
+}
+
+// extractSummaryTag returns the text inside <summary></summary> when the
+// model followed the instruction, and the whole text otherwise.
+func extractSummaryTag(text string) string {
+	start := strings.Index(text, "<summary>")
+	end := strings.LastIndex(text, "</summary>")
+	if start >= 0 && end > start {
+		return strings.TrimSpace(text[start+len("<summary>") : end])
+	}
+	return text
 }

--- a/internal/runtime/executor/helps/codex_compaction_fallback_test.go
+++ b/internal/runtime/executor/helps/codex_compaction_fallback_test.go
@@ -1,0 +1,88 @@
+package helps
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type fakeCompactionExecutor struct {
+	gotPayload []byte
+}
+
+func (f *fakeCompactionExecutor) Execute(_ context.Context, _ *cliproxyauth.Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	f.gotPayload = req.Payload
+	return cliproxyexecutor.Response{Payload: []byte(`{"id":"resp_x","object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"GOAL: finish.\nDONE: read a.go"}]}],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}`)}, nil
+}
+
+const triggerPayload = `{"model":"claude-fable-5-1","stream":true,"tools":[{"type":"function","name":"exec"}],"tool_choice":"auto","include":["reasoning.encrypted_content"],"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"do it"}]},{"type":"function_call","name":"exec","call_id":"c1","arguments":"{}"},{"type":"function_call_output","call_id":"c1","output":"ok"},{"type":"compaction_trigger"}]}`
+
+func TestSyntheticCompactionRoundTrip(t *testing.T) {
+	t.Parallel()
+	opts := cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAIResponse}
+	if !SyntheticCompactionSupported([]byte(triggerPayload), opts) {
+		t.Fatal("trigger payload not detected")
+	}
+	fake := &fakeCompactionExecutor{}
+	result, err := ExecuteSyntheticCompactionStream(context.Background(), fake, nil, cliproxyexecutor.Request{Model: "claude-fable-5-1", Payload: []byte(triggerPayload)}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gjson.GetBytes(fake.gotPayload, "tools").Exists() || gjson.GetBytes(fake.gotPayload, "stream").Bool() {
+		t.Fatalf("summary request must be tool-free and non-streaming: %s", fake.gotPayload)
+	}
+	if strings.Contains(string(fake.gotPayload), "compaction_trigger") {
+		t.Fatalf("summary request still carries the trigger: %s", fake.gotPayload)
+	}
+	var chunks [][]byte
+	for chunk := range result.Chunks {
+		chunks = append(chunks, chunk.Payload)
+	}
+	if len(chunks) != 5 {
+		t.Fatalf("expected 5 SSE chunks, got %d", len(chunks))
+	}
+	last := string(chunks[4])
+	if !strings.HasPrefix(last, "event: response.completed\ndata: ") {
+		t.Fatalf("unexpected final chunk: %s", last)
+	}
+	completed := gjson.Parse(strings.TrimPrefix(last, "event: response.completed\ndata: "))
+	output := completed.Get("response.output").Array()
+	if len(output) != 1 || output[0].Get("type").String() != "compaction" {
+		t.Fatalf("expected exactly one compaction item, got %s", completed.Get("response.output").Raw)
+	}
+	summary, ok := DecodeSyntheticCompaction(output[0].Get("encrypted_content").String())
+	if !ok || !strings.Contains(summary, "DONE: read a.go") {
+		t.Fatalf("summary not recoverable: %q %v", summary, ok)
+	}
+
+	replay := `{"model":"claude-fable-5-1","input":[{"type":"message","role":"developer","content":[{"type":"input_text","text":"sys"}]},` + output[0].Raw + `,{"type":"compaction","id":"cmp_foreign","encrypted_content":"gAAAAABforeign"},{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`
+	rewritten := RewriteSyntheticCompactionInput([]byte(replay))
+	items := gjson.GetBytes(rewritten, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items after rewrite (foreign dropped), got %d: %s", len(items), rewritten)
+	}
+	if items[1].Get("type").String() != "message" || items[1].Get("role").String() != "user" || !strings.Contains(items[1].Get("content.0.text").String(), "DONE: read a.go") {
+		t.Fatalf("compaction not restored as user message: %s", items[1].Raw)
+	}
+	if !InputHasSyntheticCompaction([]byte(gjson.Get(replay, "input").Raw)) {
+		t.Fatal("InputHasSyntheticCompaction should detect the proxy item")
+	}
+}
+
+func TestSyntheticCompactionNotSupportedForCompactAltOrOtherFormats(t *testing.T) {
+	t.Parallel()
+	if SyntheticCompactionSupported([]byte(triggerPayload), cliproxyexecutor.Options{Alt: "responses/compact", SourceFormat: sdktranslator.FormatOpenAIResponse}) {
+		t.Fatal("compact alt must keep the native path")
+	}
+	if SyntheticCompactionSupported([]byte(triggerPayload), cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}) {
+		t.Fatal("non-Responses sources must be ignored")
+	}
+	if SyntheticCompactionSupported([]byte(`{"input":[{"type":"message"}]}`), cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}) {
+		t.Fatal("payload without trigger must be ignored")
+	}
+}

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -39,7 +39,21 @@ func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header,
 // TranslateRequestWithCodexMultiAgentV2 normalizes official Codex multi-agent
 // input before translating it to a non-Codex target protocol.
 func TranslateRequestWithCodexMultiAgentV2(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, payload []byte, stream bool) []byte {
+	payload = rewriteCompactionForNonCodexTarget(from, to, payload)
 	return multiagentv2.TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, payload, stream)
+}
+
+// rewriteCompactionForNonCodexTarget restores proxy-produced compaction
+// summaries before a Responses payload is translated for an upstream that
+// cannot read compaction items natively.
+func rewriteCompactionForNonCodexTarget(from, to sdktranslator.Format, payload []byte) []byte {
+	if from != sdktranslator.FormatOpenAIResponse {
+		return payload
+	}
+	if to == sdktranslator.FormatCodex || to == sdktranslator.FormatOpenAIResponse {
+		return payload
+	}
+	return RewriteSyntheticCompactionInput(payload)
 }
 
 // TranslateRequestPairWithCodexMultiAgentV2 translates the untouched baseline
@@ -78,6 +92,7 @@ func TranslateRequestWithAPIKeyModelCompatibility(ctx context.Context, headers h
 	if !isCompat {
 		return TranslateRequestWithCodexMultiAgentV2(ctx, headers, cfg, from, to, model, payload, stream)
 	}
+	payload = rewriteCompactionForNonCodexTarget(from, to, payload)
 	if from == sdktranslator.FormatOpenAIResponse {
 		payload = RewriteCodexOrphanDelegationInput(ctx, headers, payload, cfg)
 		if to != sdktranslator.FormatCodex && to != sdktranslator.FormatOpenAIResponse {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"net/http"
 	"slices"
 	"strings"
@@ -132,7 +133,7 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	// function_call / function_call_output pairings.
 	// See: https://github.com/router-for-me/CLIProxyAPI/issues/2207
 	var mergedInput []byte
-	if allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
+	if (allowCompactionReplayBypass || helps.InputHasSyntheticCompaction([]byte(nextInput.Raw))) && inputContainsFullTranscript(nextInput) {
 		log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
 		mergedInput = []byte(nextInput.Raw)
 	} else {


### PR DESCRIPTION
## Problem

Codex CLI / Desktop 0.153 always compacts conversation history upstream ("remote compaction v2"). When the context limit is reached it sends a normal Responses request whose input ends with `{"type":"compaction_trigger"}` (turn metadata `request_kind: "compaction"`) and requires the reply to contain exactly one `compaction` output item, which it then replays as the whole earlier history.

Only Codex and xAI upstreams can answer that. For Claude, Antigravity and Gemini credentials the proxy forwards the trigger as an ordinary turn, the model answers with a `message`, and Codex aborts the turn:

```
ERROR: Error running remote compact task: Fatal error: remote compaction v2 expected exactly one compaction output item, got 0 from 1 output items
```

The client-side alternatives do not help: `features.remote_compaction_v2 = false` switches Codex to `POST /responses/compact`, which these executors answer with 501, and `requires_openai_auth = false` does not change the behaviour. So any Codex thread routed to a non-Codex upstream dies the first time it fills its context window (reproduced with `model_auto_compact_token_limit = 20000` on `claude-fable-5-1` and `gemini-3.8-flash-high`).

## Change

`internal/runtime/executor/helps/codex_compaction_fallback.go` adds a synthetic compaction for upstreams without native support:

- `SyntheticCompactionSupported` detects a Responses request carrying a `compaction_trigger` item (never for `Alt == "responses/compact"`).
- `ExecuteSyntheticCompaction` / `ExecuteSyntheticCompactionStream` run one tool-free, non-streaming summary turn on the same executor and credential, then return a Responses payload whose only output item is `{"type":"compaction","id":"cmp_…","encrypted_content":"cpa-compaction-v1:<base64url summary>"}` (as JSON or as the minimal SSE sequence `response.created → in_progress → output_item.added → output_item.done → completed`).
- `RewriteSyntheticCompactionInput` runs inside `TranslateRequestWithCodexMultiAgentV2` / `TranslateRequestWithAPIKeyModelCompatibility` for `openai-response → non-Codex` targets: a proxy-produced compaction item becomes a user message carrying the summary, stray `compaction_trigger` items are removed, and compaction items encrypted by another provider are dropped with a warning instead of the previous silent `unmapped input item type` debug line.
- Claude, Antigravity and Gemini executors call the helper at the top of `Execute` / `ExecuteStream` (right after the existing `responses/compact` guard).
- `openai_responses_websocket_requests.go`: a full-transcript replay that contains a proxy-produced compaction item takes the same "skip stale merge" path that Codex upstreams already use, so the compacted history is not re-merged with `lastRequest`.

The native OpenAI blob format is not imitated: the marker prefix makes proxy items unambiguous, and `gAAAA…` blobs from OpenAI are never decodable here anyway.

Executors and helpers only; `internal/translator` is untouched.

## Verification

```
gofmt -l internal sdk cmd                      # clean (pre-existing upstream files aside)
go vet ./...                                   # clean
go build -o test-output ./cmd/server && rm -f test-output
go test ./...                                  # 92 packages ok
```

Unit: `TestSyntheticCompactionRoundTrip` (trigger → summary request shape → 5 SSE chunks with one compaction item → replay restores the summary and drops a foreign blob) and `TestSyntheticCompactionNotSupportedForCompactAltOrOtherFormats`.

Live, Codex CLI 0.153.2 with `model_auto_compact_token_limit = 20000`, task that reads three large files:

| Upstream | Transport | Before | After |
|---|---|---|---|
| claude-fable-5-1 (OAuth) | websocket | fatal compaction error | `context compacted`, task finished with the correct answer |
| claude-fable-5-1 (OAuth) | HTTP (`supports_websockets = false`) | fatal compaction error | same |
| gemini-3.8-flash-high (Antigravity) | websocket | fatal compaction error | same |

Proxy log for each run: `synthetic compaction: produced compaction item model=… summary_chars=…`; the rollout contains one `compaction` item with the `cpa-compaction-v1:` marker and the post-compaction turn answers from the summary. Regression probes (gpt-5.6-sol root, claude root without compaction, spawn_agent to a Claude subagent) unchanged.

## Limits

The summary is written by the upstream model from a fixed handoff prompt (goal, decisions, work done, tool state, pending questions, next steps, verbatim paths/ids/errors). It preserves what the model reports, not the opaque state OpenAI's native compaction keeps. Compaction blobs produced by OpenAI and then inherited by a non-Codex subagent thread remain unreadable and are dropped with a warning.
