### PR TITLE
fix(api): support HEAD method on root and management routes + clean asset perms

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -52,6 +52,7 @@ func (s *Server) setupRoutes() {
 	s.engine.HEAD("/healthz", healthzHandler)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
+	s.engine.HEAD("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)
 	geminiHandlers := gemini.NewGeminiAPIHandler(s.handlers)
 	claudeCodeHandlers := claude.NewClaudeCodeAPIHandler(s.handlers)
@@ -128,7 +129,11 @@ func (s *Server) setupRoutes() {
 	}
 
 	// Root endpoint
-	s.engine.GET("/", func(c *gin.Context) {
+	rootHandler := func(c *gin.Context) {
+		if c.Request.Method == http.MethodHead {
+			c.Status(http.StatusOK)
+			return
+		}
 		c.JSON(http.StatusOK, gin.H{
 			"message": "CLI Proxy API Server",
 			"endpoints": []string{
@@ -137,7 +142,9 @@ func (s *Server) setupRoutes() {
 				"GET /v1/models",
 			},
 		})
-	})
+	}
+	s.engine.GET("/", rootHandler)
+	s.engine.HEAD("/", rootHandler)
 
 	// OAuth callback endpoints (reuse main server port)
 	// These endpoints receive provider redirects and persist

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -131,6 +131,7 @@ func (s *Server) setupRoutes() {
 	// Root endpoint
 	rootHandler := func(c *gin.Context) {
 		if c.Request.Method == http.MethodHead {
+			c.Header("Content-Type", "application/json; charset=utf-8")
 			c.Status(http.StatusOK)
 			return
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1833,6 +1833,40 @@ func TestExampleAPIKeySafeModeShowsWarningAndKeepsManagement(t *testing.T) {
 	})
 }
 
+func TestRootAndManagementHEADRequests(t *testing.T) {
+	staticDir := t.TempDir()
+	t.Setenv("MANAGEMENT_STATIC_PATH", staticDir)
+	if err := os.WriteFile(filepath.Join(staticDir, "management.html"), []byte("<html>management app</html>"), 0o600); err != nil {
+		t.Fatalf("failed to write management asset: %v", err)
+	}
+
+	server := newTestServer(t)
+
+	t.Run("HEAD root returns 200 without body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodHead, "/", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if rr.Body.Len() != 0 {
+			t.Fatalf("HEAD root body length = %d, want 0", rr.Body.Len())
+		}
+	})
+
+	t.Run("HEAD management.html returns 200 without body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodHead, "/management.html", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if rr.Body.Len() != 0 {
+			t.Fatalf("HEAD management.html body length = %d, want 0", rr.Body.Len())
+		}
+	})
+}
+
 func TestModelsDispatchByAnthropicVersionHeader(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
 	clientID := "test-anthropic-version-dispatch"

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1852,6 +1852,9 @@ func TestRootAndManagementHEADRequests(t *testing.T) {
 		if rr.Body.Len() != 0 {
 			t.Fatalf("HEAD root body length = %d, want 0", rr.Body.Len())
 		}
+		if contentType := rr.Header().Get("Content-Type"); !strings.Contains(contentType, "application/json") {
+			t.Fatalf("HEAD root Content-Type = %q, want application/json", contentType)
+		}
 	})
 
 	t.Run("HEAD management.html returns 200 without body", func(t *testing.T) {

--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -29,10 +29,14 @@ const (
 	defaultManagementReleaseURL  = "https://api.github.com/repos/router-for-me/Cli-Proxy-API-Management-Center/releases/latest"
 	defaultManagementFallbackURL = "https://cpamc.router-for.me/"
 	managementAssetName          = "management.html"
+	tempAssetFilePattern         = "management-*.html"
 	httpUserAgent                = "CLIProxyAPI-management-updater"
 	managementSyncMinInterval    = 30 * time.Second
 	updateCheckInterval          = 3 * time.Hour
-	maxAssetDownloadSize         = 50 << 20 // 10 MB safety limit for management asset downloads
+	maxAssetDownloadSize         = 50 << 20 // 50 MB safety limit for management asset downloads
+
+	defaultStaticDirPerm os.FileMode = 0o755
+	defaultAssetFilePerm os.FileMode = 0o644
 )
 
 // ManagementFileName exposes the control panel asset filename.
@@ -225,7 +229,7 @@ func EnsureLatestManagementHTML(ctx context.Context, staticDir string, proxyURL 
 			}
 		}
 
-		if errMkdirAll := os.MkdirAll(staticDir, 0o755); errMkdirAll != nil {
+		if errMkdirAll := os.MkdirAll(staticDir, defaultStaticDirPerm); errMkdirAll != nil {
 			log.WithError(errMkdirAll).Warn("failed to prepare static directory for management asset")
 			return nil, nil
 		}
@@ -407,7 +411,7 @@ func fileSHA256(path string) (string, error) {
 }
 
 func atomicWriteFile(path string, data []byte) error {
-	tmpFile, err := os.CreateTemp(filepath.Dir(path), "management-*.html")
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), tempAssetFilePattern)
 	if err != nil {
 		return err
 	}
@@ -422,7 +426,7 @@ func atomicWriteFile(path string, data []byte) error {
 		return err
 	}
 
-	if err = tmpFile.Chmod(0o644); err != nil {
+	if err = tmpFile.Chmod(defaultAssetFilePerm); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What's in this PR

Ever tried curling `curl -I https://proxy/management.html` or having healthcheck probes ping with `HEAD` requests only to get a sad 404 while `GET` works like a charm? 

This PR irons out those little route quirks and polishes management asset permissions:

1. **HEAD route support for `/management.html` & `/`**:
   - Registered `HEAD` method for `/management.html` so pre-flight checks and uptime monitors do not freak out.
   - Refactored root handler to cleanly return 200 without payload for `HEAD /`.

2. **Clean constants and typed permissions in `managementasset`**:
   - Replaced magic literals (`0o755`, `0o644`, `"management-*.html"`) with typed `os.FileMode` and named constants following DRY/SRP.
   - Corrected size comment calculation for `maxAssetDownloadSize`.

3. **Tests**:
   - Added `TestRootAndManagementHEADRequests` covering both endpoints.

All tests green locally!