### PR TITLE
fix(codex): restore dotted flat collaboration tool names in Multi-Agent V2 responses

### DIFF
--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -26,6 +26,7 @@ const (
 	codexCollaborationNamespace           = "collaboration"
 	codexOptimizedCollaborationNamespace  = "collaboration-optimize"
 	codexOptimizedCollaborationNamePrefix = codexOptimizedCollaborationNamespace + "__"
+	codexOptimizedCollaborationDotPrefix  = codexOptimizedCollaborationNamespace + "."
 )
 
 // CodexMultiAgentV2ToolsPreparedContextKey marks a request whose collaboration
@@ -745,6 +746,10 @@ func restoreCodexCollaborationValue(value any) bool {
 				changed = true
 			case isToolCall && strings.HasPrefix(name, codexOptimizedCollaborationNamePrefix):
 				typed["name"] = codexCollaborationNamespace + "__" + strings.TrimPrefix(name, codexOptimizedCollaborationNamePrefix)
+				changed = true
+			case isToolCall && strings.HasPrefix(name, codexOptimizedCollaborationDotPrefix):
+				typed["namespace"] = codexCollaborationNamespace
+				typed["name"] = strings.TrimPrefix(name, codexOptimizedCollaborationDotPrefix)
 				changed = true
 			}
 		}

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -665,7 +665,9 @@ func codexToolsHaveOptimizedCollaborationConflict(tools gjson.Result) bool {
 	}
 	for _, tool := range tools.Array() {
 		name := strings.TrimSpace(tool.Get("name").String())
-		if name == codexOptimizedCollaborationNamespace || strings.HasPrefix(name, codexOptimizedCollaborationNamePrefix) {
+		if name == codexOptimizedCollaborationNamespace ||
+			strings.HasPrefix(name, codexOptimizedCollaborationNamePrefix) ||
+			strings.HasPrefix(name, codexOptimizedCollaborationDotPrefix) {
 			return true
 		}
 		if strings.TrimSpace(tool.Get("type").String()) == "namespace" && codexToolsHaveOptimizedCollaborationConflict(tool.Get("tools")) {

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -245,6 +246,58 @@ func TestOptimizeCodexMultiAgentV2RequestSkipsNamespaceConflict(t *testing.T) {
 	}
 	if string(got) != string(payload) {
 		t.Fatalf("namespace conflict changed payload: %s", got)
+	}
+}
+
+// TestOptimizeCodexMultiAgentV2RequestSkipsDottedAliasConflict ensures a
+// legitimate user-defined flat function named collaboration-optimize.<tool>
+// is treated as a reserved optimized-collaboration conflict, so the optimizer
+// stays disabled and the response-side dotted restore rule can never
+// misroute calls to that user tool. See PR #5538 review (P2).
+func TestOptimizeCodexMultiAgentV2RequestSkipsDottedAliasConflict(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"tools":[{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent"}]},{"type":"function","name":"collaboration-optimize.custom_tool","parameters":{"type":"object"}}]}`)
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.145.0"}}
+	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
+	got, optimized := OptimizeCodexMultiAgentV2Request(context.Background(), headers, payload, cfg)
+	if optimized {
+		t.Fatal("dotted alias conflict unexpectedly enabled optimization")
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("dotted alias conflict changed payload: %s", got)
+	}
+	if namespace := gjson.GetBytes(got, "tools.0.name").String(); namespace != codexCollaborationNamespace {
+		t.Fatalf("collaboration namespace was renamed despite conflict: %q", namespace)
+	}
+}
+
+// TestCodexToolsHaveOptimizedCollaborationConflictForms verifies the conflict
+// matcher against all reserved optimized-name forms and near-prefix names
+// that must remain unaffected.
+func TestCodexToolsHaveOptimizedCollaborationConflictForms(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		toolName string
+		want     bool
+	}{
+		{name: "exact optimized namespace", toolName: "collaboration-optimize", want: true},
+		{name: "double-underscore alias", toolName: "collaboration-optimize__spawn_agent", want: true},
+		{name: "dotted flat alias", toolName: "collaboration-optimize.custom_tool", want: true},
+		{name: "near-prefix longer word", toolName: "collaboration-optimizer.custom_tool", want: false},
+		{name: "prefixed unrelated name", toolName: "x-collaboration-optimize.custom_tool", want: false},
+		{name: "unrelated dotted name", toolName: "unrelated.dotted_tool", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tools := gjson.Parse(`[{"type":"function","name":` + strconv.Quote(tt.toolName) + `}]`)
+			if got := codexToolsHaveOptimizedCollaborationConflict(tools); got != tt.want {
+				t.Fatalf("codexToolsHaveOptimizedCollaborationConflict(%q) = %v, want %v", tt.toolName, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -456,6 +456,65 @@ func TestRestoreCodexMultiAgentV2Response(t *testing.T) {
 	}
 }
 
+// TestRestoreCodexMultiAgentV2ResponseDottedFlatNames covers third-party
+// Responses upstreams (codex-api-key over plain HTTP) that flatten the
+// optimized collaboration namespace into dotted flat function names.
+// See router-for-me/CLIProxyAPI#5524.
+func TestRestoreCodexMultiAgentV2ResponseDottedFlatNames(t *testing.T) {
+	t.Parallel()
+
+	lifecycleTools := []string{"spawn_agent", "send_message", "followup_task", "wait_agent", "list_agents"}
+	for _, tool := range lifecycleTools {
+		payload := []byte(`{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_838779_0","name":"collaboration-optimize.` + tool + `","namespace":null,"arguments":"{\"task_name\":\"mode2_workspace_discovery\"}"}}`)
+		got := RestoreCodexMultiAgentV2Response(payload, true)
+		if name := gjson.GetBytes(got, "item.name").String(); name != tool {
+			t.Fatalf("dotted flat name restore: item.name = %q, want %q", name, tool)
+		}
+		if namespace := gjson.GetBytes(got, "item.namespace").String(); namespace != codexCollaborationNamespace {
+			t.Fatalf("dotted flat name restore: item.namespace = %q, want %q", namespace, codexCollaborationNamespace)
+		}
+		if arguments := gjson.GetBytes(got, "item.arguments").String(); !strings.Contains(arguments, "mode2_workspace_discovery") {
+			t.Fatalf("dotted flat name restore changed arguments: %s", arguments)
+		}
+		if unchanged := RestoreCodexMultiAgentV2Response(payload, false); string(unchanged) != string(payload) {
+			t.Fatalf("inactive restore changed payload: %s", unchanged)
+		}
+	}
+}
+
+// TestRestoreCodexMultiAgentV2ResponseDottedFlatNamesGuarded ensures dotted
+// normalization is restricted to actual collaboration tool-call items and
+// leaves unrelated names, non-tool items, and malformed payloads untouched.
+func TestRestoreCodexMultiAgentV2ResponseDottedFlatNamesGuarded(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{
+		"type":"response.completed",
+		"response":{
+			"output":[
+				{"type":"message","name":"collaboration-optimize.plain"},
+				{"type":"function_call","name":"unrelated.dotted_tool","arguments":"{}"},
+				{"type":"function_call","name":"collaboration-optimizer.spawn_agent","arguments":"{}"}
+			]
+		}
+	}`)
+	got := RestoreCodexMultiAgentV2Response(payload, true)
+	if name := gjson.GetBytes(got, "response.output.0.name").String(); name != "collaboration-optimize.plain" {
+		t.Fatalf("non-tool dotted name was unexpectedly rewritten: %q", name)
+	}
+	if name := gjson.GetBytes(got, "response.output.1.name").String(); name != "unrelated.dotted_tool" {
+		t.Fatalf("unrelated dotted tool name was unexpectedly rewritten: %q", name)
+	}
+	if name := gjson.GetBytes(got, "response.output.2.name").String(); name != "collaboration-optimizer.spawn_agent" {
+		t.Fatalf("near-prefix dotted name was unexpectedly rewritten: %q", name)
+	}
+
+	malformed := []byte(`{"type":"response.completed","response":{"output":[{"type":"function_call","name":"collaboration-optimize.spawn_agent"}`)
+	if string(RestoreCodexMultiAgentV2Response(malformed, true)) != string(malformed) {
+		t.Fatalf("malformed payload was changed: %s", RestoreCodexMultiAgentV2Response(malformed, true))
+	}
+}
+
 func TestRewriteCodexMultiAgentV2InputRewritesAgentMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #5524

## Problem

With `codex.optimize-multi-agent-v2: true`, requests proxied over the plain HTTP Responses route (`codex-api-key` third-party upstreams) get their collaboration namespace renamed `collaboration` → `collaboration-optimize` for upstream. Third-party endpoints flatten namespace tool calls into **dotted flat function names** and echo them verbatim:

```json
{"type":"function_call","name":"collaboration-optimize.spawn_agent","namespace":null}
```

The HTTP executors already call `RestoreCodexMultiAgentV2Response`, but the restore matcher only recognized:

1. the separate `namespace: "collaboration-optimize"` field form, and
2. the `collaboration-optimize__<tool>` prefix form.

The dotted flat form matched neither case, so the optimized name leaked back to Codex, which rejected every multi-agent tool call:

```text
unsupported call: collaboration-optimize.spawn_agent
```

## Fix

Extend `restoreCodexCollaborationValue` (the existing response-side restore helper — no new processing layer) with one additional case:

```go
codexOptimizedCollaborationDotPrefix = codexOptimizedCollaborationNamespace + "."
...
case isToolCall && strings.HasPrefix(name, codexOptimizedCollaborationDotPrefix):
    typed["namespace"] = codexCollaborationNamespace
    typed["name"] = strings.TrimPrefix(name, codexOptimizedCollaborationDotPrefix)
```

Normalization remains restricted to actual `function_call` / `custom_tool_call` items, so unrelated dotted names, non-tool items, and malformed payloads are untouched. All existing `collaboration-optimize__*` and namespace-field restoration behavior is preserved, and the generic rule applies to every collaboration lifecycle tool (`spawn_agent`, `send_message`, `followup_task`, `wait_agent`, `list_agents`), not just `spawn_agent`.

## Before/after test evidence

New regression tests in `optimize_multi_agent_v2_test.go`:

- `TestRestoreCodexMultiAgentV2ResponseDottedFlatNames` — all five lifecycle tools in dotted flat form are restored to bare name + `namespace: "collaboration"`; `optimized=false` leaves the payload unchanged; arguments preserved.
- `TestRestoreCodexMultiAgentV2ResponseDottedFlatNamesGuarded` — non-tool dotted names, unrelated dotted tool names, and near-prefix names (`collaboration-optimizer.*`) are not rewritten; malformed JSON is passed through unchanged.

Commands and results (Go 1.27.1, base `5208aec7`):

```text
go test ./internal/client/codex/optimize-multi-agent-v2/
  BEFORE fix: TestRestoreCodexMultiAgentV2ResponseDottedFlatNames FAIL
              (item.name = "collaboration-optimize.spawn_agent", want "spawn_agent")
  AFTER fix:  ok  github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/optimize-multi-agent-v2
go test ./internal/runtime/executor/   → ok
go test ./internal/...                 → 71 packages ok, 0 failures
```

Real end-to-end verification (Codex Desktop 26.901.5003.0 / cli 0.153.3, CLIProxyAPI built from this commit, fresh desktop sessions, `codex-api-key` HTTP Responses upstream, `optimize-multi-agent-v2: true`, `is-compat: true` on both models):

- Raw upstream model output contained `collaboration-optimize.spawn_agent` (dotted, `namespace: null`); the downstream response delivered to Codex contained only `spawn_agent` with `namespace: "collaboration"`.
- GLM (`glm-5.3-flash`): 3/3 fresh-session spawns succeeded; worker created, task delivered, structured result returned (391/408/435), Brain never duplicated the worker's work, zero `collaboration-optimize.*` leak to Codex, no recovery loop.
- DeepSeek (`deepseek-v4-flash:0731`): fresh-session spawn → worker "Lovelace" created → task delivered → wait completed → result `{"task_name":"e2e_ds_desktop1","result":399}`; zero leaks.

`is-compat` task-delivery behavior (`agent_message` → portable `message`/`user` input conversion) is unchanged by this patch — it only extends the response-side restore matcher.

## Affected versions

- Reproduced on CLIProxyAPI 7.2.149, 7.2.151 (binary-confirmed in 7.2.141/7.2.143 per #5524).
- Patch based on upstream `main` @ `5208aec7`.