### PR TITLE
fix(pluginhost): preserve upstream status code in host.model.execute errors

### DIFF
--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -314,6 +314,9 @@ func modelExecutionError(errMsg *interfaces.ErrorMessage) error {
 	if errMsg == nil {
 		return nil
 	}
+	if errMsg.StatusCode > 0 && errMsg.Error != nil {
+		return fmt.Errorf("model execution failed with status %d: %w", errMsg.StatusCode, errMsg.Error)
+	}
 	if errMsg.Error != nil {
 		return errMsg.Error
 	}

--- a/internal/pluginhost/host_callbacks_status_test.go
+++ b/internal/pluginhost/host_callbacks_status_test.go
@@ -1,0 +1,27 @@
+package pluginhost
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+// Regression: a plugin calling host.model.execute must be able to recover the
+// upstream HTTP status from the error when the executor sets BOTH StatusCode and
+// Error (the common case for a 429). Before the fix, Error won and the status
+// was silently dropped, leaving every status-based failover plugin blind.
+func TestModelExecutionErrorKeepsStatusWhenErrorSet(t *testing.T) {
+	upstream := errors.New(`{"type":"error","error":{"type":"rate_limit_error","message":"cooling down"}}`)
+	err := modelExecutionError(&interfaces.ErrorMessage{StatusCode: 429, Error: upstream})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Fatalf("status code lost: %q", err.Error())
+	}
+	if !errors.Is(err, upstream) {
+		t.Fatalf("upstream error not wrapped: %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Problem

When the executor returns an `ErrorMessage` with **both** `StatusCode` and `Error` set — the normal case for an upstream 429/5xx — `modelExecutionError()` in `internal/pluginhost/host_callbacks.go` returns only the bare `Error`. The `StatusCode > 0` branch below it is unreachable, so the status never reaches the plugin: `HostModelExecutionResponse.StatusCode` stays 0 and the error text carries no status either.

Reproduced on 7.2.147 with a native Executor plugin calling `host.model.execute` against a provider returning 429:

```
[conductor_execution.go:1780] 429 | upstream execution failed: provider=claude ...   ← host knows
plugin receives: host_call_failed: {"type":"error","error":{"type":"rate_limit_error","message":"cooling down"}}   ← no status
```

Effect: every status-based failover plugin is blind to rate limits. Plugins that work today do so by string-matching `"rate limit"` in the error text — which also matches auth failures (`auth_unavailable`, `no auth available`) and produces silent provider switches on configuration errors.

Both callers are affected: `callHostModelExecute` (host_callbacks.go:289) and the stream variant (host_model_stream_callbacks.go:33).

## Fix

Wrap the upstream error with the status when both are present, using `%w` so `errors.Is()` on the original cause keeps working. The existing `"model execution failed with status %d"` wording is reused so anything already parsing it keeps working.

## Test

`TestModelExecutionErrorKeepsStatusWhenErrorSet` — fails on `main` with `status code lost: "{\"type\":\"error\",...}"`, passes with the fix. `go test ./internal/pluginhost/` and `go vet` clean.
