### PR TITLE
feat(thinking): add ultra reasoning effort level for GPT-6 Astra

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2643,7 +2643,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       },
       "supportedInputModalities": [
@@ -2924,7 +2925,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       },
       "supportedInputModalities": [
@@ -3205,7 +3207,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       },
       "supportedInputModalities": [

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -375,6 +375,8 @@ func mapConfiguredHighIntent(level ThinkingLevel, modelInfo *registry.ModelInfo)
 		candidates = []ThinkingLevel{LevelXHigh, LevelMax, LevelHigh}
 	case LevelMax:
 		candidates = []ThinkingLevel{LevelMax, LevelXHigh, LevelHigh}
+	case LevelUltra:
+		candidates = []ThinkingLevel{LevelUltra, LevelMax, LevelXHigh, LevelHigh}
 	default:
 		return level
 	}

--- a/internal/thinking/convert.go
+++ b/internal/thinking/convert.go
@@ -19,6 +19,9 @@ var levelToBudgetMap = map[string]int{
 	// "max" is used by Claude adaptive thinking effort. We map it to a large budget
 	// and rely on per-model clamping when converting to budget-only providers.
 	"max": 128000,
+	// "ultra" is the highest effort level (Codex GPT-6 Astra). We map it to the
+	// same budget as "max" and rely on per-model clamping for budget-only providers.
+	"ultra": 128000,
 }
 
 // ConvertLevelToBudget converts a thinking level to a budget value.
@@ -35,6 +38,7 @@ var levelToBudgetMap = map[string]int{
 //   - high    → 24576
 //   - xhigh   → 32768
 //   - max     → 128000
+//   - ultra   → 128000
 //
 // Returns:
 //   - budget: The converted budget value

--- a/internal/thinking/provider/interactions/apply.go
+++ b/internal/thinking/provider/interactions/apply.go
@@ -170,7 +170,7 @@ func normalizeInteractionsLevel(level string, modelInfo *registry.ModelInfo) str
 		return strings.ToLower(modelInfo.Thinking.Levels[len(modelInfo.Thinking.Levels)-1])
 	}
 	switch level {
-	case string(thinking.LevelMax), string(thinking.LevelXHigh):
+	case string(thinking.LevelUltra), string(thinking.LevelMax), string(thinking.LevelXHigh):
 		return string(thinking.LevelHigh)
 	default:
 		return level

--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -122,7 +122,7 @@ func ParseSpecialSuffix(rawSuffix string) (mode ThinkingMode, ok bool) {
 //   - "none" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "auto" -> level="", ok=false (special value, use ParseSpecialSuffix)
 //   - "8192" -> level="", ok=false (numeric, use ParseNumericSuffix)
-//   - "ultra" -> level="", ok=false (unknown level)
+//   - "ultra" -> level=LevelUltra, ok=true
 func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 	if rawSuffix == "" {
 		return "", false
@@ -142,6 +142,8 @@ func ParseLevelSuffix(rawSuffix string) (level ThinkingLevel, ok bool) {
 		return LevelXHigh, true
 	case "max":
 		return LevelMax, true
+	case "ultra":
+		return LevelUltra, true
 	default:
 		return "", false
 	}

--- a/internal/thinking/types.go
+++ b/internal/thinking/types.go
@@ -57,6 +57,8 @@ const (
 	// LevelMax sets maximum thinking effort.
 	// This is currently used by Claude 4.6 adaptive thinking (opus supports "max").
 	LevelMax ThinkingLevel = "max"
+	// LevelUltra sets ultra thinking effort (Codex GPT-6 Astra).
+	LevelUltra ThinkingLevel = "ultra"
 )
 
 // ThinkingConfig represents a unified thinking configuration.

--- a/internal/thinking/ultra_budget_conversion_test.go
+++ b/internal/thinking/ultra_budget_conversion_test.go
@@ -1,0 +1,73 @@
+package thinking_test
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+)
+
+// TestConvertUltraLevelToBudget guards the budget-only provider path for the
+// "ultra" thinking level introduced by Codex GPT-6 Astra.
+//
+// Regression: ParseLevelSuffix accepts "ultra" and produces ModeLevel/LevelUltra.
+// For budget-only models (legacy Claude, Gemini 2.5) ValidateConfig delegates to
+// ConvertLevelToBudget. Without an "ultra" entry that lookup returns ok=false and
+// the request fails with ErrUnknownLevel instead of clamping to a numeric budget
+// the way "max" does.
+func TestConvertUltraLevelToBudget(t *testing.T) {
+	budget, ok := thinking.ConvertLevelToBudget(string(thinking.LevelUltra))
+	if !ok {
+		t.Fatalf("ConvertLevelToBudget(%q) returned ok=false; ultra must be convertible so budget-only providers do not fail with ErrUnknownLevel", thinking.LevelUltra)
+	}
+	if budget <= 0 {
+		t.Fatalf("ConvertLevelToBudget(%q) = %d, want a positive budget", thinking.LevelUltra, budget)
+	}
+
+	maxBudget, ok := thinking.ConvertLevelToBudget(string(thinking.LevelMax))
+	if !ok {
+		t.Fatalf("ConvertLevelToBudget(%q) returned ok=false", thinking.LevelMax)
+	}
+	// Ultra is the highest effort level, so it must not resolve to a smaller
+	// budget than max.
+	if budget < maxBudget {
+		t.Fatalf("ultra budget %d < max budget %d; ultra is the highest effort level", budget, maxBudget)
+	}
+}
+
+// TestConvertUltraLevelToBudgetIsCaseInsensitive mirrors the case-insensitive
+// contract documented on ConvertLevelToBudget.
+func TestConvertUltraLevelToBudgetIsCaseInsensitive(t *testing.T) {
+	for _, level := range []string{"ultra", "Ultra", "ULTRA"} {
+		if _, ok := thinking.ConvertLevelToBudget(level); !ok {
+			t.Fatalf("ConvertLevelToBudget(%q) returned ok=false, want case-insensitive match", level)
+		}
+	}
+}
+
+// TestParseUltraSuffixRoundTripsToBudget covers the full path:
+// suffix parsing produces LevelUltra, which must then survive the
+// level -> budget conversion used by budget-only providers.
+func TestParseUltraSuffixRoundTripsToBudget(t *testing.T) {
+	level, ok := thinking.ParseLevelSuffix("ultra")
+	if !ok {
+		t.Fatalf(`ParseLevelSuffix("ultra") returned ok=false, want LevelUltra`)
+	}
+	if level != thinking.LevelUltra {
+		t.Fatalf("ParseLevelSuffix(\"ultra\") = %q, want %q", level, thinking.LevelUltra)
+	}
+	if _, ok := thinking.ConvertLevelToBudget(string(level)); !ok {
+		t.Fatal("parsed ultra level cannot be converted to a budget; budget-only providers would fail with ErrUnknownLevel")
+	}
+}
+
+// TestParseLevelSuffixUltra verifies that ParseLevelSuffix accurately identifies "ultra"
+// case-insensitively and returns ThinkingLevel "ultra".
+func TestParseLevelSuffixUltra(t *testing.T) {
+	cases := []string{"ultra", "Ultra", "ULTRA"}
+	for _, c := range cases {
+		lvl, ok := thinking.ParseLevelSuffix(c)
+		if !ok || lvl != thinking.LevelUltra {
+			t.Fatalf("ParseLevelSuffix(%q) = (%q, %v), want (%q, true)", c, lvl, ok, thinking.LevelUltra)
+		}
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -237,7 +237,7 @@ func convertAutoToMidRange(config ThinkingConfig, support *registry.ThinkingSupp
 }
 
 // standardLevelOrder defines the canonical ordering of thinking levels from lowest to highest.
-var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax}
+var standardLevelOrder = []ThinkingLevel{LevelMinimal, LevelLow, LevelMedium, LevelHigh, LevelXHigh, LevelMax, LevelUltra}
 
 // clampLevel clamps the given level to the nearest supported level.
 // On tie, prefers the lower level.


### PR DESCRIPTION
## Summary

In commit `c77b136` (`v7.2.150`), `gpt-6-astra` was added to `models.json` and `codex_client_models.json`. In `codex_client_models.json`, `supported_reasoning_levels` declared:

```json
["low", "medium", "high", "xhigh", "max", "ultra"]
```

However, the proxy thinking pipeline (`internal/thinking/`) and `models.json` were not updated with the new `ultra` level. As a result:

1. **Explicit API requests fail:** Any request passing `{"reasoning_effort": "ultra"}` is actively rejected by `validate.go` with HTTP 400:
   ```json
   {"error":{"message":"level \"ultra\" not supported, valid levels: low, medium, high, xhigh, max","type":"invalid_request_error"}}
   ```
2. **Model suffix requests silently degrade:** Calling `gpt-6-astra(ultra)` fails to parse in `ParseLevelSuffix` (which documented `// - "ultra" -> level="", ok=false (unknown level)`), causing the proxy to drop the suffix and silently downgrade the request to default `medium` reasoning.

This PR implements full 5-file synchronization for `LevelUltra` across the thinking pipeline, aligns `models.json` with `codex_client_models.json`, and adds regression tests.

---

## Changes

| Component | File | Change |
|---|---|---|
| Enum Definition | `internal/thinking/types.go` | Added `LevelUltra ThinkingLevel = "ultra"` |
| Suffix Parser | `internal/thinking/suffix.go` | Added `case "ultra": return LevelUltra, true` in `ParseLevelSuffix` |
| Canonical Ordering | `internal/thinking/validate.go` | Added `LevelUltra` to `standardLevelOrder` (enabling proper clamping and validation) |
| Fallback Candidates | `internal/thinking/apply.go` | Added `case LevelUltra:` with fallback candidate list `[LevelUltra, LevelMax, LevelXHigh, LevelHigh]` in `mapConfiguredHighIntent` |
| Budget Mapping | `internal/thinking/convert.go` | Added `"ultra": 128000` to `levelToBudgetMap` (matching `max` with per-model clamping) to prevent budget-only providers from returning `ErrUnknownLevel` |
| Interactions Provider | `internal/thinking/provider/interactions/apply.go` | Added `LevelUltra` to `normalizeInteractionsLevel` fallback switch |
| Catalog Alignment | `internal/registry/models/models.json` | Added `"ultra"` to `thinking.levels` for `gpt-6-astra` in `codex-pro`, `codex-team`, and `codex-plus` |
| Regression Tests | `internal/thinking/ultra_budget_conversion_test.go` | Added tests verifying `ConvertLevelToBudget`, case-insensitivity, and suffix-to-budget round-tripping |

---

## Test Evidence

1. **Unit Tests:**
   - `go test -v ./internal/thinking/...` — ✅ **PASS** (all tests pass including new `TestConvertUltraLevelToBudget`, `TestConvertUltraLevelToBudgetIsCaseInsensitive`, `TestParseUltraSuffixRoundTripsToBudget`, and `TestParseLevelSuffixUltra`)
   - `go test -v ./internal/registry/...` — ✅ **PASS** (all catalog validity tests pass)
2. **Compile Verification:**
   - `go build -buildvcs=false -o test-output ./cmd/server && rm test-output` — ✅ **PASS** clean compile
3. **Runtime Probing on Isolated Instance:**
   - Launched isolated container with `--local-model`
   - Probed `POST /v1/chat/completions` with `{"model": "gpt-6-astra", "reasoning_effort": "ultra"}`:
     - Before: HTTP 400 (`level "ultra" not supported`)
     - After: Passes thinking validation layer without error
