### PR TITLE
fix(home): retry transient config transport errors during bootstrap

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -291,7 +291,7 @@ func main() {
 		}()
 
 		ctxHomeConfig, cancelHomeConfig := context.WithTimeout(context.Background(), 30*time.Second)
-		raw, errGetConfig := homeClient.GetConfig(ctxHomeConfig)
+		raw, errGetConfig := homeClient.WaitForConfig(ctxHomeConfig)
 		cancelHomeConfig()
 		if errGetConfig != nil {
 			log.Errorf("failed to fetch config from home: %v", errGetConfig)

--- a/internal/home/bootstrap.go
+++ b/internal/home/bootstrap.go
@@ -1,0 +1,43 @@
+package home
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// WaitForConfig tolerates transient transport failures during the caller's
+// bootstrap deadline. It never substitutes cached config or retries a command
+// with side effects. Authentication and configuration errors fail immediately.
+func (c *Client) WaitForConfig(ctx context.Context) ([]byte, error) {
+	ticker := time.NewTicker(homeReconnectInterval)
+	defer ticker.Stop()
+	return waitForConfig(ctx, c.GetConfig, ticker.C)
+}
+
+func waitForConfig(ctx context.Context, fetch func(context.Context) ([]byte, error), ticks <-chan time.Time) ([]byte, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		raw, err := fetch(ctx)
+		if err == nil {
+			return raw, nil
+		}
+		var networkError net.Error
+		if !errors.As(err, &networkError) && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err
+		}
+		// Do not log raw transport errors: they can contain credential URLs.
+		log.Warn("Home config transport unavailable; retrying within bootstrap deadline")
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticks:
+		}
+	}
+}

--- a/internal/home/bootstrap_test.go
+++ b/internal/home/bootstrap_test.go
@@ -4,12 +4,56 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
+
+func TestWaitForConfigReconnectsNativeClient(t *testing.T) {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) >= 2 && strings.EqualFold(args[0], "CLUSTER") {
+			return "-ERR cluster command unsupported\r\n"
+		}
+		if len(args) >= 2 && strings.EqualFold(args[0], "GET") && args[1] == redisKeyConfig {
+			payload := "port: 8317\n"
+			return fmt.Sprintf("$%d\r\n%s\r\n", len(payload), payload)
+		}
+		return "-ERR unexpected command\r\n"
+	})
+	options := cloneRedisOptions(client.cmdOptions)
+	options.DialerRetries = 1
+	var attempts atomic.Int32
+	options.Dialer = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if attempts.Add(1) == 1 {
+			return nil, &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}
+		}
+		return (&net.Dialer{}).DialContext(ctx, network, address)
+	}
+	if err := client.cmd.Close(); err != nil {
+		t.Fatal(err)
+	}
+	client.cmdOptions = cloneRedisOptions(options)
+	client.cmd = redis.NewClient(options)
+	client.homeCfg.DisableClusterDiscovery = false
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Time{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	raw, err := waitForConfig(ctx, client.GetConfig, ticks)
+	if err != nil || string(raw) != "port: 8317\n" || attempts.Load() != 2 {
+		t.Fatalf("result=%q err=%v attempts=%d", raw, err, attempts.Load())
+	}
+	if count := commands.CountCommandKey("GET", redisKeyConfig); count != 1 {
+		t.Fatalf("GET config count=%d, want 1", count)
+	}
+}
 
 func TestWaitForConfigRecoversTransportWithoutRestart(t *testing.T) {
 	ticks := make(chan time.Time, 1)

--- a/internal/home/bootstrap_test.go
+++ b/internal/home/bootstrap_test.go
@@ -1,0 +1,67 @@
+package home
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWaitForConfigRecoversTransportWithoutRestart(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	ticks <- time.Time{}
+	calls := 0
+	raw, err := waitForConfig(context.Background(), func(context.Context) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}
+		}
+		return []byte("config"), nil
+	}, ticks)
+	if err != nil || string(raw) != "config" || calls != 2 {
+		t.Fatalf("result=%q err=%v calls=%d", raw, err, calls)
+	}
+}
+
+func TestWaitForConfigRejectsPermanentFailure(t *testing.T) {
+	for _, failure := range []error{ErrConfigNotFound, ErrEmptyResponse, errors.New("authentication rejected"), x509.UnknownAuthorityError{}} {
+		calls := 0
+		_, err := waitForConfig(context.Background(), func(context.Context) ([]byte, error) {
+			calls++
+			return nil, failure
+		}, nil)
+		if !errors.Is(err, failure) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	}
+}
+
+func TestWaitForConfigCanceledBeforeFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := waitForConfig(ctx, func(context.Context) ([]byte, error) {
+		t.Fatal("canceled bootstrap must not fetch config")
+		return nil, nil
+	}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWaitForConfigCancellationStopsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	calls := 0
+	_, err := waitForConfig(ctx, func(context.Context) ([]byte, error) {
+		calls++
+		cancel()
+		return nil, io.EOF
+	}, nil)
+	if !errors.Is(err, context.Canceled) || calls != 1 {
+		t.Fatalf("err=%v calls=%d", err, calls)
+	}
+}


### PR DESCRIPTION
## Problem
In Home mode, a single transient discovery or config transport error exits CPA immediately even when the existing 30-second bootstrap deadline has not elapsed. During a brief Home restart this unnecessarily amplifies disruption through supervisor restart backoff.

## Change
- Retry read-only config acquisition on network/EOF errors at the existing Home reconnect interval, bounded by the existing caller deadline.
- Leave regular GetConfig callers unchanged.
- Do not retry config-not-found, empty config, authentication rejection, or certificate trust errors. Do not serve cached credentials/config as a fallback.
- Keep raw transport details out of retry logs.

## Evidence
Focused native Go tests pass, including real RESP client connection refusal then recovery without recreating the client, cancellation, and permanent-error cases. Server compile passes. This does not claim database corruption recovery or continuous availability through outages longer than the existing bootstrap deadline.

Base is deployed v7.2.145 commit d9cea890; only the bootstrap recovery slice is included.