### PR TITLE
fix(executor): retain overload retries and priority routing

### DIFF
--- a/internal/runtime/executor/codex_bootstrap_keepalive_test.go
+++ b/internal/runtime/executor/codex_bootstrap_keepalive_test.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// Live Astra overloads arrive after one or more keepalive events. Even a long
+// run of heartbeats must not commit the stream before a generated event arrives.
+func TestCodexBootstrapKeepaliveOverload(t *testing.T) {
+	frames := []string{codexCreatedEvent, codexInProgressEvent}
+	for range 32 {
+		frames = append(frames, `{"type":"keepalive","sequence_number":3}`)
+	}
+	frames = append(frames, codexOverloadEvent)
+
+	t.Run("sse", func(t *testing.T) {
+		server := codexSSEServer(frames...)
+		defer server.Close()
+		req, opts := codexTestRequest()
+		result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if result != nil {
+			payload, streamErr := drainChunks(result)
+			t.Fatalf("overload escaped bootstrap: payload bytes=%d, stream error=%v", len(payload), streamErr)
+		}
+		if err == nil || statusCodeFromTestError(t, err) != http.StatusServiceUnavailable {
+			t.Fatalf("expected retryable bootstrap overload, got %v", err)
+		}
+	})
+
+	t.Run("websocket", func(t *testing.T) {
+		server := codexWebsocketServer(t, frames...)
+		defer server.Close()
+		req, opts := codexWebsocketRequest()
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if result != nil {
+			payload, streamErr := drainChunks(result)
+			t.Fatalf("overload escaped bootstrap: payload bytes=%d, stream error=%v", len(payload), streamErr)
+		}
+		if err == nil || statusCodeFromTestError(t, err) != http.StatusServiceUnavailable {
+			t.Fatalf("expected retryable bootstrap overload, got %v", err)
+		}
+	})
+
+	t.Run("websocket_session_survives", func(t *testing.T) {
+		notified, err := executeWebsocketStreamInSession(t, frames...)
+		if err == nil || statusCodeFromTestError(t, err) != http.StatusServiceUnavailable {
+			t.Fatalf("expected retryable bootstrap overload, got %v", err)
+		}
+		if notified {
+			t.Fatal("bootstrap overload closed the downstream session before account failover")
+		}
+	})
+}
+
+func TestCodexBootstrapKeepaliveAfterOutputDoesNotRetry(t *testing.T) {
+	frames := []string{codexCreatedEvent, codexOutputAddedEvent, `{"type":"keepalive"}`, codexOverloadEvent}
+	t.Run("sse", func(t *testing.T) {
+		server := codexSSEServer(frames...)
+		defer server.Close()
+		req, opts := codexTestRequest()
+		result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err != nil || result == nil {
+			t.Fatalf("generated output must commit the stream: %v", err)
+		}
+		if _, streamErr := drainChunks(result); streamErr == nil {
+			t.Fatal("expected the later overload to remain an in-stream failure")
+		}
+	})
+	t.Run("websocket", func(t *testing.T) {
+		server := codexWebsocketServer(t, frames...)
+		defer server.Close()
+		req, opts := codexWebsocketRequest()
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err != nil || result == nil {
+			t.Fatalf("generated output must commit the stream: %v", err)
+		}
+		if _, streamErr := drainChunks(result); streamErr == nil {
+			t.Fatal("expected the later overload to remain an in-stream failure")
+		}
+	})
+}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -161,6 +161,15 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+			// Skip the SSE event-name line as well as its heartbeat data below.
+			// Grok clients retain their existing keepalive-to-comment conversion.
+			if !isGrokClient && bytes.HasPrefix(line, []byte("event:")) &&
+				string(bytes.TrimSpace(line[len("event:"):])) == "keepalive" {
+				continue
+			}
 			translatedLine := bytes.Clone(line)
 			isHandshake := false
 			terminalSuccess := false
@@ -174,6 +183,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				observeCodexTokenEvent(reporter, data)
 				translatedLine = append([]byte("data: "), data...)
 				eventType := gjson.GetBytes(data, "type").String()
+				// Heartbeats carry no generated output. Do not commit the stream or
+				// consume the bounded handshake buffer while waiting for admission.
+				if eventType == "keepalive" {
+					continue
+				}
 				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
 					closeBootstrapBody()
 					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -397,6 +397,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 
 			eventType := gjson.GetBytes(payload, "type").String()
+			// Heartbeats can precede a capacity rejection for an arbitrarily
+			// long time; they must not release or fill the handshake buffer.
+			if eventType == "keepalive" {
+				continue
+			}
 			isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "response.incomplete" || eventType == "response.failed" || eventType == "error"
 			if eventType == "response.output_item.done" {
 				collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)

--- a/internal/runtime/executor/openai_compat_executor_service_tier_test.go
+++ b/internal/runtime/executor/openai_compat_executor_service_tier_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// Exercise the actual outgoing request: translation must retain service_tier
+// until conditional routing has run, then the configured filter removes it.
+func TestOpenAICompatServiceTierRouting(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, tier := range []string{"", "default", "priority"} {
+			t.Run(fmt.Sprintf("stream=%t/tier=%s", stream, tier), func(t *testing.T) {
+				bodies := make(chan []byte, 1)
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					body, _ := io.ReadAll(r.Body)
+					bodies <- body
+					if stream {
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = io.WriteString(w, "data: {\"id\":\"test\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+					} else {
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = io.WriteString(w, `{"id":"test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+					}
+				}))
+				t.Cleanup(server.Close)
+				modelRule := config.PayloadModelRule{Name: "openrouter-test-exacto", Protocol: "openai"}
+				priorityRule := modelRule
+				priorityRule.Match = []map[string]any{{"service_tier": "priority"}}
+				cfg := &config.Config{Payload: config.PayloadConfig{
+					Override: []config.PayloadRule{
+						{Models: []config.PayloadModelRule{modelRule}, Params: map[string]any{
+							"provider.only": []string{"reviewed"}, "provider.quantizations": []string{"fp8", "unknown"},
+						}},
+						{Models: []config.PayloadModelRule{priorityRule}, Params: map[string]any{
+							"model": "vendor/test:nitro", "provider.only": []string{"reviewed/fast"},
+						}},
+					},
+					Filter: []config.PayloadFilterRule{{Models: []config.PayloadModelRule{modelRule}, Params: []string{"service_tier"}}},
+				}}
+				executor := NewOpenAICompatExecutor("openai-compatibility", cfg)
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL}}
+				tierField := ""
+				if tier != "" {
+					tierField = fmt.Sprintf(`,"service_tier":%q`, tier)
+				}
+				request := cliproxyexecutor.Request{
+					Model:   "vendor/test:exacto",
+					Payload: []byte(fmt.Sprintf(`{"model":"openrouter-test-exacto","reasoning":{"effort":"high"},"input":[{"role":"user","content":"hi"}]%s}`, tierField)),
+				}
+				options := cliproxyexecutor.Options{
+					SourceFormat:   sdktranslator.FormatOpenAIResponse,
+					ResponseFormat: sdktranslator.FormatOpenAI,
+					Metadata:       map[string]any{cliproxyexecutor.RequestedModelMetadataKey: "openrouter-test-exacto"},
+				}
+				if stream {
+					result, err := executor.ExecuteStream(context.Background(), auth, request, options)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for chunk := range result.Chunks {
+						if chunk.Err != nil {
+							t.Fatal(chunk.Err)
+						}
+					}
+				} else if _, err := executor.Execute(context.Background(), auth, request, options); err != nil {
+					t.Fatal(err)
+				}
+				body := <-bodies
+				wantModel, wantProvider := "vendor/test:exacto", "reviewed"
+				if tier == "priority" {
+					wantModel, wantProvider = "vendor/test:nitro", "reviewed/fast"
+				}
+				for path, want := range map[string]string{"model": wantModel, "provider.only.0": wantProvider, "reasoning_effort": "high", "provider.quantizations.0": "fp8"} {
+					if got := gjson.GetBytes(body, path).String(); got != want {
+						t.Errorf("%s = %q, want %q; body=%s", path, got, want, body)
+					}
+				}
+				if gjson.GetBytes(body, "service_tier").Exists() {
+					t.Errorf("service_tier leaked to upstream: %s", body)
+				}
+			})
+		}
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -45,6 +45,12 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 	// Set stream configuration
 	out, _ = sjson.SetBytes(out, "stream", stream)
 
+	// Both APIs accept service_tier. Preserve the client's choice so provider
+	// payload rules can select a priority route after translation.
+	if serviceTier := root.Get("service_tier"); serviceTier.Type == gjson.String {
+		out, _ = sjson.SetBytes(out, "service_tier", serviceTier.String())
+	}
+
 	// Map Responses text format to Chat Completions response format.
 	if textFormat := root.Get("text.format"); textFormat.Exists() {
 		if responseFormat := convertResponsesTextFormatToChatResponseFormat(textFormat); len(responseFormat) > 0 {


### PR DESCRIPTION
Codex capacity rejections can arrive after `response.created`, `response.in_progress`, and many `keepalive` events. With bootstrap buffering enabled, those heartbeats currently commit the stream before `server_is_overloaded` arrives, preventing credential failover and closing downstream WebSocket sessions.

This also preserves the client's priority choice through Responses-to-Chat translation so OpenAI-compatible providers can use conditional payload rules to select their priority route.

### Summary

- Ignore pre-generation Codex keepalives and empty SSE separators while bootstrap buffering is active, without filling the bounded handshake buffer.
- Return early overloads as retryable 503 errors while retaining the downstream session. Failures after generated output remain in-stream and are not replayed.
- Retain string `service_tier` values in Responses-to-Chat conversion so routing rules can inspect them before an optional outgoing filter removes them.
- Cover SSE, WebSocket session survival, long heartbeat sequences, and actual normal/priority outgoing requests in streaming and non-streaming modes.

### Tests

- [x] Reproduced the heartbeat/overload failure on v7.2.151 before the fix.
- [x] `go test ./internal/runtime/executor ./internal/translator/openai/openai/responses ./internal/translator/claude/openai/responses ./internal/runtime/executor/helps ./sdk/api/handlers -count=1`
- [x] `go build -o /tmp/cliproxyapi-candidate ./cmd/server`
- [x] `gofmt` and `git diff --check`
- [x] Linux amd64 candidate cross-compile with `CGO_ENABLED=0`

Kept as a draft. This patch has not been deployed or verified against a live priority request; bootstrap buffering remains opt-in.

The upstream `translator-path-guard` check rejects all edits under `internal/translator` and asks maintainers to implement translator changes through an issue. The combined implementation remains in this draft for review; no guard or workflow has been changed. The Go build check passed.

Maintainer request with the exact implementation and validation: https://github.com/router-for-me/CLIProxyAPI/issues/5544.
