### PR TITLE
fix(registry): retry startup model catalog fetch with exponential backoff

### DIFF
--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"sync"
@@ -17,7 +18,35 @@ import (
 const (
 	modelsFetchTimeout    = 30 * time.Second
 	modelsRefreshInterval = 3 * time.Hour
+
+	// Startup retry backoff for the initial remote catalog fetch. The first
+	// fetch runs concurrently with process startup, so a transport that is
+	// not ready yet (e.g. a local proxy that starts after login) can make it
+	// fail; without retries the registry silently falls back to the embedded
+	// catalog, which may be outdated and miss newly released models until
+	// the next periodic tick. Retries start at 10s, double with ±20% jitter,
+	// cap at 5 minutes, and never give up: once the first fetch succeeds the
+	// regular modelsRefreshInterval ticker takes over.
+	startupRetryBaseDelay = 10 * time.Second
+	startupRetryMaxDelay  = 5 * time.Minute
 )
+
+// startupSleep waits for d or until ctx is cancelled. It is a package
+// variable so tests can run the startup retry loop without real delays.
+var startupSleep = func(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// fetchModelsFromRemoteFn is the fetch entry used by the startup retry loop.
+// Tests replace it to simulate transient remote failures.
+var fetchModelsFromRemoteFn = fetchModelsFromRemote
 
 var modelsURLs = []string{
 	"https://raw.githubusercontent.com/router-for-me/models/refs/heads/main/models.json",
@@ -81,8 +110,45 @@ func StartModelsUpdater(ctx context.Context) {
 }
 
 func runModelsUpdater(ctx context.Context) {
-	tryStartupRefresh(ctx)
+	runStartupRefreshWithBackoff(ctx)
 	periodicRefresh(ctx)
+}
+
+// runStartupRefreshWithBackoff performs the initial remote catalog fetch and,
+// on failure, retries with exponential backoff (10s doubling with jitter,
+// capped at 5 minutes) until it succeeds or ctx is cancelled. Every failed
+// attempt is logged at error level so a degraded startup is visible in file
+// logs. Periodic refresh remains responsible for all subsequent updates.
+func runStartupRefreshWithBackoff(ctx context.Context) {
+	delay := startupRetryBaseDelay
+	for attempt := 1; ; attempt++ {
+		if tryStartupRefresh(ctx) {
+			if attempt > 1 {
+				log.Infof("startup model refresh succeeded on attempt %d after retries", attempt)
+			}
+			return
+		}
+		log.Errorf("startup model refresh failed (attempt %d); retrying in %s", attempt, delay)
+		if errSleep := startupSleep(ctx, jitteredDelay(delay)); errSleep != nil {
+			// Context cancelled (shutdown): periodic refresh will not run either.
+			log.Infof("startup model refresh retry loop stopped: %v", errSleep)
+			return
+		}
+		delay = min(delay*2, startupRetryMaxDelay)
+	}
+}
+
+// jitteredDelay spreads the retry delay by ±20% so a fleet of restarts (or
+// multiple local instances) does not hammer the catalog mirrors in sync.
+func jitteredDelay(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	spread := d / 5
+	if spread <= 0 {
+		return d
+	}
+	return d - spread + time.Duration(rand.Int64N(int64(2*spread)+1))
 }
 
 func periodicRefresh(ctx context.Context) {
@@ -101,24 +167,30 @@ func periodicRefresh(ctx context.Context) {
 
 // tryPeriodicRefresh fetches models from remote, compares with the current
 // catalog, and notifies the registered callback if any provider changed.
+// A failed periodic attempt keeps the current data; the next tick retries,
+// so no backoff loop is needed here.
 func tryPeriodicRefresh(ctx context.Context) {
-	tryRefreshModels(ctx, "periodic model refresh")
+	if !tryRefreshModels(ctx, "periodic model refresh") {
+		log.Errorf("periodic model refresh failed: fetch failed from all URLs; keeping current catalog until next tick (%s)", modelsRefreshInterval)
+	}
 }
 
-// tryStartupRefresh fetches models from remote in the background during
-// process startup. It uses the same change detection as periodic refresh so
-// existing auth registrations can be updated after the callback is registered.
-func tryStartupRefresh(ctx context.Context) {
-	tryRefreshModels(ctx, "startup model refresh")
+// tryStartupRefresh runs one startup fetch attempt. It reports whether the
+// remote catalog was fetched and applied.
+func tryStartupRefresh(ctx context.Context) bool {
+	return tryRefreshModels(ctx, "startup model refresh")
 }
 
-func tryRefreshModels(ctx context.Context, label string) {
+// tryRefreshModels fetches models from remote and swaps the store on success.
+// It returns true when a remote catalog was fetched (regardless of whether
+// it differed from the current data), false when all URLs failed.
+func tryRefreshModels(ctx context.Context, label string) bool {
 	oldData := getModels()
 
-	parsed, url := fetchModelsFromRemote(ctx)
+	parsed, url := fetchModelsFromRemoteFn(ctx)
 	if parsed == nil {
 		log.Warnf("%s: fetch failed from all URLs, keeping current data", label)
-		return
+		return false
 	}
 
 	// Detect changes before updating store.
@@ -131,11 +203,12 @@ func tryRefreshModels(ctx context.Context, label string) {
 
 	if len(changed) == 0 {
 		log.Infof("%s completed from %s, no changes detected", label, url)
-		return
+		return true
 	}
 
 	log.Infof("%s completed from %s, changes detected for providers: %v", label, url, changed)
 	notifyModelRefresh(changed)
+	return true
 }
 
 // fetchModelsFromRemote tries all remote URLs and returns the parsed model catalog

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -124,14 +124,19 @@ func runStartupRefreshWithBackoff(ctx context.Context) {
 	for attempt := 1; ; attempt++ {
 		if tryStartupRefresh(ctx) {
 			if attempt > 1 {
-				log.Infof("startup model refresh succeeded on attempt %d after retries", attempt)
+				log.WithFields(log.Fields{
+					"attempts": attempt,
+				}).Info("startup model refresh succeeded after retries")
 			}
 			return
 		}
-		log.Errorf("startup model refresh failed (attempt %d); retrying in %s", attempt, delay)
+		log.WithFields(log.Fields{
+			"attempt":     attempt,
+			"retry_delay": delay.String(),
+		}).Error("startup model catalog fetch failed; retrying")
 		if errSleep := startupSleep(ctx, jitteredDelay(delay)); errSleep != nil {
 			// Context cancelled (shutdown): periodic refresh will not run either.
-			log.Infof("startup model refresh retry loop stopped: %v", errSleep)
+			log.WithField("reason", errSleep.Error()).Info("startup model refresh retry loop stopped")
 			return
 		}
 		delay = min(delay*2, startupRetryMaxDelay)
@@ -171,7 +176,7 @@ func periodicRefresh(ctx context.Context) {
 // so no backoff loop is needed here.
 func tryPeriodicRefresh(ctx context.Context) {
 	if !tryRefreshModels(ctx, "periodic model refresh") {
-		log.Errorf("periodic model refresh failed: fetch failed from all URLs; keeping current catalog until next tick (%s)", modelsRefreshInterval)
+		log.WithField("next_retry_after", modelsRefreshInterval.String()).Error("periodic model refresh failed: fetch failed from all URLs; keeping current catalog until next tick")
 	}
 }
 

--- a/internal/registry/model_updater_backoff_test.go
+++ b/internal/registry/model_updater_backoff_test.go
@@ -23,13 +23,42 @@ func staticCatalog(t *testing.T) *staticModelsJSON {
 	return &parsed
 }
 
-// restoreUpdaterHooks saves package-level test hooks and restores them via
-// t.Cleanup so parallel tests in the package are not affected.
+// restoreUpdaterHooks saves package-level test hooks and global state, then
+// restores them via t.Cleanup so tests stay isolated regardless of order
+// (go test -shuffle=on). It returns a slice that records sleep durations.
 func restoreUpdaterHooks(t *testing.T) (sleepCalls *[]time.Duration) {
 	t.Helper()
 	origSleep, origFetch := startupSleep, fetchModelsFromRemoteFn
+
+	// Snapshot the global catalog store so a mocked successful fetch (which
+	// swaps modelsCatalogStore.data via tryRefreshModels) cannot leak into
+	// other tests.
+	modelsCatalogStore.mu.Lock()
+	origData := modelsCatalogStore.data
+	modelsCatalogStore.mu.Unlock()
+
+	// Snapshot refresh-callback state; tryRefreshModels appends to
+	// pendingRefreshChanges when no callback is registered.
+	refreshCallbackMu.Lock()
+	origCallback := refreshCallback
+	origPending := pendingRefreshChanges
+	refreshCallbackMu.Unlock()
+
+	// Capture the global logger configuration before any test mutates it.
+	origLogOut := log.StandardLogger().Out
+	origLogLevel := log.GetLevel()
+
 	t.Cleanup(func() {
 		startupSleep, fetchModelsFromRemoteFn = origSleep, origFetch
+		modelsCatalogStore.mu.Lock()
+		modelsCatalogStore.data = origData
+		modelsCatalogStore.mu.Unlock()
+		refreshCallbackMu.Lock()
+		refreshCallback = origCallback
+		pendingRefreshChanges = origPending
+		refreshCallbackMu.Unlock()
+		log.SetOutput(origLogOut)
+		log.SetLevel(origLogLevel)
 	})
 	calls := &[]time.Duration{}
 	return calls
@@ -172,21 +201,17 @@ func TestRunStartupRefreshWithBackoff_LogsFailedAttempts(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	log.SetLevel(log.ErrorLevel)
-	t.Cleanup(func() {
-		log.SetOutput(log.StandardLogger().Out)
-		log.SetLevel(log.InfoLevel)
-	})
 
 	startupSleep = func(ctx context.Context, d time.Duration) error { return nil }
 
 	runStartupRefreshWithBackoff(context.Background())
 
 	out := buf.String()
-	if !strings.Contains(out, "startup model refresh failed (attempt 1)") {
+	if !strings.Contains(out, "startup model catalog fetch failed") {
 		t.Errorf("error-level log for failed attempt missing, got: %q", out)
 	}
-	if !strings.Contains(out, "retrying in") {
-		t.Errorf("retry delay missing from error log, got: %q", out)
+	if !strings.Contains(out, "attempt=1") || !strings.Contains(out, "retry_delay=10s") {
+		t.Errorf("structured fields (attempt, retry_delay) missing from error log, got: %q", out)
 	}
 }
 
@@ -200,10 +225,6 @@ func TestTryPeriodicRefresh_LogsFailure(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	log.SetLevel(log.ErrorLevel)
-	t.Cleanup(func() {
-		log.SetOutput(log.StandardLogger().Out)
-		log.SetLevel(log.InfoLevel)
-	})
 
 	tryPeriodicRefresh(context.Background())
 

--- a/internal/registry/model_updater_backoff_test.go
+++ b/internal/registry/model_updater_backoff_test.go
@@ -1,0 +1,228 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// staticCatalog builds a minimal valid catalog so tryRefreshModels treats a
+// mocked fetch as a successful remote response.
+func staticCatalog(t *testing.T) *staticModelsJSON {
+	t.Helper()
+	var parsed staticModelsJSON
+	if err := json.Unmarshal([]byte(`{"gemini": []}`), &parsed); err != nil {
+		t.Fatalf("unmarshal static catalog: %v", err)
+	}
+	return &parsed
+}
+
+// restoreUpdaterHooks saves package-level test hooks and restores them via
+// t.Cleanup so parallel tests in the package are not affected.
+func restoreUpdaterHooks(t *testing.T) (sleepCalls *[]time.Duration) {
+	t.Helper()
+	origSleep, origFetch := startupSleep, fetchModelsFromRemoteFn
+	t.Cleanup(func() {
+		startupSleep, fetchModelsFromRemoteFn = origSleep, origFetch
+	})
+	calls := &[]time.Duration{}
+	return calls
+}
+
+func TestRunStartupRefreshWithBackoff_SucceedsFirstTry(t *testing.T) {
+	calls := restoreUpdaterHooks(t)
+
+	fetchOK := false
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		fetchOK = true
+		return staticCatalog(t), "https://example.test/models.json"
+	}
+	startupSleep = func(ctx context.Context, d time.Duration) error {
+		t.Fatalf("startupSleep must not be called when the first fetch succeeds (got delay %s)", d)
+		return nil
+	}
+
+	runStartupRefreshWithBackoff(context.Background())
+	if !fetchOK {
+		t.Fatal("fetch was never attempted")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("unexpected sleep calls: %v", *calls)
+	}
+}
+
+func TestRunStartupRefreshWithBackoff_ExponentialCapped(t *testing.T) {
+	calls := restoreUpdaterHooks(t)
+
+	var mu sync.Mutex
+	fetches := 0
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		fetches++
+		if fetches <= 4 {
+			return nil, "" // fail the first 4 attempts
+		}
+		return staticCatalog(t), "https://example.test/models.json"
+	}
+
+	var sleepOrder []time.Duration
+	startupSleep = func(ctx context.Context, d time.Duration) error {
+		sleepOrder = append(sleepOrder, d)
+		*calls = append(*calls, d)
+		return nil
+	}
+
+	runStartupRefreshWithBackoff(context.Background())
+
+	if len(sleepOrder) != 4 {
+		t.Fatalf("expected 4 retry sleeps, got %d: %v", len(sleepOrder), sleepOrder)
+	}
+	// Nominal sequence: 10s, 20s, 40s, 80s (jitter ±20% must stay in band).
+	wantNominal := []time.Duration{10 * time.Second, 20 * time.Second, 40 * time.Second, 80 * time.Second}
+	for i, got := range sleepOrder {
+		nominal := wantNominal[i]
+		lo := nominal - nominal/5
+		hi := nominal + nominal/5
+		if got < lo || got > hi {
+			t.Errorf("sleep[%d]=%s outside jitter band [%s, %s] (nominal %s)", i, got, lo, hi, nominal)
+		}
+		if i > 0 && got <= sleepOrder[i-1]/2 {
+			t.Errorf("sleep[%d]=%s did not grow from previous %s", i, got, sleepOrder[i-1])
+		}
+	}
+}
+
+func TestRunStartupRefreshWithBackoff_CapsAtFiveMinutes(t *testing.T) {
+	calls := restoreUpdaterHooks(t)
+
+	var mu sync.Mutex
+	fetches := 0
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		fetches++
+		if fetches <= 12 {
+			return nil, "" // long failure streak: 10,20,40,80,160,300(cap hits here)
+		}
+		return staticCatalog(t), "https://example.test/models.json"
+	}
+
+	startupSleep = func(ctx context.Context, d time.Duration) error {
+		*calls = append(*calls, d)
+		return nil
+	}
+
+	runStartupRefreshWithBackoff(context.Background())
+
+	slept := *calls
+	if len(slept) != 12 {
+		t.Fatalf("expected 12 retry sleeps, got %d", len(slept))
+	}
+	for i, got := range slept {
+		if got > startupRetryMaxDelay+startupRetryMaxDelay/5 {
+			t.Errorf("sleep[%d]=%s exceeds 5min cap + jitter", i, got)
+		}
+	}
+	if last := slept[len(slept)-1]; last < startupRetryMaxDelay-startupRetryMaxDelay/5 {
+		t.Errorf("final sleep %s should be near the 5min cap (jitter floor 4m)", last)
+	}
+}
+
+func TestRunStartupRefreshWithBackoff_StopsOnContextCancel(t *testing.T) {
+	calls := restoreUpdaterHooks(t)
+
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		return nil, "" // always fail
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startupSleep = func(ctx context.Context, d time.Duration) error {
+		cancel() // simulate shutdown during the first backoff wait
+		return ctx.Err()
+	}
+
+	runStartupRefreshWithBackoff(ctx)
+	if len(*calls) != 0 {
+		t.Fatalf("unexpected sleeps after cancel: %v", *calls)
+	}
+}
+
+func TestRunStartupRefreshWithBackoff_LogsFailedAttempts(t *testing.T) {
+	restoreUpdaterHooks(t)
+
+	var mu sync.Mutex
+	fetches := 0
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		fetches++
+		if fetches <= 1 {
+			return nil, ""
+		}
+		return staticCatalog(t), "https://example.test/models.json"
+	}
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetLevel(log.ErrorLevel)
+	t.Cleanup(func() {
+		log.SetOutput(log.StandardLogger().Out)
+		log.SetLevel(log.InfoLevel)
+	})
+
+	startupSleep = func(ctx context.Context, d time.Duration) error { return nil }
+
+	runStartupRefreshWithBackoff(context.Background())
+
+	out := buf.String()
+	if !strings.Contains(out, "startup model refresh failed (attempt 1)") {
+		t.Errorf("error-level log for failed attempt missing, got: %q", out)
+	}
+	if !strings.Contains(out, "retrying in") {
+		t.Errorf("retry delay missing from error log, got: %q", out)
+	}
+}
+
+func TestTryPeriodicRefresh_LogsFailure(t *testing.T) {
+	restoreUpdaterHooks(t)
+
+	fetchModelsFromRemoteFn = func(ctx context.Context) (*staticModelsJSON, string) {
+		return nil, ""
+	}
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetLevel(log.ErrorLevel)
+	t.Cleanup(func() {
+		log.SetOutput(log.StandardLogger().Out)
+		log.SetLevel(log.InfoLevel)
+	})
+
+	tryPeriodicRefresh(context.Background())
+
+	if out := buf.String(); !strings.Contains(out, "periodic model refresh failed") {
+		t.Errorf("error-level log for periodic failure missing, got: %q", out)
+	}
+}
+
+func TestJitteredDelay_ZeroAndSmall(t *testing.T) {
+	if got := jitteredDelay(0); got != 0 {
+		t.Errorf("jitteredDelay(0)=%s, want 0", got)
+	}
+	if got := jitteredDelay(time.Nanosecond); got != time.Nanosecond {
+		t.Errorf("jitteredDelay(1ns)=%s, want 1ns (no sub-spread floor)", got)
+	}
+	for range 200 {
+		got := jitteredDelay(10 * time.Second)
+		if got < 8*time.Second || got > 12*time.Second {
+			t.Fatalf("jitteredDelay(10s)=%s outside ±20%% band", got)
+		}
+	}
+}


### PR DESCRIPTION
## What

The initial remote model catalog fetch currently gives up permanently on a single failure and silently falls back to the embedded catalog until the next periodic tick (3h). Retry it with exponential backoff instead.

## Why

The startup fetch runs concurrently with process startup. When its transport is not ready yet (e.g. a desktop install whose system proxy starts after login, or a container whose sidecar comes up later), the first fetch fails, the registry silently serves the embedded catalog, and models that only exist in the remote catalog return `unknown provider` until the periodic tick up to 3 hours later.

A concrete reproduction (observed on a Windows host running v7.2.148): a scheduled reboot at 23:07 relaunched CLIProxyAPI 36 seconds before the system proxy came up. The startup fetch failed; every request for a recently-released model then failed with `400 unknown provider` for ~3h until the periodic refresh finally succeeded at ~02:07. The embedded catalog was a release behind and did not know the model, so the "keep embedded data on failure" fallback served a stale catalog with no warning.

## Changes

- `internal/registry/model_updater.go`:
  - `runStartupRefreshWithBackoff`: retries the startup fetch with 10s base delay, x2 growth, ±20% jitter, 5m cap, until success or context cancellation; hands over to the unchanged periodic ticker on success.
  - `tryRefreshModels` returns success; failed startup attempts are logged at error level (previously the only trace was a debug-level fetch message plus the warn, invisible when file logging is off).
  - Failed periodic attempts are also logged at error level (behavior unchanged: keep current data, next tick retries).
- `internal/registry/model_updater_backoff_test.go`: new tests — success on first attempt (no sleeps), exponential growth within the jitter band, 5m cap, context cancellation stop, error-level logs for failed startup/periodic attempts, jitter boundary values.

## Notes

- Periodic refresh semantics are unchanged (no backoff loop added there).
- `logging-to-file` was off on the affected host, which is why the original `Warnf` was invisible; this PR makes the degradation visible at error level regardless of sink configuration.
- Related context: #3151 (closed as working-as-intended because the embedded catalog is a fallback; but the embedded catalog can be a release behind, which turns the fallback into hours of `unknown provider` for models that only exist remotely), #5291 (overridable catalog URLs, overlapping file).
