### PR TITLE
feat(config): support optional names for client api-keys entries

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -63,7 +63,7 @@ func shouldEnableExampleAPIKeySafeMode(cfg *config.Config, commandMode, tuiMode,
 	if tuiMode && !standalone {
 		return false
 	}
-	return safemode.HasExampleAPIKeys(cfg.APIKeys)
+	return safemode.HasExampleAPIKeys(cfg.APIKeyValues())
 }
 
 // main is the entry point of the application.
@@ -594,7 +594,7 @@ func main() {
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
 	serverOptions := []api.ServerOption(nil)
 	if exampleAPIKeySafeMode {
-		matches := safemode.ExampleAPIKeys(cfg.APIKeys)
+		matches := safemode.ExampleAPIKeys(cfg.APIKeyValues())
 		log.WithField("api_keys", strings.Join(matches, ",")).Error("unsafe example API key configured; proxy API endpoints disabled until api-keys is updated")
 		serverOptions = append(serverOptions, api.WithExampleAPIKeySafeMode())
 	}

--- a/cmd/server/main_api_key_entry_test.go
+++ b/cmd/server/main_api_key_entry_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/safemode"
+)
+
+// A named entry must still be checked against the template key list, so a name
+// cannot hide an example API key from safe mode.
+func TestExampleAPIKeyDetectionWithNamedEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []config.APIKeyEntry
+		want    bool
+	}{
+		{
+			name:    "named template key detected",
+			entries: []config.APIKeyEntry{{Key: "your-api-key-1", Name: "alice"}},
+			want:    true,
+		},
+		{
+			name:    "mixed entries detect template key",
+			entries: []config.APIKeyEntry{{Key: "real-key"}, {Key: " your-api-key-2 ", Name: "bob"}},
+			want:    true,
+		},
+		{
+			name:    "named real keys are safe",
+			entries: []config.APIKeyEntry{{Key: "real-key", Name: "alice"}, {Key: "another-key"}},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{SDKConfig: config.SDKConfig{APIKeys: tt.entries}}
+			if got := safemode.HasExampleAPIKeys(cfg.APIKeyValues()); got != tt.want {
+				t.Fatalf("HasExampleAPIKeys() = %v, want %v", got, tt.want)
+			}
+			if got := shouldEnableExampleAPIKeySafeMode(cfg, false, false, false, false, false); got != tt.want {
+				t.Fatalf("shouldEnableExampleAPIKeySafeMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -9,12 +9,12 @@ import (
 func TestShouldEnableExampleAPIKeySafeMode(t *testing.T) {
 	cfgWithExampleKey := &config.Config{
 		SDKConfig: config.SDKConfig{
-			APIKeys: []string{"real-key", " your-api-key-1 "},
+			APIKeys: config.APIKeysFromStrings([]string{"real-key", " your-api-key-1 "}),
 		},
 	}
 	cfgWithRealKey := &config.Config{
 		SDKConfig: config.SDKConfig{
-			APIKeys: []string{"real-key"},
+			APIKeys: config.APIKeysFromStrings([]string{"real-key"}),
 		},
 	}
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,10 +36,14 @@ remote-management:
 auth-dir: "~/.cli-proxy-api"
 
 # API keys for authentication
+# An entry may also be a mapping with an optional name. The name replaces the raw key
+# in usage records and request logs.
 api-keys:
   - "your-api-key-1"
   - "your-api-key-2"
   - "your-api-key-3"
+#  - key: "your-api-key-4"
+#    name: "alice"
 
 # Enable debug logging
 debug: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,8 +36,8 @@ remote-management:
 auth-dir: "~/.cli-proxy-api"
 
 # API keys for authentication
-# An entry may also be a mapping with an optional name. The name replaces the raw key
-# in usage records and request logs.
+# An entry may also be a mapping with an optional name. The name is used for attribution
+# in usage records and request logs; authorization still uses the raw key.
 api-keys:
   - "your-api-key-1"
   - "your-api-key-2"

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -31,7 +31,7 @@ func Register(cfg *sdkconfig.SDKConfig) {
 type provider struct {
 	name string
 	// keys maps a raw API key to its display name; an empty name means the key
-	// itself is used as the principal.
+	// has no attribution label.
 	keys map[string]string
 }
 
@@ -92,13 +92,12 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 			continue
 		}
 		if name, ok := p.keys[candidate.value]; ok {
-			principal := name
-			if principal == "" {
-				principal = candidate.value
-			}
+			// The raw key stays the principal so authorization and cache
+			// isolation keep their per-key scope; the name is attribution only.
 			return &sdkaccess.Result{
-				Provider:  p.Identifier(),
-				Principal: principal,
+				Provider:       p.Identifier(),
+				Principal:      candidate.value,
+				PrincipalLabel: name,
 				Metadata: map[string]string{
 					"source": candidate.source,
 				},

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -30,17 +30,19 @@ func Register(cfg *sdkconfig.SDKConfig) {
 
 type provider struct {
 	name string
-	keys map[string]struct{}
+	// keys maps a raw API key to its display name; an empty name means the key
+	// itself is used as the principal.
+	keys map[string]string
 }
 
-func newProvider(name string, keys []string) *provider {
+func newProvider(name string, keys []sdkaccess.APIKeyEntry) *provider {
 	providerName := strings.TrimSpace(name)
 	if providerName == "" {
 		providerName = sdkaccess.DefaultAccessProviderName
 	}
-	keySet := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		keySet[key] = struct{}{}
+	keySet := make(map[string]string, len(keys))
+	for _, entry := range keys {
+		keySet[entry.Key] = entry.Name
 	}
 	return &provider{name: providerName, keys: keySet}
 }
@@ -89,10 +91,14 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		if candidate.value == "" {
 			continue
 		}
-		if _, ok := p.keys[candidate.value]; ok {
+		if name, ok := p.keys[candidate.value]; ok {
+			principal := name
+			if principal == "" {
+				principal = candidate.value
+			}
 			return &sdkaccess.Result{
 				Provider:  p.Identifier(),
-				Principal: candidate.value,
+				Principal: principal,
 				Metadata: map[string]string{
 					"source": candidate.source,
 				},
@@ -117,22 +123,29 @@ func extractBearerToken(header string) string {
 	return strings.TrimSpace(parts[1])
 }
 
-func normalizeKeys(keys []string) []string {
+// normalizeKeys trims entries, drops empty keys and deduplicates by key while
+// keeping the first occurrence. When the first occurrence carries no name, a
+// later duplicate may still supply one.
+func normalizeKeys(keys []sdkaccess.APIKeyEntry) []sdkaccess.APIKeyEntry {
 	if len(keys) == 0 {
 		return nil
 	}
-	normalized := make([]string, 0, len(keys))
-	seen := make(map[string]struct{}, len(keys))
-	for _, key := range keys {
-		trimmedKey := strings.TrimSpace(key)
+	normalized := make([]sdkaccess.APIKeyEntry, 0, len(keys))
+	seen := make(map[string]int, len(keys))
+	for _, entry := range keys {
+		trimmedKey := strings.TrimSpace(entry.Key)
 		if trimmedKey == "" {
 			continue
 		}
-		if _, exists := seen[trimmedKey]; exists {
+		trimmedName := strings.TrimSpace(entry.Name)
+		if index, exists := seen[trimmedKey]; exists {
+			if normalized[index].Name == "" && trimmedName != "" {
+				normalized[index].Name = trimmedName
+			}
 			continue
 		}
-		seen[trimmedKey] = struct{}{}
-		normalized = append(normalized, trimmedKey)
+		seen[trimmedKey] = len(normalized)
+		normalized = append(normalized, sdkaccess.APIKeyEntry{Key: trimmedKey, Name: trimmedName})
 	}
 	if len(normalized) == 0 {
 		return nil

--- a/internal/access/config_access/provider_principal_test.go
+++ b/internal/access/config_access/provider_principal_test.go
@@ -11,40 +11,40 @@ import (
 
 func TestProviderPrincipalResolution(t *testing.T) {
 	tests := []struct {
-		name    string
-		entries []sdkaccess.APIKeyEntry
-		key     string
-		want    string
+		name      string
+		entries   []sdkaccess.APIKeyEntry
+		key       string
+		wantLabel string
 	}{
 		{
-			name:    "named entry uses name",
-			entries: []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}},
-			key:     "k1",
-			want:    "alice",
+			name:      "named entry labels the raw key",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}},
+			key:       "k1",
+			wantLabel: "alice",
 		},
 		{
-			name:    "unnamed entry uses raw key",
-			entries: []sdkaccess.APIKeyEntry{{Key: "k1"}},
-			key:     "k1",
-			want:    "k1",
+			name:      "unnamed entry has no label",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "k1"}},
+			key:       "k1",
+			wantLabel: "",
 		},
 		{
-			name:    "duplicate key adopts first non-empty name",
-			entries: []sdkaccess.APIKeyEntry{{Key: "k1"}, {Key: "k1", Name: "alice"}},
-			key:     "k1",
-			want:    "alice",
+			name:      "duplicate key adopts first non-empty name",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "k1"}, {Key: "k1", Name: "alice"}},
+			key:       "k1",
+			wantLabel: "alice",
 		},
 		{
-			name:    "duplicate key keeps first name",
-			entries: []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}, {Key: "k1", Name: "bob"}},
-			key:     "k1",
-			want:    "alice",
+			name:      "duplicate key keeps first name",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}, {Key: "k1", Name: "bob"}},
+			key:       "k1",
+			wantLabel: "alice",
 		},
 		{
-			name:    "whitespace is trimmed",
-			entries: []sdkaccess.APIKeyEntry{{Key: "  k1  ", Name: "  alice  "}},
-			key:     "k1",
-			want:    "alice",
+			name:      "whitespace is trimmed",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "  k1  ", Name: "  alice  "}},
+			key:       "k1",
+			wantLabel: "alice",
 		},
 	}
 
@@ -58,8 +58,11 @@ func TestProviderPrincipalResolution(t *testing.T) {
 			if authErr != nil {
 				t.Fatalf("Authenticate() error = %v", authErr)
 			}
-			if result.Principal != tt.want {
-				t.Fatalf("Principal = %q, want %q", result.Principal, tt.want)
+			if result.Principal != tt.key {
+				t.Fatalf("Principal = %q, want raw key %q", result.Principal, tt.key)
+			}
+			if result.PrincipalLabel != tt.wantLabel {
+				t.Fatalf("PrincipalLabel = %q, want %q", result.PrincipalLabel, tt.wantLabel)
 			}
 		})
 	}

--- a/internal/access/config_access/provider_principal_test.go
+++ b/internal/access/config_access/provider_principal_test.go
@@ -1,0 +1,83 @@
+package configaccess
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+func TestProviderPrincipalResolution(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []sdkaccess.APIKeyEntry
+		key     string
+		want    string
+	}{
+		{
+			name:    "named entry uses name",
+			entries: []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}},
+			key:     "k1",
+			want:    "alice",
+		},
+		{
+			name:    "unnamed entry uses raw key",
+			entries: []sdkaccess.APIKeyEntry{{Key: "k1"}},
+			key:     "k1",
+			want:    "k1",
+		},
+		{
+			name:    "duplicate key adopts first non-empty name",
+			entries: []sdkaccess.APIKeyEntry{{Key: "k1"}, {Key: "k1", Name: "alice"}},
+			key:     "k1",
+			want:    "alice",
+		},
+		{
+			name:    "duplicate key keeps first name",
+			entries: []sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}, {Key: "k1", Name: "bob"}},
+			key:     "k1",
+			want:    "alice",
+		},
+		{
+			name:    "whitespace is trimmed",
+			entries: []sdkaccess.APIKeyEntry{{Key: "  k1  ", Name: "  alice  "}},
+			key:     "k1",
+			want:    "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newProvider("", normalizeKeys(tt.entries))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.key)
+
+			result, authErr := p.Authenticate(context.Background(), req)
+			if authErr != nil {
+				t.Fatalf("Authenticate() error = %v", authErr)
+			}
+			if result.Principal != tt.want {
+				t.Fatalf("Principal = %q, want %q", result.Principal, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderRejectsUnknownKey(t *testing.T) {
+	p := newProvider("", normalizeKeys([]sdkaccess.APIKeyEntry{{Key: "k1", Name: "alice"}}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer other")
+
+	if _, authErr := p.Authenticate(context.Background(), req); authErr == nil {
+		t.Fatal("Authenticate() error = nil, want invalid credential error")
+	}
+}
+
+func TestNormalizeKeysDropsEmptyEntries(t *testing.T) {
+	got := normalizeKeys([]sdkaccess.APIKeyEntry{{Key: "  "}, {Key: "k1"}, {Key: ""}})
+	if len(got) != 1 || got[0].Key != "k1" {
+		t.Fatalf("normalizeKeys() = %#v, want one k1 entry", got)
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -143,17 +143,125 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 }
 
 // api-keys
+// Entries marshal as plain JSON strings when unnamed, so existing clients keep working.
 func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
+
+// PutAPIKeys replaces the whole list. It accepts a plain string array, an array
+// mixing strings and {"key","name"} objects, or an {"items": [...]} wrapper.
 func (h *Handler) PutAPIKeys(c *gin.Context) {
-	h.putStringList(c, func(v []string) {
-		h.cfg.APIKeys = append([]string(nil), v...)
-	}, nil)
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var entries []config.APIKeyEntry
+	if err = json.Unmarshal(data, &entries); err != nil {
+		var obj struct {
+			Items []config.APIKeyEntry `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil || len(obj.Items) == 0 {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		entries = obj.Items
+	}
+	h.cfg.APIKeys = append([]config.APIKeyEntry(nil), entries...)
+	h.persist(c)
 }
+
+// PatchAPIKeys updates a single entry by index or by matching an existing key.
+// A string value updates the key and keeps any existing name; an object value
+// replaces both fields.
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	var body struct {
+		Old   *string         `json:"old"`
+		New   json.RawMessage `json:"new"`
+		Index *int            `json:"index"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	target := &h.cfg.APIKeys
+	if body.Index != nil && len(body.Value) > 0 && *body.Index >= 0 && *body.Index < len(*target) {
+		entry, err := mergeAPIKeyPatch((*target)[*body.Index], body.Value)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		(*target)[*body.Index] = entry
+		h.persist(c)
+		return
+	}
+	if body.Old != nil && len(body.New) > 0 {
+		for i := range *target {
+			if (*target)[i].Key != *body.Old {
+				continue
+			}
+			entry, err := mergeAPIKeyPatch((*target)[i], body.New)
+			if err != nil {
+				c.JSON(400, gin.H{"error": "invalid body"})
+				return
+			}
+			(*target)[i] = entry
+			h.persist(c)
+			return
+		}
+		entry, err := mergeAPIKeyPatch(config.APIKeyEntry{}, body.New)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		*target = append(*target, entry)
+		h.persist(c)
+		return
+	}
+	c.JSON(400, gin.H{"error": "missing fields"})
 }
+
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	target := &h.cfg.APIKeys
+	if idxStr := c.Query("index"); idxStr != "" {
+		var idx int
+		_, err := fmt.Sscanf(idxStr, "%d", &idx)
+		if err == nil && idx >= 0 && idx < len(*target) {
+			*target = append((*target)[:idx], (*target)[idx+1:]...)
+			h.persist(c)
+			return
+		}
+	}
+	if val := strings.TrimSpace(c.Query("value")); val != "" {
+		out := make([]config.APIKeyEntry, 0, len(*target))
+		for _, entry := range *target {
+			if strings.TrimSpace(entry.Key) != val {
+				out = append(out, entry)
+			}
+		}
+		*target = out
+		h.persist(c)
+		return
+	}
+	c.JSON(400, gin.H{"error": "missing index or value"})
+}
+
+// mergeAPIKeyPatch applies a patch value to an entry. String values only replace
+// the key so an existing name survives; object values replace the whole entry.
+func mergeAPIKeyPatch(current config.APIKeyEntry, raw json.RawMessage) (config.APIKeyEntry, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var key string
+		if err := json.Unmarshal(trimmed, &key); err != nil {
+			return current, err
+		}
+		current.Key = key
+		return current, nil
+	}
+	var entry config.APIKeyEntry
+	if err := json.Unmarshal(trimmed, &entry); err != nil {
+		return current, err
+	}
+	return entry, nil
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/api/handlers/management/config_lists_api_keys_test.go
+++ b/internal/api/handlers/management/config_lists_api_keys_test.go
@@ -1,0 +1,163 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func newAPIKeysHandler(t *testing.T, entries []config.APIKeyEntry) *Handler {
+	t.Helper()
+	return &Handler{
+		cfg:            &config.Config{SDKConfig: config.SDKConfig{APIKeys: entries}},
+		configFilePath: writeTestConfigFile(t),
+	}
+}
+
+func TestPutAPIKeysAcceptsPlainAndMixedPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []config.APIKeyEntry
+	}{
+		{
+			name: "plain string array",
+			body: `["k1","k2"]`,
+			want: []config.APIKeyEntry{{Key: "k1"}, {Key: "k2"}},
+		},
+		{
+			name: "mixed array",
+			body: `["k1",{"key":"k2","name":"alice"}]`,
+			want: []config.APIKeyEntry{{Key: "k1"}, {Key: "k2", Name: "alice"}},
+		},
+		{
+			name: "items wrapper",
+			body: `{"items":["k1",{"key":"k2","name":"bob"}]}`,
+			want: []config.APIKeyEntry{{Key: "k1"}, {Key: "k2", Name: "bob"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newAPIKeysHandler(t, nil)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPut, "/v0/management/api-keys", strings.NewReader(tt.body))
+
+			h.PutAPIKeys(c)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if len(h.cfg.APIKeys) != len(tt.want) {
+				t.Fatalf("api keys = %#v, want %#v", h.cfg.APIKeys, tt.want)
+			}
+			for i := range tt.want {
+				if h.cfg.APIKeys[i] != tt.want[i] {
+					t.Fatalf("entry[%d] = %#v, want %#v", i, h.cfg.APIKeys[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAPIKeysRendersUnnamedEntriesAsStrings(t *testing.T) {
+	h := newAPIKeysHandler(t, []config.APIKeyEntry{{Key: "k1"}, {Key: "k2", Name: "alice"}})
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/api-keys", nil)
+
+	h.GetAPIKeys(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var payload struct {
+		APIKeys []json.RawMessage `json:"api-keys"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.APIKeys) != 2 {
+		t.Fatalf("api keys = %s", rec.Body.String())
+	}
+	if string(payload.APIKeys[0]) != `"k1"` {
+		t.Fatalf("unnamed entry = %s, want plain string", payload.APIKeys[0])
+	}
+	if !strings.Contains(string(payload.APIKeys[1]), `"name":"alice"`) {
+		t.Fatalf("named entry = %s, want object with name", payload.APIKeys[1])
+	}
+}
+
+func TestPatchAPIKeysStringValuePreservesName(t *testing.T) {
+	h := newAPIKeysHandler(t, []config.APIKeyEntry{{Key: "k1", Name: "alice"}})
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/api-keys", strings.NewReader(`{"index":0,"value":"k1-new"}`))
+
+	h.PatchAPIKeys(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if h.cfg.APIKeys[0] != (config.APIKeyEntry{Key: "k1-new", Name: "alice"}) {
+		t.Fatalf("entry = %#v, want k1-new/alice", h.cfg.APIKeys[0])
+	}
+}
+
+func TestPatchAPIKeysOldNewPreservesNameAndAppends(t *testing.T) {
+	h := newAPIKeysHandler(t, []config.APIKeyEntry{{Key: "k1", Name: "alice"}})
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/api-keys", strings.NewReader(`{"old":"k1","new":"k1-new"}`))
+	h.PatchAPIKeys(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if h.cfg.APIKeys[0] != (config.APIKeyEntry{Key: "k1-new", Name: "alice"}) {
+		t.Fatalf("entry = %#v, want k1-new/alice", h.cfg.APIKeys[0])
+	}
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/api-keys", strings.NewReader(`{"old":"missing","new":{"key":"k2","name":"bob"}}`))
+	h.PatchAPIKeys(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("append status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(h.cfg.APIKeys) != 2 || h.cfg.APIKeys[1] != (config.APIKeyEntry{Key: "k2", Name: "bob"}) {
+		t.Fatalf("entries = %#v, want appended k2/bob", h.cfg.APIKeys)
+	}
+}
+
+func TestDeleteAPIKeysByIndexAndValue(t *testing.T) {
+	h := newAPIKeysHandler(t, []config.APIKeyEntry{{Key: "k1"}, {Key: "k2", Name: "alice"}})
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/v0/management/api-keys?index=0", nil)
+	h.DeleteAPIKeys(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(h.cfg.APIKeys) != 1 || h.cfg.APIKeys[0].Key != "k2" {
+		t.Fatalf("entries = %#v, want only k2", h.cfg.APIKeys)
+	}
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/v0/management/api-keys?value=k2", nil)
+	h.DeleteAPIKeys(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(h.cfg.APIKeys) != 0 {
+		t.Fatalf("entries = %#v, want empty", h.cfg.APIKeys)
+	}
+}

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -60,7 +60,7 @@ func (s *Server) homeHeartbeatMiddleware() gin.HandlerFunc {
 }
 
 func (s *Server) exampleAPIKeySafeModeRequired(cfg *config.Config) bool {
-	return s != nil && s.exampleAPIKeySafeModeEnabled && cfg != nil && safemode.HasExampleAPIKeys(cfg.APIKeys)
+	return s != nil && s.exampleAPIKeySafeModeEnabled && cfg != nil && safemode.HasExampleAPIKeys(cfg.APIKeyValues())
 }
 
 func (s *Server) exampleAPIKeySafeModeMiddleware() gin.HandlerFunc {
@@ -96,7 +96,7 @@ func (s *Server) serveExampleAPIKeyWarningPage(c *gin.Context) {
 	cfg := s.cfg
 	var keys []string
 	if cfg != nil {
-		keys = safemode.ExampleAPIKeys(cfg.APIKeys)
+		keys = safemode.ExampleAPIKeys(cfg.APIKeyValues())
 	}
 	c.Header("Content-Type", "text/html; charset=utf-8")
 	c.Header("Cache-Control", "no-store")

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -167,6 +167,9 @@ func accessAuthMiddleware(manager *sdkaccess.Manager, realtimeError bool) gin.Ha
 		if err == nil {
 			if result != nil {
 				c.Set("userApiKey", result.Principal)
+				if label := strings.TrimSpace(result.PrincipalLabel); label != "" {
+					c.Set("userApiKeyLabel", label)
+				}
 				c.Set("accessProvider", result.Provider)
 				if len(result.Metadata) > 0 {
 					c.Set("accessMetadata", result.Metadata)

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -228,6 +228,10 @@ func realtimeAuthMiddleware(manager *sdkaccess.Manager, handler *codexlive.Handl
 			provider = "realtime-client-secret"
 		}
 		c.Set("userApiKey", principal)
+		// Carry the issuing key's display label so usage records stay attributed to it.
+		if label := strings.TrimSpace(authorization.IssuerLabel); label != "" {
+			c.Set("userApiKeyLabel", label)
+		}
 		c.Set("accessProvider", provider)
 		c.Set(codexlive.ClientSecretSessionContextKey, authorization.Session)
 		c.Set(codexlive.ClientSecretPrincipalContextKey, authorization.Principal)

--- a/internal/api/server_middleware_principal_test.go
+++ b/internal/api/server_middleware_principal_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gin "github.com/gin-gonic/gin"
+	configaccess "github.com/router-for-me/CLIProxyAPI/v7/internal/access/config_access"
+	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+)
+
+func TestAuthMiddlewareKeepsRawKeyAndExposesLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   []sdkaccess.APIKeyEntry
+		key       string
+		wantLabel string
+		hasLabel  bool
+	}{
+		{
+			name:      "named key exposes label",
+			entries:   []sdkaccess.APIKeyEntry{{Key: "sk-alice", Name: "alice"}},
+			key:       "sk-alice",
+			wantLabel: "alice",
+			hasLabel:  true,
+		},
+		{
+			name:    "unnamed key sets no label",
+			entries: []sdkaccess.APIKeyEntry{{Key: "sk-plain"}},
+			key:     "sk-plain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configaccess.Register(&proxyconfig.SDKConfig{APIKeys: tt.entries})
+			t.Cleanup(func() { configaccess.Register(nil) })
+
+			manager := sdkaccess.NewManager()
+			manager.SetProviders(sdkaccess.RegisteredProviders())
+
+			gin.SetMode(gin.TestMode)
+			engine := gin.New()
+			engine.Use(AuthMiddleware(manager))
+
+			var (
+				gotKey      any
+				gotLabel    any
+				labelExists bool
+			)
+			engine.GET("/v1/models", func(c *gin.Context) {
+				gotKey, _ = c.Get("userApiKey")
+				gotLabel, labelExists = c.Get("userApiKeyLabel")
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.key)
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, req)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+			}
+			if gotKey != tt.key {
+				t.Fatalf("userApiKey = %v, want raw key %q", gotKey, tt.key)
+			}
+			if labelExists != tt.hasLabel {
+				t.Fatalf("userApiKeyLabel present = %v, want %v", labelExists, tt.hasLabel)
+			}
+			if tt.hasLabel && gotLabel != tt.wantLabel {
+				t.Fatalf("userApiKeyLabel = %v, want %q", gotLabel, tt.wantLabel)
+			}
+		})
+	}
+}

--- a/internal/api/server_middleware_realtime_label_test.go
+++ b/internal/api/server_middleware_realtime_label_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gin "github.com/gin-gonic/gin"
+	codexlive "github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/live"
+)
+
+// mintRealtimeClientSecret issues an ephemeral realtime secret for the given issuer identity.
+func mintRealtimeClientSecret(t *testing.T, handler *codexlive.Handler, principal, provider, label string) string {
+	t.Helper()
+	router := gin.New()
+	router.POST("/v1/realtime/client_secrets", func(c *gin.Context) {
+		c.Set("userApiKey", principal)
+		c.Set("accessProvider", provider)
+		if label != "" {
+			c.Set("userApiKeyLabel", label)
+		}
+		c.Next()
+	}, handler.CreateClientSecret)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/realtime/client_secrets", strings.NewReader(`{"session":{"type":"realtime","model":"gpt-realtime"}}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("mint status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response struct {
+		Value string `json:"value"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("unmarshal mint response: %v", errUnmarshal)
+	}
+	return response.Value
+}
+
+func TestRealtimeAuthMiddlewareRestoresIssuerLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		label     string
+		wantLabel string
+		hasLabel  bool
+	}{
+		{name: "named issuer restores label", label: "alice", wantLabel: "alice", hasLabel: true},
+		{name: "unnamed issuer sets no label", label: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			handler := codexlive.NewHandler(nil, nil)
+			token := mintRealtimeClientSecret(t, handler, "sk-issuer", "config-api-key", tt.label)
+
+			var (
+				gotKey      any
+				gotProvider any
+				gotLabel    any
+				labelExists bool
+			)
+			engine := gin.New()
+			engine.Use(realtimeAuthMiddleware(nil, handler))
+			engine.POST("/v1/realtime/calls", func(c *gin.Context) {
+				gotKey, _ = c.Get("userApiKey")
+				gotProvider, _ = c.Get("accessProvider")
+				gotLabel, labelExists = c.Get("userApiKeyLabel")
+				c.Status(http.StatusOK)
+			})
+
+			request := httptest.NewRequest(http.MethodPost, "/v1/realtime/calls", nil)
+			request.Header.Set("Authorization", "Bearer "+token)
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+			}
+			if gotKey != "sk-issuer" {
+				t.Fatalf("userApiKey = %v, want issuer principal %q", gotKey, "sk-issuer")
+			}
+			if gotProvider != "config-api-key" {
+				t.Fatalf("accessProvider = %v, want %q", gotProvider, "config-api-key")
+			}
+			if labelExists != tt.hasLabel {
+				t.Fatalf("userApiKeyLabel present = %v, want %v", labelExists, tt.hasLabel)
+			}
+			if tt.hasLabel && gotLabel != tt.wantLabel {
+				t.Fatalf("userApiKeyLabel = %v, want %q", gotLabel, tt.wantLabel)
+			}
+		})
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -611,7 +611,7 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 
 	cfg := &proxyconfig.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"test-key"},
+			APIKeys: proxyconfig.APIKeysFromStrings([]string{"test-key"}),
 		},
 		Port:                   0,
 		AuthDir:                authDir,
@@ -1724,7 +1724,7 @@ func TestExampleAPIKeySafeModeShowsWarningAndKeepsManagement(t *testing.T) {
 
 	server := newTestServerWithOptions(t, WithExampleAPIKeySafeMode())
 	cfg := *server.cfg
-	cfg.APIKeys = []string{"your-api-key-1"}
+	cfg.APIKeys = proxyconfig.APIKeysFromStrings([]string{"your-api-key-1"})
 	server.UpdateClients(&cfg)
 
 	t.Run("root warning page includes management link", func(t *testing.T) {
@@ -1820,7 +1820,7 @@ func TestExampleAPIKeySafeModeShowsWarningAndKeepsManagement(t *testing.T) {
 
 	t.Run("safe mode clears after key update", func(t *testing.T) {
 		nextCfg := cfg
-		nextCfg.APIKeys = []string{"real-key"}
+		nextCfg.APIKeys = proxyconfig.APIKeysFromStrings([]string{"real-key"})
 		server.UpdateClients(&nextCfg)
 
 		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)

--- a/internal/client/codex/live/client_secret.go
+++ b/internal/client/codex/live/client_secret.go
@@ -38,7 +38,10 @@ type ClientSecretAuthorization struct {
 	Principal       string
 	IssuerPrincipal string
 	IssuerProvider  string
-	Session         json.RawMessage
+	// IssuerLabel is the attribution-only display label of the issuing API key.
+	// It MUST NOT participate in authorization, capacity accounting, or identity comparisons.
+	IssuerLabel string
+	Session     json.RawMessage
 }
 
 type clientSecretEntry struct {
@@ -73,7 +76,7 @@ func newClientSecretStore() *clientSecretStore {
 	}
 }
 
-func (s *clientSecretStore) create(session json.RawMessage, lifetime time.Duration, issuerPrincipal, issuerProvider string) (string, ClientSecretAuthorization, time.Time, error) {
+func (s *clientSecretStore) create(session json.RawMessage, lifetime time.Duration, issuerPrincipal, issuerProvider, issuerLabel string) (string, ClientSecretAuthorization, time.Time, error) {
 	if s == nil {
 		return "", ClientSecretAuthorization{}, time.Time{}, errors.New("Realtime client secret store unavailable")
 	}
@@ -89,6 +92,7 @@ func (s *clientSecretStore) create(session json.RawMessage, lifetime time.Durati
 		Principal:       sessionID,
 		IssuerPrincipal: strings.TrimSpace(issuerPrincipal),
 		IssuerProvider:  strings.TrimSpace(issuerProvider),
+		IssuerLabel:     strings.TrimSpace(issuerLabel),
 		Session:         append(json.RawMessage(nil), session...),
 	}
 	now := s.currentTime()
@@ -99,6 +103,8 @@ func (s *clientSecretStore) create(session json.RawMessage, lifetime time.Durati
 		s.mu.Unlock()
 		return "", ClientSecretAuthorization{}, time.Time{}, errClientSecretCapacity
 	}
+	// Capacity buckets are keyed by issuer principal and provider only; the label is
+	// attribution metadata and must not widen or split a bucket.
 	if authorization.IssuerPrincipal != "" {
 		issuerEntries := 0
 		for _, entry := range s.entries {
@@ -267,9 +273,11 @@ func (h *Handler) createClientSecret(c *gin.Context, session json.RawMessage, ex
 	}
 	issuerPrincipal, _ := c.Get("userApiKey")
 	issuerProvider, _ := c.Get("accessProvider")
+	issuerLabel, _ := c.Get("userApiKeyLabel")
 	issuerPrincipalValue, _ := issuerPrincipal.(string)
 	issuerProviderValue, _ := issuerProvider.(string)
-	token, authorization, expiresAt, errCreate := h.clientSecrets.create(upstreamSession, lifetime, issuerPrincipalValue, issuerProviderValue)
+	issuerLabelValue, _ := issuerLabel.(string)
+	token, authorization, expiresAt, errCreate := h.clientSecrets.create(upstreamSession, lifetime, issuerPrincipalValue, issuerProviderValue, issuerLabelValue)
 	if errCreate != nil {
 		if errors.Is(errCreate, errClientSecretCapacity) {
 			c.Header("Retry-After", "1")

--- a/internal/client/codex/live/client_secret_label_test.go
+++ b/internal/client/codex/live/client_secret_label_test.go
@@ -1,0 +1,112 @@
+package live
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// mintClientSecret issues a client secret through the HTTP handler and returns its token.
+func mintClientSecret(t *testing.T, handler *Handler, principal, provider, label string) string {
+	t.Helper()
+	router := gin.New()
+	router.POST("/v1/realtime/client_secrets", func(c *gin.Context) {
+		if principal != "" {
+			c.Set("userApiKey", principal)
+		}
+		if provider != "" {
+			c.Set("accessProvider", provider)
+		}
+		if label != "" {
+			c.Set("userApiKeyLabel", label)
+		}
+		c.Next()
+	}, handler.CreateClientSecret)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/realtime/client_secrets", strings.NewReader(`{"session":{"type":"realtime","model":"gpt-realtime"}}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if principal != "" && strings.Contains(recorder.Body.String(), principal) {
+		t.Fatalf("response leaked the issuer key: %s", recorder.Body.String())
+	}
+	if label != "" && strings.Contains(recorder.Body.String(), strings.TrimSpace(label)) {
+		t.Fatalf("response leaked the issuer label: %s", recorder.Body.String())
+	}
+	var response struct {
+		Value string `json:"value"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("unmarshal response: %v", errUnmarshal)
+	}
+	return response.Value
+}
+
+func TestCreateClientSecretCarriesTrimmedIssuerLabel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := &Handler{clientSecrets: newClientSecretStore()}
+	token := mintClientSecret(t, handler, "issuer-key", "static", "  alice  ")
+
+	authRequest := httptest.NewRequest(http.MethodPost, "/v1/realtime/calls", nil)
+	authRequest.Header.Set("Authorization", "Bearer "+token)
+	authorization, matched, errAuthenticate := handler.AuthenticateClientSecret(authRequest)
+	if errAuthenticate != nil || !matched {
+		t.Fatalf("AuthenticateClientSecret() matched=%t error=%v", matched, errAuthenticate)
+	}
+	if authorization.IssuerLabel != "alice" {
+		t.Fatalf("IssuerLabel = %q, want %q", authorization.IssuerLabel, "alice")
+	}
+	if authorization.IssuerPrincipal != "issuer-key" || authorization.IssuerProvider != "static" {
+		t.Fatalf("issuer = %q/%q", authorization.IssuerPrincipal, authorization.IssuerProvider)
+	}
+	if !strings.HasPrefix(authorization.Principal, "sess_") {
+		t.Fatalf("Principal = %q, want a sess_ identifier", authorization.Principal)
+	}
+}
+
+func TestCreateClientSecretWithoutLabelLeavesIssuerLabelEmpty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := &Handler{clientSecrets: newClientSecretStore()}
+	token := mintClientSecret(t, handler, "issuer-key", "static", "")
+
+	authRequest := httptest.NewRequest(http.MethodPost, "/v1/realtime/calls", nil)
+	authRequest.Header.Set("Authorization", "Bearer "+token)
+	authorization, _, errAuthenticate := handler.AuthenticateClientSecret(authRequest)
+	if errAuthenticate != nil {
+		t.Fatalf("AuthenticateClientSecret() error = %v", errAuthenticate)
+	}
+	if authorization.IssuerLabel != "" {
+		t.Fatalf("IssuerLabel = %q, want empty", authorization.IssuerLabel)
+	}
+}
+
+func TestClientSecretStoreIssuerCapacityIgnoresLabel(t *testing.T) {
+	store := newClientSecretStore()
+	session := json.RawMessage(`{"type":"realtime","model":"gpt-live-1-codex"}`)
+	for i := 0; i < clientSecretMaxEntriesPerIssuer; i++ {
+		label := "alice"
+		if i%2 == 1 {
+			label = "bob"
+		}
+		if _, _, _, errCreate := store.create(session, time.Minute, "issuer", "static", label); errCreate != nil {
+			t.Fatalf("create(%d) error = %v", i, errCreate)
+		}
+	}
+	// Varying the label must not unlock extra capacity for the same principal and provider.
+	if _, _, _, errCreate := store.create(session, time.Minute, "issuer", "static", "carol"); !errors.Is(errCreate, errClientSecretCapacity) {
+		t.Fatalf("create() error = %v, want %v", errCreate, errClientSecretCapacity)
+	}
+	// A distinct principal keeps its own bucket even when the label matches.
+	if _, _, _, errCreate := store.create(session, time.Minute, "other-issuer", "static", "alice"); errCreate != nil {
+		t.Fatalf("create() for distinct issuer error = %v", errCreate)
+	}
+}

--- a/internal/client/codex/live/client_secret_test.go
+++ b/internal/client/codex/live/client_secret_test.go
@@ -119,7 +119,7 @@ func TestClientSecretStoreRejectsExpiredToken(t *testing.T) {
 	store := newClientSecretStore()
 	now := time.Unix(1700000000, 0)
 	store.now = func() time.Time { return now }
-	token, _, _, errCreate := store.create(json.RawMessage(`{"type":"realtime","model":"gpt-live-1-codex"}`), time.Minute, "issuer", "test")
+	token, _, _, errCreate := store.create(json.RawMessage(`{"type":"realtime","model":"gpt-live-1-codex"}`), time.Minute, "issuer", "test", "")
 	if errCreate != nil {
 		t.Fatalf("create() error = %v", errCreate)
 	}

--- a/internal/config/api_key_entry_persist_test.go
+++ b/internal/config/api_key_entry_persist_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const mixedAPIKeysConfig = `# Top comment
+port: 8317
+
+# API keys for authentication
+api-keys:
+  # first key
+  - "plain-key"
+  - key: "named-key"
+    name: "alice"
+  - "second-plain"
+`
+
+func TestSaveConfigPreserveCommentsKeepsMixedAPIKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(mixedAPIKeysConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	want := []APIKeyEntry{
+		{Key: "plain-key"},
+		{Key: "named-key", Name: "alice"},
+		{Key: "second-plain"},
+	}
+	for i := range want {
+		if cfg.APIKeys[i] != want[i] {
+			t.Fatalf("loaded entry[%d] = %#v, want %#v", i, cfg.APIKeys[i], want[i])
+		}
+	}
+
+	if errSave := SaveConfigPreserveComments(path, cfg); errSave != nil {
+		t.Fatalf("save config: %v", errSave)
+	}
+
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	text := string(saved)
+	if !strings.Contains(text, "# Top comment") || !strings.Contains(text, "# API keys for authentication") || !strings.Contains(text, "# first key") {
+		t.Fatalf("comments not preserved:\n%s", text)
+	}
+	if !strings.Contains(text, `- "plain-key"`) || !strings.Contains(text, `- "second-plain"`) {
+		t.Fatalf("scalar entries not preserved:\n%s", text)
+	}
+	if !strings.Contains(text, "name: alice") && !strings.Contains(text, `name: "alice"`) {
+		t.Fatalf("named entry name not preserved:\n%s", text)
+	}
+
+	reloaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if len(reloaded.APIKeys) != len(want) {
+		t.Fatalf("reloaded entries = %#v, want %#v", reloaded.APIKeys, want)
+	}
+	for i := range want {
+		if reloaded.APIKeys[i] != want[i] {
+			t.Fatalf("reloaded entry[%d] = %#v, want %#v", i, reloaded.APIKeys[i], want[i])
+		}
+	}
+}

--- a/internal/config/api_key_entry_test.go
+++ b/internal/config/api_key_entry_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestAPIKeyEntryUnmarshalMixedYAML(t *testing.T) {
+	const doc = `api-keys:
+  - "plain-key"
+  - key: "named-key"
+    name: "alice"
+  - unquoted-key
+`
+
+	var parsed struct {
+		APIKeys []APIKeyEntry `yaml:"api-keys"`
+	}
+	if err := yaml.Unmarshal([]byte(doc), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := []APIKeyEntry{
+		{Key: "plain-key"},
+		{Key: "named-key", Name: "alice"},
+		{Key: "unquoted-key"},
+	}
+	if len(parsed.APIKeys) != len(want) {
+		t.Fatalf("entries = %#v, want %#v", parsed.APIKeys, want)
+	}
+	for i := range want {
+		if parsed.APIKeys[i] != want[i] {
+			t.Fatalf("entry[%d] = %#v, want %#v", i, parsed.APIKeys[i], want[i])
+		}
+	}
+}
+
+func TestAPIKeyEntryMarshalYAMLScalarForUnnamed(t *testing.T) {
+	entries := []APIKeyEntry{
+		{Key: "plain-key"},
+		{Key: "named-key", Name: "alice"},
+	}
+
+	out, err := yaml.Marshal(map[string]any{"api-keys": entries})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "- plain-key\n") {
+		t.Fatalf("unnamed entry not rendered as scalar: %s", got)
+	}
+	if !strings.Contains(got, "key: named-key") || !strings.Contains(got, "name: alice") {
+		t.Fatalf("named entry not rendered as mapping: %s", got)
+	}
+}
+
+func TestAPIKeyEntryJSONRoundTrip(t *testing.T) {
+	var entries []APIKeyEntry
+	if err := json.Unmarshal([]byte(`["plain-key",{"key":"named-key","name":"alice"}]`), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 2 || entries[0] != (APIKeyEntry{Key: "plain-key"}) || entries[1] != (APIKeyEntry{Key: "named-key", Name: "alice"}) {
+		t.Fatalf("entries = %#v", entries)
+	}
+
+	out, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != `["plain-key",{"key":"named-key","name":"alice"}]` {
+		t.Fatalf("marshal = %s", out)
+	}
+}
+
+func TestAPIKeyValues(t *testing.T) {
+	cfg := &SDKConfig{APIKeys: []APIKeyEntry{{Key: "a"}, {Key: "b", Name: "bob"}}}
+	got := cfg.APIKeyValues()
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("APIKeyValues() = %#v, want [a b]", got)
+	}
+	if values := (*SDKConfig)(nil).APIKeyValues(); values != nil {
+		t.Fatalf("nil config APIKeyValues() = %#v, want nil", values)
+	}
+}

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -46,8 +46,8 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	if clone.Home.Host != "home.local" {
 		t.Fatalf("clone.Home.Host = %q, want home.local", clone.Home.Host)
 	}
-	if clone.APIKeys[0] != "client-key" {
-		t.Fatalf("clone.APIKeys[0] = %q, want client-key", clone.APIKeys[0])
+	if clone.APIKeys[0].Key != "client-key" {
+		t.Fatalf("clone.APIKeys[0] = %q, want client-key", clone.APIKeys[0].Key)
 	}
 	if clone.OAuthExcludedModels["codex"][0] != "hidden-model" {
 		t.Fatalf("clone.OAuthExcludedModels[codex][0] = %q, want hidden-model", clone.OAuthExcludedModels["codex"][0])
@@ -65,7 +65,7 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 		t.Fatalf("clone payload object key = %#v, want value", got)
 	}
 
-	clone.APIKeys[0] = "clone-client-key"
+	clone.APIKeys[0].Key = "clone-client-key"
 	clone.OAuthExcludedModels["codex"][0] = "clone-hidden-model"
 	clone.OAuthModelAlias["codex"][0].Alias = "clone-client-model"
 	clone.OpenAICompatibility[0].Models[0].Thinking.Levels[0] = "clone-low"
@@ -74,8 +74,8 @@ func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	setPluginRawScalar(t, &plugin.Raw, "mode", "third")
 	clone.Plugins.Configs["sample"] = plugin
 
-	if cfg.APIKeys[0] != "mutated-client-key" {
-		t.Fatalf("cfg.APIKeys[0] = %q, want mutated-client-key", cfg.APIKeys[0])
+	if cfg.APIKeys[0].Key != "mutated-client-key" {
+		t.Fatalf("cfg.APIKeys[0] = %q, want mutated-client-key", cfg.APIKeys[0].Key)
 	}
 	if cfg.OAuthExcludedModels["codex"][0] != "mutated-hidden-model" {
 		t.Fatalf("cfg.OAuthExcludedModels[codex][0] = %q, want mutated-hidden-model", cfg.OAuthExcludedModels["codex"][0])
@@ -109,7 +109,7 @@ func sampleCloneRuntimeConfig() *Config {
 
 	return &Config{
 		SDKConfig: SDKConfig{
-			APIKeys: []string{"client-key"},
+			APIKeys: APIKeysFromStrings([]string{"client-key"}),
 			Streaming: StreamingConfig{
 				KeepAliveSeconds: 3,
 				BootstrapRetries: 2,
@@ -209,7 +209,7 @@ func sampleCloneRuntimeConfig() *Config {
 
 func mutateOriginalConfig(cfg *Config) {
 	cfg.Home.Host = "mutated-home.local"
-	cfg.APIKeys[0] = "mutated-client-key"
+	cfg.APIKeys[0].Key = "mutated-client-key"
 	cfg.OAuthExcludedModels["codex"][0] = "mutated-hidden-model"
 	cfg.OAuthModelAlias["codex"][0].Alias = "mutated-client-model"
 	cfg.OpenAICompatibility[0].Models[0].Thinking.Levels[0] = "mutated-low"

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -61,7 +61,9 @@ type SDKConfig struct {
 	ClaudeCode ClaudeCodeConfig `yaml:"claude-code" json:"claude-code"`
 
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
-	// Each entry is a plain key string or a mapping with an optional name.
+	// Each entry is a plain key string or a mapping with an optional name. The
+	// name is used for attribution in usage records and request logs;
+	// authorization still uses the raw key.
 	APIKeys []APIKeyEntry `yaml:"api-keys" json:"api-keys"`
 
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -4,6 +4,15 @@
 // debug settings, proxy configuration, and API keys.
 package config
 
+import sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+
+// APIKeyEntry is a client-facing API key with an optional name. It accepts and
+// re-emits plain strings, so existing configurations keep working unchanged.
+type APIKeyEntry = sdkaccess.APIKeyEntry
+
+// APIKeysFromStrings converts raw key strings into unnamed entries.
+func APIKeysFromStrings(keys []string) []APIKeyEntry { return sdkaccess.APIKeysFromStrings(keys) }
+
 // SDKConfig represents the application's configuration, loaded from a YAML file.
 type SDKConfig struct {
 	// ProxyURL is the URL of an optional proxy server to use for outbound requests.
@@ -52,7 +61,8 @@ type SDKConfig struct {
 	ClaudeCode ClaudeCodeConfig `yaml:"claude-code" json:"claude-code"`
 
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
-	APIKeys []string `yaml:"api-keys" json:"api-keys"`
+	// Each entry is a plain key string or a mapping with an optional name.
+	APIKeys []APIKeyEntry `yaml:"api-keys" json:"api-keys"`
 
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).
@@ -83,4 +93,12 @@ type StreamingConfig struct {
 	// to allow auth rotation / transient recovery.
 	// <= 0 disables bootstrap retries. Default is 0.
 	BootstrapRetries int `yaml:"bootstrap-retries,omitempty" json:"bootstrap-retries,omitempty"`
+}
+
+// APIKeyValues returns the raw key values of the configured client API keys.
+func (c *SDKConfig) APIKeyValues() []string {
+	if c == nil {
+		return nil
+	}
+	return sdkaccess.APIKeyValues(c.APIKeys)
 }

--- a/internal/runtime/executor/helps/usage_api_key_label_test.go
+++ b/internal/runtime/executor/helps/usage_api_key_label_test.go
@@ -1,0 +1,55 @@
+package helps
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func usageLabelContext(apiKey, label string) context.Context {
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	if apiKey != "" {
+		ginCtx.Set("userApiKey", apiKey)
+	}
+	if label != "" {
+		ginCtx.Set("userApiKeyLabel", label)
+	}
+	ginCtx.Request = httptest.NewRequest("POST", "/v1/messages", nil)
+	return context.WithValue(context.Background(), "gin", ginCtx)
+}
+
+func TestNewUsageReporterPrefersAPIKeyLabelForAttribution(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiKey string
+		label  string
+		want   string
+	}{
+		{name: "label wins when present", apiKey: "sk-raw-key", label: "alice", want: "alice"},
+		{name: "raw key used without label", apiKey: "sk-raw-key", want: "sk-raw-key"},
+		{name: "blank label falls back to raw key", apiKey: "sk-raw-key", label: "   ", want: "sk-raw-key"},
+		{name: "no credentials yields empty attribution"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := usageLabelContext(tt.apiKey, tt.label)
+			reporter := NewUsageReporter(ctx, "codex", "gpt-5.4", nil)
+			record := reporter.buildRecord(usage.Detail{}, false)
+			if record.APIKey != tt.want {
+				t.Fatalf("record.APIKey = %q, want %q", record.APIKey, tt.want)
+			}
+			if record.Source != tt.want {
+				t.Fatalf("record.Source = %q, want %q", record.Source, tt.want)
+			}
+			// The raw key stays reachable for authorization and cache scoping.
+			if got := APIKeyFromContext(ctx); got != tt.apiKey {
+				t.Fatalf("APIKeyFromContext() = %q, want %q", got, tt.apiKey)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -64,7 +64,12 @@ func NewExecutorUsageReporter(ctx context.Context, executor usageExecutor, model
 }
 
 func NewUsageReporter(ctx context.Context, provider, model string, auth *cliproxyauth.Auth) *UsageReporter {
+	// Attribution prefers the configured key name when one is set; the raw key
+	// stays available through APIKeyFromContext for identity-critical callers.
 	apiKey := APIKeyFromContext(ctx)
+	if label := strings.TrimSpace(APIKeyLabelFromContext(ctx)); label != "" {
+		apiKey = label
+	}
 	alias := usage.RequestedModelAliasFromContext(ctx)
 	if alias == "" {
 		alias = model
@@ -517,6 +522,16 @@ func (r *usageTTFTReadCloser) Read(p []byte) (int, error) {
 }
 
 func APIKeyFromContext(ctx context.Context) string {
+	return ginStringValue(ctx, "userApiKey")
+}
+
+// APIKeyLabelFromContext returns the configured display name of the matched
+// client API key. It is attribution-only and never an authorization identity.
+func APIKeyLabelFromContext(ctx context.Context) string {
+	return ginStringValue(ctx, "userApiKeyLabel")
+}
+
+func ginStringValue(ctx context.Context, key string) string {
 	if ctx == nil {
 		return ""
 	}
@@ -524,7 +539,7 @@ func APIKeyFromContext(ctx context.Context) string {
 	if !ok || ginCtx == nil {
 		return ""
 	}
-	if v, exists := ginCtx.Get("userApiKey"); exists {
+	if v, exists := ginCtx.Get(key); exists {
 		switch value := v.(type) {
 		case string:
 			return value

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -234,9 +235,39 @@ func (c *Client) GetLogs(after int64, limit int) ([]string, int64, error) {
 	return lines, latest, nil
 }
 
+// APIKeyItem is a client API key with its optional name.
+type APIKeyItem struct {
+	Key  string
+	Name string
+}
+
+// UnmarshalJSON accepts either a plain key string or a {"key","name"} object.
+func (i *APIKeyItem) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var key string
+		if err := json.Unmarshal(trimmed, &key); err != nil {
+			return err
+		}
+		i.Key = key
+		i.Name = ""
+		return nil
+	}
+	var raw struct {
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return err
+	}
+	i.Key = raw.Key
+	i.Name = raw.Name
+	return nil
+}
+
 // GetAPIKeys fetches the list of API keys.
-// API returns {"api-keys": [...]}.
-func (c *Client) GetAPIKeys() ([]string, error) {
+// API returns {"api-keys": [...]} with plain strings or named objects.
+func (c *Client) GetAPIKeys() ([]APIKeyItem, error) {
 	wrapper, err := c.getJSON("/v0/management/api-keys")
 	if err != nil {
 		return nil, err
@@ -249,7 +280,7 @@ func (c *Client) GetAPIKeys() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var result []string
+	var result []APIKeyItem
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -23,13 +23,13 @@ type dashboardModel struct {
 	// Cached data for re-rendering on locale change
 	lastConfig    map[string]any
 	lastAuthFiles []map[string]any
-	lastAPIKeys   []string
+	lastAPIKeys   []APIKeyItem
 }
 
 type dashboardDataMsg struct {
 	config    map[string]any
 	authFiles []map[string]any
-	apiKeys   []string
+	apiKeys   []APIKeyItem
 	err       error
 }
 
@@ -117,7 +117,7 @@ func (m dashboardModel) View() string {
 	return m.viewport.View()
 }
 
-func (m dashboardModel) renderDashboard(cfg map[string]any, authFiles []map[string]any, apiKeys []string) string {
+func (m dashboardModel) renderDashboard(cfg map[string]any, authFiles []map[string]any, apiKeys []APIKeyItem) string {
 	var sb strings.Builder
 
 	sb.WriteString(titleStyle.Render(T("dashboard_title")))

--- a/internal/tui/keys_tab.go
+++ b/internal/tui/keys_tab.go
@@ -15,7 +15,7 @@ import (
 type keysTabModel struct {
 	client       *Client
 	viewport     viewport.Model
-	keys         []string
+	keys         []APIKeyItem
 	gemini       []map[string]any
 	interactions []map[string]any
 	claude       []map[string]any
@@ -39,7 +39,7 @@ type keysTabModel struct {
 }
 
 type keysDataMsg struct {
-	apiKeys      []string
+	apiKeys      []APIKeyItem
 	gemini       []map[string]any
 	interactions []map[string]any
 	claude       []map[string]any
@@ -221,7 +221,7 @@ func (m keysTabModel) Update(msg tea.Msg) (keysTabModel, tea.Cmd) {
 				m.editing = true
 				m.adding = false
 				m.editIdx = m.cursor
-				m.editInput.SetValue(m.keys[m.cursor])
+				m.editInput.SetValue(m.keys[m.cursor].Key)
 				m.editInput.Prompt = T("edit_key_prompt")
 				m.editInput.Focus()
 				m.viewport.SetContent(m.renderContent())
@@ -238,7 +238,7 @@ func (m keysTabModel) Update(msg tea.Msg) (keysTabModel, tea.Cmd) {
 		case "c":
 			// Copy selected key to clipboard
 			if m.cursor < len(m.keys) {
-				key := m.keys[m.cursor]
+				key := m.keys[m.cursor].Key
 				if err := clipboard.WriteAll(key); err != nil {
 					m.status = errorStyle.Render(T("copy_failed") + ": " + err.Error())
 				} else {
@@ -316,13 +316,14 @@ func (m keysTabModel) renderContent() string {
 			rowStyle = lipgloss.NewStyle().Bold(true)
 		}
 
-		row := fmt.Sprintf("%s%d. %s", cursor, i+1, maskKey(key))
+		label := describeAPIKey(key)
+		row := fmt.Sprintf("%s%d. %s", cursor, i+1, label)
 		sb.WriteString(rowStyle.Render(row))
 		sb.WriteString("\n")
 
 		// Delete confirmation
 		if m.confirm == i {
-			sb.WriteString(warningStyle.Render(fmt.Sprintf("    "+T("confirm_delete_key"), maskKey(key))))
+			sb.WriteString(warningStyle.Render(fmt.Sprintf("    "+T("confirm_delete_key"), label)))
 			sb.WriteString("\n")
 		}
 
@@ -405,6 +406,14 @@ func renderProviderKeys(sb *strings.Builder, title string, keys []map[string]any
 		sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, info))
 	}
 	sb.WriteString("\n")
+}
+
+func describeAPIKey(item APIKeyItem) string {
+	masked := maskKey(item.Key)
+	if strings.TrimSpace(item.Name) == "" {
+		return masked
+	}
+	return fmt.Sprintf("%s (%s)", item.Name, masked)
 }
 
 func maskKey(key string) string {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -161,7 +161,7 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	// API keys (redacted) and counts
 	if len(oldCfg.APIKeys) != len(newCfg.APIKeys) {
 		changes = append(changes, fmt.Sprintf("api-keys count: %d -> %d", len(oldCfg.APIKeys), len(newCfg.APIKeys)))
-	} else if !reflect.DeepEqual(trimStrings(oldCfg.APIKeys), trimStrings(newCfg.APIKeys)) {
+	} else if !reflect.DeepEqual(trimAPIKeyEntries(oldCfg.APIKeys), trimAPIKeyEntries(newCfg.APIKeys)) {
 		changes = append(changes, "api-keys: values updated (count unchanged, redacted)")
 	}
 	if len(oldCfg.GeminiKey) != len(newCfg.GeminiKey) {
@@ -459,10 +459,15 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	return changes
 }
 
-func trimStrings(in []string) []string {
-	out := make([]string, len(in))
+// trimAPIKeyEntries normalizes entries for comparison. Names are compared so a
+// name-only change still triggers a reload; no value is included in messages.
+func trimAPIKeyEntries(in []config.APIKeyEntry) []config.APIKeyEntry {
+	out := make([]config.APIKeyEntry, len(in))
 	for i := range in {
-		out[i] = strings.TrimSpace(in[i])
+		out[i] = config.APIKeyEntry{
+			Key:  strings.TrimSpace(in[i].Key),
+			Name: strings.TrimSpace(in[i].Name),
+		}
 	}
 	return out
 }

--- a/internal/watcher/diff/config_diff_api_keys_test.go
+++ b/internal/watcher/diff/config_diff_api_keys_test.go
@@ -1,0 +1,54 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestBuildConfigChangeDetailsAPIKeyNameOnlyChange(t *testing.T) {
+	tests := []struct {
+		name       string
+		oldEntries []config.APIKeyEntry
+		newEntries []config.APIKeyEntry
+		wantChange bool
+	}{
+		{
+			name:       "name added",
+			oldEntries: []config.APIKeyEntry{{Key: "secret-key"}},
+			newEntries: []config.APIKeyEntry{{Key: "secret-key", Name: "alice"}},
+			wantChange: true,
+		},
+		{
+			name:       "name changed",
+			oldEntries: []config.APIKeyEntry{{Key: "secret-key", Name: "alice"}},
+			newEntries: []config.APIKeyEntry{{Key: "secret-key", Name: "bob"}},
+			wantChange: true,
+		},
+		{
+			name:       "no change",
+			oldEntries: []config.APIKeyEntry{{Key: "secret-key", Name: "alice"}},
+			newEntries: []config.APIKeyEntry{{Key: " secret-key ", Name: " alice "}},
+			wantChange: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldCfg := &config.Config{SDKConfig: sdkconfig.SDKConfig{APIKeys: tt.oldEntries}}
+			newCfg := &config.Config{SDKConfig: sdkconfig.SDKConfig{APIKeys: tt.newEntries}}
+
+			details := BuildConfigChangeDetails(oldCfg, newCfg)
+			joined := strings.Join(details, "\n")
+			hasChange := strings.Contains(joined, "api-keys: values updated (count unchanged, redacted)")
+			if hasChange != tt.wantChange {
+				t.Fatalf("api-keys change = %v, want %v; details=%v", hasChange, tt.wantChange, details)
+			}
+			if strings.Contains(joined, "secret-key") || strings.Contains(joined, "alice") || strings.Contains(joined, "bob") {
+				t.Fatalf("change message leaked key or name: %v", details)
+			}
+		})
+	}
+}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -286,7 +286,7 @@ func TestBuildConfigChangeDetails_NilSafe(t *testing.T) {
 func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 	oldCfg := &config.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"a"},
+			APIKeys: config.APIKeysFromStrings([]string{"a"}),
 		},
 		RemoteManagement: config.RemoteManagement{
 			SecretKey: "",
@@ -294,7 +294,7 @@ func TestBuildConfigChangeDetails_SecretsAndCounts(t *testing.T) {
 	}
 	newCfg := &config.Config{
 		SDKConfig: sdkconfig.SDKConfig{
-			APIKeys: []string{"a", "b", "c"},
+			APIKeys: config.APIKeysFromStrings([]string{"a", "b", "c"}),
 		},
 		RemoteManagement: config.RemoteManagement{
 			SecretKey: "new-secret",
@@ -359,7 +359,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
-			APIKeys:                    []string{"key-1"},
+			APIKeys:                    config.APIKeysFromStrings([]string{"key-1"}),
 			ForceModelPrefix:           false,
 			NonStreamKeepAliveInterval: 0,
 		},
@@ -397,7 +397,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 true,
 			ProxyURL:                   "http://new-proxy",
-			APIKeys:                    []string{" key-1 ", "key-2"},
+			APIKeys:                    config.APIKeysFromStrings([]string{" key-1 ", "key-2"}),
 			ForceModelPrefix:           true,
 			NonStreamKeepAliveInterval: 5,
 			DisableImageGeneration:     config.DisableImageGenerationAll,
@@ -475,7 +475,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog: false,
 			ProxyURL:   "http://old-proxy",
-			APIKeys:    []string{" keyA "},
+			APIKeys:    config.APIKeysFromStrings([]string{" keyA "}),
 		},
 		OAuthExcludedModels: map[string][]string{"p1": {"a"}},
 		OpenAICompatibility: []config.OpenAICompatibility{
@@ -524,7 +524,7 @@ func TestBuildConfigChangeDetails_AllBranches(t *testing.T) {
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:             true,
 			ProxyURL:               "http://new-proxy",
-			APIKeys:                []string{"keyB"},
+			APIKeys:                config.APIKeysFromStrings([]string{"keyB"}),
 			DisableImageGeneration: config.DisableImageGenerationAll,
 		},
 		OAuthExcludedModels: map[string][]string{"p1": {"b", "c"}, "p2": {"d"}},
@@ -651,11 +651,4 @@ func TestBuildConfigChangeDetails_CountBranches(t *testing.T) {
 	expectContains(t, changes, "codex-api-key count: 0 -> 1")
 	expectContains(t, changes, "xai-api-key count: 0 -> 1")
 	expectContains(t, changes, "vertex-api-key count: 0 -> 1")
-}
-
-func TestTrimStrings(t *testing.T) {
-	out := trimStrings([]string{" a ", "b", "  c"})
-	if len(out) != 3 || out[0] != "a" || out[1] != "b" || out[2] != "c" {
-		t.Fatalf("unexpected trimmed strings: %v", out)
-	}
 }

--- a/sdk/access/api_key_entry.go
+++ b/sdk/access/api_key_entry.go
@@ -16,8 +16,8 @@ type APIKeyEntry struct {
 	// Key is the raw credential value clients send.
 	Key string `yaml:"key" json:"key"`
 
-	// Name optionally labels the key. When set it replaces the raw key as the
-	// authenticated principal in usage records and request logs.
+	// Name optionally labels the key. When set it is used for attribution in
+	// usage records and request logs; authorization still uses the raw key.
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 }
 

--- a/sdk/access/api_key_entry.go
+++ b/sdk/access/api_key_entry.go
@@ -1,0 +1,117 @@
+package access
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// APIKeyEntry is a client-facing API key with an optional display name.
+// A plain string is accepted and re-emitted as a plain string, so existing
+// configurations keep working and round-trip unchanged.
+type APIKeyEntry struct {
+	// Key is the raw credential value clients send.
+	Key string `yaml:"key" json:"key"`
+
+	// Name optionally labels the key. When set it replaces the raw key as the
+	// authenticated principal in usage records and request logs.
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// namedAPIKeyEntry is the mapping representation used when a name is present.
+type namedAPIKeyEntry struct {
+	Key  string `yaml:"key" json:"key"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// UnmarshalYAML accepts either a plain scalar key or a mapping with key and name.
+func (e *APIKeyEntry) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var key string
+		if err := value.Decode(&key); err != nil {
+			return err
+		}
+		e.Key = key
+		e.Name = ""
+		return nil
+	case yaml.MappingNode:
+		var raw namedAPIKeyEntry
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		e.Key = raw.Key
+		e.Name = raw.Name
+		return nil
+	default:
+		return fmt.Errorf("api key entry must be a string or a mapping")
+	}
+}
+
+// MarshalYAML emits a plain scalar when no name is set to stay byte-for-byte
+// compatible with plain string entries.
+func (e APIKeyEntry) MarshalYAML() (any, error) {
+	if strings.TrimSpace(e.Name) == "" {
+		return e.Key, nil
+	}
+	return namedAPIKeyEntry{Key: e.Key, Name: e.Name}, nil
+}
+
+// UnmarshalJSON accepts either a JSON string or an object with key and name.
+func (e *APIKeyEntry) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var key string
+		if err := json.Unmarshal(trimmed, &key); err != nil {
+			return err
+		}
+		e.Key = key
+		e.Name = ""
+		return nil
+	}
+	var raw namedAPIKeyEntry
+	if err := json.Unmarshal(trimmed, &raw); err != nil {
+		return err
+	}
+	e.Key = raw.Key
+	e.Name = raw.Name
+	return nil
+}
+
+// MarshalJSON emits a plain string when no name is set.
+func (e APIKeyEntry) MarshalJSON() ([]byte, error) {
+	if strings.TrimSpace(e.Name) == "" {
+		return json.Marshal(e.Key)
+	}
+	return json.Marshal(namedAPIKeyEntry{Key: e.Key, Name: e.Name})
+}
+
+// APIKeysFromStrings converts raw key strings into unnamed entries.
+func APIKeysFromStrings(keys []string) []APIKeyEntry {
+	if len(keys) == 0 {
+		return nil
+	}
+	entries := make([]APIKeyEntry, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, APIKeyEntry{Key: key})
+	}
+	return entries
+}
+
+// APIKeyValues returns the raw key values of the supplied entries.
+func APIKeyValues(entries []APIKeyEntry) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		keys = append(keys, entry.Key)
+	}
+	return keys
+}

--- a/sdk/access/registry.go
+++ b/sdk/access/registry.go
@@ -17,7 +17,11 @@ type Provider interface {
 type Result struct {
 	Provider  string
 	Principal string
-	Metadata  map[string]string
+	// PrincipalLabel is an optional display label for attribution only
+	// (usage records and request logs). It MUST NOT be used for authorization,
+	// session ownership, or cache isolation; use Principal for those.
+	PrincipalLabel string
+	Metadata       map[string]string
 }
 
 var (

--- a/sdk/access/types.go
+++ b/sdk/access/types.go
@@ -18,7 +18,7 @@ type AccessProvider struct {
 	SDK string `yaml:"sdk,omitempty" json:"sdk,omitempty"`
 
 	// APIKeys lists inline keys for providers that require them.
-	APIKeys []string `yaml:"api-keys,omitempty" json:"api-keys,omitempty"`
+	APIKeys []APIKeyEntry `yaml:"api-keys,omitempty" json:"api-keys,omitempty"`
 
 	// Config passes provider-specific options to the implementation.
 	Config map[string]any `yaml:"config,omitempty" json:"config,omitempty"`
@@ -34,14 +34,14 @@ const (
 
 // MakeInlineAPIKeyProvider constructs an inline API key provider configuration.
 // It returns nil when no keys are supplied.
-func MakeInlineAPIKeyProvider(keys []string) *AccessProvider {
+func MakeInlineAPIKeyProvider(keys []APIKeyEntry) *AccessProvider {
 	if len(keys) == 0 {
 		return nil
 	}
 	provider := &AccessProvider{
 		Name:    DefaultAccessProviderName,
 		Type:    AccessProviderTypeConfigAPIKey,
-		APIKeys: append([]string(nil), keys...),
+		APIKeys: append([]APIKeyEntry(nil), keys...),
 	}
 	return provider
 }

--- a/sdk/cliproxy/auth/home_result.go
+++ b/sdk/cliproxy/auth/home_result.go
@@ -50,6 +50,7 @@ func (m *Manager) reportHomeUnauthorized(ctx context.Context, auth *Auth, provid
 		ExecutorType:      homeResultExecutorType,
 		Model:             model,
 		Alias:             alias,
+		APIKey:            homeAPIKeyLabelFromContext(ctx),
 		AuthID:            auth.ID,
 		AuthIndex:         authIndex,
 		AccessTokenSHA256: accessTokenSHA256,
@@ -65,4 +66,22 @@ func (m *Manager) reportHomeUnauthorized(ctx context.Context, auth *Auth, provid
 			Body:       failureBody,
 		},
 	})
+}
+
+// homeAPIKeyLabelFromContext returns the configured display name of the matched
+// client API key. It is attribution-only: the raw key is never used as a
+// fallback, so unnamed keys stay unattributed on this path.
+func homeAPIKeyLabelFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	ginCtx, ok := ctx.Value("gin").(interface{ Get(string) (any, bool) })
+	if !ok || ginCtx == nil {
+		return ""
+	}
+	rawLabel, ok := ginCtx.Get("userApiKeyLabel")
+	if !ok {
+		return ""
+	}
+	return contextStringValue(rawLabel)
 }

--- a/sdk/cliproxy/auth/home_result_label_test.go
+++ b/sdk/cliproxy/auth/home_result_label_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+// Context and auth metadata keys used by the Home unauthorized reporting path.
+var (
+	homeResultLabelTokenKey = "access_token"
+	homeResultRawKeyName    = "userApiKey"
+	homeResultLabelKeyName  = "userApiKeyLabel"
+)
+
+// homeResultLabelGinContext mimics the subset of *gin.Context read by the auth package.
+type homeResultLabelGinContext struct {
+	values map[string]any
+}
+
+func (c *homeResultLabelGinContext) Get(key string) (any, bool) {
+	if c == nil {
+		return nil, false
+	}
+	value, ok := c.values[key]
+	return value, ok
+}
+
+type homeResultLabelCapture struct {
+	authID  string
+	records chan coreusage.Record
+}
+
+func (p *homeResultLabelCapture) HandleUsage(_ context.Context, record coreusage.Record) {
+	if p == nil || record.ExecutorType != homeResultExecutorType || record.AuthID != p.authID {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func (p *homeResultLabelCapture) wait(t *testing.T) coreusage.Record {
+	t.Helper()
+	select {
+	case record := <-p.records:
+		return record
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Home unauthorized usage record")
+		return coreusage.Record{}
+	}
+}
+
+type homeResultLabelNoopPlugin struct{}
+
+func (homeResultLabelNoopPlugin) HandleUsage(context.Context, coreusage.Record) {}
+
+func registerHomeResultLabelCapture(t *testing.T, name, authID string) *homeResultLabelCapture {
+	t.Helper()
+	capture := &homeResultLabelCapture{authID: authID, records: make(chan coreusage.Record, 1)}
+	coreusage.RegisterNamedPlugin(name, capture)
+	t.Cleanup(func() {
+		coreusage.RegisterNamedPlugin(name, homeResultLabelNoopPlugin{})
+	})
+	return capture
+}
+
+func newHomeResultLabelAuth(id string) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: "home-result-label",
+		Status:   StatusActive,
+		Metadata: map[string]any{homeResultLabelTokenKey: "home-result-label-token"},
+	}
+}
+
+func newHomeResultLabelContext(values map[string]any) context.Context {
+	ginCtx := &homeResultLabelGinContext{values: values}
+	//nolint:staticcheck // the runtime stores the gin context under this plain string key
+	return context.WithValue(context.Background(), "gin", ginCtx)
+}
+
+func TestReportHomeUnauthorizedUsesAPIKeyLabel(t *testing.T) {
+	authID := "home-result-label-auth"
+	capture := registerHomeResultLabelCapture(t, "home-result-label-capture", authID)
+
+	ctx := newHomeResultLabelContext(map[string]any{
+		homeResultRawKeyName:   "raw-client-key",
+		homeResultLabelKeyName: "alice",
+	})
+
+	(&Manager{}).ReportHomeUnauthorized(ctx, newHomeResultLabelAuth(authID), "home-result-label", "test-model")
+
+	if record := capture.wait(t); record.APIKey != "alice" {
+		t.Fatalf("record.APIKey = %q, want %q", record.APIKey, "alice")
+	}
+}
+
+func TestReportHomeUnauthorizedWithoutLabelOmitsRawAPIKey(t *testing.T) {
+	authID := "home-result-no-label-auth"
+	capture := registerHomeResultLabelCapture(t, "home-result-no-label-capture", authID)
+
+	ctx := newHomeResultLabelContext(map[string]any{
+		homeResultRawKeyName: "raw-client-key",
+	})
+
+	(&Manager{}).ReportHomeUnauthorized(ctx, newHomeResultLabelAuth(authID), "home-result-label", "test-model")
+
+	if record := capture.wait(t); record.APIKey != "" {
+		t.Fatalf("record.APIKey = %q, want empty (raw keys must never be recorded)", record.APIKey)
+	}
+}
+
+func TestReportHomeUnauthorizedWithoutGinContext(t *testing.T) {
+	authID := "home-result-no-gin-auth"
+	capture := registerHomeResultLabelCapture(t, "home-result-no-gin-capture", authID)
+
+	(&Manager{}).ReportHomeUnauthorized(context.Background(), newHomeResultLabelAuth(authID), "home-result-label", "test-model")
+
+	if record := capture.wait(t); record.APIKey != "" {
+		t.Fatalf("record.APIKey = %q, want empty", record.APIKey)
+	}
+}

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -10,6 +10,13 @@ type SDKConfig = internalconfig.SDKConfig
 
 type Config = internalconfig.Config
 
+type APIKeyEntry = internalconfig.APIKeyEntry
+
+// APIKeysFromStrings converts raw key strings into unnamed client API key entries.
+func APIKeysFromStrings(keys []string) []APIKeyEntry {
+	return internalconfig.APIKeysFromStrings(keys)
+}
+
 type StreamingConfig = internalconfig.StreamingConfig
 type ClaudeCodeConfig = internalconfig.ClaudeCodeConfig
 type TLSConfig = internalconfig.TLSConfig


### PR DESCRIPTION
Usage records and request logs currently carry the raw API key as the Principal of an authenticated request. This has two problems:

1. Secret leakage: Raw client keys end up in logs and metrics, so any system that stores or ships those artifacts also stores the credentials.
2. No usage attribution: Per-client usage analysis requires an external mapping from key to client identity

Named API keys fix both with a fully backward-compatible config change: when a key has a name, the name becomes the `Principal`; the raw key never appears in logs or usage records for that client.

## What changed

- **Config format.** Each `api-keys` entry accepts either the existing plain
  string or a mapping `{key: "...", name: "alice"}`. The new `APIKeyEntry`
  type (in `sdk/access`, aliased in `internal/config`) has custom
  YAML/JSON marshalers: unnamed entries are re-emitted as plain scalars, so
  existing configs round-trip byte-for-byte through the comment-preserving
  persist. `SDKConfig.APIKeyValues()` keeps a `[]string` view for call sites
  that only need raw keys.
- **Principal resolution.** `internal/access/config_access` maps key → name.
  A matched named key sets `Result.Principal` to the name; unnamed keys keep
  the current behavior (raw key). Duplicate keys dedup to the first
  occurrence; the first non-empty name wins. Propagation to `userApiKey`,
  usage records, and request logs is automatic — the usage pipeline is
  untouched.
- **Management API.** `GET/PUT/PATCH/DELETE /v0/management/api-keys` accept
  and emit both payload shapes. Plain-string payloads from the Management
  Center keep working unchanged; a string PATCH value updates the key and
  preserves the entry's name.
- **Config watcher.** A name-only change now triggers a reload; diff messages
  stay redacted (no keys, no names).
- **Safe mode.** Template-key detection works with mixed entries via
  `APIKeyValues()`.
- **TUI.** The keys tab and dashboard show `name (masked-key)` for named
  entries; unnamed entries render exactly as before. Editing operates on the
  raw key; the name survives server-side.
- **Docs.** `config.example.yaml` gains a commented named-entry example.

## Tests

- Mixed-format YAML/JSON parsing and marshal round-trip (`internal/config`).
- Principal resolution: named, unnamed, duplicate keys
  (`internal/access/config_access`).
- Management API round-trip with both payload shapes, PATCH name
  preservation, DELETE by index/value (`internal/api/handlers/management`).
- Comment-preserving persist round-trip of a mixed scalar/mapping sequence
  (`internal/config`).
- Name-only change triggers a reload; message contains no secrets
  (`internal/watcher/diff`).
- Safe-mode template detection with mixed entries (`cmd/server`).

## Verification

- `gofmt -w .` — clean (three pre-existing unformatted files left untouched)
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go build -o test-output ./cmd/server && rm test-output` — clean