### PR TITLE
Allow orphan Codex delegation without spawn header

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -265,8 +265,7 @@ codex:
   # When true, enable opt-in compatibility for orphan Codex delegation outputs.
   # Converts orphan function_call_output items from codex_app/create_thread and
   # codex_app/send_message_to_thread (which lack a valid call_id or matching function_call)
-  # into standard user messages across Responses and non-Codex protocols when the request
-  # header contains X-Openai-Subagent: collab_spawn.
+  # into standard user messages across Responses and non-Codex protocols.
   orphan-delegation-compatibility: false
   # Terminate and relay Codex Live WebRTC audio and DataChannel traffic in this process.
   # This requires inbound UDP reachability. Keep disabled to preserve direct media behavior.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -263,9 +263,10 @@ codex:
   # into standard user messages for non-Codex upstream protocols.
   optimize-multi-agent-v2: false
   # When true, enable opt-in compatibility for orphan Codex delegation outputs.
-  # Converts orphan function_call_output items from codex_app/create_thread and
-  # codex_app/send_message_to_thread (which lack a valid call_id or matching function_call)
-  # into standard user messages across Responses and non-Codex protocols.
+  # Converts orphan function_call_output items from codex_app/create_thread,
+  # codex_app/send_message_to_thread, and codex_app/automation_update (which lack a valid
+  # call_id or matching function_call) into standard user messages across Responses and
+  # non-Codex protocols. Stateless HTTP does not treat previous_response_id as proof of pairing.
   orphan-delegation-compatibility: false
   # Terminate and relay Codex Live WebRTC audio and DataChannel traffic in this process.
   # This requires inbound UDP reachability. Keep disabled to preserve direct media behavior.

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -72,7 +72,7 @@ func RewriteCodexMultiAgentV2Input(ctx context.Context, headers http.Header, pay
 }
 
 // RewriteCodexOrphanDelegationInputForConfig applies RewriteCodexOrphanDelegationInput
-// based on cfg.Codex.OrphanDelegationCompatibility and the X-Openai-Subagent header.
+// based on cfg.Codex.OrphanDelegationCompatibility.
 func RewriteCodexOrphanDelegationInputForConfig(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) []byte {
 	if cfg == nil || !cfg.Codex.OrphanDelegationCompatibility {
 		return payload

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -77,7 +77,7 @@ func RewriteCodexOrphanDelegationInputForConfig(ctx context.Context, headers htt
 	if cfg == nil || !cfg.Codex.OrphanDelegationCompatibility {
 		return payload
 	}
-	return RewriteCodexOrphanDelegationInput(ctx, headers, payload, true)
+	return RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(ctx, headers, payload, true, pendingToolCallIDsFromContext(ctx))
 }
 
 // TranslateRequestWithCodexMultiAgentV2 normalizes official Codex multi-agent

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -17,15 +16,12 @@ const (
 	codexSendMessageToThreadName = "send_message_to_thread"
 	codexAppCreateThreadTool     = "codex_app__create_thread"
 	codexAppSendMessageTool      = "codex_app__send_message_to_thread"
-	codexOpenAISubagentHeader    = "X-Openai-Subagent"
-	codexCollabSpawnSubagent     = "collab_spawn"
 )
 
 // RewriteCodexOrphanDelegationInput converts orphan Codex delegation outputs into
-// standard user messages when orphan delegation compatibility is enabled and the
-// request carries the X-Openai-Subagent: collab_spawn header.
+// standard user messages when orphan delegation compatibility is enabled.
 func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header, payload []byte, enabled bool) []byte {
-	if !enabled || len(payload) == 0 || !isCodexCollabSpawnSubagent(ctx, headers) {
+	if !enabled || len(payload) == 0 {
 		return payload
 	}
 
@@ -74,19 +70,6 @@ func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header,
 	}
 
 	return updated
-}
-
-func codexSubagentHeader(ctx context.Context, headers http.Header) string {
-	if ctx != nil {
-		if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
-			return headerValueCaseInsensitive(ginCtx.Request.Header, codexOpenAISubagentHeader)
-		}
-	}
-	return headerValueCaseInsensitive(headers, codexOpenAISubagentHeader)
-}
-
-func isCodexCollabSpawnSubagent(ctx context.Context, headers http.Header) bool {
-	return strings.EqualFold(codexSubagentHeader(ctx, headers), codexCollabSpawnSubagent)
 }
 
 func matchCodexDelegationTool(item gjson.Result) (string, bool) {

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
@@ -21,6 +21,13 @@ const (
 // RewriteCodexOrphanDelegationInput converts orphan Codex delegation outputs into
 // standard user messages when orphan delegation compatibility is enabled.
 func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header, payload []byte, enabled bool) []byte {
+	return RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(ctx, headers, payload, enabled, nil)
+}
+
+// RewriteCodexOrphanDelegationInputWithPendingToolCallIDs converts orphan Codex
+// delegation outputs while preserving outputs paired with pending calls from the
+// preceding response.
+func RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(ctx context.Context, headers http.Header, payload []byte, enabled bool, pendingToolCallIDs []string) []byte {
 	if !enabled || len(payload) == 0 {
 		return payload
 	}
@@ -40,6 +47,13 @@ func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header,
 			}
 		}
 	}
+	pendingCalls := make(map[string]int, len(pendingToolCallIDs))
+	for _, callID := range pendingToolCallIDs {
+		if strings.TrimSpace(callID) != "" {
+			pendingCalls[callID]++
+		}
+	}
+	hasPreviousResponseID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
 
 	updated := payload
 	for itemIndex, item := range inputItems {
@@ -53,9 +67,18 @@ func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header,
 			availableCalls[callID]--
 			continue
 		}
+		if pendingCalls[callID] > 0 {
+			// Paired with a pending function call from the preceding response.
+			pendingCalls[callID]--
+			continue
+		}
 
 		toolLabel, isTarget := matchCodexDelegationTool(item)
 		if !isTarget {
+			continue
+		}
+		if hasPreviousResponseID && strings.TrimSpace(callID) != "" {
+			// Without response state, a non-empty call_id may still be a valid continuation.
 			continue
 		}
 

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
@@ -53,7 +53,6 @@ func RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(ctx context.Context
 			pendingCalls[callID]++
 		}
 	}
-	hasPreviousResponseID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
 
 	updated := payload
 	for itemIndex, item := range inputItems {
@@ -75,10 +74,6 @@ func RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(ctx context.Context
 
 		toolLabel, isTarget := matchCodexDelegationTool(item)
 		if !isTarget {
-			continue
-		}
-		if hasPreviousResponseID && strings.TrimSpace(callID) != "" {
-			// Without response state, a non-empty call_id may still be a valid continuation.
 			continue
 		}
 

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation.go
@@ -14,9 +14,31 @@ const (
 	codexAppNamespace            = "codex_app"
 	codexCreateThreadName        = "create_thread"
 	codexSendMessageToThreadName = "send_message_to_thread"
+	codexAutomationUpdateName    = "automation_update"
 	codexAppCreateThreadTool     = "codex_app__create_thread"
 	codexAppSendMessageTool      = "codex_app__send_message_to_thread"
+	codexAppAutomationUpdateTool = "codex_app__automation_update"
 )
+
+type pendingToolCallIDsContextKey struct{}
+
+// WithPendingToolCallIDs stores verified pending tool-call IDs on ctx so later
+// translator/executor rewrites preserve the same pairing decision.
+func WithPendingToolCallIDs(ctx context.Context, pendingToolCallIDs []string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	copied := append([]string(nil), pendingToolCallIDs...)
+	return context.WithValue(ctx, pendingToolCallIDsContextKey{}, copied)
+}
+
+func pendingToolCallIDsFromContext(ctx context.Context) []string {
+	if ctx == nil {
+		return nil
+	}
+	ids, _ := ctx.Value(pendingToolCallIDsContextKey{}).([]string)
+	return ids
+}
 
 // RewriteCodexOrphanDelegationInput converts orphan Codex delegation outputs into
 // standard user messages when orphan delegation compatibility is enabled.
@@ -100,6 +122,8 @@ func matchCodexDelegationTool(item gjson.Result) (string, bool) {
 		return codexAppCreateThreadTool, true
 	case codexSendMessageToThreadName:
 		return codexAppSendMessageTool, true
+	case codexAutomationUpdateName:
+		return codexAppAutomationUpdateTool, true
 	default:
 		return "", false
 	}

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func testRewriteCodexOrphan(payload []byte, enabled bool) []byte {
-	headers := http.Header{"X-Openai-Subagent": []string{"collab_spawn"}}
-	return RewriteCodexOrphanDelegationInput(context.Background(), headers, payload, enabled)
+	return RewriteCodexOrphanDelegationInput(context.Background(), http.Header{}, payload, enabled)
 }
 
 func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
@@ -35,7 +34,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		}
 	})
 
-	t.Run("missing subagent header leaves payload unchanged", func(t *testing.T) {
+	t.Run("missing subagent header rewrites matching orphan", func(t *testing.T) {
 		payload := []byte(`{
 			"model": "deepseek-v4-pro",
 			"input": [
@@ -48,12 +47,12 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 			]
 		}`)
 		got := RewriteCodexOrphanDelegationInput(context.Background(), http.Header{}, payload, true)
-		if string(got) != string(payload) {
-			t.Fatalf("expected payload unchanged without header, got: %s", string(got))
+		if gjson.GetBytes(got, "input.0.type").String() != "message" {
+			t.Fatalf("expected matching orphan to be rewritten without header, got: %s", string(got))
 		}
 	})
 
-	t.Run("different subagent header leaves payload unchanged", func(t *testing.T) {
+	t.Run("different subagent header still rewrites matching orphan", func(t *testing.T) {
 		payload := []byte(`{
 			"model": "deepseek-v4-pro",
 			"input": [
@@ -67,8 +66,8 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		}`)
 		headers := http.Header{"X-Openai-Subagent": []string{"other_subagent"}}
 		got := RewriteCodexOrphanDelegationInput(context.Background(), headers, payload, true)
-		if string(got) != string(payload) {
-			t.Fatalf("expected payload unchanged with wrong header, got: %s", string(got))
+		if gjson.GetBytes(got, "input.0.type").String() != "message" {
+			t.Fatalf("expected matching orphan to be rewritten with unrelated header, got: %s", string(got))
 		}
 	})
 
@@ -110,7 +109,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		}
 	})
 
-	t.Run("case-insensitive header key and value works", func(t *testing.T) {
+	t.Run("header value does not affect structural eligibility", func(t *testing.T) {
 		payload := []byte(`{
 			"model": "deepseek-v4-pro",
 			"input": [
@@ -128,7 +127,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 
 		item0 := parsed.Get("input.0")
 		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
-			t.Fatalf("case-insensitive header should rewrite, got: %s", item0.Raw)
+			t.Fatalf("matching orphan should rewrite regardless of header value, got: %s", item0.Raw)
 		}
 	})
 
@@ -474,7 +473,7 @@ func TestTranslateRequestWithCodexMultiAgentV2OrphanDelegation(t *testing.T) {
 	}`)
 	collabHeaders := http.Header{"X-Openai-Subagent": []string{"collab_spawn"}}
 
-	t.Run("enabled but missing X-Openai-Subagent header does not rewrite", func(t *testing.T) {
+	t.Run("enabled without X-Openai-Subagent header rewrites", func(t *testing.T) {
 		cfg := &config.Config{
 			Codex: config.CodexConfig{
 				OrphanDelegationCompatibility: true,
@@ -484,12 +483,12 @@ func TestTranslateRequestWithCodexMultiAgentV2OrphanDelegation(t *testing.T) {
 		parsed := gjson.ParseBytes(got)
 
 		item0 := parsed.Get("input.0")
-		if item0.Get("type").String() != "function_call_output" {
-			t.Fatalf("input.0 = %s, want function_call_output when X-Openai-Subagent header is missing", item0.Raw)
+		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
+			t.Fatalf("input.0 = %s, want message/user when X-Openai-Subagent header is missing", item0.Raw)
 		}
 	})
 
-	t.Run("enabled with wrong X-Openai-Subagent header value does not rewrite", func(t *testing.T) {
+	t.Run("enabled with unrelated X-Openai-Subagent header rewrites", func(t *testing.T) {
 		cfg := &config.Config{
 			Codex: config.CodexConfig{
 				OrphanDelegationCompatibility: true,
@@ -500,8 +499,8 @@ func TestTranslateRequestWithCodexMultiAgentV2OrphanDelegation(t *testing.T) {
 		parsed := gjson.ParseBytes(got)
 
 		item0 := parsed.Get("input.0")
-		if item0.Get("type").String() != "function_call_output" {
-			t.Fatalf("input.0 = %s, want function_call_output when X-Openai-Subagent header is wrong", item0.Raw)
+		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
+			t.Fatalf("input.0 = %s, want message/user when X-Openai-Subagent header is unrelated", item0.Raw)
 		}
 	})
 

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
@@ -15,6 +15,10 @@ func testRewriteCodexOrphan(payload []byte, enabled bool) []byte {
 	return RewriteCodexOrphanDelegationInput(context.Background(), http.Header{}, payload, enabled)
 }
 
+func testRewriteCodexOrphanWithPendingCalls(payload []byte, pendingToolCallIDs []string) []byte {
+	return RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(context.Background(), http.Header{}, payload, true, pendingToolCallIDs)
+}
+
 func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 	t.Run("disabled leaves payload unchanged", func(t *testing.T) {
 		payload := []byte(`{
@@ -154,6 +158,65 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		wantText := "Tool output from codex_app__send_message_to_thread:\n<codex_delegation>msg</codex_delegation>"
 		if text := item0.Get("content.0.text").String(); text != wantText {
 			t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		tool string
+	}{
+		{name: "create thread", tool: codexCreateThreadName},
+		{name: "send message to thread", tool: codexSendMessageToThreadName},
+	} {
+		t.Run("preserves incremental pending "+tc.name+" output", func(t *testing.T) {
+			payload := []byte(`{
+				"previous_response_id": "resp_previous",
+				"input": [{
+					"type": "function_call_output",
+					"call_id": "call_pending",
+					"name": "` + tc.tool + `",
+					"namespace": "codex_app",
+					"output": "completed"
+				}]
+			}`)
+			got := testRewriteCodexOrphanWithPendingCalls(payload, []string{"call_pending"})
+			if itemType := gjson.GetBytes(got, "input.0.type").String(); itemType != "function_call_output" {
+				t.Fatalf("incremental pending output was rewritten: %s", got)
+			}
+		})
+	}
+
+	t.Run("response append preserves pending output without previous response id", func(t *testing.T) {
+		payload := []byte(`{
+			"type": "response.append",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call_pending",
+				"name": "create_thread",
+				"namespace": "codex_app",
+				"output": "completed"
+			}]
+		}`)
+		got := testRewriteCodexOrphanWithPendingCalls(payload, []string{"call_pending"})
+		if itemType := gjson.GetBytes(got, "input.0.type").String(); itemType != "function_call_output" {
+			t.Fatalf("pending append output was rewritten: %s", got)
+		}
+	})
+
+	t.Run("ordinary request preserves unknown call id with previous response", func(t *testing.T) {
+		payload := []byte(`{
+			"previous_response_id": "resp_previous",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call_unknown",
+				"name": "create_thread",
+				"namespace": "codex_app",
+				"output": "completed"
+			}]
+		}`)
+		got := testRewriteCodexOrphan(payload, true)
+		if itemType := gjson.GetBytes(got, "input.0.type").String(); itemType != "function_call_output" {
+			t.Fatalf("ordinary incremental output was rewritten: %s", got)
 		}
 	})
 

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
@@ -203,7 +203,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		}
 	})
 
-	t.Run("ordinary request preserves unknown call id with previous response", func(t *testing.T) {
+	t.Run("ordinary request rewrites unknown call id with previous response", func(t *testing.T) {
 		payload := []byte(`{
 			"previous_response_id": "resp_previous",
 			"input": [{
@@ -215,8 +215,37 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 			}]
 		}`)
 		got := testRewriteCodexOrphan(payload, true)
-		if itemType := gjson.GetBytes(got, "input.0.type").String(); itemType != "function_call_output" {
-			t.Fatalf("ordinary incremental output was rewritten: %s", got)
+		parsed := gjson.ParseBytes(got)
+		item0 := parsed.Get("input.0")
+		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
+			t.Fatalf("ordinary incremental unknown call should be rewritten: %s", item0.Raw)
+		}
+		wantText := "Tool output from codex_app__create_thread:\ncompleted"
+		if text := item0.Get("content.0.text").String(); text != wantText {
+			t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
+		}
+	})
+
+	t.Run("ordinary request rewrites previous_response_id with stale non-empty call_id", func(t *testing.T) {
+		payload := []byte(`{
+			"previous_response_id": "resp_previous",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call_stale_123",
+				"name": "send_message_to_thread",
+				"namespace": "codex_app",
+				"output": "<codex_delegation>msg</codex_delegation>"
+			}]
+		}`)
+		got := testRewriteCodexOrphan(payload, true)
+		parsed := gjson.ParseBytes(got)
+		item0 := parsed.Get("input.0")
+		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
+			t.Fatalf("stale call_id with previous_response_id should be rewritten: %s", item0.Raw)
+		}
+		wantText := "Tool output from codex_app__send_message_to_thread:\n<codex_delegation>msg</codex_delegation>"
+		if text := item0.Get("content.0.text").String(); text != wantText {
+			t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
 		}
 	})
 
@@ -604,6 +633,48 @@ func TestTranslateRequestWithCodexMultiAgentV2OrphanDelegation(t *testing.T) {
 			t.Fatalf("messages.0.role = %q, want user (should not be tool message with empty id)", msg0.Get("role").String())
 		}
 		wantText := "Tool output from codex_app__create_thread:\n<codex_delegation><message>handoff</message></codex_delegation>"
+		var text string
+		if msg0.Get("content").IsArray() {
+			text = msg0.Get("content.0.text").String()
+		} else {
+			text = msg0.Get("content").String()
+		}
+		if text != wantText {
+			t.Fatalf("messages.0.content = %q, want %q", text, wantText)
+		}
+	})
+
+	t.Run("enabled translates previous_response_id unknown call_id to chat user message without empty tool_call_id", func(t *testing.T) {
+		cfg := &config.Config{
+			Codex: config.CodexConfig{
+				OrphanDelegationCompatibility: true,
+			},
+		}
+		incremental := []byte(`{
+			"model": "test-model",
+			"previous_response_id": "resp_previous",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call_unknown",
+				"name": "create_thread",
+				"namespace": "codex_app",
+				"output": "completed"
+			}]
+		}`)
+		got := TranslateRequestWithCodexMultiAgentV2(context.Background(), collabHeaders, cfg, sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, "test-model", incremental, false)
+		parsed := gjson.ParseBytes(got)
+		messages := parsed.Get("messages").Array()
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d: %s", len(messages), string(got))
+		}
+		msg0 := messages[0]
+		if msg0.Get("role").String() != "user" {
+			t.Fatalf("messages.0.role = %q, want user (should not remain a tool message)", msg0.Get("role").String())
+		}
+		if toolCallID := msg0.Get("tool_call_id"); toolCallID.Exists() {
+			t.Fatalf("messages.0.tool_call_id = %q, want absent", toolCallID.String())
+		}
+		wantText := "Tool output from codex_app__create_thread:\ncompleted"
 		var text string
 		if msg0.Get("content").IsArray() {
 			text = msg0.Get("content.0.text").String()

--- a/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/orphan_delegation_test.go
@@ -167,6 +167,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 	}{
 		{name: "create thread", tool: codexCreateThreadName},
 		{name: "send message to thread", tool: codexSendMessageToThreadName},
+		{name: "automation update", tool: codexAutomationUpdateName},
 	} {
 		t.Run("preserves incremental pending "+tc.name+" output", func(t *testing.T) {
 			payload := []byte(`{
@@ -281,7 +282,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		}
 	})
 
-	t.Run("preserves non-whitelisted tools", func(t *testing.T) {
+	t.Run("rewrites orphan automation_update without call_id", func(t *testing.T) {
 		payload := []byte(`{
 			"model": "deepseek-v4-pro",
 			"input": [
@@ -289,8 +290,26 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 					"type": "function_call_output",
 					"name": "automation_update",
 					"namespace": "codex_app",
-					"output": "ignored"
-				},
+					"output": "<heartbeat>check</heartbeat>"
+				}
+			]
+		}`)
+		got := testRewriteCodexOrphan(payload, true)
+		parsed := gjson.ParseBytes(got)
+		item0 := parsed.Get("input.0")
+		if item0.Get("type").String() != "message" || item0.Get("role").String() != "user" {
+			t.Fatalf("automation_update orphan was not rewritten: %s", item0.Raw)
+		}
+		wantText := "Tool output from codex_app__automation_update:\n<heartbeat>check</heartbeat>"
+		if text := item0.Get("content.0.text").String(); text != wantText {
+			t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
+		}
+	})
+
+	t.Run("preserves non-whitelisted tools", func(t *testing.T) {
+		payload := []byte(`{
+			"model": "deepseek-v4-pro",
+			"input": [
 				{
 					"type": "function_call_output",
 					"name": "create_thread",
@@ -303,10 +322,7 @@ func TestRewriteCodexOrphanDelegationInput(t *testing.T) {
 		parsed := gjson.ParseBytes(got)
 
 		if parsed.Get("input.0.type").String() != "function_call_output" {
-			t.Fatalf("automation_update should not be rewritten: %s", parsed.Get("input.0").Raw)
-		}
-		if parsed.Get("input.1.type").String() != "function_call_output" {
-			t.Fatalf("other_namespace should not be rewritten: %s", parsed.Get("input.1").Raw)
+			t.Fatalf("other_namespace should not be rewritten: %s", parsed.Get("input.0").Raw)
 		}
 	})
 
@@ -683,6 +699,73 @@ func TestTranslateRequestWithCodexMultiAgentV2OrphanDelegation(t *testing.T) {
 		}
 		if text != wantText {
 			t.Fatalf("messages.0.content = %q, want %q", text, wantText)
+		}
+	})
+
+	t.Run("enabled translates orphan automation_update to chat user message", func(t *testing.T) {
+		cfg := &config.Config{
+			Codex: config.CodexConfig{
+				OrphanDelegationCompatibility: true,
+			},
+		}
+		heartbeat := []byte(`{
+			"model": "test-model",
+			"input": [{
+				"type": "function_call_output",
+				"name": "automation_update",
+				"namespace": "codex_app",
+				"output": "<heartbeat>check</heartbeat>"
+			}]
+		}`)
+		got := TranslateRequestWithCodexMultiAgentV2(context.Background(), http.Header{}, cfg, sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, "test-model", heartbeat, false)
+		parsed := gjson.ParseBytes(got)
+		messages := parsed.Get("messages").Array()
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d: %s", len(messages), string(got))
+		}
+		msg0 := messages[0]
+		if msg0.Get("role").String() != "user" {
+			t.Fatalf("messages.0.role = %q, want user", msg0.Get("role").String())
+		}
+		if toolCallID := msg0.Get("tool_call_id"); toolCallID.Exists() {
+			t.Fatalf("messages.0.tool_call_id = %q, want absent", toolCallID.String())
+		}
+		wantText := "Tool output from codex_app__automation_update:\n<heartbeat>check</heartbeat>"
+		var text string
+		if msg0.Get("content").IsArray() {
+			text = msg0.Get("content.0.text").String()
+		} else {
+			text = msg0.Get("content").String()
+		}
+		if text != wantText {
+			t.Fatalf("messages.0.content = %q, want %q", text, wantText)
+		}
+	})
+
+	t.Run("enabled preserves context pending output through executor rewrite", func(t *testing.T) {
+		cfg := &config.Config{
+			Codex: config.CodexConfig{
+				OrphanDelegationCompatibility: true,
+			},
+		}
+		payload := []byte(`{
+			"model": "test-model",
+			"previous_response_id": "resp_previous",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call_pending",
+				"name": "create_thread",
+				"namespace": "codex_app",
+				"output": "completed"
+			}]
+		}`)
+		ctx := WithPendingToolCallIDs(context.Background(), []string{"call_pending"})
+		got := TranslateRequestWithCodexMultiAgentV2(ctx, http.Header{}, cfg, sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAIResponse, "test-model", payload, false)
+		if itemType := gjson.GetBytes(got, "input.0.type").String(); itemType != "function_call_output" {
+			t.Fatalf("context pending output was rewritten: %s", got)
+		}
+		if callID := gjson.GetBytes(got, "input.0.call_id").String(); callID != "call_pending" {
+			t.Fatalf("call_id = %q, want call_pending; payload=%s", callID, got)
 		}
 	})
 

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -30,8 +30,7 @@ func RewriteCodexMultiAgentV2Input(ctx context.Context, headers http.Header, pay
 }
 
 // RewriteCodexOrphanDelegationInput converts orphan Codex delegation outputs into
-// standard user messages when orphan delegation compatibility is enabled and the
-// request carries the X-Openai-Subagent: collab_spawn header.
+// standard user messages when orphan delegation compatibility is enabled.
 func RewriteCodexOrphanDelegationInput(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) []byte {
 	return multiagentv2.RewriteCodexOrphanDelegationInputForConfig(ctx, headers, payload, cfg)
 }

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -170,6 +170,65 @@ func TestKimiExecutorPreservesAssistantContentAndToolCallsFromResponsesHistory(t
 	}
 }
 
+func TestKimiExecutorRewritesOrphanCodexDelegationWithoutSubagentHeader(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"k3","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{
+		Codex: config.CodexConfig{OrphanDelegationCompatibility: true},
+	})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := []byte(`{
+		"model":"kimi-k3",
+		"input":[
+			{"type":"function_call_output","name":"create_thread","namespace":"codex_app","output":"<codex_delegation>handoff</codex_delegation>"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		]
+	}`)
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(upstreamBody, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("upstream messages count = %d, want 2; body=%s", len(messages), upstreamBody)
+	}
+	if role := messages[0].Get("role").String(); role != "user" {
+		t.Fatalf("messages.0.role = %q, want user; body=%s", role, upstreamBody)
+	}
+	if toolCallID := messages[0].Get("tool_call_id"); toolCallID.Exists() {
+		t.Fatalf("messages.0.tool_call_id = %q, want absent; body=%s", toolCallID.String(), upstreamBody)
+	}
+	wantText := "Tool output from codex_app__create_thread:\n<codex_delegation>handoff</codex_delegation>"
+	if content := messages[0].Get("content.0.text").String(); content != wantText {
+		t.Fatalf("messages.0.content.0.text = %q, want %q; body=%s", content, wantText, upstreamBody)
+	}
+}
+
 func TestKimiExecutorCountTokensUsesCanonicalUpstreamModel(t *testing.T) {
 	var upstreamRequest *http.Request
 	var upstreamBody []byte

--- a/internal/runtime/executor/xai_orphan_pending_handler_test.go
+++ b/internal/runtime/executor/xai_orphan_pending_handler_test.go
@@ -1,0 +1,283 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	openai "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/tidwall/gjson"
+)
+
+// xaiHandlerPrepareCaptureExecutor is the xAI executor boundary used by the
+// Responses handler. It runs the real prepare path on the handler ctx, then
+// returns a synthetic completion so the test never dials upstream.
+type xaiHandlerPrepareCaptureExecutor struct {
+	ws              *XAIWebsocketsExecutor
+	mu              sync.Mutex
+	prepared        [][]byte
+	responseOutputs [][]byte
+	done            chan struct{}
+	doneOnce        sync.Once
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) Identifier() string { return "xai" }
+
+func (e *xaiHandlerPrepareCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if err := e.capturePrepared(ctx, req, opts, false); err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(`{"id":"resp-http","output":[]}`)}, nil
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if err := e.capturePrepared(ctx, req, opts, true); err != nil {
+		return nil, err
+	}
+
+	e.mu.Lock()
+	count := len(e.prepared)
+	responseOutput := []byte(`[]`)
+	if count <= len(e.responseOutputs) {
+		responseOutput = e.responseOutputs[count-1]
+	}
+	e.mu.Unlock()
+
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%d","output":%s}}`, count, responseOutput))}
+	close(chunks)
+	if count >= 2 && e.done != nil {
+		e.doneOnce.Do(func() { close(e.done) })
+	}
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) capturePrepared(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) error {
+	var (
+		prepared *xaiPreparedRequest
+		err      error
+	)
+	if stream {
+		prepared, err = e.ws.prepareResponsesWebsocketRequest(ctx, req, opts)
+	} else {
+		prepared, err = e.ws.prepareResponsesRequest(ctx, req, opts, false)
+	}
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.prepared = append(e.prepared, bytes.Clone(prepared.body))
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, fmt.Errorf("not implemented")
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (e *xaiHandlerPrepareCaptureExecutor) preparedBodies() [][]byte {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([][]byte, len(e.prepared))
+	for i := range e.prepared {
+		out[i] = bytes.Clone(e.prepared[i])
+	}
+	return out
+}
+
+func newXAIOrphanPendingHandler(t *testing.T, executor *xaiHandlerPrepareCaptureExecutor, websockets bool) (*openai.OpenAIResponsesAPIHandler, string) {
+	t.Helper()
+
+	modelID := "xai-orphan-" + strings.ReplaceAll(t.Name(), "/", "-")
+	authID := "auth-" + modelID
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+		ProxyURL: "direct",
+	}
+	if websockets {
+		auth.Attributes = map[string]string{"websockets": "true"}
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, manager)
+	return openai.NewOpenAIResponsesAPIHandler(base), modelID
+}
+
+func newEnabledXAIWebsocketsExecutor() *XAIWebsocketsExecutor {
+	return NewXAIWebsocketsExecutor(&config.Config{
+		Codex: config.CodexConfig{OrphanDelegationCompatibility: true},
+	})
+}
+
+func TestXAIHandlerPendingDelegationThroughExecutorPrepare(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("native websocket continuation preserves pending output", func(t *testing.T) {
+		executor := &xaiHandlerPrepareCaptureExecutor{
+			ws:   newEnabledXAIWebsocketsExecutor(),
+			done: make(chan struct{}),
+			responseOutputs: [][]byte{
+				[]byte(`[{"type":"function_call","call_id":"call-pending","name":"create_thread","namespace":"codex_app","arguments":"{}"}]`),
+				[]byte(`[]`),
+			},
+		}
+		handler, modelID := newXAIOrphanPendingHandler(t, executor, true)
+		router := gin.New()
+		router.GET("/v1/responses/ws", handler.ResponsesWebsocket)
+		server := httptest.NewServer(router)
+		t.Cleanup(server.Close)
+
+		conn := dialResponsesWebsocket(t, server)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		writeResponsesWebsocketJSON(t, conn, fmt.Sprintf(`{"type":"response.create","model":%q,"input":[{"type":"message","role":"user","content":"start"}]}`, modelID))
+		readResponsesWebsocketMessage(t, conn)
+		writeResponsesWebsocketJSON(t, conn, `{"type":"response.append","input":[{"type":"function_call_output","call_id":"call-pending","name":"create_thread","namespace":"codex_app","output":"completed"}]}`)
+		readResponsesWebsocketMessage(t, conn)
+		waitPrepared(t, executor.done)
+
+		prepared := executor.preparedBodies()
+		if len(prepared) != 2 {
+			t.Fatalf("prepared payload count = %d, want 2", len(prepared))
+		}
+		if itemType := firstInputType(prepared[1]); itemType != "function_call_output" {
+			t.Fatalf("xAI continuation rewrite dropped pending output: %s", prepared[1])
+		}
+	})
+
+	t.Run("native websocket reset does not inherit pending", func(t *testing.T) {
+		executor := &xaiHandlerPrepareCaptureExecutor{
+			ws:   newEnabledXAIWebsocketsExecutor(),
+			done: make(chan struct{}),
+			responseOutputs: [][]byte{
+				[]byte(`[{"type":"function_call","call_id":"call-pending","name":"create_thread","namespace":"codex_app","arguments":"{}"}]`),
+				[]byte(`[]`),
+			},
+		}
+		handler, modelID := newXAIOrphanPendingHandler(t, executor, true)
+		router := gin.New()
+		router.GET("/v1/responses/ws", handler.ResponsesWebsocket)
+		server := httptest.NewServer(router)
+		t.Cleanup(server.Close)
+
+		conn := dialResponsesWebsocket(t, server)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		writeResponsesWebsocketJSON(t, conn, fmt.Sprintf(`{"type":"response.create","model":%q,"input":[{"type":"message","role":"user","content":"start"}]}`, modelID))
+		readResponsesWebsocketMessage(t, conn)
+		writeResponsesWebsocketJSON(t, conn, `{"type":"response.create","input":[{"type":"function_call_output","call_id":"call-pending","name":"create_thread","namespace":"codex_app","output":"completed"}]}`)
+		readResponsesWebsocketMessage(t, conn)
+		waitPrepared(t, executor.done)
+
+		prepared := executor.preparedBodies()
+		if len(prepared) != 2 {
+			t.Fatalf("prepared payload count = %d, want 2", len(prepared))
+		}
+		if itemType := firstInputType(prepared[1]); itemType != "message" {
+			t.Fatalf("xAI reset retained stale pending output: %s", prepared[1])
+		}
+	})
+
+	t.Run("stateless HTTP does not inherit pending", func(t *testing.T) {
+		executor := &xaiHandlerPrepareCaptureExecutor{ws: newEnabledXAIWebsocketsExecutor()}
+		handler, modelID := newXAIOrphanPendingHandler(t, executor, false)
+		router := gin.New()
+		router.POST("/v1/responses", handler.Responses)
+
+		payload := fmt.Sprintf(`{
+			"model": %q,
+			"stream": false,
+			"previous_response_id": "resp-previous",
+			"input": [{
+				"type": "function_call_output",
+				"call_id": "call-pending",
+				"name": "create_thread",
+				"namespace": "codex_app",
+				"output": "completed"
+			}]
+		}`, modelID)
+		request := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(payload))
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+		}
+
+		prepared := executor.preparedBodies()
+		if len(prepared) != 1 {
+			t.Fatalf("prepared payload count = %d, want 1", len(prepared))
+		}
+		if itemType := firstInputType(prepared[0]); itemType != "message" {
+			t.Fatalf("stateless HTTP retained unpaired output: %s", prepared[0])
+		}
+	})
+}
+
+func dialResponsesWebsocket(t *testing.T, server *httptest.Server) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	return conn
+}
+
+func writeResponsesWebsocketJSON(t *testing.T, conn *websocket.Conn, payload string) {
+	t.Helper()
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(payload)); errWrite != nil {
+		t.Fatalf("write websocket message: %v", errWrite)
+	}
+}
+
+func readResponsesWebsocketMessage(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read websocket response: %v", errRead)
+	}
+}
+
+func waitPrepared(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for xAI prepare")
+	}
+}
+
+func firstInputType(payload []byte) string {
+	return gjson.GetBytes(payload, "input.0.type").String()
+}

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -512,6 +512,10 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexMultiAgentV2Tools(c *gin.Context
 }
 
 func (h *OpenAIResponsesAPIHandler) prepareCodexOrphanDelegation(c *gin.Context, payload []byte) []byte {
+	return h.prepareCodexOrphanDelegationWithPendingToolCallIDs(c, payload, nil)
+}
+
+func (h *OpenAIResponsesAPIHandler) prepareCodexOrphanDelegationWithPendingToolCallIDs(c *gin.Context, payload []byte, pendingToolCallIDs []string) []byte {
 	if h == nil || h.Cfg == nil || !h.Cfg.CodexOrphanDelegationCompatibility {
 		return payload
 	}
@@ -522,7 +526,7 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexOrphanDelegation(c *gin.Context,
 		requestHeaders = c.Request.Header
 	}
 	requestCtx = context.WithValue(requestCtx, "gin", c)
-	return multiagentv2.RewriteCodexOrphanDelegationInput(requestCtx, requestHeaders, payload, true)
+	return multiagentv2.RewriteCodexOrphanDelegationInputWithPendingToolCallIDs(requestCtx, requestHeaders, payload, true, pendingToolCallIDs)
 }
 
 // Responses handles the /v1/responses endpoint.

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -177,6 +177,71 @@ func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
 	}
 }
 
+func TestResponsesWebsocketFallbackRewritesOrphansAfterExpandingHistory(t *testing.T) {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, nil)
+	handler := NewOpenAIResponsesAPIHandler(base)
+	lastRequest := []byte(`{"model":"test-model","input":[{"type":"message","role":"user","content":"start"}]}`)
+
+	for _, tc := range []struct {
+		name               string
+		callID             string
+		lastResponseOutput []byte
+		wantInputTypes     []string
+	}{
+		{
+			name:               "preserves paired output",
+			callID:             "call-pending",
+			lastResponseOutput: []byte(`[{"type":"function_call","call_id":"call-pending","name":"create_thread","namespace":"codex_app"}]`),
+			wantInputTypes:     []string{"message", "function_call", "function_call_output"},
+		},
+		{
+			name:               "rewrites unknown orphan",
+			callID:             "call-unknown",
+			lastResponseOutput: []byte(`[]`),
+			wantInputTypes:     []string{"message", "message"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte(`{
+				"type":"response.create",
+				"previous_response_id":"resp-previous",
+				"input":[{
+					"type":"function_call_output",
+					"call_id":"` + tc.callID + `",
+					"name":"create_thread",
+					"namespace":"codex_app",
+					"output":"completed"
+				}]
+			}`)
+			normalized, _, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(
+				payload,
+				lastRequest,
+				tc.lastResponseOutput,
+				"resp-previous",
+				nil,
+				false,
+				false,
+			)
+			if errMsg != nil {
+				t.Fatalf("normalize fallback request: %v", errMsg.Error)
+			}
+			if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+				t.Fatalf("fallback retained previous_response_id: %s", normalized)
+			}
+			rewritten := handler.prepareCodexOrphanDelegation(nil, normalized)
+			input := gjson.GetBytes(rewritten, "input").Array()
+			if len(input) != len(tc.wantInputTypes) {
+				t.Fatalf("input length = %d, want %d: %s", len(input), len(tc.wantInputTypes), rewritten)
+			}
+			for i, wantType := range tc.wantInputTypes {
+				if gotType := input[i].Get("type").String(); gotType != wantType {
+					t.Fatalf("input.%d.type = %q, want %q: %s", i, gotType, wantType, rewritten)
+				}
+			}
+		})
+	}
+}
+
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients(t *testing.T) {
 	t.Parallel()
 
@@ -287,5 +352,31 @@ func TestResponsesOrphanCodexDelegationCompatibility(t *testing.T) {
 	}
 	if text := parsedWithUnrelatedHeader.Get("input.0.content.0.text").String(); text != wantText {
 		t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
+	}
+
+	incrementalPayload := fmt.Sprintf(`{
+		"model": %q,
+		"stream": false,
+		"previous_response_id": "resp-previous",
+		"input": [{
+			"type": "function_call_output",
+			"call_id": "call-unknown",
+			"name": "create_thread",
+			"namespace": "codex_app",
+			"output": "completed"
+		}]
+	}`, modelID)
+	incrementalRequest := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(incrementalPayload))
+	incrementalRecorder := httptest.NewRecorder()
+	router.ServeHTTP(incrementalRecorder, incrementalRequest)
+	if incrementalRecorder.Code != http.StatusOK {
+		t.Fatalf("incremental status = %d, want 200; body=%s", incrementalRecorder.Code, incrementalRecorder.Body.String())
+	}
+	payloads = executor.Payloads()
+	if len(payloads) != 3 {
+		t.Fatalf("captured payload count = %d, want 3", len(payloads))
+	}
+	if itemType := gjson.GetBytes(payloads[2], "input.0.type").String(); itemType != "function_call_output" {
+		t.Fatalf("ordinary incremental output was rewritten: %s", payloads[2])
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -246,7 +246,6 @@ func TestResponsesOrphanCodexDelegationCompatibility(t *testing.T) {
 	}`, modelID)
 
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(payload))
-	request.Header.Set("X-Openai-Subagent", "collab_spawn")
 	recorder := httptest.NewRecorder()
 	router.ServeHTTP(recorder, request)
 	if recorder.Code != http.StatusOK {
@@ -270,20 +269,23 @@ func TestResponsesOrphanCodexDelegationCompatibility(t *testing.T) {
 		t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
 	}
 
-	// Without X-Openai-Subagent header, payload should remain function_call_output
-	requestNoHeader := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(payload))
-	recorderNoHeader := httptest.NewRecorder()
-	router.ServeHTTP(recorderNoHeader, requestNoHeader)
-	if recorderNoHeader.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", recorderNoHeader.Code, recorderNoHeader.Body.String())
+	requestWithUnrelatedHeader := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(payload))
+	requestWithUnrelatedHeader.Header.Set("X-Openai-Subagent", "other_agent")
+	recorderWithUnrelatedHeader := httptest.NewRecorder()
+	router.ServeHTTP(recorderWithUnrelatedHeader, requestWithUnrelatedHeader)
+	if recorderWithUnrelatedHeader.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorderWithUnrelatedHeader.Code, recorderWithUnrelatedHeader.Body.String())
 	}
 	payloads = executor.Payloads()
 	if len(payloads) != 2 {
 		t.Fatalf("captured payload count = %d, want 2", len(payloads))
 	}
-	capturedNoHeader := payloads[1]
-	parsedNoHeader := gjson.ParseBytes(capturedNoHeader)
-	if itemType := parsedNoHeader.Get("input.0.type").String(); itemType != "function_call_output" {
-		t.Fatalf("input.0.type = %q, want function_call_output without header; captured=%s", itemType, capturedNoHeader)
+	capturedWithUnrelatedHeader := payloads[1]
+	parsedWithUnrelatedHeader := gjson.ParseBytes(capturedWithUnrelatedHeader)
+	if itemType := parsedWithUnrelatedHeader.Get("input.0.type").String(); itemType != "message" {
+		t.Fatalf("input.0.type = %q, want message with unrelated header; captured=%s", itemType, capturedWithUnrelatedHeader)
+	}
+	if text := parsedWithUnrelatedHeader.Get("input.0.content.0.text").String(); text != wantText {
+		t.Fatalf("input.0.content.0.text = %q, want %q", text, wantText)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -376,7 +376,16 @@ func TestResponsesOrphanCodexDelegationCompatibility(t *testing.T) {
 	if len(payloads) != 3 {
 		t.Fatalf("captured payload count = %d, want 3", len(payloads))
 	}
-	if itemType := gjson.GetBytes(payloads[2], "input.0.type").String(); itemType != "function_call_output" {
-		t.Fatalf("ordinary incremental output was rewritten: %s", payloads[2])
+	capturedIncremental := payloads[2]
+	parsedIncremental := gjson.ParseBytes(capturedIncremental)
+	if itemType := parsedIncremental.Get("input.0.type").String(); itemType != "message" {
+		t.Fatalf("ordinary incremental input.0.type = %q, want message; captured=%s", itemType, capturedIncremental)
+	}
+	if role := parsedIncremental.Get("input.0.role").String(); role != "user" {
+		t.Fatalf("ordinary incremental input.0.role = %q, want user; captured=%s", role, capturedIncremental)
+	}
+	wantIncrementalText := "Tool output from codex_app__create_thread:\ncompleted"
+	if text := parsedIncremental.Get("input.0.content.0.text").String(); text != wantIncrementalText {
+		t.Fatalf("ordinary incremental input.0.content.0.text = %q, want %q; captured=%s", text, wantIncrementalText, capturedIncremental)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -534,7 +534,17 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 
 		requestJSON = h.prepareCodexMultiAgentV2Tools(c, requestJSON)
-		requestJSON = h.prepareCodexOrphanDelegation(c, requestJSON)
+		var nextNativePendingToolCallIDs []string
+		if nativeWebsocketPassthrough {
+			requestJSON = h.prepareCodexOrphanDelegationWithPendingToolCallIDs(c, requestJSON, lastResponsePendingToolCallIDs)
+			if requestRequiresCurrentUpstreamWebsocket {
+				nextNativePendingToolCallIDs = consumeResponsesWebsocketPendingToolCallIDs(lastResponsePendingToolCallIDs, requestJSON)
+			} else {
+				nextNativePendingToolCallIDs = nil
+			}
+		} else {
+			requestJSON = h.prepareCodexOrphanDelegation(c, requestJSON)
+		}
 
 		if !useUpstreamWebsocketPassthrough && shouldHandleResponsesWebsocketPrewarmLocally(payload, lastRequest, false) {
 			if updated, errDelete := sjson.DeleteBytes(requestJSON, "generate"); errDelete == nil {
@@ -661,7 +671,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			lastRequest = nil
 			lastResponseOutput = []byte("[]")
 			lastResponseID = ""
-			lastResponsePendingToolCallIDs = nil
+			lastResponsePendingToolCallIDs = mergeResponsesWebsocketPendingToolCallIDs(nextNativePendingToolCallIDs, completedPendingToolCallIDs)
 		} else {
 			upstreamWebsocketAuthID = ""
 			lastRequest = nextLastRequest
@@ -679,6 +689,56 @@ func responsesWebsocketHTTPReplayRequiredError() error {
 func responsesWebsocketRequestRequiresCurrentUpstream(payload []byte) bool {
 	return strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != "" ||
 		strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == wsRequestTypeAppend
+}
+
+func consumeResponsesWebsocketPendingToolCallIDs(pendingToolCallIDs []string, payload []byte) []string {
+	if len(pendingToolCallIDs) == 0 {
+		return nil
+	}
+
+	outputsByCallID := make(map[string]int)
+	input := gjson.GetBytes(payload, "input")
+	if input.IsArray() {
+		for _, item := range input.Array() {
+			switch item.Get("type").String() {
+			case "function_call_output", "custom_tool_call_output":
+			default:
+				continue
+			}
+			callID := item.Get("call_id").String()
+			if strings.TrimSpace(callID) != "" {
+				outputsByCallID[callID]++
+			}
+		}
+	}
+
+	remaining := make([]string, 0, len(pendingToolCallIDs))
+	for _, callID := range pendingToolCallIDs {
+		if outputsByCallID[callID] > 0 {
+			outputsByCallID[callID]--
+			continue
+		}
+		remaining = append(remaining, callID)
+	}
+	return remaining
+}
+
+func mergeResponsesWebsocketPendingToolCallIDs(pendingToolCallIDs []string, completedToolCallIDs []string) []string {
+	seen := make(map[string]struct{}, len(pendingToolCallIDs)+len(completedToolCallIDs))
+	merged := make([]string, 0, len(pendingToolCallIDs)+len(completedToolCallIDs))
+	for _, callIDs := range [][]string{pendingToolCallIDs, completedToolCallIDs} {
+		for _, callID := range callIDs {
+			if strings.TrimSpace(callID) == "" {
+				continue
+			}
+			if _, exists := seen[callID]; exists {
+				continue
+			}
+			seen[callID] = struct{}{}
+			merged = append(merged, callID)
+		}
+	}
+	return merged
 }
 
 func responsesWebsocketNativePassthroughAllowed(upstreamMode string, useUpstreamWebsocket bool, pinnedAuthID string, upstreamAuthID string) bool {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -536,7 +536,11 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		requestJSON = h.prepareCodexMultiAgentV2Tools(c, requestJSON)
 		var nextNativePendingToolCallIDs []string
 		if nativeWebsocketPassthrough {
-			requestJSON = h.prepareCodexOrphanDelegationWithPendingToolCallIDs(c, requestJSON, lastResponsePendingToolCallIDs)
+			pendingToolCallIDs := []string(nil)
+			if requestRequiresCurrentUpstreamWebsocket {
+				pendingToolCallIDs = lastResponsePendingToolCallIDs
+			}
+			requestJSON = h.prepareCodexOrphanDelegationWithPendingToolCallIDs(c, requestJSON, pendingToolCallIDs)
 			if requestRequiresCurrentUpstreamWebsocket {
 				nextNativePendingToolCallIDs = consumeResponsesWebsocketPendingToolCallIDs(lastResponsePendingToolCallIDs, requestJSON)
 			} else {

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/optimize-multi-agent-v2"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -535,12 +536,14 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 
 		requestJSON = h.prepareCodexMultiAgentV2Tools(c, requestJSON)
 		var nextNativePendingToolCallIDs []string
+		var executorPendingToolCallIDs []string
 		if nativeWebsocketPassthrough {
 			pendingToolCallIDs := []string(nil)
 			if requestRequiresCurrentUpstreamWebsocket {
 				pendingToolCallIDs = lastResponsePendingToolCallIDs
 			}
 			requestJSON = h.prepareCodexOrphanDelegationWithPendingToolCallIDs(c, requestJSON, pendingToolCallIDs)
+			executorPendingToolCallIDs = pendingToolCallIDs
 			if requestRequiresCurrentUpstreamWebsocket {
 				nextNativePendingToolCallIDs = consumeResponsesWebsocketPendingToolCallIDs(lastResponsePendingToolCallIDs, requestJSON)
 			} else {
@@ -584,6 +587,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		attemptedUpstreamMode := responsesWebsocketUpstreamModeUnknown
 		selectedAuthObserved := false
 		pinnedAuthAttempted := false
+		executionParent = multiagentv2.WithPendingToolCallIDs(executionParent, executorPendingToolCallIDs)
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, executionParent)
 		cliCtx = cliproxyexecutor.WithDownstreamWebsocket(cliCtx)
 		if nativeWebsocketPassthrough && requestRequiresCurrentUpstreamWebsocket {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -3405,6 +3405,81 @@ func TestResponsesWebsocketNativePreservesPendingDelegationOutputOnAppend(t *tes
 	}
 }
 
+func TestResponsesWebsocketNativeResetRewritesStalePendingDelegationOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketDirectCaptureExecutor{
+		done: make(chan struct{}),
+		responseOutputs: [][]byte{
+			[]byte(`[{"type":"function_call","call_id":"call-pending","name":"create_thread","namespace":"codex_app","arguments":"{}"}]`),
+			[]byte(`[]`),
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-native-reset",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	const modelName = "native-reset-model"
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelName}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, manager)
+	handler := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", handler.ResponsesWebsocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() { _ = conn.Close() }()
+
+	firstRequest := fmt.Sprintf(`{"type":"response.create","model":%q,"input":[{"type":"message","role":"user","content":"start"}]}`, modelName)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(firstRequest)); errWrite != nil {
+		t.Fatalf("write first request: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read first response: %v", errRead)
+	}
+
+	resetRequest := `{"type":"response.create","input":[{"type":"function_call_output","call_id":"call-pending","name":"create_thread","namespace":"codex_app","output":"completed"}]}`
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(resetRequest)); errWrite != nil {
+		t.Fatalf("write reset request: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read reset response: %v", errRead)
+	}
+
+	select {
+	case <-executor.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for native reset")
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 2 {
+		t.Fatalf("captured payload count = %d, want 2", len(payloads))
+	}
+	if itemType := gjson.GetBytes(payloads[1], "input.0.type").String(); itemType != "message" {
+		t.Fatalf("self-contained reset retained stale function output: %s", payloads[1])
+	}
+	if required := executor.RequiredUpstreamWebsocketFlags(); len(required) != 2 || required[1] {
+		t.Fatalf("required upstream websocket flags = %v, want second request false", required)
+	}
+}
+
 func TestResponsesWebsocketNativeRetryPreservesPendingDelegationOutput(t *testing.T) {
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -675,6 +675,7 @@ type websocketDirectCaptureExecutor struct {
 	mu                        sync.Mutex
 	provider                  string
 	failStatus                int
+	responseOutputs           [][]byte
 	authIDs                   []string
 	models                    []string
 	payloads                  [][]byte
@@ -799,7 +800,11 @@ func (e *websocketDirectCaptureExecutor) ExecuteStream(ctx context.Context, auth
 		return &coreexecutor.StreamResult{Chunks: chunks}, nil
 	}
 	responseID := fmt.Sprintf("resp-%d", count)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"output":[{"type":"message","id":"out-%d"}]}}`, responseID, count))}
+	responseOutput := []byte(fmt.Sprintf(`[{"type":"message","id":"out-%d"}]`, count))
+	if count <= len(e.responseOutputs) {
+		responseOutput = e.responseOutputs[count-1]
+	}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"output":%s}}`, responseID, responseOutput))}
 	close(chunks)
 	if count >= 2 && e.done != nil {
 		e.doneOnce.Do(func() {
@@ -3322,6 +3327,123 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 	authIDs := executor.AuthIDs()
 	if len(authIDs) != 2 || authIDs[0] != "auth-ws" || authIDs[1] != "auth-ws" {
 		t.Fatalf("passthrough auth IDs = %v, want [auth-ws auth-ws]", authIDs)
+	}
+}
+
+func TestResponsesWebsocketNativePreservesPendingDelegationOutputOnAppend(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &websocketDirectCaptureExecutor{
+		done: make(chan struct{}),
+		responseOutputs: [][]byte{
+			[]byte(`[{"type":"function_call","call_id":"call-pending","name":"create_thread","namespace":"codex_app","arguments":"{}"}]`),
+			[]byte(`[]`),
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{
+		ID:         "auth-native-pending",
+		Provider:   "codex",
+		Status:     coreauth.StatusActive,
+		Attributes: map[string]string{"websockets": "true"},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	const modelName = "native-pending-model"
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelName}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, manager)
+	handler := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.GET("/v1/responses/ws", handler.ResponsesWebsocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses/ws"
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() { _ = conn.Close() }()
+
+	firstRequest := fmt.Sprintf(`{"type":"response.create","model":%q,"input":[{"type":"message","role":"user","content":"start"}]}`, modelName)
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(firstRequest)); errWrite != nil {
+		t.Fatalf("write first request: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read first response: %v", errRead)
+	}
+
+	appendRequest := `{"type":"response.append","input":[{"type":"function_call_output","call_id":"call-pending","name":"create_thread","namespace":"codex_app","output":"completed"}]}`
+	if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(appendRequest)); errWrite != nil {
+		t.Fatalf("write append request: %v", errWrite)
+	}
+	if _, _, errRead := conn.ReadMessage(); errRead != nil {
+		t.Fatalf("read append response: %v", errRead)
+	}
+
+	select {
+	case <-executor.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for native append")
+	}
+
+	payloads := executor.Payloads()
+	if len(payloads) != 2 {
+		t.Fatalf("captured payload count = %d, want 2", len(payloads))
+	}
+	if itemType := gjson.GetBytes(payloads[1], "input.0.type").String(); itemType != "function_call_output" {
+		t.Fatalf("native append output was rewritten: %s", payloads[1])
+	}
+	if required := executor.RequiredUpstreamWebsocketFlags(); len(required) != 2 || !required[1] {
+		t.Fatalf("required upstream websocket flags = %v, want second request true", required)
+	}
+}
+
+func TestResponsesWebsocketNativeRetryPreservesPendingDelegationOutput(t *testing.T) {
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOrphanDelegationCompatibility: true}, nil)
+	handler := NewOpenAIResponsesAPIHandler(base)
+	pending := []string{"call-pending"}
+	appendRequest := []byte(`{"type":"response.append","input":[{"type":"function_call_output","call_id":"call-pending","name":"create_thread","namespace":"codex_app","output":"completed"}]}`)
+
+	firstAttempt := handler.prepareCodexOrphanDelegationWithPendingToolCallIDs(nil, appendRequest, pending)
+	if itemType := gjson.GetBytes(firstAttempt, "input.0.type").String(); itemType != "function_call_output" {
+		t.Fatalf("first native append output was rewritten: %s", firstAttempt)
+	}
+	candidate := consumeResponsesWebsocketPendingToolCallIDs(pending, firstAttempt)
+	if len(candidate) != 0 {
+		t.Fatalf("successful-submit candidate = %v, want empty", candidate)
+	}
+
+	// An upstream failure exits before the candidate is committed, so retrying
+	// with the current connection state must retain the original association.
+	retryAttempt := handler.prepareCodexOrphanDelegationWithPendingToolCallIDs(nil, appendRequest, pending)
+	if itemType := gjson.GetBytes(retryAttempt, "input.0.type").String(); itemType != "function_call_output" {
+		t.Fatalf("retried native append output was rewritten: %s", retryAttempt)
+	}
+
+	pending = mergeResponsesWebsocketPendingToolCallIDs(candidate, nil)
+	if len(pending) != 0 {
+		t.Fatalf("successful submit retained consumed pending ids: %v", pending)
+	}
+}
+
+func TestConsumeResponsesWebsocketPendingToolCallIDs(t *testing.T) {
+	pending := []string{"call-first", "call-second", "call-custom", "call-first"}
+	payload := []byte(`{"input":[
+		{"type":"function_call_output","call_id":"call-first"},
+		{"type":"custom_tool_call_output","call_id":"call-custom"},
+		{"type":"function_call_output","call_id":"call-first"}
+	]}`)
+
+	remaining := consumeResponsesWebsocketPendingToolCallIDs(pending, payload)
+	if len(remaining) != 1 || remaining[0] != "call-second" {
+		t.Fatalf("remaining pending call ids = %v, want [call-second]", remaining)
 	}
 }
 


### PR DESCRIPTION
## Summary

Opt-in compatibility rewrite for orphan Codex App `function_call_output` items, without requiring `X-Openai-Subagent: collab_spawn`.

When `codex.orphan-delegation-compatibility` is enabled (default off):

- Rewrite unpaired `codex_app` outputs from `create_thread`, `send_message_to_thread`, and `automation_update` into labeled user messages.
- Keep same-request `function_call` / `function_call_output` pairs unchanged.
- On native WebSocket continuations, keep outputs that match real pending-call IDs from the current upstream session. That pairing decision is stored on the request context so later executor/translator passes (including xAI WebSocket) do not undo it.
- Stateless HTTP does not treat `previous_response_id` plus a nonempty `call_id` as proof of pairing. Those outputs are rewritten so Responses-to-Chat paths such as Kimi cannot emit a bare `role: "tool"` message.

## Update

`706131bd` adds native coverage for the same heartbeat path the `cpa-codex-app-multisession-compat` plugin added in v0.2.4.

Codex App scheduled automations inject `codex_app` / `automation_update` `function_call_output` items. Heartbeats usually have no matching `function_call` in the current request, and often no `call_id`. With the compatibility switch on, those unpaired outputs are rewritten to a labeled user message (`Tool output from codex_app__automation_update:`) instead of being forwarded as a bare tool result.

The same commit keeps verified native WebSocket pending-call IDs on the request context, so xAI translation cannot undo a continuation the handler already paired. HTTP still does not treat `previous_response_id` as pairing proof.

`df28a4ad` covers that handler-to-xAI prepare path: a native WebSocket continuation keeps the pending output after `prepareResponsesWebsocketRequest`; a self-contained reset and a stateless HTTP `previous_response_id` request still rewrite. Disconnecting `WithPendingToolCallIDs` makes the continuation case fail.

## Related issue

- #5401

## Tests

- `go test ./internal/runtime/executor -run TestXAIHandlerPendingDelegationThroughExecutorPrepare`
- `go test ./...`
- `go build -o test-output ./cmd/server`