### PR TITLE
feat(usage): propagate session and parent session hierarchy to usage reporting queue

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -332,6 +332,7 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		selectionHeaders.Set("X-Session-ID", sessionID)
 	}
 	ctx := context.WithValue(c.Request.Context(), "gin", c)
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, selectionHeaders, body, nil)
 	selectionModel, errRoute := s.codexAlphaSearchSelectionModel(ctx, c, body, strings.TrimSpace(routing.Model))
 	if errRoute != nil {
 		log.WithError(errRoute).Warn("codex alpha search: model router returned an unsupported target")
@@ -363,6 +364,19 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		}
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth unavailable"})
 		return
+	}
+	if selection != nil && selection.CanonicalSessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = selection.CanonicalSessionID
+		if selection.ParentSessionID != "" {
+			meta.ParentSessionID = selection.ParentSessionID
+		} else {
+			meta.ParentSessionID = ""
+		}
+		if meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
 	}
 	var releaseAttempt func()
 	if selection != nil {

--- a/internal/client/codex/live/capabilities.go
+++ b/internal/client/codex/live/capabilities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -60,6 +61,15 @@ func (h *Handler) HandleHangup(c *gin.Context) {
 	}
 
 	ctx := context.WithValue(c.Request.Context(), "gin", c)
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, liveSelectionHeaders(c), nil, map[string]any{
+		coreexecutor.ExecutionSessionMetadataKey: callID,
+	})
+	if session.sessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = session.sessionID
+		meta.ParentSessionID = session.parentSessionID
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
+	}
 	var activeSelection *auth.HomeDispatchSelection
 	var temporarySelection bool
 	var selected *auth.Auth
@@ -78,6 +88,19 @@ func (h *Handler) HandleHangup(c *gin.Context) {
 		if errSelect != nil {
 			writeSelectionError(c, errSelect)
 			return
+		}
+		if selection != nil && selection.CanonicalSessionID != "" {
+			meta := logging.GetClientRequestMetadata(ctx)
+			meta.SessionID = selection.CanonicalSessionID
+			if selection.ParentSessionID != "" {
+				meta.ParentSessionID = selection.ParentSessionID
+			} else {
+				meta.ParentSessionID = ""
+			}
+			if meta.SessionID == meta.ParentSessionID {
+				meta.ParentSessionID = ""
+			}
+			ctx = logging.WithClientRequestMetadata(ctx, meta)
 		}
 		activeSelection = selection
 		selected = selectedAuth

--- a/internal/client/codex/live/live.go
+++ b/internal/client/codex/live/live.go
@@ -21,6 +21,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -218,6 +219,7 @@ func (h *Handler) Handle(c *gin.Context) {
 		Headers:         liveSelectionHeaders(c),
 		OriginalRequest: body,
 	}
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, selectionOpts.Headers, body, nil)
 	selection, selected, errSelect := h.selectOAuth(ctx, model, selectionOpts)
 	if errSelect != nil {
 		writeSelectionError(c, errSelect)
@@ -229,6 +231,19 @@ func (h *Handler) Handle(c *gin.Context) {
 		}
 		writeLiveError(c, http.StatusServiceUnavailable, "Codex auth unavailable")
 		return
+	}
+	if selection != nil && selection.CanonicalSessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = selection.CanonicalSessionID
+		if selection.ParentSessionID != "" {
+			meta.ParentSessionID = selection.ParentSessionID
+		} else {
+			meta.ParentSessionID = ""
+		}
+		if meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
 	}
 
 	if selection != nil {
@@ -401,7 +416,14 @@ func (h *Handler) Handle(c *gin.Context) {
 	sessionStored := false
 	if success && h.sessions != nil {
 		if callID != "" {
-			session := liveSession{authID: selected.ID, model: model, media: mediaSession}
+			clientMeta := logging.GetClientRequestMetadata(ctx)
+			session := liveSession{
+				authID:          selected.ID,
+				model:           model,
+				media:           mediaSession,
+				sessionID:       clientMeta.SessionID,
+				parentSessionID: clientMeta.ParentSessionID,
+			}
 			session.ownerPrincipal, session.ownerProvider = requestOwner(c)
 			if principal, ok := c.Get(ClientSecretPrincipalContextKey); ok {
 				session.clientSecretPrincipal, _ = principal.(string)

--- a/internal/client/codex/live/sideband.go
+++ b/internal/client/codex/live/sideband.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
@@ -45,6 +46,8 @@ type liveSession struct {
 	callID                string
 	authID                string
 	model                 string
+	sessionID             string
+	parentSessionID       string
 	ownerPrincipal        string
 	ownerProvider         string
 	clientSecretPrincipal string
@@ -354,6 +357,15 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 
 	ctx := context.WithValue(c.Request.Context(), "gin", c)
 	ctx = coreexecutor.WithDownstreamWebsocket(ctx)
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, c.Request.Header, nil, map[string]any{
+		coreexecutor.ExecutionSessionMetadataKey: session.callID,
+	})
+	if session.sessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = session.sessionID
+		meta.ParentSessionID = session.parentSessionID
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
+	}
 	var selection *auth.HomeDispatchSelection
 	var selected *auth.Auth
 	var errSelect error
@@ -378,6 +390,19 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 	if errSelect != nil {
 		writeSelectionError(c, errSelect)
 		return
+	}
+	if selection != nil && selection.CanonicalSessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = selection.CanonicalSessionID
+		if selection.ParentSessionID != "" {
+			meta.ParentSessionID = selection.ParentSessionID
+		} else {
+			meta.ParentSessionID = ""
+		}
+		if meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
 	}
 	if selected == nil {
 		writeLiveError(c, http.StatusServiceUnavailable, "Codex auth unavailable")

--- a/internal/client/codex/live/websocket.go
+++ b/internal/client/codex/live/websocket.go
@@ -12,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -56,6 +57,7 @@ func (h *Handler) HandleDirectWebsocket(c *gin.Context) {
 	ctx := context.WithValue(c.Request.Context(), "gin", c)
 	ctx = coreexecutor.WithDownstreamWebsocket(ctx)
 	selectionOpts := coreexecutor.Options{Headers: liveSelectionHeaders(c)}
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, selectionOpts.Headers, nil, nil)
 	selection, selected, errSelect := h.selectOAuth(ctx, selectionModel, selectionOpts)
 	if errSelect != nil {
 		writeSelectionError(c, errSelect)
@@ -67,6 +69,19 @@ func (h *Handler) HandleDirectWebsocket(c *gin.Context) {
 		}
 		writeRealtimeError(c, http.StatusServiceUnavailable, "Codex auth unavailable", "server_error", "codex_auth_unavailable")
 		return
+	}
+	if selection != nil && selection.CanonicalSessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = selection.CanonicalSessionID
+		if selection.ParentSessionID != "" {
+			meta.ParentSessionID = selection.ParentSessionID
+		} else {
+			meta.ParentSessionID = ""
+		}
+		if meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
 	}
 	if selection != nil {
 		attemptCtx, releaseAttempt, errAttempt := selection.AttemptContext(ctx)

--- a/internal/logging/requestmeta.go
+++ b/internal/logging/requestmeta.go
@@ -14,9 +14,11 @@ type clientRequestMetadataKey struct{}
 
 // ClientRequestMetadata stores immutable downstream request metadata for asynchronous consumers.
 type ClientRequestMetadata struct {
-	ClientIP      string
-	XForwardedFor string
-	UserAgent     string
+	ClientIP        string
+	XForwardedFor   string
+	UserAgent       string
+	SessionID       string
+	ParentSessionID string
 }
 
 type responseStatusHolder struct {

--- a/internal/pluginhost/adapters_executors_usage_test.go
+++ b/internal/pluginhost/adapters_executors_usage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -832,5 +833,56 @@ func TestObservePluginExecutorStreamTTFT_Antigravity(t *testing.T) {
 	helps.ObservePluginExecutorStreamTTFT("antigravity", reporter, antigravityChunk)
 	if !reporter.IsTTFTSet() {
 		t.Errorf("ObservePluginExecutorStreamTTFT for antigravity should set TTFT on token event")
+	}
+}
+
+type capturingUsagePlugin struct {
+	captured chan pluginapi.UsageRecord
+}
+
+func (p *capturingUsagePlugin) HandleUsage(_ context.Context, record pluginapi.UsageRecord) {
+	p.captured <- record
+}
+
+func TestUsageAdapterRecoversSessionHierarchyFromContext(t *testing.T) {
+	plugin := &capturingUsagePlugin{captured: make(chan pluginapi.UsageRecord, 1)}
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-session",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{
+		host:     host,
+		pluginID: "usage-session",
+	}
+
+	ctx := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "sess-ctx-1",
+		ParentSessionID: "parent-ctx-1",
+	})
+
+	// 1. Record has empty session fields, should recover from context
+	adapter.HandleUsage(ctx, coreusage.Record{
+		Provider: "test-provider",
+		Model:    "test-model",
+	})
+	rec := <-plugin.captured
+	if rec.SessionID != "sess-ctx-1" || rec.ParentSessionID != "parent-ctx-1" {
+		t.Fatalf("recovered session = (%q, %q), want (sess-ctx-1, parent-ctx-1)", rec.SessionID, rec.ParentSessionID)
+	}
+
+	// 2. Self-referential loop protection in context
+	ctxLoop := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "loop-sess",
+		ParentSessionID: "loop-sess",
+	})
+	adapter.HandleUsage(ctxLoop, coreusage.Record{
+		Provider: "test-provider",
+		Model:    "test-model",
+	})
+	recLoop := <-plugin.captured
+	if recLoop.SessionID != "loop-sess" || recLoop.ParentSessionID != "" {
+		t.Fatalf("loop protection = (%q, %q), want (loop-sess, empty)", recLoop.SessionID, recLoop.ParentSessionID)
 	}
 }

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
@@ -146,12 +147,29 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			a.host.fusePlugin(a.pluginID, "UsagePlugin.HandleUsage", recovered)
 		}
 	}()
+	sessionID := strings.TrimSpace(record.SessionID)
+	parentSessionID := strings.TrimSpace(record.ParentSessionID)
+	if sessionID == "" {
+		clientMeta := logging.GetClientRequestMetadata(ctx)
+		sessionID = strings.TrimSpace(clientMeta.SessionID)
+		parentSessionID = strings.TrimSpace(clientMeta.ParentSessionID)
+	} else if parentSessionID == "" {
+		clientMeta := logging.GetClientRequestMetadata(ctx)
+		if sessionID == strings.TrimSpace(clientMeta.SessionID) {
+			parentSessionID = strings.TrimSpace(clientMeta.ParentSessionID)
+		}
+	}
+	if sessionID == "" || sessionID == parentSessionID {
+		parentSessionID = ""
+	}
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
 		Provider:        record.Provider,
 		ExecutorType:    record.ExecutorType,
 		Model:           record.Model,
 		Alias:           record.Alias,
 		APIKey:          record.APIKey,
+		SessionID:       sessionID,
+		ParentSessionID: parentSessionID,
 		AuthID:          record.AuthID,
 		AuthIndex:       record.AuthIndex,
 		AuthType:        record.AuthType,

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -65,6 +65,17 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
 	clientRequestMetadata := internallogging.GetClientRequestMetadata(ctx)
+	sessionID := strings.TrimSpace(record.SessionID)
+	parentSessionID := strings.TrimSpace(record.ParentSessionID)
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(clientRequestMetadata.SessionID)
+		parentSessionID = strings.TrimSpace(clientRequestMetadata.ParentSessionID)
+	} else if parentSessionID == "" && sessionID == strings.TrimSpace(clientRequestMetadata.SessionID) {
+		parentSessionID = strings.TrimSpace(clientRequestMetadata.ParentSessionID)
+	}
+	if sessionID == "" || sessionID == parentSessionID {
+		parentSessionID = ""
+	}
 
 	usageDetail := coreusage.EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	tokens := tokenStats{
@@ -119,6 +130,8 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		AuthType:            authType,
 		APIKey:              apiKey,
 		RequestID:           requestID,
+		SessionID:           sessionID,
+		ParentSessionID:     parentSessionID,
 		ReasoningEffort:     reasoningEffort,
 		ServiceTier:         serviceTier,
 		ResponseServiceTier: responseServiceTier,
@@ -141,6 +154,8 @@ type queuedUsageDetail struct {
 	AuthType            string                   `json:"auth_type"`
 	APIKey              string                   `json:"api_key"`
 	RequestID           string                   `json:"request_id"`
+	SessionID           string                   `json:"session_id,omitempty"`
+	ParentSessionID     string                   `json:"parent_session_id,omitempty"`
 	ReasoningEffort     string                   `json:"reasoning_effort"`
 	ServiceTier         string                   `json:"service_tier"`
 	ResponseServiceTier string                   `json:"response_service_tier,omitempty"`

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -584,3 +584,92 @@ func requireHeaderField(t *testing.T, payload map[string]json.RawMessage, field,
 		}
 	}
 }
+
+func TestUsageQueuePluginPayloadIncludesExplicitSessionHierarchy(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "ctx-session-req-1")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithClientRequestMetadata(ctx, internallogging.ClientRequestMetadata{
+			ClientIP:        "192.0.2.10",
+			SessionID:       "slot:pi-worker-1",
+			ParentSessionID: "slot:pi-main-root",
+		})
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:        "openai",
+			Model:           "gpt-5.6-sol",
+			APIKey:          "test-key",
+			SessionID:       "slot:pi-worker-1",
+			ParentSessionID: "slot:pi-main-root",
+			RequestedAt:     time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+			Latency:         5000 * time.Millisecond,
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "request_id", "ctx-session-req-1")
+		requireStringField(t, payload, "session_id", "slot:pi-worker-1")
+		requireStringField(t, payload, "parent_session_id", "slot:pi-main-root")
+	})
+}
+
+func TestUsageQueuePluginPayloadPreventsSelfReferentialLoop(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "ctx-loop-req-1")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:        "openai",
+			Model:           "gpt-5.6-sol",
+			APIKey:          "test-key",
+			SessionID:       "loop-sess-1",
+			ParentSessionID: "loop-sess-1",
+			RequestedAt:     time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+			Latency:         1000 * time.Millisecond,
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "request_id", "ctx-loop-req-1")
+		requireStringField(t, payload, "session_id", "loop-sess-1")
+		if _, exists := payload["parent_session_id"]; exists {
+			t.Fatalf("expected parent_session_id to be omitted on self-referential loop, got %s", payload["parent_session_id"])
+		}
+	})
+}
+
+func TestUsageQueuePluginPayloadSameOriginFallback(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "ctx-same-origin-1")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithClientRequestMetadata(ctx, internallogging.ClientRequestMetadata{
+			SessionID:       "old-root",
+			ParentSessionID: "old-parent",
+		})
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		// Record explicitly defines an independent root session without parent.
+		// It should NOT pick up old-parent from context.
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:        "openai",
+			Model:           "gpt-5.6-sol",
+			APIKey:          "test-key",
+			SessionID:       "new-custom-root",
+			ParentSessionID: "",
+			RequestedAt:     time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+			Latency:         1000 * time.Millisecond,
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "session_id", "new-custom-root")
+		if _, exists := payload["parent_session_id"]; exists {
+			t.Fatalf("expected parent_session_id to be omitted when record is independent root, got %s", payload["parent_session_id"])
+		}
+	})
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -34,6 +34,8 @@ type UsageReporter struct {
 	accessTokenHash     string
 	authType            string
 	apiKey              string
+	sessionID           string
+	parentSessionID     string
 	source              string
 	reasoning           string
 	serviceTier         string
@@ -69,18 +71,30 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 	if alias == "" {
 		alias = model
 	}
+	sessionID := ""
+	parentSessionID := ""
+	clientMeta := internallogging.GetClientRequestMetadata(ctx)
+	if clientMeta.SessionID != "" {
+		sessionID = clientMeta.SessionID
+		parentSessionID = clientMeta.ParentSessionID
+		if sessionID == parentSessionID || !isHierarchyParent(sessionID, parentSessionID) {
+			parentSessionID = ""
+		}
+	}
 	reporter := &UsageReporter{
-		provider:    provider,
-		model:       model,
-		alias:       strings.TrimSpace(alias),
-		requestedAt: time.Now(),
-		apiKey:      apiKey,
-		source:      resolveUsageSource(auth, apiKey),
-		authType:    resolveUsageAuthType(auth),
-		reasoning:   usage.ReasoningEffortFromContext(ctx),
-		serviceTier: usage.ServiceTierFromContext(ctx),
-		generate:    usage.GenerateFromContext(ctx),
-		stream:      usage.StreamFromContext(ctx),
+		provider:        provider,
+		model:           model,
+		alias:           strings.TrimSpace(alias),
+		requestedAt:     time.Now(),
+		apiKey:          apiKey,
+		sessionID:       sessionID,
+		parentSessionID: parentSessionID,
+		source:          resolveUsageSource(auth, apiKey),
+		authType:        resolveUsageAuthType(auth),
+		reasoning:       usage.ReasoningEffortFromContext(ctx),
+		serviceTier:     usage.ServiceTierFromContext(ctx),
+		generate:        usage.GenerateFromContext(ctx),
+		stream:          usage.StreamFromContext(ctx),
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -96,6 +110,34 @@ func (r *UsageReporter) SetStream(stream bool) {
 		return
 	}
 	r.stream = stream
+}
+
+// SetSessionHierarchy sets the explicit session and parent session identifiers.
+// Callers should invoke this method before Publish or EnsurePublished on the request thread.
+func (r *UsageReporter) SetSessionHierarchy(sessionID, parentSessionID string) {
+	if r == nil {
+		return
+	}
+	r.sessionID = strings.TrimSpace(sessionID)
+	r.parentSessionID = strings.TrimSpace(parentSessionID)
+	if r.sessionID == "" || r.sessionID == r.parentSessionID || !isHierarchyParent(r.sessionID, r.parentSessionID) {
+		r.parentSessionID = ""
+	}
+}
+
+func isHierarchyParent(primary, parent string) bool {
+	if parent == "" || primary == "" || primary == parent {
+		return false
+	}
+	if strings.Contains(primary, ":agent:") {
+		return true
+	}
+	idx1 := strings.Index(primary, ":")
+	idx2 := strings.Index(parent, ":")
+	if idx1 > 0 && idx2 > 0 && primary[:idx1] == parent[:idx2] {
+		return true
+	}
+	return false
 }
 
 // UpdateAccessTokenFingerprint records the token version actually used upstream.
@@ -393,6 +435,8 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		Alias:               r.alias,
 		Source:              r.source,
 		APIKey:              r.apiKey,
+		SessionID:           r.sessionID,
+		ParentSessionID:     r.parentSessionID,
 		AuthID:              r.authID,
 		AuthIndex:           r.authIndex,
 		AccessTokenSHA256:   r.accessTokenFingerprint(),

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
@@ -956,4 +957,55 @@ type TestUsageExecutor struct{}
 
 func (TestUsageExecutor) Identifier() string {
 	return "test-provider"
+}
+
+func TestUsageReporterPropagatesSessionHierarchy(t *testing.T) {
+	ctx := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "claude:sess-1:agent:sub-1",
+		ParentSessionID: "claude:sess-1",
+	})
+
+	reporter := NewUsageReporter(ctx, "claude", "claude-3-7-sonnet", nil)
+	record := reporter.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if record.SessionID != "claude:sess-1:agent:sub-1" || record.ParentSessionID != "claude:sess-1" {
+		t.Fatalf("record session hierarchy = (%q, %q), want (claude:sess-1:agent:sub-1, claude:sess-1)", record.SessionID, record.ParentSessionID)
+	}
+
+	// Test explicit override via SetSessionHierarchy
+	reporter.SetSessionHierarchy("override:child", "override:parent")
+	record2 := reporter.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if record2.SessionID != "override:child" || record2.ParentSessionID != "override:parent" {
+		t.Fatalf("overridden record session hierarchy = (%q, %q), want (override:child, override:parent)", record2.SessionID, record2.ParentSessionID)
+	}
+
+	// Test self-loop elimination in SetSessionHierarchy
+	reporter.SetSessionHierarchy("loop:node", "loop:node")
+	record3 := reporter.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if record3.SessionID != "loop:node" || record3.ParentSessionID != "" {
+		t.Fatalf("self loop record session hierarchy = (%q, %q), want (loop:node, empty)", record3.SessionID, record3.ParentSessionID)
+	}
+
+	// Test orphan parent elimination when sessionID is empty
+	reporter.SetSessionHierarchy("", "orphan:parent")
+	record4 := reporter.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if record4.SessionID != "" || record4.ParentSessionID != "" {
+		t.Fatalf("orphan parent record session hierarchy = (%q, %q), want empty both", record4.SessionID, record4.ParentSessionID)
+	}
+
+	// Test cross-prefix alias rejection (e.g. pck:* and conv:* are aliases, not parent-child)
+	ctxAlias := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "pck:prompt-key-123",
+		ParentSessionID: "conv:conv-456",
+	})
+	reporterAlias := NewUsageReporter(ctxAlias, "openai", "gpt-5.4", nil)
+	recordAlias := reporterAlias.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if recordAlias.SessionID != "pck:prompt-key-123" || recordAlias.ParentSessionID != "" {
+		t.Fatalf("cross prefix alias emitted as parent: (%q, %q), want (pck:prompt-key-123, empty)", recordAlias.SessionID, recordAlias.ParentSessionID)
+	}
+
+	reporterAlias.SetSessionHierarchy("pck:key-999", "conv:alias-888")
+	recordAlias2 := reporterAlias.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
+	if recordAlias2.SessionID != "pck:key-999" || recordAlias2.ParentSessionID != "" {
+		t.Fatalf("SetSessionHierarchy cross prefix alias emitted as parent: (%q, %q), want (pck:key-999, empty)", recordAlias2.SessionID, recordAlias2.ParentSessionID)
+	}
 }

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -210,6 +210,40 @@ func requestClientIP(request *http.Request) string {
 	return remoteAddr
 }
 
+func extractSessionIDsFromRequest(request *http.Request) (string, string) {
+	if request == nil || request.Header == nil {
+		return "", ""
+	}
+	if info, ok := coresession.ExtractSessionInfo(request.Header, nil, nil); ok {
+		return info.SessionID, info.ParentSessionID
+	}
+	return "", ""
+}
+
+// EnrichContextWithSessionHierarchy extracts canonical session and parent session identities
+// from headers, payload, and metadata and records them in ClientRequestMetadata.
+func EnrichContextWithSessionHierarchy(ctx context.Context, headers http.Header, payload []byte, metadata map[string]any) context.Context {
+	meta := logging.GetClientRequestMetadata(ctx)
+	if info, ok := coresession.ExtractSessionInfo(headers, payload, metadata); ok {
+		meta.SessionID = info.SessionID
+		meta.ParentSessionID = info.ParentSessionID
+		if meta.SessionID != "" && meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		return logging.WithClientRequestMetadata(ctx, meta)
+	}
+	if meta.SessionID != "" || meta.ParentSessionID != "" {
+		meta.SessionID = ""
+		meta.ParentSessionID = ""
+		return logging.WithClientRequestMetadata(ctx, meta)
+	}
+	return ctx
+}
+
+func enrichContextWithSessionHierarchy(ctx context.Context, headers http.Header, payload []byte, metadata map[string]any) context.Context {
+	return EnrichContextWithSessionHierarchy(ctx, headers, payload, metadata)
+}
+
 func requestCallerScope(ginCtx *gin.Context) string {
 	if ginCtx == nil {
 		return ""
@@ -431,10 +465,13 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 		newCtx = logging.WithEndpoint(newCtx, endpoint)
 	}
 	if c != nil && c.Request != nil {
+		sessionID, parentSessionID := extractSessionIDsFromRequest(c.Request)
 		newCtx = logging.WithClientRequestMetadata(newCtx, logging.ClientRequestMetadata{
-			ClientIP:      requestClientIP(c.Request),
-			XForwardedFor: strings.TrimSpace(strings.Join(c.Request.Header.Values("X-Forwarded-For"), ", ")),
-			UserAgent:     strings.TrimSpace(c.Request.UserAgent()),
+			ClientIP:        requestClientIP(c.Request),
+			XForwardedFor:   strings.TrimSpace(strings.Join(c.Request.Header.Values("X-Forwarded-For"), ", ")),
+			UserAgent:       strings.TrimSpace(c.Request.UserAgent()),
+			SessionID:       sessionID,
+			ParentSessionID: parentSessionID,
 		})
 	}
 	newCtx = logging.WithResponseStatusHolder(newCtx)

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -86,12 +86,14 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 		WebSocketResponseObserver:   h.webSocketResponseObserver(lifecycle.requestID(), execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	var interceptErr *interfaces.ErrorMessage
 	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
 		lifecycle.completeError(ctx, interceptErr)
 		return nil, nil, interceptErr
 	}
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -100,6 +102,7 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 		return nil, nil, errMsg
 	}
 	executedReq, executedOpts := afterAuthCapture.apply(req, opts)
+	ctx = enrichContextWithSessionHierarchy(ctx, executedOpts.Headers, executedReq.Payload, executedOpts.Metadata)
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
 	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), responseProtocol, normalizedModel, originalRequestedModel, executedOpts, rawResponseHeaders, responseHeaders, executedOpts.OriginalRequest, executedReq.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
@@ -151,12 +154,14 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 		WebSocketResponseObserver:   h.webSocketResponseObserver(lifecycle.requestID(), execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	var interceptErr *interfaces.ErrorMessage
 	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(ctx, handlerType, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
 		lifecycle.completeError(ctx, interceptErr)
 		return nil, nil, interceptErr
 	}
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	resp, err := h.AuthManager.ExecuteCount(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -165,6 +170,7 @@ func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handle
 		return nil, nil, errMsg
 	}
 	executedReq, executedOpts := afterAuthCapture.apply(req, opts)
+	ctx = enrichContextWithSessionHierarchy(ctx, executedOpts.Headers, executedReq.Payload, executedOpts.Metadata)
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
 	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), handlerType, normalizedModel, originalRequestedModel, executedOpts, rawResponseHeaders, responseHeaders, executedOpts.OriginalRequest, executedReq.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
@@ -194,6 +200,7 @@ func (h *BaseAPIHandler) executeWithPluginExecutor(ctx context.Context, entryPro
 		lifecycle.completeError(execCtx, interceptErr)
 		return nil, nil, interceptErr
 	}
+	execCtx = enrichContextWithSessionHierarchy(execCtx, opts.Headers, req.Payload, opts.Metadata)
 	var reporter *helps.UsageReporter
 	if !execOptions.InternalSource {
 		reporter = helps.NewUsageReporter(execCtx, executorPluginID, modelName, nil)
@@ -241,6 +248,7 @@ func (h *BaseAPIHandler) countWithPluginExecutor(ctx context.Context, handlerTyp
 		lifecycle.completeError(ctx, interceptErr)
 		return nil, nil, interceptErr
 	}
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	resp, errCount := host.CountPluginExecutor(ctx, executorPluginID, req, opts)
 	if errCount != nil {
 		errMsg := executionErrorMessage(errCount)

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -180,5 +181,106 @@ func TestSetGenerateMetadataHonorsExplicitFalse(t *testing.T) {
 
 	if got := meta[coreexecutor.GenerateMetadataKey]; got != false {
 		t.Fatalf("GenerateMetadataKey = %v, want false", got)
+	}
+}
+
+func TestExtractSessionIDsFromRequestCanonicalHierarchy(t *testing.T) {
+	// 1. Claude Code main session
+	reqMain := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	reqMain.Header.Set("X-Claude-Code-Session-Id", "sess-claude-main")
+	sid, pid := extractSessionIDsFromRequest(reqMain)
+	if sid != "claude:sess-claude-main" || pid != "" {
+		t.Fatalf("claude main session = (%q, %q), want (claude:sess-claude-main, empty)", sid, pid)
+	}
+
+	// 2. Claude Code subagent with parent agent
+	reqSub := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	reqSub.Header.Set("X-Claude-Code-Session-Id", "sess-claude-main")
+	reqSub.Header.Set("X-Claude-Code-Agent-Id", "agent-worker-1")
+	reqSub.Header.Set("X-Claude-Code-Parent-Agent-Id", "agent-orchestrator")
+	sid, pid = extractSessionIDsFromRequest(reqSub)
+	if sid != "claude:sess-claude-main:agent:agent-worker-1" || pid != "claude:sess-claude-main:agent:agent-orchestrator" {
+		t.Fatalf("claude subagent = (%q, %q), want (claude:sess-claude-main:agent:agent-worker-1, claude:sess-claude-main:agent:agent-orchestrator)", sid, pid)
+	}
+
+	// 3. Generic X-Session-ID and X-Parent-Session-ID
+	reqGeneric := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	reqGeneric.Header.Set("X-Session-ID", "sess-worker-99")
+	reqGeneric.Header.Set("X-Parent-Session-ID", "sess-root-1")
+	sid, pid = extractSessionIDsFromRequest(reqGeneric)
+	if sid != "header:sess-worker-99" || pid != "header:sess-root-1" {
+		t.Fatalf("generic header session = (%q, %q), want (header:sess-worker-99, header:sess-root-1)", sid, pid)
+	}
+
+	// 4. Codex Session-Id
+	reqCodex := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	reqCodex.Header.Set("Session-Id", "codex-sess-uuid")
+	sid, pid = extractSessionIDsFromRequest(reqCodex)
+	if sid != "codex:codex-sess-uuid" || pid != "" {
+		t.Fatalf("codex session = (%q, %q), want (codex:codex-sess-uuid, empty)", sid, pid)
+	}
+}
+
+func TestEnrichContextWithSessionHierarchyFromBody(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Body payload contains session_id and parent_session_id
+	bodyJSON := []byte(`{"session_id":"body-task-1","parent_session_id":"body-parent-task"}`)
+	ctx = enrichContextWithSessionHierarchy(ctx, nil, bodyJSON, nil)
+	meta := logging.GetClientRequestMetadata(ctx)
+	if meta.SessionID != "session:body-task-1" || meta.ParentSessionID != "session:body-parent-task" {
+		t.Fatalf("body session = (%q, %q), want (session:body-task-1, session:body-parent-task)", meta.SessionID, meta.ParentSessionID)
+	}
+
+	// 2. Claude Code header combined with metadata.agent_id in body
+	headers := http.Header{"X-Claude-Code-Session-Id": []string{"claude-root-001"}}
+	subagentBody := []byte(`{"metadata":{"agent_id":"search-specialist"}}`)
+	ctx2 := enrichContextWithSessionHierarchy(context.Background(), headers, subagentBody, nil)
+	meta2 := logging.GetClientRequestMetadata(ctx2)
+	if meta2.SessionID != "claude:claude-root-001:agent:search-specialist" || meta2.ParentSessionID != "claude:claude-root-001" {
+		t.Fatalf("claude body subagent = (%q, %q), want (claude:claude-root-001:agent:search-specialist, claude:claude-root-001)", meta2.SessionID, meta2.ParentSessionID)
+	}
+
+	// 3. Ghost Parent avoidance: Context had parent, but body resolves to a top-level root session
+	ctxWithOldParent := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "header:old-child",
+		ParentSessionID: "header:old-parent",
+	})
+	topLevelBody := []byte(`{"session_id":"top-level-session"}`)
+	ctx3 := enrichContextWithSessionHierarchy(ctxWithOldParent, nil, topLevelBody, nil)
+	meta3 := logging.GetClientRequestMetadata(ctx3)
+	if meta3.SessionID != "session:top-level-session" || meta3.ParentSessionID != "" {
+		t.Fatalf("top level body session = (%q, %q), want (session:top-level-session, empty parent)", meta3.SessionID, meta3.ParentSessionID)
+	}
+
+	// 4. Self-loop avoidance: SessionID == ParentSessionID
+	selfLoopBody := []byte(`{"session_id":"same-id","parent_session_id":"same-id"}`)
+	ctx4 := enrichContextWithSessionHierarchy(context.Background(), nil, selfLoopBody, nil)
+	meta4 := logging.GetClientRequestMetadata(ctx4)
+	if meta4.SessionID != "session:same-id" || meta4.ParentSessionID != "" {
+		t.Fatalf("self loop session = (%q, %q), want (session:same-id, empty parent)", meta4.SessionID, meta4.ParentSessionID)
+	}
+
+	// 5. Length bound: ID length is bounded to 256 bytes
+	longID := strings.Repeat("a", 250)
+	longBody := []byte(`{"session_id":"` + longID + `"}`)
+	ctx5 := EnrichContextWithSessionHierarchy(context.Background(), nil, longBody, nil)
+	meta5 := logging.GetClientRequestMetadata(ctx5)
+	if len(meta5.SessionID) > 256 {
+		t.Fatalf("SessionID length = %d, want <= 256", len(meta5.SessionID))
+	}
+	if !strings.HasPrefix(meta5.SessionID, "session:") {
+		t.Fatalf("SessionID = %q, want session: prefix", meta5.SessionID)
+	}
+
+	// 6. Clearing hierarchy when interceptor removes all session headers and body has no session
+	ctxWithHeaderSession := logging.WithClientRequestMetadata(context.Background(), logging.ClientRequestMetadata{
+		SessionID:       "header:cleared-session",
+		ParentSessionID: "header:cleared-parent",
+	})
+	ctxCleared := EnrichContextWithSessionHierarchy(ctxWithHeaderSession, nil, nil, nil)
+	metaCleared := logging.GetClientRequestMetadata(ctxCleared)
+	if metaCleared.SessionID != "" || metaCleared.ParentSessionID != "" {
+		t.Fatalf("cleared context = (%q, %q), want (empty, empty)", metaCleared.SessionID, metaCleared.ParentSessionID)
 	}
 }

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -61,6 +61,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		close(errChan)
 		return nil, nil, errChan
 	}
+	execCtx = enrichContextWithSessionHierarchy(execCtx, opts.Headers, req.Payload, opts.Metadata)
 	var reporter *helps.UsageReporter
 	if !execOptions.InternalSource {
 		reporter = helps.NewUsageReporter(execCtx, executorPluginID, modelName, nil)
@@ -346,6 +347,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		WebSocketResponseObserver:   h.webSocketResponseObserver(lifecycle.requestID(), execOptions.SkipInterceptorPluginID),
 	}
 	opts.Metadata = reqMeta
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	var interceptErr *interfaces.ErrorMessage
 	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
@@ -355,6 +357,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		close(errChan)
 		return nil, nil, errChan
 	}
+	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
 		err = enrichAuthSelectionError(err, providers, normalizedModel)
@@ -375,6 +378,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 	executedRequest := func() (coreexecutor.Request, coreexecutor.Options) {
 		return afterAuthCapture.apply(req, opts)
+	}
+	if executedReq, executedOpts := executedRequest(); len(executedOpts.Headers) > 0 || len(executedReq.Payload) > 0 || len(executedOpts.Metadata) > 0 {
+		ctx = enrichContextWithSessionHierarchy(ctx, executedOpts.Headers, executedReq.Payload, executedOpts.Metadata)
 	}
 	passthroughHeadersEnabled := PassthroughHeadersEnabled(h.Cfg)
 	interceptorHost := h.interceptorHost()

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -351,6 +351,38 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 			Body:       bytes.Clone(resp.ResponseBody),
 		}
 	}
+	if len(resp.ClearHeaders) > 0 || len(resp.Body) > 0 {
+		evalPayload := opts.OriginalRequest
+		if len(evalPayload) == 0 {
+			evalPayload = req.Payload
+		}
+		info, ok := cliproxysession.ExtractSessionInfo(opts.Headers, evalPayload, opts.Metadata)
+		if ok && info.SessionID != "" {
+			if opts.Metadata == nil {
+				opts.Metadata = make(map[string]any, 2)
+			}
+			opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey] = cliproxysession.BoundSessionIdentity(info.SessionID)
+			if info.ParentSessionID != "" && info.ParentSessionID != info.SessionID {
+				opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = cliproxysession.BoundSessionIdentity(info.ParentSessionID)
+			} else {
+				delete(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+			}
+		} else {
+			delete(opts.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey)
+			delete(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+			delete(opts.Metadata, cliproxyexecutor.LCPAffinitySessionIDMetadataKey)
+		}
+	} else if len(resp.Headers) > 0 {
+		if info, ok := cliproxysession.ExtractSessionInfo(opts.Headers, nil, opts.Metadata); ok && info.SessionID != "" {
+			if opts.Metadata == nil {
+				opts.Metadata = make(map[string]any, 2)
+			}
+			opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey] = cliproxysession.BoundSessionIdentity(info.SessionID)
+			if info.ParentSessionID != "" && info.ParentSessionID != info.SessionID {
+				opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = cliproxysession.BoundSessionIdentity(info.ParentSessionID)
+			}
+		}
+	}
 	return req, opts, nil
 }
 
@@ -408,6 +440,11 @@ func mergeRequestHeaders(current, updates http.Header, clear []string) http.Head
 	}
 	for _, key := range clear {
 		out.Del(key)
+		for existingKey := range out {
+			if strings.EqualFold(existingKey, key) {
+				delete(out, existingKey)
+			}
+		}
 	}
 	for key, values := range updates {
 		out.Del(key)
@@ -501,6 +538,21 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				execReq.Model = executionModel
 			}
 			execOpts := opts
+			if pickOpts.Metadata != nil {
+				if canonicalID, ok := pickOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; ok {
+					meta := make(map[string]any, len(execOpts.Metadata)+2)
+					for k, v := range execOpts.Metadata {
+						meta[k] = v
+					}
+					meta[cliproxyexecutor.CanonicalSessionIDMetadataKey] = canonicalID
+					if parentID, okParent := pickOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; okParent && parentID != canonicalID {
+						meta[cliproxyexecutor.ParentSessionIDMetadataKey] = parentID
+					} else {
+						delete(meta, cliproxyexecutor.ParentSessionIDMetadataKey)
+					}
+					execOpts.Metadata = meta
+				}
+			}
 			var errIntercept error
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
@@ -509,6 +561,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 			startExec := time.Now()
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -525,6 +578,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					auth = refreshed
 					didRefreshOnUnauthorized = true
 					execCtx = newUpstreamAttemptContext(execCtx)
+					execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 					startRetry := time.Now()
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
 					errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -692,6 +746,21 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				execReq.Model = executionModel
 			}
 			execOpts := opts
+			if pickOpts.Metadata != nil {
+				if canonicalID, ok := pickOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; ok {
+					meta := make(map[string]any, len(execOpts.Metadata)+2)
+					for k, v := range execOpts.Metadata {
+						meta[k] = v
+					}
+					meta[cliproxyexecutor.CanonicalSessionIDMetadataKey] = canonicalID
+					if parentID, okParent := pickOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; okParent && parentID != canonicalID {
+						meta[cliproxyexecutor.ParentSessionIDMetadataKey] = parentID
+					} else {
+						delete(meta, cliproxyexecutor.ParentSessionIDMetadataKey)
+					}
+					execOpts.Metadata = meta
+				}
+			}
 			var errIntercept error
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
@@ -700,6 +769,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 			startExec := time.Now()
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -716,6 +786,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 					auth = refreshed
 					didRefreshOnUnauthorized = true
 					execCtx = newUpstreamAttemptContext(execCtx)
+					execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 					startRetry := time.Now()
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
 					errExec = markUpstreamExecutionAttemptFromContext(execCtx, errExec)
@@ -1029,7 +1100,35 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		execOpts := opts
 		if selection != nil {
 			execOpts.ExecutionLifecycle = selection
+			if selection.CanonicalSessionID != "" {
+				meta := make(map[string]any, len(execOpts.Metadata)+2)
+				for k, v := range execOpts.Metadata {
+					meta[k] = v
+				}
+				meta[cliproxyexecutor.CanonicalSessionIDMetadataKey] = selection.CanonicalSessionID
+				if selection.ParentSessionID != "" && selection.ParentSessionID != selection.CanonicalSessionID {
+					meta[cliproxyexecutor.ParentSessionIDMetadataKey] = selection.ParentSessionID
+				} else {
+					delete(meta, cliproxyexecutor.ParentSessionIDMetadataKey)
+				}
+				execOpts.Metadata = meta
+			}
+		} else if pickOpts.Metadata != nil {
+			if canonicalID, ok := pickOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; ok {
+				meta := make(map[string]any, len(execOpts.Metadata)+2)
+				for k, v := range execOpts.Metadata {
+					meta[k] = v
+				}
+				meta[cliproxyexecutor.CanonicalSessionIDMetadataKey] = canonicalID
+				if parentID, okParent := pickOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; okParent && parentID != canonicalID {
+					meta[cliproxyexecutor.ParentSessionIDMetadataKey] = parentID
+				} else {
+					delete(meta, cliproxyexecutor.ParentSessionIDMetadataKey)
+				}
+				execOpts.Metadata = meta
+			}
 		}
+		execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 		if homeMode && len(models) > 1 {
 			models = models[:1]
 			pooled = false
@@ -1909,4 +2008,58 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
 	return exec.HttpRequest(ctx, auth, req)
+}
+
+func syncMetadataSessionToContext(ctx context.Context, metadata map[string]any) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	canonicalID := ""
+	if len(metadata) > 0 {
+		canonicalID, _ = metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+		if canonicalID == "" {
+			canonicalID, _ = metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+		}
+		if canonicalID == "" {
+			if execID, _ := metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string); execID != "" {
+				execID = strings.TrimSpace(execID)
+				if !strings.HasPrefix(execID, "execution:") {
+					canonicalID = "execution:" + execID
+				} else {
+					canonicalID = execID
+				}
+			}
+		}
+		if canonicalID == "" {
+			if derivedID, _ := metadata[cliproxyexecutor.DerivedSessionIDMetadataKey].(string); derivedID != "" {
+				derivedID = strings.TrimSpace(derivedID)
+				if !strings.HasPrefix(derivedID, "derived:") {
+					canonicalID = "derived:" + derivedID
+				} else {
+					canonicalID = derivedID
+				}
+			}
+		}
+	}
+	canonicalID = strings.TrimSpace(canonicalID)
+	if canonicalID == "" {
+		clientMeta := logging.GetClientRequestMetadata(ctx)
+		if clientMeta.SessionID != "" || clientMeta.ParentSessionID != "" {
+			clientMeta.SessionID = ""
+			clientMeta.ParentSessionID = ""
+			return logging.WithClientRequestMetadata(ctx, clientMeta)
+		}
+		return ctx
+	}
+	clientMeta := logging.GetClientRequestMetadata(ctx)
+	clientMeta.SessionID = cliproxysession.BoundSessionIdentity(canonicalID)
+	if parentID, ok := metadata[cliproxyexecutor.ParentSessionIDMetadataKey].(string); ok && strings.TrimSpace(parentID) != "" {
+		clientMeta.ParentSessionID = cliproxysession.BoundSessionIdentity(strings.TrimSpace(parentID))
+	} else {
+		clientMeta.ParentSessionID = ""
+	}
+	if clientMeta.SessionID == clientMeta.ParentSessionID {
+		clientMeta.ParentSessionID = ""
+	}
+	return logging.WithClientRequestMetadata(ctx, clientMeta)
 }

--- a/sdk/cliproxy/auth/conductor_execution_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_quota_test.go
@@ -9,6 +9,7 @@ import (
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 )
 
 type quotaAttemptIsolationSelector struct{}
@@ -129,5 +130,221 @@ func TestExecutionAttemptsDoNotReuseQuotaResponseHeaders(t *testing.T) {
 				t.Fatalf("attempt headers leaked into request holder: %#v", headers)
 			}
 		})
+	}
+}
+
+func TestSyncMetadataSessionToContext(t *testing.T) {
+	// 1. Canonical session from metadata overrides raw/pre-alias context session
+	ctxExplicit := internallogging.WithClientRequestMetadata(context.Background(), internallogging.ClientRequestMetadata{
+		SessionID: "raw-alias-sid",
+	})
+	res1 := syncMetadataSessionToContext(ctxExplicit, map[string]any{
+		cliproxyexecutor.CanonicalSessionIDMetadataKey: "canonical-override",
+	})
+	meta1 := internallogging.GetClientRequestMetadata(res1)
+	if meta1.SessionID != "canonical-override" {
+		t.Fatalf("sessionID = %q, want canonical-override", meta1.SessionID)
+	}
+
+	// 2. Syncs canonical and parent session from metadata
+	res2 := syncMetadataSessionToContext(context.Background(), map[string]any{
+		cliproxyexecutor.CanonicalSessionIDMetadataKey: "lcp:branch-123",
+		cliproxyexecutor.ParentSessionIDMetadataKey:    "lcp:trunk-000",
+	})
+	meta2 := internallogging.GetClientRequestMetadata(res2)
+	if meta2.SessionID != "lcp:branch-123" || meta2.ParentSessionID != "lcp:trunk-000" {
+		t.Fatalf("synced session = (%q, %q), want (lcp:branch-123, lcp:trunk-000)", meta2.SessionID, meta2.ParentSessionID)
+	}
+
+	// 3. Eliminates self-loop
+	res3 := syncMetadataSessionToContext(context.Background(), map[string]any{
+		cliproxyexecutor.CanonicalSessionIDMetadataKey: "same-loop",
+		cliproxyexecutor.ParentSessionIDMetadataKey:    "same-loop",
+	})
+	meta3 := internallogging.GetClientRequestMetadata(res3)
+	if meta3.SessionID != "same-loop" || meta3.ParentSessionID != "" {
+		t.Fatalf("self-loop session = (%q, %q), want (same-loop, empty)", meta3.SessionID, meta3.ParentSessionID)
+	}
+
+	// 4. Clears stale parent when syncing a new root session without parent metadata
+	ctxWithStaleParent := internallogging.WithClientRequestMetadata(context.Background(), internallogging.ClientRequestMetadata{
+		SessionID:       "old-child",
+		ParentSessionID: "old-stale-parent",
+	})
+	res4 := syncMetadataSessionToContext(ctxWithStaleParent, map[string]any{
+		cliproxyexecutor.CanonicalSessionIDMetadataKey: "new-root-session",
+	})
+	meta4 := internallogging.GetClientRequestMetadata(res4)
+	if meta4.SessionID != "new-root-session" || meta4.ParentSessionID != "" {
+		t.Fatalf("stale parent not cleared: (%q, %q), want (new-root-session, empty)", meta4.SessionID, meta4.ParentSessionID)
+	}
+
+	// 5. Execution session key fallback with prefix
+	res5 := syncMetadataSessionToContext(context.Background(), map[string]any{
+		cliproxyexecutor.ExecutionSessionMetadataKey: "call-live-123",
+	})
+	meta5 := internallogging.GetClientRequestMetadata(res5)
+	if meta5.SessionID != "execution:call-live-123" {
+		t.Fatalf("execution session = %q, want execution:call-live-123", meta5.SessionID)
+	}
+
+	// 6. Derived session key fallback gets derived: prefix
+	res6 := syncMetadataSessionToContext(context.Background(), map[string]any{
+		cliproxyexecutor.DerivedSessionIDMetadataKey: "ctx:v1:raw-hash",
+	})
+	meta6 := internallogging.GetClientRequestMetadata(res6)
+	if meta6.SessionID != "derived:ctx:v1:raw-hash" {
+		t.Fatalf("derived session = %q, want derived:ctx:v1:raw-hash", meta6.SessionID)
+	}
+
+	// 7. Clears hierarchy completely when metadata has no canonical session
+	ctxWithExistingSession := internallogging.WithClientRequestMetadata(context.Background(), internallogging.ClientRequestMetadata{
+		SessionID:       "old-stale-session",
+		ParentSessionID: "old-stale-parent",
+	})
+	res7 := syncMetadataSessionToContext(ctxWithExistingSession, map[string]any{})
+	meta7 := internallogging.GetClientRequestMetadata(res7)
+	if meta7.SessionID != "" || meta7.ParentSessionID != "" {
+		t.Fatalf("hierarchy not cleared when metadata empty: (%q, %q), want empty", meta7.SessionID, meta7.ParentSessionID)
+	}
+}
+
+func TestApplyRequestAfterAuthInterceptorSessionClearing(t *testing.T) {
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-luna",
+		Payload: nil,
+	}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-ID": []string{"initial-session"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.CanonicalSessionIDMetadataKey: "session:initial-session",
+			cliproxyexecutor.ParentSessionIDMetadataKey:    "session:initial-parent",
+		},
+		RequestAfterAuthInterceptor: func(ctx context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{
+				ClearHeaders: []string{"X-Session-ID"},
+			}
+		},
+	}
+
+	finalReq, finalOpts, err := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt-5.6-luna")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(finalOpts.Headers) != 0 {
+		t.Fatalf("headers not cleared: %v", finalOpts.Headers)
+	}
+	if _, ok := finalOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; ok {
+		t.Fatalf("canonical session was not cleared from metadata after interceptor cleared headers")
+	}
+	if _, ok := finalOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; ok {
+		t.Fatalf("parent session was not cleared from metadata after interceptor cleared headers")
+	}
+
+	// Context synced from cleared metadata also has empty session
+	ctxWithSession := internallogging.WithClientRequestMetadata(context.Background(), internallogging.ClientRequestMetadata{
+		SessionID:       "session:initial-session",
+		ParentSessionID: "session:initial-parent",
+	})
+	syncedCtx := syncMetadataSessionToContext(ctxWithSession, finalOpts.Metadata)
+	meta := internallogging.GetClientRequestMetadata(syncedCtx)
+	if meta.SessionID != "" || meta.ParentSessionID != "" {
+		t.Fatalf("context retained stale session after interceptor cleared headers: (%q, %q)", meta.SessionID, meta.ParentSessionID)
+	}
+	_ = finalReq
+}
+
+func TestGhostParentElimination(t *testing.T) {
+	// Request has explicit root session (no parent), but options metadata carries a stale parent key
+	req := cliproxyexecutor.Request{}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-ID": []string{"clean-root-session"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.ParentSessionIDMetadataKey: "ghost-parent-from-prior-turn",
+		},
+	}
+
+	_, enrichedOpts := coresession.Enrich(req, opts)
+	if _, hasGhost := enrichedOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; hasGhost {
+		t.Fatalf("ghost parent was not removed by session.Enrich")
+	}
+	if canonical := enrichedOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; canonical != "header:clean-root-session" {
+		t.Fatalf("canonical session = %v, want header:clean-root-session", canonical)
+	}
+}
+
+func TestApplyRequestAfterAuthInterceptorPreservesOriginalRequestSessionOnUnrelatedHeaderChange(t *testing.T) {
+	bodyWithSession := []byte(`{"session_id":"important-session"}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-luna",
+		Payload: nil, // Translated or omitted payload
+	}
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: bodyWithSession,
+		Headers:         make(http.Header),
+		Metadata: map[string]any{
+			cliproxyexecutor.CanonicalSessionIDMetadataKey: "session:important-session",
+		},
+		RequestAfterAuthInterceptor: func(ctx context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{
+				Headers: http.Header{
+					"X-Trace-ID": []string{"trace-abc"},
+				},
+			}
+		},
+	}
+
+	_, finalOpts, err := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt-5.6-luna")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	canonical, ok := finalOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok || canonical != "session:important-session" {
+		t.Fatalf("canonical session = %q (ok=%v), want session:important-session", canonical, ok)
+	}
+}
+
+func TestApplyRequestAfterAuthInterceptorPreservesLCPHierarchyOnUnrelatedHeaderChange(t *testing.T) {
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-luna",
+		Payload: []byte(`{"messages":[{"role":"user","content":"hello"}]}`),
+	}
+	opts := cliproxyexecutor.Options{
+		Headers: make(http.Header),
+		Metadata: map[string]any{
+			cliproxyexecutor.LCPAffinitySessionIDMetadataKey: "lcp:v1:child-fork-123",
+			cliproxyexecutor.ParentSessionIDMetadataKey:      "lcp:v1:parent-trunk-000",
+			cliproxyexecutor.CanonicalSessionIDMetadataKey:   "lcp:v1:child-fork-123",
+		},
+		RequestAfterAuthInterceptor: func(ctx context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{
+				Headers: http.Header{
+					"X-Trace-ID": []string{"trace-xyz"},
+				},
+			}
+		},
+	}
+
+	_, finalOpts, err := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt-5.6-luna")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	canonical, ok := finalOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok || canonical != "lcp:v1:child-fork-123" {
+		t.Fatalf("canonical session = %q (ok=%v), want lcp:v1:child-fork-123", canonical, ok)
+	}
+	parent, okParent := finalOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey].(string)
+	if !okParent || parent != "lcp:v1:parent-trunk-000" {
+		t.Fatalf("parent session = %q (ok=%v), want lcp:v1:parent-trunk-000", parent, okParent)
+	}
+
+	syncedCtx := syncMetadataSessionToContext(context.Background(), finalOpts.Metadata)
+	meta := internallogging.GetClientRequestMetadata(syncedCtx)
+	if meta.SessionID != "lcp:v1:child-fork-123" || meta.ParentSessionID != "lcp:v1:parent-trunk-000" {
+		t.Fatalf("synced context hierarchy = (%q, %q), want (lcp:v1:child-fork-123, lcp:v1:parent-trunk-000)", meta.SessionID, meta.ParentSessionID)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -998,6 +998,14 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	}
 
 	sessionID, parentSessionID := m.homeDispatchSessionIDs(opts)
+	if sessionID != "" && opts.Metadata != nil {
+		opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey] = sessionID
+		if parentSessionID != "" {
+			opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = parentSessionID
+		} else {
+			delete(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+		}
+	}
 	dispatchHeaders := homeDispatchHeaders(ctx, opts.Headers)
 	credentialPolicy := credentialPolicyFromContext(ctx)
 	var raw []byte
@@ -1200,6 +1208,8 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 			return nil, errEnd
 		}
 	}
+	selection.CanonicalSessionID = sessionID
+	selection.ParentSessionID = parentSessionID
 	return selection, nil
 }
 
@@ -1391,6 +1401,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			resultModel := m.stateModelForExecution(c.auth, routeModel, upstreamModel, pooled)
 			execReq := req
 			execReq.Model = upstreamModel
+			creditsCtx = syncMetadataSessionToContext(creditsCtx, creditsOpts.Metadata)
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
 			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, RouteModel: routeModel, Success: errExec == nil, Options: creditsOpts}
 			if errExec != nil {
@@ -1448,6 +1459,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		if len(models) == 0 {
 			continue
 		}
+		creditsCtx = syncMetadataSessionToContext(creditsCtx, creditsOpts.Metadata)
 		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, "", models, pooled, aliasResult, routing, true, false)
 		if errStream != nil {
 			continue

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -178,6 +178,19 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 			}
 			execOpts := opts
 			execOpts.ExecutionLifecycle = selection
+			if selection != nil && selection.CanonicalSessionID != "" {
+				meta := make(map[string]any, len(execOpts.Metadata)+2)
+				for k, v := range execOpts.Metadata {
+					meta[k] = v
+				}
+				meta[cliproxyexecutor.CanonicalSessionIDMetadataKey] = selection.CanonicalSessionID
+				if selection.ParentSessionID != "" && selection.ParentSessionID != selection.CanonicalSessionID {
+					meta[cliproxyexecutor.ParentSessionIDMetadataKey] = selection.ParentSessionID
+				} else {
+					delete(meta, cliproxyexecutor.ParentSessionIDMetadataKey)
+				}
+				execOpts.Metadata = meta
+			}
 			var errIntercept error
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, selection.Executor, selection.Provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
@@ -214,6 +227,7 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 				}
 				return effectiveAuth.Clone(), AccessTokenSHA256(effectiveAuth)
 			}
+			execCtx = syncMetadataSessionToContext(execCtx, execOpts.Metadata)
 			executorCtx := execCtx
 			if countTokens {
 				executorCtx = withAccessTokenFingerprintObserver(execCtx, setEffectiveAuth)

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -232,6 +232,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			return nil, errCtx
 		}
 		entry := logEntryWithRequestID(ctx)
+		ctx = syncMetadataSessionToContext(ctx, execOpts.Metadata)
 		startStream := time.Now()
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		errStream = markUpstreamExecutionAttemptFromContext(ctx, errStream)
@@ -251,6 +252,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
 					ctx = newUpstreamAttemptContext(ctx)
+					ctx = syncMetadataSessionToContext(ctx, execOpts.Metadata)
 					startRetry := time.Now()
 					streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
 					errStream = markUpstreamExecutionAttemptFromContext(ctx, errStream)

--- a/sdk/cliproxy/auth/home_result.go
+++ b/sdk/cliproxy/auth/home_result.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -45,11 +46,14 @@ func (m *Manager) reportHomeUnauthorized(ctx context.Context, auth *Auth, provid
 	if alias == "" {
 		alias = model
 	}
+	clientMeta := logging.GetClientRequestMetadata(ctx)
 	coreusage.PublishRecord(ctx, coreusage.Record{
 		Provider:          provider,
 		ExecutorType:      homeResultExecutorType,
 		Model:             model,
 		Alias:             alias,
+		SessionID:         clientMeta.SessionID,
+		ParentSessionID:   clientMeta.ParentSessionID,
 		AuthID:            auth.ID,
 		AuthIndex:         authIndex,
 		AccessTokenSHA256: accessTokenSHA256,

--- a/sdk/cliproxy/auth/home_selection.go
+++ b/sdk/cliproxy/auth/home_selection.go
@@ -138,10 +138,12 @@ func (r *executionResources) Close() error {
 
 // HomeDispatchSelection keeps a Home execution scope separate from its auth.
 type HomeDispatchSelection struct {
-	Auth      *Auth
-	Executor  ProviderExecutor
-	Provider  string
-	modelInfo *registry.ModelInfo
+	Auth               *Auth
+	Executor           ProviderExecutor
+	Provider           string
+	CanonicalSessionID string
+	ParentSessionID    string
+	modelInfo          *registry.ModelInfo
 
 	authMu           sync.RWMutex
 	scope            *executionregistry.Scope

--- a/sdk/cliproxy/auth/home_session_alias.go
+++ b/sdk/cliproxy/auth/home_session_alias.go
@@ -8,6 +8,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 )
 
 const (
@@ -240,16 +241,17 @@ func isHierarchyParent(primary, fallback string) bool {
 	if strings.Contains(primary, ":agent:") {
 		return true
 	}
-	for _, prefix := range []string{"codex:", "header:", "affinity:", "slot:", "thread:", "conv:", "session:", "claude:", "agy:", "geminicache:", "lcp:"} {
-		if strings.HasPrefix(primary, prefix) && strings.HasPrefix(fallback, prefix) && primary != fallback {
-			return true
-		}
+	idx1 := strings.Index(primary, ":")
+	idx2 := strings.Index(fallback, ":")
+	if idx1 > 0 && idx2 > 0 && primary[:idx1] == fallback[:idx2] {
+		return true
 	}
 	return false
 }
 
 func (m *Manager) homeDispatchSessionIDs(opts cliproxyexecutor.Options) (string, string) {
 	primary, fallback := extractExplicitSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	hasAuthoritativeInput := primary != ""
 	if primary == "" {
 		if canonicalID, ok := opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string); ok && strings.TrimSpace(canonicalID) != "" {
 			primary = strings.TrimSpace(canonicalID)
@@ -257,6 +259,7 @@ func (m *Manager) homeDispatchSessionIDs(opts cliproxyexecutor.Options) (string,
 			primary = strings.TrimSpace(lcpID)
 		} else {
 			primary, fallback = extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
+			hasAuthoritativeInput = primary != ""
 		}
 	}
 	if primary == "" || m == nil {
@@ -272,7 +275,7 @@ func (m *Manager) homeDispatchSessionIDs(opts cliproxyexecutor.Options) (string,
 			aliasFallback = fallback
 		}
 	}
-	if parentSessionID == "" && opts.Metadata != nil {
+	if !hasAuthoritativeInput && parentSessionID == "" && opts.Metadata != nil {
 		if metaParent, ok := opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey].(string); ok && strings.TrimSpace(metaParent) != "" {
 			parentSessionID = strings.TrimSpace(metaParent)
 		}
@@ -291,6 +294,13 @@ func (m *Manager) homeDispatchSessionIDs(opts cliproxyexecutor.Options) (string,
 				parentSessionID = ""
 			}
 		}
+	}
+	canonical = cliproxysession.BoundSessionIdentity(canonical)
+	if parentSessionID != "" {
+		parentSessionID = cliproxysession.BoundSessionIdentity(parentSessionID)
+	}
+	if canonical == parentSessionID {
+		parentSessionID = ""
 	}
 	return canonical, parentSessionID
 }

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -961,7 +961,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		delete(opts.Metadata, cliproxyexecutor.LCPAffinitySessionIDMetadataKey)
 		delete(opts.Metadata, cliproxyexecutor.LCPAccessGenerationMetadataKey)
 		if explicitFallbackID != "" {
-			opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = explicitFallbackID
+			opts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = cliproxysession.BoundSessionIdentity(explicitFallbackID)
 		} else {
 			delete(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
 		}
@@ -974,8 +974,14 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if primaryID == "" {
 		primaryID, fallbackID = extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
 	}
-	if primaryID != "" && opts.Metadata != nil {
-		opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey] = primaryID
+	if primaryID != "" {
+		primaryID = cliproxysession.BoundSessionIdentity(primaryID)
+		if fallbackID != "" {
+			fallbackID = cliproxysession.BoundSessionIdentity(fallbackID)
+		}
+		if opts.Metadata != nil {
+			opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey] = primaryID
+		}
 	}
 	now := time.Now()
 	availabilityCandidates := auths
@@ -1267,6 +1273,12 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 
 	explicitID, explicitFallbackID := extractExplicitSessionIDs(res.Options.Headers, res.Options.OriginalRequest, res.Options.Metadata)
+	if explicitID != "" {
+		explicitID = cliproxysession.BoundSessionIdentity(explicitID)
+		if explicitFallbackID != "" {
+			explicitFallbackID = cliproxysession.BoundSessionIdentity(explicitFallbackID)
+		}
+	}
 	ns := res.Provider
 	if raw, ok := res.Options.Metadata[cliproxyexecutor.SessionAffinityProviderMetadataKey].(string); ok && raw != "" {
 		ns = raw
@@ -1322,6 +1334,12 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 	if primaryID == "" && fallbackID == "" {
 		return
+	}
+	if primaryID != "" {
+		primaryID = cliproxysession.BoundSessionIdentity(primaryID)
+	}
+	if fallbackID != "" {
+		fallbackID = cliproxysession.BoundSessionIdentity(fallbackID)
 	}
 
 	cacheKey := ns + "::" + primaryID + "::" + nsModel
@@ -1404,17 +1422,17 @@ func sessionHeaderValue(headers http.Header, name string) string {
 // CanonicalSessionID resolves the single authoritative session identity from request options and metadata.
 func CanonicalSessionID(headers http.Header, payload []byte, metadata map[string]any) string {
 	if explicitID, _ := extractExplicitSessionIDs(headers, payload, metadata); explicitID != "" {
-		return explicitID
+		return cliproxysession.BoundSessionIdentity(explicitID)
 	}
 	if metadata != nil {
 		if canonicalID, ok := metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string); ok && strings.TrimSpace(canonicalID) != "" {
-			return strings.TrimSpace(canonicalID)
+			return cliproxysession.BoundSessionIdentity(strings.TrimSpace(canonicalID))
 		}
 		if lcpID, ok := metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string); ok && strings.TrimSpace(lcpID) != "" {
-			return strings.TrimSpace(lcpID)
+			return cliproxysession.BoundSessionIdentity(strings.TrimSpace(lcpID))
 		}
 	}
-	return ExtractSessionID(headers, payload, metadata)
+	return cliproxysession.BoundSessionIdentity(ExtractSessionID(headers, payload, metadata))
 }
 
 // ExtractSessionID extracts a session identifier from explicit client signals,

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -2552,3 +2552,86 @@ func TestManagerSetSelectorConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestSessionAffinitySelector_LongCompositeIDBoundConsistency(t *testing.T) {
+	t.Parallel()
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelector(fallback)
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-1"}}
+	longSession := strings.Repeat("s", 200)
+	longAgent := strings.Repeat("a", 100)
+
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Claude-Code-Session-Id": []string{longSession},
+			"X-Claude-Code-Agent-Id":   []string{longAgent},
+		},
+		Metadata: make(map[string]any),
+	}
+
+	auth, err := selector.Pick(context.Background(), "claude", "claude-3-7-sonnet", opts, auths)
+	if err != nil || auth == nil {
+		t.Fatalf("selector.Pick failed: %v", err)
+	}
+
+	canonicalID, ok := opts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok || canonicalID == "" {
+		t.Fatalf("canonical session ID not set in metadata")
+	}
+	if len(canonicalID) > 256 {
+		t.Fatalf("canonical ID length = %d, want <= 256", len(canonicalID))
+	}
+	if !strings.Contains(canonicalID, "#") {
+		t.Fatalf("canonical ID %q missing hash separator", canonicalID)
+	}
+
+	// Verify CanonicalSessionID helper returns the same bounded identity
+	resolvedID := CanonicalSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata)
+	if resolvedID != canonicalID {
+		t.Fatalf("CanonicalSessionID %q != metadata canonical %q", resolvedID, canonicalID)
+	}
+}
+
+func TestSessionAffinitySelector_DerivedIDBoundConsistencyOnResult(t *testing.T) {
+	t.Parallel()
+	fallback := &RoundRobinSelector{}
+	selector := NewSessionAffinitySelector(fallback)
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	longDerivedRaw := strings.Repeat("d", 250)
+
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.DerivedSessionIDMetadataKey: longDerivedRaw,
+		},
+	}
+
+	// 1. Pick establishes initial binding
+	pickedAuth, err := selector.Pick(context.Background(), "openai", "gpt-5.4", opts, auths)
+	if err != nil || pickedAuth == nil {
+		t.Fatalf("Pick failed: %v", err)
+	}
+
+	// 2. OnResult records success under bounded derived key
+	res := Result{
+		AuthID:   pickedAuth.ID,
+		Provider: "openai",
+		Model:    "gpt-5.4",
+		Success:  true,
+		Options:  opts,
+	}
+	selector.OnResult(res)
+
+	// 3. Next Pick with reverse candidates must hit the same bound credential
+	reverseAuths := []*Auth{{ID: "auth-b"}, {ID: "auth-a"}}
+	secondPicked, err := selector.Pick(context.Background(), "openai", "gpt-5.4", opts, reverseAuths)
+	if err != nil || secondPicked == nil {
+		t.Fatalf("second Pick failed: %v", err)
+	}
+	if secondPicked.ID != pickedAuth.ID {
+		t.Fatalf("affinity failed: got auth %s, want %s", secondPicked.ID, pickedAuth.ID)
+	}
+}

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -124,18 +124,94 @@ func Enrich(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (clipro
 		opts.OriginalRequest = bytes.Clone(req.Payload)
 		payload = opts.OriginalRequest
 	}
-	if executionID := firstNormalizedMetadataID(cliproxyexecutor.ExecutionSessionMetadataKey, opts.Metadata, req.Metadata); executionID != "" {
-		req.Metadata = metadataWithValue(metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey), cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
-		opts.Metadata = metadataWithValue(metadataWithoutKey(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey), cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
-		return req, opts
-	}
-	req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
-	opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+	executionID := firstNormalizedMetadataID(cliproxyexecutor.ExecutionSessionMetadataKey, opts.Metadata, req.Metadata)
+
 	if hasExplicitSession(opts.Headers, payload) {
 		req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
 		opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
+		if executionID != "" {
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+		} else {
+			req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+			opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+		}
+		if info, ok := ExtractSessionInfo(opts.Headers, payload, opts.Metadata); ok && info.SessionID != "" {
+			canonicalSessionID := BoundSessionIdentity(info.SessionID)
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalSessionID)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalSessionID)
+			if info.ParentSessionID != "" && info.ParentSessionID != info.SessionID {
+				parentSessionID := BoundSessionIdentity(info.ParentSessionID)
+				req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, parentSessionID)
+				opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, parentSessionID)
+			} else {
+				req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+				opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+			}
+		}
 		return req, opts
 	}
+
+	// Metadata-provided canonical or LCP session (e.g. embeddable SDK callers or pre-routed stages)
+	if canonicalID := firstNormalizedMetadataID(cliproxyexecutor.CanonicalSessionIDMetadataKey, opts.Metadata, req.Metadata); canonicalID != "" {
+		req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
+		opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
+		if executionID != "" {
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+		} else {
+			req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+			opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+		}
+		canonicalSessionID := BoundSessionIdentity(canonicalID)
+		req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalSessionID)
+		opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalSessionID)
+		if parentID := firstNormalizedMetadataID(cliproxyexecutor.ParentSessionIDMetadataKey, opts.Metadata, req.Metadata); parentID != "" && parentID != canonicalID {
+			boundedParent := BoundSessionIdentity(parentID)
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, boundedParent)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, boundedParent)
+		} else {
+			req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+			opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+		}
+		return req, opts
+	}
+
+	if lcpID := firstNormalizedMetadataID(cliproxyexecutor.LCPAffinitySessionIDMetadataKey, opts.Metadata, req.Metadata); lcpID != "" {
+		req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
+		opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)
+		if executionID != "" {
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey, executionID)
+		} else {
+			req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+			opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+		}
+		canonicalLCP := BoundSessionIdentity(lcpID)
+		req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalLCP)
+		opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalLCP)
+		if parentID := firstNormalizedMetadataID(cliproxyexecutor.ParentSessionIDMetadataKey, opts.Metadata, req.Metadata); parentID != "" && parentID != lcpID {
+			boundedParent := BoundSessionIdentity(parentID)
+			req.Metadata = metadataWithValue(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, boundedParent)
+			opts.Metadata = metadataWithValue(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey, boundedParent)
+		} else {
+			req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+			opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+		}
+		return req, opts
+	}
+
+	if executionID != "" {
+		canonicalExecutionID := BoundSessionIdentity("execution:" + executionID)
+		req.Metadata = metadataWithValue(metadataWithValue(metadataWithoutKey(metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey), cliproxyexecutor.ParentSessionIDMetadataKey), cliproxyexecutor.ExecutionSessionMetadataKey, executionID), cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalExecutionID)
+		opts.Metadata = metadataWithValue(metadataWithValue(metadataWithoutKey(metadataWithoutKey(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey), cliproxyexecutor.ParentSessionIDMetadataKey), cliproxyexecutor.ExecutionSessionMetadataKey, executionID), cliproxyexecutor.CanonicalSessionIDMetadataKey, canonicalExecutionID)
+		return req, opts
+	}
+
+	req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+	opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey)
+	req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
+	opts.Metadata = metadataWithoutKey(opts.Metadata, cliproxyexecutor.ParentSessionIDMetadataKey)
 
 	derivedID := firstNormalizedMetadataID(cliproxyexecutor.DerivedSessionIDMetadataKey, opts.Metadata, req.Metadata)
 	req.Metadata = metadataWithoutKey(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)

--- a/sdk/cliproxy/session/identity_test.go
+++ b/sdk/cliproxy/session/identity_test.go
@@ -393,3 +393,88 @@ func TestClaudeMetadataIdentitiesNormalizesAgentID(t *testing.T) {
 		t.Fatalf("expected badAgentID to be empty for control character, got %q", badAgentID)
 	}
 }
+
+func TestEnrich_ExplicitSessionPreferredOverExecutionSession(t *testing.T) {
+	t.Parallel()
+
+	// Scenario 1: Responses WebSocket provides ExecutionSessionMetadataKey for transport reuse,
+	// but the client payload carries an explicit conversation/session identity.
+	wsPayload := []byte(`{"session_id":"explicit-ws-session"}`)
+	req1 := cliproxyexecutor.Request{
+		Payload: wsPayload,
+	}
+	opts1 := cliproxyexecutor.Options{
+		OriginalRequest: wsPayload,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "conn-ws-uuid-123",
+		},
+	}
+
+	enrichedReq1, enrichedOpts1 := Enrich(req1, opts1)
+	canonical1, ok1 := enrichedOpts1.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok1 || canonical1 != "session:explicit-ws-session" {
+		t.Fatalf("canonical session = %q (ok=%v), want session:explicit-ws-session", canonical1, ok1)
+	}
+	execID1, okExec1 := enrichedOpts1.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string)
+	if !okExec1 || execID1 != "conn-ws-uuid-123" {
+		t.Fatalf("execution session was not preserved: %q (ok=%v)", execID1, okExec1)
+	}
+	_ = enrichedReq1
+
+	// Scenario 2: Only ExecutionSessionMetadataKey exists (no explicit session headers or payload).
+	req2 := cliproxyexecutor.Request{
+		Payload: []byte(`{"model":"test"}`),
+	}
+	opts2 := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "conn-ws-uuid-456",
+		},
+	}
+	_, enrichedOpts2 := Enrich(req2, opts2)
+	canonical2, ok2 := enrichedOpts2.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok2 || canonical2 != "execution:conn-ws-uuid-456" {
+		t.Fatalf("canonical fallback = %q (ok=%v), want execution:conn-ws-uuid-456", canonical2, ok2)
+	}
+	execID2, okExec2 := enrichedOpts2.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string)
+	if !okExec2 || execID2 != "conn-ws-uuid-456" {
+		t.Fatalf("execution session was not preserved in fallback: %q (ok=%v)", execID2, okExec2)
+	}
+}
+
+func TestEnrich_MetadataOnlyCanonicalAndParentSessionPreserved(t *testing.T) {
+	t.Parallel()
+
+	// Embeddable SDK caller provides explicit canonical and parent session in Options.Metadata
+	// without HTTP session headers or body session fields.
+	req := cliproxyexecutor.Request{
+		Payload: []byte(`{"model":"gpt-5.4"}`),
+	}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.CanonicalSessionIDMetadataKey: "session:sdk-child-001",
+			cliproxyexecutor.ParentSessionIDMetadataKey:    "session:sdk-parent-999",
+		},
+	}
+
+	_, enrichedOpts := Enrich(req, opts)
+	canonical, ok := enrichedOpts.Metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey].(string)
+	if !ok || canonical != "session:sdk-child-001" {
+		t.Fatalf("canonical session = %q (ok=%v), want session:sdk-child-001", canonical, ok)
+	}
+	parent, okParent := enrichedOpts.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey].(string)
+	if !okParent || parent != "session:sdk-parent-999" {
+		t.Fatalf("parent session = %q (ok=%v), want session:sdk-parent-999", parent, okParent)
+	}
+
+	// Self-loop elimination in metadata-only mode
+	optsLoop := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.CanonicalSessionIDMetadataKey: "session:same-loop",
+			cliproxyexecutor.ParentSessionIDMetadataKey:    "session:same-loop",
+		},
+	}
+	_, enrichedLoop := Enrich(req, optsLoop)
+	if _, hasLoopParent := enrichedLoop.Metadata[cliproxyexecutor.ParentSessionIDMetadataKey]; hasLoopParent {
+		t.Fatalf("self-loop parent was not eliminated in metadata-only mode")
+	}
+}

--- a/sdk/cliproxy/session/info.go
+++ b/sdk/cliproxy/session/info.go
@@ -2,8 +2,11 @@
 package session
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -592,8 +595,8 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		if pck != "" {
 			info.ClientType = "generic"
 			info.SessionID = "pck:" + pck
-			if conversationID != "" {
-				info.ParentSessionID = conversationID
+			if parentCandidate != "" && parentCandidate != pck {
+				info.ParentSessionID = "pck:" + parentCandidate
 				info.AgentName = "subagent"
 			} else {
 				info.AgentName = "main"
@@ -654,6 +657,26 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		}
 	}
 
+	// 8. LCPAffinitySessionIDMetadataKey
+	if lcpID, ok := metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string); ok {
+		if lcpID = normalizedSessionCandidate(lcpID); lcpID != "" {
+			info.ClientType = "lcp"
+			info.SessionID = lcpID
+			if parentID, okParent := metadata[cliproxyexecutor.ParentSessionIDMetadataKey].(string); okParent {
+				if parentID = normalizedSessionCandidate(parentID); parentID != "" && parentID != lcpID {
+					info.ParentSessionID = parentID
+					info.AgentName = "subagent"
+					info.IsFork = true
+				} else {
+					info.AgentName = "main"
+				}
+			} else {
+				info.AgentName = "main"
+			}
+			return finalizeSessionInfo(info)
+		}
+	}
+
 	return SessionInfo{}, false
 }
 
@@ -678,9 +701,32 @@ func isBodyForkCandidate(root, reqRoot gjson.Result, hasNestedReq bool) bool {
 	return false
 }
 
+// BoundSessionIdentity bounds an identifier to <= 256 bytes safely,
+// preserving uniqueness via SHA256 and guarding against splitting multibyte UTF-8 characters.
+func BoundSessionIdentity(id string) string {
+	if len(id) <= 256 {
+		return id
+	}
+	sum := sha256.Sum256([]byte(id))
+	hashHex := hex.EncodeToString(sum[:]) // 64 bytes
+	prefixLen := 255 - 1 - len(hashHex)   // 190 bytes
+	if prefixLen > len(id) {
+		prefixLen = len(id)
+	}
+	prefix := id[:prefixLen]
+	for !utf8.ValidString(prefix) && len(prefix) > 0 {
+		prefix = prefix[:len(prefix)-1]
+	}
+	return prefix + "#" + hashHex
+}
+
 func finalizeSessionInfo(info SessionInfo) (SessionInfo, bool) {
 	if info.SessionID == "" {
 		return SessionInfo{}, false
+	}
+	info.SessionID = BoundSessionIdentity(info.SessionID)
+	if info.ParentSessionID != "" {
+		info.ParentSessionID = BoundSessionIdentity(info.ParentSessionID)
 	}
 	if info.AgentName == "" {
 		info.AgentName = "main"

--- a/sdk/cliproxy/session/info_test.go
+++ b/sdk/cliproxy/session/info_test.go
@@ -2,7 +2,9 @@ package session
 
 import (
 	"net/http"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -449,11 +451,18 @@ func TestExtractSessionInfoClaudePayloadOutranksGenericHeader(t *testing.T) {
 func TestExtractSessionInfoPromptCacheKeyAndClientReqAndMetadata(t *testing.T) {
 	t.Parallel()
 
-	// 1. prompt_cache_key
+	// 1. prompt_cache_key with conversation alias (not a parent-child edge)
 	payloadPCK := []byte(`{"prompt_cache_key":"prompt-key-123","conversation":{"id":"conv-456"}}`)
 	info, ok := ExtractSessionInfo(nil, payloadPCK, nil)
-	if !ok || info.SessionID != "pck:prompt-key-123" || info.ParentSessionID != "conv:conv-456" {
-		t.Fatalf("pck extraction failed: %+v", info)
+	if !ok || info.SessionID != "pck:prompt-key-123" || info.ParentSessionID != "" {
+		t.Fatalf("pck extraction failed (should not treat conv alias as parent): %+v", info)
+	}
+
+	// 1b. prompt_cache_key with explicit parentCandidate
+	payloadPCKWithParent := []byte(`{"prompt_cache_key":"prompt-key-123","conversation":{"id":"conv-456"},"parent_session_id":"pck-parent-789"}`)
+	infoWithParent, okWithParent := ExtractSessionInfo(nil, payloadPCKWithParent, nil)
+	if !okWithParent || infoWithParent.SessionID != "pck:prompt-key-123" || infoWithParent.ParentSessionID != "pck:pck-parent-789" {
+		t.Fatalf("pck with parent candidate extraction failed: %+v", infoWithParent)
 	}
 
 	// 2. plain metadata.user_id
@@ -604,5 +613,37 @@ func TestExtractSessionInfoNestedSubagentIDAndUserID(t *testing.T) {
 	}
 	if infoShadow.SessionID != "pck:nested-pck-valid" {
 		t.Fatalf("SessionID = %q, want pck:nested-pck-valid", infoShadow.SessionID)
+	}
+}
+
+func TestBoundSessionIdentitySafetyAndUniqueness(t *testing.T) {
+	t.Parallel()
+
+	// Short ID remains unchanged
+	shortID := "session:normal-length-session"
+	if got := BoundSessionIdentity(shortID); got != shortID {
+		t.Fatalf("shortID = %q, want %q", got, shortID)
+	}
+
+	// Long ID with Chinese UTF-8 characters exceeding 256 bytes
+	longChinese := strings.Repeat("会话测试超长标识符", 20) // ~18 bytes * 20 = 360 bytes
+	bounded1 := BoundSessionIdentity(longChinese)
+	if len(bounded1) > 256 {
+		t.Fatalf("bounded length = %d, want <= 256", len(bounded1))
+	}
+	if !utf8.ValidString(bounded1) {
+		t.Fatalf("bounded string is not valid UTF-8: %q", bounded1)
+	}
+
+	// Uniqueness: two long strings differing only at the end must produce distinct bounded IDs
+	longA := strings.Repeat("a", 250) + "-worker-1"
+	longB := strings.Repeat("a", 250) + "-worker-2"
+	boundedA := BoundSessionIdentity(longA)
+	boundedB := BoundSessionIdentity(longB)
+	if boundedA == boundedB {
+		t.Fatalf("collision detected between boundedA and boundedB: %q", boundedA)
+	}
+	if len(boundedA) > 256 || len(boundedB) > 256 {
+		t.Fatalf("bounded lengths = (%d, %d), want <= 256", len(boundedA), len(boundedB))
 	}
 }

--- a/sdk/cliproxy/session/tree_compat.go
+++ b/sdk/cliproxy/session/tree_compat.go
@@ -11,7 +11,6 @@ import (
 type SessionTreeNode struct {
 	SessionID       string         `json:"session_id"`
 	ParentSessionID string         `json:"parent_session_id,omitempty"`
-	RootSessionID   string         `json:"root_session_id"`
 	TreePath        string         `json:"tree_path"`
 	TreeDepth       int            `json:"tree_depth"`
 	AgentName       string         `json:"agent_name,omitempty"`
@@ -83,7 +82,6 @@ func (s *InMemorySessionTreeStore) RecordNode(info SessionTreeInfo) *SessionTree
 	node := &SessionTreeNode{
 		SessionID:       info.SessionID,
 		ParentSessionID: info.ParentSessionID,
-		RootSessionID:   info.SessionID,
 		TreePath:        info.SessionID,
 		TreeDepth:       0,
 		AgentName:       info.AgentName,
@@ -97,7 +95,6 @@ func (s *InMemorySessionTreeStore) RecordNode(info SessionTreeInfo) *SessionTree
 		Metadata:        info.Metadata,
 	}
 	if info.ParentSessionID != "" {
-		node.RootSessionID = info.ParentSessionID
 		node.TreePath = info.ParentSessionID + "/" + info.SessionID
 		node.TreeDepth = 1
 	}
@@ -130,7 +127,7 @@ func (s *InMemorySessionTreeStore) GetTree(rootSessionID string) []*SessionTreeN
 	defer s.mu.RUnlock()
 	var res []*SessionTreeNode
 	for _, n := range s.nodes {
-		if n.RootSessionID == rootSessionID || n.SessionID == rootSessionID {
+		if n.ParentSessionID == rootSessionID || n.SessionID == rootSessionID {
 			res = append(res, n.Clone())
 		}
 	}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -22,12 +22,14 @@ const AutoServiceTier = "auto"
 type Record struct {
 	Provider string
 	// ExecutorType stores the concrete executor type that handled the request.
-	ExecutorType string
-	Model        string
-	Alias        string
-	APIKey       string
-	AuthID       string
-	AuthIndex    string
+	ExecutorType    string
+	Model           string
+	Alias           string
+	APIKey          string
+	SessionID       string
+	ParentSessionID string
+	AuthID          string
+	AuthIndex       string
 	// AccessTokenSHA256 identifies the OAuth token version without exposing the token.
 	AccessTokenSHA256 string
 	AuthType          string

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1354,6 +1354,10 @@ type UsageRecord struct {
 	Alias string
 	// APIKey is the client API key identifier when available.
 	APIKey string
+	// SessionID identifies the session when present.
+	SessionID string
+	// ParentSessionID identifies the parent session in a hierarchy or fork.
+	ParentSessionID string
 	// AuthID identifies the selected credential.
 	AuthID string
 	// AuthIndex identifies the credential index when applicable.


### PR DESCRIPTION
### Summary
This PR connects the downstream client session hierarchy to the usage reporting and Redis/Home queuing pipeline, complementing the routing-stage session affinity capabilities introduced in #5454.

### Architectural Alignment
- **Minimal Adjacency List Topology**: Strictly propagates only `session_id` and `parent_session_id`. Root session derivation and tree reconstruction are naturally maintained by downstream consumers (e.g. Home's tree BFS recovery), keeping the proxy stateless and eliminating false root collapse in multi-tier agent chains.
- **Unified Canonical Namespace**: Completely reuses `coresession.ExtractSessionInfo` for usage metadata, guaranteeing that `claude:...`, `codex:...`, `header:...`, `slot:...`, and `session:...` prefix namespaces 100% align with the scheduler and Home dispatch.

### Key Technical Changes
1. **Two-Phase Hierarchy Extraction**:
   - **Phase 1 (Entry)**: Extracts baseline session identity from HTTP headers in `GetContextWithCancel`.
   - **Phase 2 (Deep Extraction)**: Enriches context using headers, request payload, and metadata across all 6 execution routes (standard sync/stream/count and plugin executor sync/stream/count) once bodies are ready, accurately capturing Claude Code subagents (`metadata.agent_id`), Codex fork lineages, and body session parameters.
2. **Defensive Ghost Parent & Self-Loop Elimination**:
   - Authority overwrite in `enrichContextWithSessionHierarchy` prevents legacy header parents from polluting independent body root sessions.
   - Enforces same-origin paired fallback in `internal/redisqueue/plugin.go` so independent root records never inherit stale context parents.
   - Multi-tier guards automatically nullify self-referential loops (`session_id == parent_session_id`) and orphan parents (`session_id == ""`).
3. **Usage Pipeline & Plugin Host Parity**:
   - Propagates `SessionID` and `ParentSessionID` across `ClientRequestMetadata`, `helps.UsageReporter`, `coreusage.Record`, and `queuedUsageDetail` (with `omitempty`).
   - Upgrades `pluginapi.UsageRecord` and `internal/pluginhost/adapters_usage_translation.go` to provide external Go/RPC usage plugins with the same visibility.

### Verification & Testing
- `go build -ldflags="-s -w" -o /dev/null ./cmd/server` (PASS)
- `go test -race ./sdk/api/handlers ./internal/redisqueue ./internal/runtime/executor/helps` (PASS, 0 race warnings)
- Added 6 comprehensive test groups in `handlers_metadata_test.go`, `usage_helpers_test.go`, and `plugin_test.go` covering canonical header matrix, body deep extraction, ghost parent elimination, same-origin fallback, and self-loop guards.