### PR TITLE
fix(openai-compat): reject out-of-range Retry-After seconds instead of overflowing

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -1044,7 +1045,7 @@ func openAICompatRetryAfter(status int, headers http.Header, body []byte, now ti
 		return nil
 	}
 	if raw := strings.TrimSpace(headers.Get("Retry-After")); raw != "" {
-		if seconds, errParse := strconv.ParseInt(raw, 10, 64); errParse == nil && seconds >= 0 {
+		if seconds, errParse := strconv.ParseInt(raw, 10, 64); errParse == nil && seconds >= 0 && seconds <= math.MaxInt64/int64(time.Second) {
 			delay := time.Duration(seconds) * time.Second
 			return &delay
 		}

--- a/internal/runtime/executor/openai_compat_executor_retry_test.go
+++ b/internal/runtime/executor/openai_compat_executor_retry_test.go
@@ -2,8 +2,10 @@ package executor
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -140,4 +142,54 @@ func TestOpenAICompatExecutorPropagatesRetryAfter(t *testing.T) {
 
 func durationPointer(value time.Duration) *time.Duration {
 	return &value
+}
+
+func TestOpenAICompatRetryAfterSecondsBoundary(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	// Largest whole-second count that fits in time.Duration (int64 nanoseconds)
+	// without overflowing when multiplied by time.Second.
+	maxWholeSeconds := int64(math.MaxInt64) / int64(time.Second)
+
+	tests := []struct {
+		name    string
+		seconds int64
+		want    *time.Duration
+	}{
+		{
+			name:    "ordinary seconds",
+			seconds: 17,
+			want:    durationPointer(17 * time.Second),
+		},
+		{
+			name:    "largest whole seconds representable",
+			seconds: maxWholeSeconds,
+			want:    durationPointer(time.Duration(maxWholeSeconds) * time.Second),
+		},
+		{
+			name:    "one second beyond representable range must not wrap",
+			seconds: maxWholeSeconds + 1,
+			want:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			headers := http.Header{"Retry-After": {strconv.FormatInt(test.seconds, 10)}}
+			got := openAICompatRetryAfter(http.StatusTooManyRequests, headers, nil, now)
+			if test.want == nil {
+				if got != nil {
+					t.Fatalf("actual = %v, want nil", *got)
+				}
+				t.Logf("actual = nil, want nil")
+				return
+			}
+			if got == nil {
+				t.Fatalf("actual = nil, want %v", *test.want)
+			}
+			t.Logf("actual = %v, want %v", *got, *test.want)
+			if *got != *test.want {
+				t.Fatalf("actual = %v, want %v", *got, *test.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
A numeric Retry-After one second past the largest representable time.Duration overflowed to a negative delay. Treat out-of-range values as an invalid header, so the caller takes its existing invalid-header handling (including the TPM fallback) instead of a negative wait. This is robustness against hostile or broken upstream input, not a case seen in ordinary traffic. Check: `go test ./internal/runtime/executor -run '^TestOpenAICompatRetryAfterSecondsBoundary$' -count=1 -v`