### PR TITLE
fix(auth): keep the longest live cooldown across failure writes and align the model projection

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -794,6 +794,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
+					prevModelRetryAfter := state.NextRetryAfter
 					if result.Error != nil {
 						state.LastError = cloneError(result.Error)
 						state.StatusMessage = result.Error.Message
@@ -873,6 +874,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 										if otherState.Quota.Exceeded && otherState.Quota.NextRecoverAt.After(otherNext) {
 											otherNext = otherState.Quota.NextRecoverAt
 										}
+										// Propagation only extends a sibling's still-live
+										// per-model deadline; it never shortens one.
+										if !otherState.NextRetryAfter.IsZero() && otherState.NextRetryAfter.After(otherNext) {
+											otherNext = otherState.NextRetryAfter
+										}
 										otherState.NextRetryAfter = otherNext
 										applyCooldownFields(&otherState.Quota, QuotaState{
 											Exceeded:      true,
@@ -888,6 +894,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								authNext := next
 								if auth.Quota.NextRecoverAt.After(authNext) {
 									authNext = auth.Quota.NextRecoverAt
+								}
+								if !auth.NextRetryAfter.IsZero() && auth.NextRetryAfter.After(authNext) {
+									authNext = auth.NextRetryAfter
 								}
 								auth.Quota.NextRecoverAt = authNext
 								auth.NextRetryAfter = authNext
@@ -908,6 +917,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown && state.NextRetryAfter.IsZero() {
 						state.NextRetryAfter = now.Add(transientErrorCooldown)
 						state.Unavailable = true
+					}
+					// A later failure only extends a still-live cooldown; it never
+					// shortens one. A deliberate zero write (disableCooling) still
+					// clears the deadline.
+					if !state.NextRetryAfter.IsZero() && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
+						state.NextRetryAfter = prevModelRetryAfter
 					}
 					auth.Status = StatusError
 					updateAggregatedAvailability(auth, now)
@@ -1985,6 +2000,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if auth == nil {
 		return
 	}
+	prevAuthRetryAfter := auth.NextRetryAfter
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
@@ -2078,6 +2094,11 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
+	}
+	// A later failure only extends a still-live credential cooldown; a
+	// deliberate zero write (disableCooling) still clears it.
+	if !auth.NextRetryAfter.IsZero() && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
+		auth.NextRetryAfter = prevAuthRetryAfter
 	}
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -2001,6 +2001,12 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		return
 	}
 	prevAuthRetryAfter := auth.NextRetryAfter
+	// A later failure only extends a still-live credential cooldown; it never
+	// shortens one, including the Cloudflare-challenge and invalid-grant returns
+	// above. A deliberate zero write (disableCooling) still clears it.
+	defer func() {
+		auth.NextRetryAfter = keepLongerLiveCooldown(auth.NextRetryAfter, prevAuthRetryAfter, now)
+	}()
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
@@ -2095,15 +2101,22 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
-	// A later failure only extends a still-live credential cooldown; a
-	// deliberate zero write (disableCooling) still clears it.
-	if !auth.NextRetryAfter.IsZero() && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
-		auth.NextRetryAfter = prevAuthRetryAfter
-	}
+	// A later failure only extends a still-live credential cooldown; it never
+	// shortens one. The deferred clamp above covers every return path.
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)
 		auth.Unavailable = true
 	}
+}
+
+// keepLongerLiveCooldown returns whichever deadline is later: the freshly
+// computed one or a still-live previous cooldown. A zero newDeadline (a
+// deliberate clear, e.g. disableCooling) is returned untouched.
+func keepLongerLiveCooldown(newDeadline, prev, now time.Time) time.Time {
+	if !newDeadline.IsZero() && prev.After(newDeadline) && prev.After(now) {
+		return prev
+	}
+	return newDeadline
 }
 
 // quotaCooldownAfterFailure returns the recovery deadline and backoff level for

--- a/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
@@ -1,0 +1,153 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// Later failure writes must never shorten a still-live cooldown; they may only
+// extend it (#5501). A deliberate zero write (disableCooling) still clears.
+
+func newCooldownMonotonicManager(t *testing.T, models ...string) (*Manager, *Auth) {
+	t.Helper()
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-monotonic-" + models[0], Provider: "claude"}
+	reg := registry.GetGlobalRegistry()
+	infos := make([]*registry.ModelInfo, 0, len(models))
+	now := time.Now().Unix()
+	for _, model := range models {
+		infos = append(infos, &registry.ModelInfo{ID: model, Created: now})
+	}
+	reg.RegisterClient(auth.ID, auth.Provider, infos)
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	return m, auth
+}
+
+func TestManager_MarkResult_CredentialScopeKeepsLongerSiblingDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "model-a", "model-b")
+
+	// Long per-model deadline on model-b: a credential-wide 401 (~30m).
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-b",
+		Success: false, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "long 401"},
+	})
+	before := time.Now()
+	sibling, _ := m.GetByID(auth.ID)
+	bState := existingModelState(sibling, canonicalModelKey("model-b"))
+	if bState == nil || bState.NextRetryAfter.Before(before.Add(25*time.Minute)) {
+		t.Fatalf("precondition failed: model-b long deadline missing: %+v", bState)
+	}
+
+	// Shorter credential-scoped 429 on model-a must not shorten model-b.
+	short := 5 * time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+		Success: false, RetryAfter: &short, CredentialScope: true,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "credential 429"},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	bStateAfter := existingModelState(updated, canonicalModelKey("model-b"))
+	if bStateAfter == nil {
+		t.Fatal("model-b state missing after sibling failure")
+	}
+	if bStateAfter.NextRetryAfter.Before(before.Add(25 * time.Minute)) {
+		t.Fatalf("credential-scoped failure shortened model-b deadline to %v", bStateAfter.NextRetryAfter.Sub(before))
+	}
+}
+
+func TestManager_MarkResult_LaterShorterFailureKeepsLongerModelDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	tests := []struct {
+		name   string
+		second func(m *Manager, authID string)
+	}{
+		{
+			name: "401_then_short_429",
+			second: func(m *Manager, authID string) {
+				short := 2 * time.Minute
+				m.MarkResult(context.Background(), Result{
+					AuthID: authID, Provider: "claude", Model: "model-a",
+					Success: false, RetryAfter: &short,
+					Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "short 429"},
+				})
+			},
+		},
+		{
+			name: "401_then_transient_500",
+			second: func(m *Manager, authID string) {
+				m.MarkResult(context.Background(), Result{
+					AuthID: authID, Provider: "claude", Model: "model-a",
+					Success: false, Error: &Error{HTTPStatus: http.StatusInternalServerError, Message: "transient 500"},
+				})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, auth := newCooldownMonotonicManager(t, "model-a")
+			m.MarkResult(context.Background(), Result{
+				AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+				Success: false, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "long 401"},
+			})
+			before := time.Now()
+			snap, _ := m.GetByID(auth.ID)
+			state := existingModelState(snap, canonicalModelKey("model-a"))
+			if state == nil || state.NextRetryAfter.Before(before.Add(25*time.Minute)) {
+				t.Fatalf("precondition failed: 401 deadline missing: %+v", state)
+			}
+
+			tc.second(m, auth.ID)
+
+			updated, _ := m.GetByID(auth.ID)
+			stateAfter := existingModelState(updated, canonicalModelKey("model-a"))
+			if stateAfter == nil {
+				t.Fatal("model state missing after second writer")
+			}
+			if stateAfter.NextRetryAfter.Before(before.Add(25 * time.Minute)) {
+				t.Fatalf("second writer shortened live deadline to %v", stateAfter.NextRetryAfter.Sub(before))
+			}
+		})
+	}
+}
+
+// The client-facing projection must agree with scheduling: a live credential-wide
+// cooldown (auth.Unavailable + auth.NextRetryAfter) suspends models that carry no
+// per-model state (#5501).
+func TestManager_ClientModelProjection_ReflectsAuthLevelCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "model-a")
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "",
+		Success: false, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "credential-wide 401"},
+	})
+
+	snap, _ := m.GetByID(auth.ID)
+	if !snap.Unavailable || snap.NextRetryAfter.Before(time.Now().Add(25*time.Minute)) {
+		t.Fatalf("precondition failed: expected live auth-level cooldown, got Unavailable=%v NextRetryAfter=%v", snap.Unavailable, snap.NextRetryAfter)
+	}
+
+	blocked, _, _ := isAuthBlockedForModel(snap, "model-a", time.Now())
+	projection := m.clientModelProjectionForAuth(snap, "model-a", time.Now())
+	if blocked && !projection.Suspended {
+		t.Fatalf("scheduling blocks the model while projection reports Suspended=false: %+v", projection)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_monotonic_test.go
@@ -125,6 +125,36 @@ func TestManager_MarkResult_LaterShorterFailureKeepsLongerModelDeadline(t *testi
 	}
 }
 
+// A Cloudflare-challenge result arriving after a longer credential-wide
+// cooldown must not shorten it: the clamp covers every failure path in
+// applyAuthFailureState, including the early-return branches (#5519 review).
+func TestManager_MarkResult_CloudflareKeepsLongerCredentialDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "model-a")
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "",
+		Success: false, Error: &Error{HTTPStatus: http.StatusNotFound, Message: "not found"},
+	})
+	before := time.Now()
+	snap, _ := m.GetByID(auth.ID)
+	if snap.NextRetryAfter.Before(before.Add(6 * time.Hour)) {
+		t.Fatalf("precondition failed: expected a long 404 deadline, got %v", snap.NextRetryAfter.Sub(before))
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "",
+		Success: false, Error: &Error{Message: "cloudflare challenge"},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated.NextRetryAfter.Before(before.Add(6 * time.Hour)) {
+		t.Fatalf("cloudflare challenge shortened the live credential deadline to %v", updated.NextRetryAfter.Sub(before))
+	}
+}
+
 // The client-facing projection must agree with scheduling: a live credential-wide
 // cooldown (auth.Unavailable + auth.NextRetryAfter) suspends models that carry no
 // per-model state (#5501).

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -252,6 +252,13 @@ func (m *Manager) clientModelProjectionForAuth(auth *Auth, routeModel string, no
 			suspendReason = cooldownReason(state.StatusMessage, state.Quota, state.LastError)
 		}
 	}
+	if len(auth.ModelStates) == 0 && auth.Unavailable && auth.NextRetryAfter.After(now) {
+		// With no per-model states, scheduling falls back to the credential-wide
+		// cooldown (isAuthBlockedForModel); the projection must agree with it.
+		// When states exist, unmatched models stay schedulable by design, so the
+		// credential-wide fields must not suspend them here either.
+		isSuspended = true
+	}
 	if isSuspended && suspendReason == "" {
 		suspendReason = cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError)
 	}


### PR DESCRIPTION
## Summary

Fixes the three gaps reported in #5501 (the issue proposes no design; the invariant chosen here is that a failure write may only extend a still-live cooldown, never shorten it):

1. **Cross-model propagation** — a credential-scoped 429 on model A overwrote sibling model B's longer live deadline (repro: 30m 401 on B, then 5min credential-scoped 429 on A, B dropped to 5m). The propagation loop now takes the longest of the incoming deadline, the sibling's quota window, and the sibling's live `NextRetryAfter` (same for the credential-level write in that loop).
2. **Same-model sequences** — a later short 429 or transient 500 overwrote the model's longer live deadline (repro: 30m 401 → 2m/1m). Failure writes to `state.NextRetryAfter` and `auth.NextRetryAfter` are now clamped to keep a still-live earlier deadline. A deliberate zero write (`disableCooling`) still clears.
3. **Projection vs scheduling** — `clientModelProjectionForAuth` never consulted the credential-wide cooldown, reporting `Suspended=false` while `isAuthBlockedForModel` blocked the model (repro: credential-wide 401, no per-model state). The projection now applies the credential-wide cooldown exactly where scheduling does: only when the auth has no per-model states at all — with states present, unmatched models stay schedulable by design (locked by `TestManager_NoForkAlias_PerModelIsolation_NoAggregationFallbackFlip`).

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Finding 1: sibling deadline preserved (fails before: shortened to 5m) | `go test ./sdk/cliproxy/auth/ -run TestManager_MarkResult_CredentialScopeKeepsLongerSiblingDeadline -v -count=1` | red before, green after |
| Finding 2: later shorter writes preserve 30m deadline (fails before: 2m/1m) | `go test ./sdk/cliproxy/auth/ -run TestManager_MarkResult_LaterShorterFailureKeepsLongerModelDeadline -v -count=1` | red before, green after |
| Finding 3: projection agrees with scheduling (fails before: Suspended=false) | `go test ./sdk/cliproxy/auth/ -run TestManager_ClientModelProjection_ReflectsAuthLevelCooldown -v -count=1` | red before, green after |
| No regression incl. per-model isolation lock | `go test -p 1 ./sdk/cliproxy/auth/ -count=1` | ok (first pass caught the over-broad projection condition via that lock; narrowed to the `len(ModelStates)==0` fallback) |
| Build | `go build -o test-output ./cmd/server` | ok |
| Format | `gofmt -l` on changed files | clean |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
