### PR TITLE
fix(cliproxy): do not reconfigure plugins on auth updates

### DIFF
--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -146,7 +146,7 @@ func (s *Service) handleAuthUpdates(ctx context.Context, updates []watcher.AuthU
 	}
 	s.runModelRegistrationTasks(registrationCtx, tasks)
 	if needsPluginSync {
-		s.syncPluginRuntime(registrationCtx)
+		s.syncPluginRuntimeForAuthChange(registrationCtx)
 	}
 }
 
@@ -266,7 +266,7 @@ func (s *Service) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 		return
 	}
 	s.completeModelRegistrationForAuth(ctx, auth)
-	s.syncPluginRuntime(ctx)
+	s.syncPluginRuntimeForAuthChange(ctx)
 }
 
 func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth *coreauth.Auth) *coreauth.Auth {
@@ -351,7 +351,7 @@ func (s *Service) applyCoreAuthRemoval(ctx context.Context, id string) {
 	if strings.EqualFold(provider, "xai") {
 		executor.CloseXAIWebsocketSessionsForAuthID(id, "auth_removed")
 	}
-	s.syncPluginRuntime(ctx)
+	s.syncPluginRuntimeForAuthChange(ctx)
 }
 
 func (s *Service) applyRetryConfig(cfg *config.Config) {

--- a/sdk/cliproxy/service_plugins.go
+++ b/sdk/cliproxy/service_plugins.go
@@ -75,6 +75,21 @@ func (s *Service) syncPluginRuntime(ctx context.Context) {
 	s.syncPluginModelRuntime(ctx)
 }
 
+// syncPluginRuntimeForAuthChange refreshes what an auth change can affect - the
+// models that plugin providers expose for the changed credential - without
+// re-applying the plugin configuration.
+//
+// ApplyConfig sends plugin.reconfigure to every registered plugin, and an
+// auth-file write happens on every token refresh, several times an hour with
+// several credentials. That is not a plugin configuration change, and plugins
+// that keep state in memory were losing it on every refresh.
+func (s *Service) syncPluginRuntimeForAuthChange(ctx context.Context) {
+	if s == nil || s.pluginHost == nil {
+		return
+	}
+	s.syncPluginModelRuntime(ctx)
+}
+
 func (s *Service) syncPluginRuntimeConfig(ctx context.Context) bool {
 	if s == nil {
 		sdkAuth.RegisterPluginAuthParser(nil)


### PR DESCRIPTION
## What

`handleAuthUpdates`, `applyCoreAuthAddOrUpdate` and `applyCoreAuthRemoval` in `sdk/cliproxy/service_auth.go` call `syncPluginRuntime`, whose `pluginHost.ApplyConfig` re-registers every plugin: `callRegister` in `internal/pluginhost/host.go` sends `plugin.reconfigure` to each plugin that is already registered, without comparing the stored `configYAML`. An auth-file write happens on every token refresh, so plugins were being reconfigured several times an hour with their configuration unchanged.

The three call sites now use `syncPluginRuntimeForAuthChange`, which runs only `syncPluginModelRuntime` (plugin models for the changed credential, executor registration, scheduler refresh). Plugin configuration is still re-applied on configuration changes exactly as before.

## Why

Observed on 2026-09-04 against v7.2.151 with a native plugin that keeps per-session state in memory. Every `auth file changed (WRITE) ... processing incrementally` line (a token refresh; sixteen between 10:57 and 17:10, four credentials refreshing every thirty minutes) was followed within seconds by the plugin's store reading zero sessions, with `config.yaml` untouched. A plugin that rebuilds on `reconfigure` — the natural reading of the method — lost everything it had built within half an hour of building it.

This is the same class of problem as #4567 (websocket sessions terminated on unrelated auth updates), and the same shape of fix: scope the reaction to what the auth change actually affects.

## Alternative considered

Skipping `reconfigure` inside `ApplyConfig` when the config block is byte-identical would also fix it, but `TestHostApplyConfig_ReconfigureCalledOnReload` asserts the current behaviour and other plugins may rely on it, so this change leaves `ApplyConfig` alone.

## Testing

`go build ./...`, `go test ./sdk/cliproxy/ ./internal/pluginhost/` pass. The plugin that surfaced the problem no longer sees a reconfigure on token refresh with this applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pgk4LoiDz5mjToL4xcXMx
