### PR TITLE
fix(responses): preserve escapes after invalid UTF-16 surrogate pairs

### DIFF
--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -1119,7 +1119,7 @@ func unwrapCustomToolInput(arguments string) string {
 							if i+4 < len(content) {
 								if r, err := strconv.ParseUint(content[i+1:i+5], 16, 16); err == nil {
 									if utf16.IsSurrogate(rune(r)) && i+10 < len(content) && content[i+5:i+7] == `\u` {
-										if r2, err2 := strconv.ParseUint(content[i+7:i+11], 16, 16); err2 == nil {
+										if r2, err2 := strconv.ParseUint(content[i+7:i+11], 16, 16); err2 == nil && utf16.DecodeRune(rune(r), rune(r2)) != '\uFFFD' {
 											unescaped.WriteRune(utf16.DecodeRune(rune(r), rune(r2)))
 											i += 10
 											inEscape = false

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -11,6 +11,55 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
+func TestUnwrapCustomToolInput_TruncatedFallbackSurrogateHandling(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments string
+		want      string
+	}{
+		{
+			// 😀 is a valid UTF-16 surrogate pair encoding U+1F600
+			// (grinning face). Written as literal \u escapes, not the raw UTF-8
+			// bytes, so the assertion exercises the surrogate-decode branch
+			// rather than the plain byte-copy branch.
+			name:      "valid supplementary pair",
+			arguments: "{\"input\":\"\\ud83d\\ude00",
+			want:      "\U0001F600",
+		},
+		{
+			// \ud800 is an unpaired high surrogate; A is an ordinary
+			// escaped letter (A), not a low surrogate, so it must not be
+			// consumed as part of a (nonexistent) pair — the letter must
+			// survive alongside the replacement character for \ud800.
+			name:      "unpaired surrogate followed by ordinary escaped letter",
+			arguments: "{\"input\":\"\\ud800\\u0041",
+			want:      "�A",
+		},
+		{
+			// \ud800 and \ud801 are both high surrogates; neither forms a valid
+			// pair with the other, so each must decode independently to its own
+			// replacement character.
+			name:      "two unpaired surrogates",
+			arguments: `{"input":"\ud800\ud801`,
+			want:      "��",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trimmed := strings.TrimSpace(tt.arguments)
+			if v := gjson.Get(trimmed, "input"); v.Exists() {
+				t.Fatalf("COULD-NOT-DETERMINE: gjson resolved %q via structured lookup (%q); this case exercises the primary path, not the truncated fallback", tt.arguments, v.String())
+			}
+			got := unwrapCustomToolInput(tt.arguments)
+			t.Logf("input=%s actual=%q want=%q", tt.arguments, got, tt.want)
+			if got != tt.want {
+				t.Fatalf("unwrapCustomToolInput(%q) = %q, want %q", tt.arguments, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToClaude_SanitizesToolCallIDsForClaude(t *testing.T) {
 	inputJSON := `{
 		"model": "gpt-4.1",


### PR DESCRIPTION
The truncated custom-tool input fallback consumed two Unicode escapes even when they did not form a valid UTF-16 surrogate pair, losing the second escape's character. Consume both escapes only when pair decoding succeeds; otherwise decode the second escape independently. The check forces the fallback path and covers a valid pair, a high surrogate followed by an escaped letter, and two high surrogates.