### PR TITLE
chore(models): declare the 0.153.x Codex client identity for gpt-6-astra

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -116,7 +116,49 @@ func GetXAIModels() []*ModelInfo {
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
 func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo())
+	return withCodexBuiltinOverrideHeaders(upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo()))
+}
+
+// codexBuiltinOverrideHeaders are upstream client-version gates that must hold
+// regardless of which models.json (embedded or remote) is in effect. The
+// remote catalog replaces the embedded one wholesale on refresh, so a gate
+// carried only in the JSON is lost the moment the remote copy lacks it.
+//
+// gpt-6-astra: codex_client_models.json declares minimal_client_version
+// 0.153.0, above the executor's default cloak, and upstream rejects older
+// identities with "not supported when using Codex with a ChatGPT account".
+var codexBuiltinOverrideHeaders = map[string]map[string]string{
+	"gpt-6-astra": {
+		"user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+		"originator": "codex-tui",
+	},
+}
+
+// withCodexBuiltinOverrideHeaders fills in a built-in override_header for any
+// listed model whose catalog entry does not already carry one. A catalog that
+// does carry one wins, so the JSON stays the place to tune the value.
+func withCodexBuiltinOverrideHeaders(models []*ModelInfo) []*ModelInfo {
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		headers, ok := codexBuiltinOverrideHeaders[strings.ToLower(strings.TrimSpace(model.ID))]
+		if !ok {
+			continue
+		}
+		if model.Config != nil && len(model.Config.OverrideHeader) > 0 {
+			continue
+		}
+		override := make(map[string]string, len(headers))
+		for key, value := range headers {
+			override[key] = value
+		}
+		if model.Config == nil {
+			model.Config = &ModelConfig{}
+		}
+		model.Config.OverrideHeader = override
+	}
+	return models
 }
 
 // WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
@@ -353,7 +395,10 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 	for _, models := range allModels {
 		for _, m := range models {
 			if m != nil && m.ID == modelID {
-				return cloneModelInfo(m)
+				// Apply the same built-in Codex gates the tier getters apply, so a
+				// static lookup (the executor's ModelOverrideHeaders fallback) never
+				// returns a weaker definition than the registered one.
+				return withCodexBuiltinOverrideHeaders([]*ModelInfo{cloneModelInfo(m)})[0]
 			}
 		}
 	}

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -23,6 +23,40 @@ func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
 	}
 }
 
+// gpt-6-astra is gated upstream on the Codex client version
+// (codex_client_models.json: minimal_client_version 0.153.0). The executor's
+// default cloak is older than that, so the model must carry its own
+// override_header or every OAuth request is rejected with "not supported when
+// using Codex with a ChatGPT account".
+func TestGPT6AstraOverrideHeadersMeetMinimalClientVersion(t *testing.T) {
+	const wantUA = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+	got := ModelOverrideHeaders("gpt-6-astra")
+	if got == nil {
+		t.Fatal("ModelOverrideHeaders(gpt-6-astra) = nil, want headers")
+	}
+	if got["user-agent"] != wantUA {
+		t.Fatalf("user-agent = %q, want %q", got["user-agent"], wantUA)
+	}
+	if got["originator"] != "codex-tui" {
+		t.Fatalf("originator = %q, want codex-tui", got["originator"])
+	}
+	for _, models := range [][]*ModelInfo{GetCodexTeamModels(), GetCodexPlusModels(), GetCodexProModels()} {
+		found := false
+		for _, model := range models {
+			if model.ID != "gpt-6-astra" {
+				continue
+			}
+			found = true
+			if model.Config == nil || model.Config.OverrideHeader["user-agent"] != wantUA {
+				t.Fatalf("gpt-6-astra tier definition lacks the override_header user-agent: %#v", model.Config)
+			}
+		}
+		if !found {
+			t.Fatal("gpt-6-astra missing from a Codex tier that should list it")
+		}
+	}
+}
+
 func TestGeminiVertexModelsUseFlashLiteReleaseID(t *testing.T) {
 	const releaseID = "gemini-3.1-flash-lite"
 	const previewID = releaseID + "-preview"

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -23,22 +23,19 @@ func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
 	}
 }
 
-// gpt-6-astra is gated upstream on the Codex client version
-// (codex_client_models.json: minimal_client_version 0.153.0). The executor's
-// default cloak is older than that, so the model must carry its own
-// override_header or every OAuth request is rejected with "not supported when
-// using Codex with a ChatGPT account".
-func TestGPT6AstraOverrideHeadersMeetMinimalClientVersion(t *testing.T) {
-	const wantUA = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+const astraWantUA = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+
+func assertAstraOverrideHeaders(t *testing.T, label string) {
+	t.Helper()
 	got := ModelOverrideHeaders("gpt-6-astra")
 	if got == nil {
-		t.Fatal("ModelOverrideHeaders(gpt-6-astra) = nil, want headers")
+		t.Fatalf("%s: ModelOverrideHeaders(gpt-6-astra) = nil, want headers", label)
 	}
-	if got["user-agent"] != wantUA {
-		t.Fatalf("user-agent = %q, want %q", got["user-agent"], wantUA)
+	if got["user-agent"] != astraWantUA {
+		t.Fatalf("%s: user-agent = %q, want %q", label, got["user-agent"], astraWantUA)
 	}
 	if got["originator"] != "codex-tui" {
-		t.Fatalf("originator = %q, want codex-tui", got["originator"])
+		t.Fatalf("%s: originator = %q, want codex-tui", label, got["originator"])
 	}
 	for _, models := range [][]*ModelInfo{GetCodexTeamModels(), GetCodexPlusModels(), GetCodexProModels()} {
 		found := false
@@ -47,13 +44,75 @@ func TestGPT6AstraOverrideHeadersMeetMinimalClientVersion(t *testing.T) {
 				continue
 			}
 			found = true
-			if model.Config == nil || model.Config.OverrideHeader["user-agent"] != wantUA {
-				t.Fatalf("gpt-6-astra tier definition lacks the override_header user-agent: %#v", model.Config)
+			if model.Config == nil || model.Config.OverrideHeader["user-agent"] != astraWantUA {
+				t.Fatalf("%s: gpt-6-astra tier definition lacks the override_header user-agent: %#v", label, model.Config)
 			}
 		}
 		if !found {
-			t.Fatal("gpt-6-astra missing from a Codex tier that should list it")
+			t.Fatalf("%s: gpt-6-astra missing from a Codex tier that should list it", label)
 		}
+	}
+}
+
+// gpt-6-astra is gated upstream on the Codex client version
+// (codex_client_models.json: minimal_client_version 0.153.0). The executor's
+// default cloak is older than that, so the model must carry its own
+// override_header or every OAuth request is rejected with "not supported when
+// using Codex with a ChatGPT account".
+func TestGPT6AstraOverrideHeadersMeetMinimalClientVersion(t *testing.T) {
+	assertAstraOverrideHeaders(t, "embedded catalog")
+}
+
+// The remote models.json replaces the embedded catalog on refresh. A remote
+// copy that predates the Astra gate (no `config` on its entries) must not
+// strip the override, or the fix only holds until the first successful fetch.
+func TestGPT6AstraOverrideHeadersSurviveRemoteCatalogWithoutConfig(t *testing.T) {
+	modelsCatalogStore.mu.RLock()
+	original := modelsCatalogStore.data
+	modelsCatalogStore.mu.RUnlock()
+	t.Cleanup(func() {
+		modelsCatalogStore.mu.Lock()
+		modelsCatalogStore.data = original
+		modelsCatalogStore.mu.Unlock()
+	})
+
+	// Simulate a remote payload: same catalog, but every Astra entry has lost
+	// its config block, exactly as router-for-me/models serves it today.
+	remote := &staticModelsJSON{}
+	*remote = *original
+	strip := func(models []*ModelInfo) []*ModelInfo {
+		out := cloneModelInfos(models)
+		for _, model := range out {
+			if model != nil && model.ID == "gpt-6-astra" {
+				model.Config = nil
+			}
+		}
+		return out
+	}
+	remote.CodexTeam = strip(original.CodexTeam)
+	remote.CodexPlus = strip(original.CodexPlus)
+	remote.CodexPro = strip(original.CodexPro)
+
+	modelsCatalogStore.mu.Lock()
+	modelsCatalogStore.data = remote
+	modelsCatalogStore.mu.Unlock()
+
+	assertAstraOverrideHeaders(t, "remote catalog without config")
+}
+
+// A catalog that ships its own override for a gated model wins over the
+// built-in, so the JSON remains the place to tune the value.
+func TestCodexBuiltinOverrideHeadersDeferToCatalog(t *testing.T) {
+	models := withCodexBuiltinOverrideHeaders([]*ModelInfo{
+		{ID: "gpt-6-astra", Config: &ModelConfig{OverrideHeader: map[string]string{"user-agent": "custom/9.9.9"}}},
+		{ID: "gpt-5.4"},
+		nil,
+	})
+	if got := models[0].Config.OverrideHeader["user-agent"]; got != "custom/9.9.9" {
+		t.Fatalf("catalog override was replaced: user-agent = %q", got)
+	}
+	if models[1].Config != nil {
+		t.Fatalf("gpt-5.4 gained a Config it should not have: %#v", models[1].Config)
 	}
 }
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2646,6 +2646,12 @@
           "max"
         ]
       },
+      "config": {
+        "override_header": {
+          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "originator": "codex-tui"
+        }
+      },
       "supportedInputModalities": [
         "text",
         "image"
@@ -2927,6 +2933,12 @@
           "max"
         ]
       },
+      "config": {
+        "override_header": {
+          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "originator": "codex-tui"
+        }
+      },
       "supportedInputModalities": [
         "text",
         "image"
@@ -3207,6 +3219,12 @@
           "xhigh",
           "max"
         ]
+      },
+      "config": {
+        "override_header": {
+          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "originator": "codex-tui"
+        }
       },
       "supportedInputModalities": [
         "text",


### PR DESCRIPTION
Closes #5521

## Problem

`gpt-6-astra` was added in c77b136 with `"minimal_client_version": "0.153.0"` in `codex_client_models.json`, and the fetcher that produced that entry was bumped to `codex_cli_rs/0.153.3` in the same commit. The request executor, however, still cloaks every OAuth Codex request as `codex-tui/0.146.0` (`codexUserAgent` in `codex_executor_request.go`), and Astra carries no per-model `override_header`, so upstream rejects every request:

```json
{"detail":"The 'gpt-6-astra' model is not supported when using Codex with a ChatGPT account."}
```

CPA then marks the credential's Astra model state unavailable and the model drops out of `/v1/models`. The same Plus and Team accounts can use Astra with a current client identity, so this is a fingerprint gate, not an entitlement gate. Because `applyCodexCloakingHeaders` runs last, a `codex-header-defaults.user-agent` in `config.yaml` cannot work around it either.

## Fix

Give `gpt-6-astra` a `config.override_header` in each Codex tier that lists it (`codex-team`, `codex-plus`, `codex-pro`) — the same mechanism the `gpt-5.6-*` entries already use for their `0.144.0` gate — with a `codex-tui/0.153.3` user-agent that satisfies Astra's declared minimum. `applyModelHeaderOverrides` runs after the cloaking pass, so the override wins for this model only; every other model keeps the executor's default fingerprint.

This is deliberately the narrow fix. Bumping the global `codexUserAgent` would also work but changes the fingerprint for every OAuth request; that is a separate decision for the maintainers.

## Verification

Built this branch with the repo `Dockerfile` and ran it in an isolated container against real Plus and Team Codex credentials, with the remote `models.json` URLs blackholed so the embedded (patched) catalog was in effect:

| Request | Result |
| --- | --- |
| `POST /v1/responses` `gpt-6-astra`, non-streaming, `reasoning.effort: low` | **200**, `status: completed`, output `pong`, `total_tokens: 314` |
| 3× `POST /v1/responses` streaming | **200** each, `response.completed` received |
| Credential spread across the 4 requests | 3 on the Team credential, 1 on the Plus credential — both accepted |

The same request against the stock `v7.2.150` image returns the 400 above from both credentials (log excerpt in #5521).

Tests:

- `go test ./internal/registry/` — adds `TestGPT6AstraOverrideHeadersMeetMinimalClientVersion`, which pins the override on `ModelOverrideHeaders("gpt-6-astra")` and on each tier's static definition
- `go test ./internal/runtime/executor/ -run "ModelHeaderOverrides|CodexHeaders|Cloak"` — passes unchanged

## Note on the remote catalog

The startup/periodic model refresh replaces the embedded catalog with `router-for-me/models` `models.json`, and that file currently has no `config` on the Astra entries, so this fix is only effective at runtime once the same override lands there. I can open a matching PR against `router-for-me/models` if you would like; the change is the three `config` blocks in this diff.
