### PR TITLE
fix(codex): restore flat collaboration tool names

### DIFF
--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -26,6 +26,7 @@ const (
 	codexCollaborationNamespace           = "collaboration"
 	codexOptimizedCollaborationNamespace  = "collaboration-optimize"
 	codexOptimizedCollaborationNamePrefix = codexOptimizedCollaborationNamespace + "__"
+	codexOptimizedCollaborationDotPrefix  = codexOptimizedCollaborationNamespace + "."
 )
 
 // CodexMultiAgentV2ToolsPreparedContextKey marks a request whose collaboration
@@ -742,6 +743,10 @@ func restoreCodexCollaborationValue(value any) bool {
 			switch {
 			case name == codexOptimizedCollaborationNamespace && itemType == "namespace":
 				typed["name"] = codexCollaborationNamespace
+				changed = true
+			case isToolCall && strings.HasPrefix(name, codexOptimizedCollaborationDotPrefix):
+				typed["name"] = strings.TrimPrefix(name, codexOptimizedCollaborationDotPrefix)
+				typed["namespace"] = codexCollaborationNamespace
 				changed = true
 			case isToolCall && strings.HasPrefix(name, codexOptimizedCollaborationNamePrefix):
 				typed["name"] = codexCollaborationNamespace + "__" + strings.TrimPrefix(name, codexOptimizedCollaborationNamePrefix)

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -456,6 +456,24 @@ func TestRestoreCodexMultiAgentV2Response(t *testing.T) {
 	}
 }
 
+func TestRestoreCodexMultiAgentV2ResponseFlatFunctionName(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{
+		"type":"response.completed",
+		"response":{"output":[
+			{"type":"function_call","name":"collaboration-optimize.spawn_agent","namespace":null,"arguments":"{}"}
+		]}
+	}`)
+	got := RestoreCodexMultiAgentV2Response(payload, true)
+	if namespace := gjson.GetBytes(got, "response.output.0.namespace").String(); namespace != codexCollaborationNamespace {
+		t.Fatalf("flat function namespace = %q, want collaboration; payload=%s", namespace, got)
+	}
+	if name := gjson.GetBytes(got, "response.output.0.name").String(); name != "spawn_agent" {
+		t.Fatalf("flat function name = %q, want spawn_agent; payload=%s", name, got)
+	}
+}
+
 func TestRewriteCodexMultiAgentV2InputRewritesAgentMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fixes: A plain HTTP Responses upstream can return collaboration-optimize.spawn_agent with no namespace, which reaches Codex unchanged and is rejected as an unsupported call.
- Root cause: RestoreCodexMultiAgentV2Response recognized separate collaboration-optimize namespaces and double-underscore qualified names, but not the dotted flat name emitted by third-party Responses upstreams.
- Restores that flat form to `namespace: collaboration` plus the original tool name before returning the response to Codex.

Closes #5524.

## Regression evidence

- Before: `go test ./internal/client/codex/optimize-multi-agent-v2 -run '^TestRestoreCodexMultiAgentV2Response(FlatFunctionName)?$' -count=1 -v` exited `1`

- After: `go test ./internal/client/codex/optimize-multi-agent-v2 -run '^TestRestoreCodexMultiAgentV2Response(FlatFunctionName)?$' -count=1 -v` exited `0`

## Verification

- `go test ./internal/client/codex/optimize-multi-agent-v2 -count=1`
- `go test ./internal/runtime/executor -run 'CodexExecutorOptimizeMultiAgentV2' -count=1`
- `go test -race ./internal/client/codex/optimize-multi-agent-v2 ./internal/runtime/executor -count=1`
- `go list ./... | rg -v '/internal/client/codex/live$' | xargs go test -count=1`
- `go vet ./...`
- `go build -o <temporary-output>/cli-proxy-api ./cmd/server`
- `gofmt -l <changed-files> && git diff --check`

The literal full-suite command `go test ./... -count=1` was also run. It passed the changed helper and executor packages, but the repository-wide run failed in unrelated timing-sensitive tests: `TestPionMediaRelayBridgesAudioAndDataChannel` and, under parallel load only, `TestEnsureClientsWaitsForPreviousTargetClose`. The WebRTC failure reproduced on the unchanged base (2 failures in 3 isolated runs); the home test passed 3/3 on the unchanged base. A serial full-suite run still failed only in the same WebRTC test. The broad command above excludes only `internal/client/codex/live` and passed every other package.

## Scope

- 2 files changed, +23 / -0 lines
