### PR TITLE
fix(payload): apply parameters in deterministic order

### DIFF
--- a/internal/runtime/executor/helps/payload_helpers.go
+++ b/internal/runtime/executor/helps/payload_helpers.go
@@ -2,8 +2,10 @@ package helps
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -75,7 +77,8 @@ func ApplyPayloadConfigWithTrackedPaths(cfg *config.Config, model, protocol, fro
 				if !payloadModelRulesMatch(rule.Models, protocol, fromProtocol, headers, out, root, candidates) {
 					continue
 				}
-				for path, value := range rule.Params {
+				for _, path := range slices.Sorted(maps.Keys(rule.Params)) {
+					value := rule.Params[path]
 					fullPath := buildPayloadPath(root, path)
 					if fullPath == "" {
 						continue
@@ -103,7 +106,8 @@ func ApplyPayloadConfigWithTrackedPaths(cfg *config.Config, model, protocol, fro
 				if !payloadModelRulesMatch(rule.Models, protocol, fromProtocol, headers, out, root, candidates) {
 					continue
 				}
-				for path, value := range rule.Params {
+				for _, path := range slices.Sorted(maps.Keys(rule.Params)) {
+					value := rule.Params[path]
 					fullPath := buildPayloadPath(root, path)
 					if fullPath == "" {
 						continue
@@ -135,7 +139,8 @@ func ApplyPayloadConfigWithTrackedPaths(cfg *config.Config, model, protocol, fro
 				if !payloadModelRulesMatch(rule.Models, protocol, fromProtocol, headers, out, root, candidates) {
 					continue
 				}
-				for path, value := range rule.Params {
+				for _, path := range slices.Sorted(maps.Keys(rule.Params)) {
+					value := rule.Params[path]
 					fullPath := buildPayloadPath(root, path)
 					if fullPath == "" {
 						continue
@@ -155,7 +160,8 @@ func ApplyPayloadConfigWithTrackedPaths(cfg *config.Config, model, protocol, fro
 				if !payloadModelRulesMatch(rule.Models, protocol, fromProtocol, headers, out, root, candidates) {
 					continue
 				}
-				for path, value := range rule.Params {
+				for _, path := range slices.Sorted(maps.Keys(rule.Params)) {
+					value := rule.Params[path]
 					fullPath := buildPayloadPath(root, path)
 					if fullPath == "" {
 						continue

--- a/internal/runtime/executor/helps/payload_mutations_test.go
+++ b/internal/runtime/executor/helps/payload_mutations_test.go
@@ -92,6 +92,48 @@ func TestApplyPayloadConfigReusesCanonicalOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyPayloadConfigParameterOrderDeterministic(t *testing.T) {
+	t.Run("positive_control", func(t *testing.T) {
+		cfg := &config.Config{Payload: config.PayloadConfig{
+			Override: []config.PayloadRule{{
+				Models: []config.PayloadModelRule{{Name: "gpt-test", Protocol: "openai"}},
+				Params: map[string]any{"model": "gpt-test"},
+			}},
+		}}
+		input := []byte(`{"model":"original"}`)
+		output := ApplyPayloadConfigWithRoot(cfg, "gpt-test", "openai", "", bytes.Clone(input), nil, "", "")
+		t.Logf("positive control: input=%s override=model:gpt-test output=%s", input, output)
+		if string(output) != `{"model":"gpt-test"}` {
+			t.Fatalf("positive control output = %s, want {\"model\":\"gpt-test\"}", output)
+		}
+	})
+
+	cfg := &config.Config{Payload: config.PayloadConfig{
+		Override: []config.PayloadRule{{
+			Models: []config.PayloadModelRule{{Name: "gpt-test", Protocol: "openai"}},
+			Params: map[string]any{
+				"messages.0.role":                  "system",
+				`messages.#(role=="user").content`: "changed",
+			},
+		}},
+	}}
+	input := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	distinctOutputs := make(map[string]int)
+	for range 512 {
+		output := ApplyPayloadConfigWithRoot(cfg, "gpt-test", "openai", "", bytes.Clone(input), nil, "", "")
+		distinctOutputs[string(output)]++
+	}
+	for output, count := range distinctOutputs {
+		t.Logf("output=%s count=%d", output, count)
+	}
+	if len(distinctOutputs) != 1 {
+		t.Fatalf("distinct outputs = %d across 512 calls, want 1", len(distinctOutputs))
+	}
+	if want := `{"messages":[{"role":"system","content":"changed"}]}`; distinctOutputs[want] == 0 {
+		t.Fatalf("outputs = %v, want %s", distinctOutputs, want)
+	}
+}
+
 func TestApplyPayloadConfigWithRequestTrackedReportsContextManagementTouches(t *testing.T) {
 	const automatic = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
 	modelRules := []config.PayloadModelRule{{Name: "claude-opus-5", Protocol: "claude"}}


### PR DESCRIPTION
Payload parameters were applied in Go map iteration order, so identical inputs could apply or skip an interacting content override. Apply parameter keys in lexicographic order because declaration order is not retained in the decoded Params map; rule-list order remains unchanged. Check: `go test ./internal/runtime/executor/helps -run ^TestApplyPayloadConfigParameterOrderDeterministic$ -count=1 -v` verifies the expected serialized body on all 512 calls; the full helps package also passes.