### PR TITLE
fix(codex): keep template reasoning levels for budget-only thinking models

### DIFF
--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -377,6 +377,19 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 	if thinking == nil {
 		return
 	}
+	// Models that support thinking as a token budget without declaring discrete
+	// levels (for example {"min":1024,"max":64000}) still support reasoning, they
+	// just have no level list to apply. Keep the default template's reasoning
+	// metadata instead of reporting no levels at all. The template is guaranteed to
+	// carry a non-empty list: ValidateCodexClientModelsJSON rejects any catalog
+	// whose entries lack one.
+	//
+	// An entirely empty ThinkingSupport declares no capability at all
+	// (detectModelCapability reports CapabilityNone for it) and is excluded here, so
+	// it falls through to the empty-array path below.
+	if len(thinking.Levels) == 0 && (thinking.Min > 0 || thinking.Max > 0) {
+		return
+	}
 
 	levels := make([]any, 0, len(thinking.Levels))
 	defaultLevel := ""
@@ -398,6 +411,9 @@ func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.T
 		})
 	}
 	if len(levels) == 0 {
+		// Every declared level was filtered out for this client version, so the
+		// template's levels do not apply either. Keep the required field as an
+		// empty array rather than dropping it.
 		entry["supported_reasoning_levels"] = levels
 		delete(entry, "default_reasoning_level")
 		return

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -506,16 +506,6 @@ func TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels(t *te
 		{name: "modern client", version: "0.144.0", thinking: registry.ThinkingSupport{Levels: []string{"max", "ultra"}}, wantEfforts: []string{"max", "ultra"}, wantDefault: "max"},
 		{name: "legacy client with no compatible level", version: "0.143.9", thinking: registry.ThinkingSupport{Levels: []string{"max", "ultra"}}},
 		{name: "legacy client with one compatible level", version: "0.143.9", thinking: registry.ThinkingSupport{Levels: []string{"high", "max"}}, wantEfforts: []string{"high"}, wantDefault: "high"},
-		{
-			name:    "budget-only model",
-			version: "0.153.3",
-			thinking: registry.ThinkingSupport{
-				Min:            1024,
-				Max:            64000,
-				ZeroAllowed:    true,
-				DynamicAllowed: true,
-			},
-		},
 		{name: "empty levels", version: "0.153.3", thinking: registry.ThinkingSupport{Levels: []string{}}},
 	}
 
@@ -587,6 +577,79 @@ func TestSanitizeCodexClientReasoningMetadataPreservesEmptyArray(t *testing.T) {
 			}
 			if got, want := string(encodedEntry), `{"supported_reasoning_levels":[]}`; got != want {
 				t.Fatalf("model metadata JSON = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponseKeepsTemplateReasoningLevelsWhenModelDeclaresNone(t *testing.T) {
+	// Models such as Antigravity's claude-sonnet-4-6 advertise thinking as a token
+	// budget ({"min":1024,"max":64000}) without a level list. They still support
+	// reasoning, so the entry keeps the default template's levels instead of
+	// reporting none. A support block that declares no budget at all reports an
+	// empty array, matching detectModelCapability's CapabilityNone.
+	//
+	// wantEfforts is asserted exactly: inheriting a level the client cannot use
+	// (say "ultra" on a legacy client) is the failure this test exists to catch, so
+	// it must not pass merely because some levels are present.
+	templateEfforts := []string{"low", "medium", "high", "xhigh"}
+	tests := []struct {
+		name        string
+		version     string
+		thinking    *registry.ThinkingSupport
+		wantEfforts []string
+		wantDefault string
+	}{
+		{name: "budget only modern client", version: "0.153.0", thinking: &registry.ThinkingSupport{Min: 1024, Max: 64000}, wantEfforts: templateEfforts, wantDefault: "medium"},
+		{name: "budget only legacy client", version: "0.143.9", thinking: &registry.ThinkingSupport{Min: 1024, Max: 64000}, wantEfforts: templateEfforts, wantDefault: "medium"},
+		{name: "min only budget", version: "0.153.0", thinking: &registry.ThinkingSupport{Min: 1024}, wantEfforts: templateEfforts, wantDefault: "medium"},
+		{name: "max only budget", version: "0.153.0", thinking: &registry.ThinkingSupport{Max: 64000}, wantEfforts: templateEfforts, wantDefault: "medium"},
+		{name: "zero and dynamic allowed budget", version: "0.153.3", thinking: &registry.ThinkingSupport{Min: 1024, Max: 64000, ZeroAllowed: true, DynamicAllowed: true}, wantEfforts: templateEfforts, wantDefault: "medium"},
+		{name: "empty thinking support", version: "0.153.0", thinking: &registry.ThinkingSupport{}},
+		{name: "negative budget", version: "0.153.0", thinking: &registry.ThinkingSupport{Min: -1, Max: -5}},
+		{name: "flags only without budget", version: "0.153.0", thinking: &registry.ThinkingSupport{ZeroAllowed: true, DynamicAllowed: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := BuildResponseForClient([]map[string]any{{
+				"id":       "home-budget-thinking-model-test",
+				"thinking": tt.thinking,
+			}}, nil, false, tt.version)
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+			model := models[0]
+
+			rawLevels, ok := model["supported_reasoning_levels"].([]any)
+			if !ok {
+				t.Fatalf("supported_reasoning_levels = %#v, want an array", model["supported_reasoning_levels"])
+			}
+
+			if len(tt.wantEfforts) == 0 {
+				// No declared budget: the required field stays present but empty, and
+				// the optional default is omitted.
+				if len(rawLevels) != 0 {
+					t.Fatalf("supported_reasoning_levels = %#v, want an empty array", rawLevels)
+				}
+				if _, exists := model["default_reasoning_level"]; exists {
+					t.Fatalf("default_reasoning_level = %#v, want absent", model["default_reasoning_level"])
+				}
+				return
+			}
+
+			if len(rawLevels) != len(tt.wantEfforts) {
+				t.Fatalf("supported_reasoning_levels = %#v, want %v", rawLevels, tt.wantEfforts)
+			}
+			for index, want := range tt.wantEfforts {
+				level, okLevel := rawLevels[index].(map[string]any)
+				if !okLevel || stringModelValue(level, "effort") != want {
+					t.Fatalf("supported_reasoning_levels[%d] = %#v, want %q", index, rawLevels[index], want)
+				}
+			}
+			if got := stringModelValue(model, "default_reasoning_level"); got != tt.wantDefault {
+				t.Fatalf("default_reasoning_level = %q, want %q", got, tt.wantDefault)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to #5505, which I closed prematurely. Rebased onto current `dev` (v7.2.151, includes 5208aec).

## What 5208aec already fixed

Emitting `[]` instead of deleting the key keeps the catalog decodable, so Codex no longer rejects the whole response. That resolves the breakage in #5500 — verified on a live deployment after upgrading 7.2.148 → 7.2.151 with the `oauth-excluded-models` workaround removed: all 35 entries carry the field, and `codex exec` no longer reports `failed to decode models response`.

## What is still wrong

Budget-only models now report no levels at all. Against current `dev`:

| `thinking` | `supported_reasoning_levels` | |
| --- | --- | --- |
| `{}` | `[]` | correct, no capability declared |
| `{"levels":["max","ultra"]}` on client `0.143.9` | `[]` | correct, all levels filtered out |
| `{"min":1024,"max":64000}` | `[]` | **wrong — this model does support reasoning** |

`ThinkingSupport.Levels` documents budgets and levels as two alternative modes — *"When set, the model uses level-based reasoning instead of token budgets"* — so an absent level list means "not level-based", not "no reasoning".

These models do accept a level. For `CapabilityBudgetOnly`, `validate.go` converts an incoming level through `ConvertLevelToBudget` (`xhigh` → 32768, `max` → 128000) and `clampBudget` then pins the result to the model's own `[Min, Max]`, so advertising the template's levels exposes choices the model can actually honor. Reporting `[]` instead leaves them with no selectable effort in the picker.

That clamp covers registry models. Models declared in `config.yaml` are user-defined, and `ApplyThinking` deliberately skips `ValidateConfig` for them ("we skip validation and still apply the thinking config so the upstream can validate it"). For those, `normalizeUserDefinedConfig` converts the level without consulting the model's `Max`, so a config-declared budget-only model with `max: 16384` would surface `xhigh` and forward 32768 upstream unclamped.

Checked which targets this actually reaches, since the paths differ: with `toFormat` `gemini` the level becomes budget 32768 (unclamped, above the declared 16384); with `claude` and `openai` `normalizeUserDefinedConfig` returns early and the level passes through as a level, so no budget is synthesised at all. I do not think this blocks the change — those models currently offer no selectable effort, so there is no working behaviour to regress, and the template tops out at `xhigh` — but it is worth naming rather than leaving to be found.

One cosmetic consequence worth naming: on models with `Max` below 32768 (the Gemini flash family, `Max: 24576`) `high` and `xhigh` both clamp to the same budget, so the top two entries behave identically. That is the cost of inheriting a generic template rather than a per-family one — see the note below.

## Scope

Not limited to the two Antigravity models from #5500. Counting entries in the upstream `models.json` whose `thinking` has a budget but no `levels` — **28 catalog entries spanning six providers, 19 unique model IDs** (`gemini-2.5-pro` and friends are listed under several providers, so a single deployment sees at most 19, usually fewer):

| provider | count | examples |
| --- | --- | --- |
| claude | 7 | `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001` |
| aistudio | 9 | `gemini-3-pro-preview`, `gemini-3.1-pro-preview`, `gemini-2.5-pro` |
| vertex | 4 | `gemini-2.5-pro`, `gemini-2.5-flash` |
| gemini | 3 | `gemini-2.5-pro`, `gemini-2.5-flash` |
| gemini-cli | 3 | `gemini-2.5-pro`, `gemini-2.5-flash` |
| antigravity | 2 | `claude-sonnet-4-6`, `claude-opus-4-6-thinking` |

A plain Claude OAuth or Gemini setup is affected too.

## Fix

Return early when the model declares a budget but no levels, keeping the default template's reasoning metadata. An entirely empty `ThinkingSupport` falls through to the existing empty-array path, matching `detectModelCapability`, which reports `CapabilityNone` when neither a budget nor levels are present.

**This cannot reintroduce the missing-field rejection.** `ValidateCodexClientModelsJSON` requires every catalog entry to carry a non-empty `supported_reasoning_levels` whose `default_reasoning_level` is one of its members, and rejects the whole payload otherwise (`internal/registry/codex_client_models.go`); `buildCodexClientModels` bails out when the default template is missing. So any entry reaching this early return is a clone of a template that already holds a valid non-empty list.

The inherited levels are still version-filtered: `sanitizeCodexClientReasoningMetadata` runs afterwards on the same entry, so a legacy client keeps seeing only the levels it understands.

Net effect on top of `dev`:

| `thinking` | before | after |
| --- | --- | --- |
| `{}` | `[]` | `[]` (unchanged) |
| all levels filtered out | `[]` | `[]` (unchanged) |
| `{"min":1024,"max":64000}` | `[]` | `[low medium high xhigh]`, default `medium` |

## Tests

The `budget-only model` case added in 5208aec asserts `[]` for `Min: 1024, Max: 64000`, which is the behavior this PR changes. It moves from `TestCodexClientModelsResponseDoesNotInheritUnsupportedReasoningLevels` into the budget-only test with its parameters preserved (including `ZeroAllowed`/`DynamicAllowed`), since those levels are supported rather than unsupported — the enclosing test is about levels a client cannot use.

- `TestCodexClientModelsResponseKeepsTemplateReasoningLevelsWhenModelDeclaresNone`: eight cases — modern client, legacy client, `Min`-only and `Max`-only budgets, the relocated `ZeroAllowed`/`DynamicAllowed` case, and three that must stay empty: an empty `ThinkingSupport`, a negative budget, and flags without a budget. The inherited levels are asserted exactly (`[low medium high xhigh]`, default `medium`) rather than "non-empty", since silently inheriting a level the client cannot use is the failure this test exists to catch.

  Checked the assertions actually bite, by mutating the source and confirming each is caught: disabling the early return fails the budget cases; weakening the guard to `Min != 0 || Max != 0` fails `negative budget`; appending an `ultra` level to the inherited list fails the exact-match cases.
- `TestSanitizeCodexClientReasoningMetadataPreservesEmptyArray` from 5208aec unchanged and passing.
- `go build ./cmd/server` clean; `gofmt` clean; `go test ./...` green apart from `TestPionMediaRelayBridgesAudioAndDataChannel` in `internal/client/codex/live`, which is flaky here independently of this change (2 of 3 runs fail on an unmodified tree; unrelated package).

## Verified against a live deployment

Built this branch and ran it side by side with stock v7.2.151 on the same host, same credentials, same upstream registry, so the only variable is this patch. Diffing `/v1/models?client_version=0.153.2` between the two ports — 35 entries each, **2 differ, 33 byte-identical, neither side missing the field**:

| model | v7.2.151 | this PR |
| --- | --- | --- |
| `claude-sonnet-4-6` | `[]`, no default | `[low medium high xhigh]`, default `medium` |
| `claude-opus-4-6-thinking` | `[]`, no default | `[low medium high xhigh]`, default `medium` |

Then pointed a real Codex CLI (0.153.2) at the patched instance:

- `codex exec` completes with no `failed to refresh available models`, so the catalog still decodes;
- `codex exec -c model=claude-sonnet-4-6 -c model_reasoning_effort=xhigh` runs, reporting `reasoning effort: xhigh` — an effort that simply does not exist for that model on stock v7.2.151, where its level list is empty.

(Only these two of the 28 entries are reachable from this deployment; it runs Antigravity plus a Claude-compatible relay, not the Gemini providers.)

## Why the generic template, rather than per-family levels

Two alternatives I looked at and rejected:

- **A template per provider family.** `internal/registry/models/codex_client_models.json` holds ten slugs, all `gpt-*`/`codex-*` — it describes model shapes the Codex client understands, not the upstream provider catalog, so there is no Claude or Gemini template to inherit from. Inventing and maintaining them is out of scope here, and the file is remotely refreshable (`codex_client_models_updater.go`), so locally authored templates would be overwritten anyway.
- **Deriving levels from `Min`/`Max`.** Filtering the template's levels by the model's ceiling would drop the duplicate top entry on the flash family. It also means importing `internal/thinking`'s level→budget table into the catalog builder, adding a cross-package dependency for a display-only nicety that changes nothing for Claude (`Max: 128000`) or Gemini Pro (`Max: 32768`). Happy to do it if you would rather have it.

## Relation to #5507

@Vurliy reached the same conclusion in #5507 — its description already states that a model with a nonzero budget "keeps the validated default template levels". That PR currently shows as CONFLICTING against `dev` after 5208aec landed. This one is rebased and green, and additionally reconciles the conflicting test expectation.

Worth flagging for whoever picks: #5507 needs more than a rebase. Applying just its early-return to a clean `dev` still fails the package suite —

```
--- FAIL: ...DoesNotInheritUnsupportedReasoningLevels/budget-only_model
    supported_reasoning_levels JSON = [{low},{medium},{high},{xhigh}], want []
```

— because the `budget-only model` expectation from 5208aec has to be reconciled either way, which its description does not mention. This PR already does that.

Happy to close this in favour of #5507 once it is rebased and that expectation reconciled — whichever the maintainers prefer. I have no attachment to which PR carries it.
