### PR TITLE
feat(provider): add CodeBuddy CN (WorkBuddy CN) provider support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -81,6 +81,7 @@ func main() {
 	var antigravityLogin bool
 	var kimiLogin bool
 	var xaiLogin bool
+	var codebuddyCnLogin bool
 	var vertexImport string
 	var vertexImportPrefix string
 	var configPath string
@@ -100,6 +101,7 @@ func main() {
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
 	flag.BoolVar(&kimiLogin, "kimi-login", false, "Login to Kimi using OAuth")
 	flag.BoolVar(&xaiLogin, "xai-login", false, "Login to xAI using OAuth")
+	flag.BoolVar(&codebuddyCnLogin, "codebuddy-cn-login", false, "Login to CodeBuddy CN (WorkBuddy) using OAuth")
 	flag.StringVar(&configPath, "config", DefaultConfigPath, "Configure File Path")
 	flag.StringVar(&vertexImport, "vertex-import", "", "Import Vertex service account key JSON file")
 	flag.StringVar(&vertexImportPrefix, "vertex-import-prefix", "", "Prefix for Vertex model namespacing (use with -vertex-import)")
@@ -588,7 +590,7 @@ func main() {
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin || codebuddyCnLogin
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -662,6 +664,9 @@ func main() {
 		cmd.DoKimiLogin(cfg, options)
 	} else if xaiLogin {
 		cmd.DoXAILogin(cfg, options)
+	} else if codebuddyCnLogin {
+		// Handle CodeBuddy (WorkBuddy) login
+		cmd.DoCodeBuddyLogin(cfg, options)
 	} else {
 		// In cloud deploy mode without config file, just wait for shutdown signals
 		if isCloudDeploy && !configFileExists {

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -71,6 +71,8 @@ type apiCallResponse struct {
 //     2) attributes.api_key
 //     3) metadata.token / metadata.id_token / metadata.cookie
 //     Example: {"Authorization":"Bearer $TOKEN$"}.
+//     Also supports magic variable "$UID$" which is replaced with metadata.uid
+//     (used by providers whose upstream APIs require the account UID, e.g. CodeBuddy CN billing).
 //     Note: if you need to override the HTTP Host header, set header["Host"].
 //   - data (optional): Raw request body as string (useful for POST/PUT/PATCH).
 //
@@ -160,6 +162,23 @@ func (h *Handler) APICall(c *gin.Context) {
 			continue
 		}
 		reqHeaders[key] = strings.ReplaceAll(value, "$TOKEN$", token)
+	}
+
+	for key, value := range reqHeaders {
+		if !strings.Contains(value, "$UID$") {
+			continue
+		}
+		uid := ""
+		if auth != nil && auth.Metadata != nil {
+			if raw, ok := auth.Metadata["uid"].(string); ok {
+				uid = strings.TrimSpace(raw)
+			}
+		}
+		if uid == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "auth uid not found"})
+			return
+		}
+		reqHeaders[key] = strings.ReplaceAll(value, "$UID$", uid)
 	}
 
 	var requestBody io.Reader

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/antigravity"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
+	codebuddyauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
@@ -735,6 +736,129 @@ func watchOAuthSessionCancel(pollCtx context.Context, cancel context.CancelFunc,
 			}
 		}
 	}
+}
+
+func (h *Handler) RequestCodeBuddyToken(c *gin.Context) {
+	ctx := context.Background()
+	ctx = PopulateAuthContext(ctx, c)
+
+	fmt.Println("Initializing CodeBuddy (WorkBuddy) authentication...")
+
+	client := codebuddyauth.NewClient(h.cfg, "")
+	stateResult, errFetchState := client.FetchState(ctx)
+	if errFetchState != nil {
+		log.Errorf("Failed to generate CodeBuddy authorization URL: %v", errFetchState)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to generate authorization url"})
+		return
+	}
+	state := stateResult.State
+	authURL := stateResult.AuthURL
+
+	RegisterOAuthSession(state, "codebuddy-cn")
+
+	go func() {
+		pollCtx, cancelPoll := context.WithCancel(ctx)
+		defer cancelPoll()
+		go watchOAuthSessionCancel(pollCtx, cancelPoll, state, "codebuddy-cn")
+
+		fmt.Println("Waiting for CodeBuddy authorization...")
+		token, errWaitForAuthorization := client.WaitForToken(pollCtx, state)
+		if errWaitForAuthorization != nil {
+			if !IsOAuthSessionPending(state, "codebuddy-cn") {
+				return
+			}
+			SetOAuthSessionError(state, oauthSessionErrorWithCause("Authentication failed", errWaitForAuthorization))
+			fmt.Printf("Authentication failed: %v\n", errWaitForAuthorization)
+			return
+		}
+		if !IsOAuthSessionPending(state, "codebuddy-cn") {
+			return
+		}
+
+		// Account info and available models are optional extras.
+		account, accErr := client.GetAccountInfo(pollCtx, token.AccessToken, state)
+		if accErr != nil {
+			log.Warnf("codebuddy-cn: failed to fetch account info: %v", accErr)
+			account = nil
+		}
+		var models []codebuddyauth.ModelInfo
+		if configData, cfgErr := client.FetchConfig(pollCtx, token.AccessToken, accountUIDValue(account)); cfgErr != nil {
+			log.Warnf("codebuddy-cn: failed to fetch model config: %v", cfgErr)
+		} else if parsed, parseErr := codebuddyauth.ParseModels(configData); parseErr != nil {
+			log.Warnf("codebuddy-cn: failed to parse model config: %v", parseErr)
+		} else {
+			models = parsed
+		}
+
+		tokenStorage := codebuddyauth.BuildTokenStorage(token, account, models)
+
+		metadata := map[string]any{
+			"type":          "codebuddy-cn",
+			"access_token":  tokenStorage.AccessToken,
+			"refresh_token": tokenStorage.RefreshToken,
+			"token_type":    tokenStorage.TokenType,
+			"timestamp":     time.Now().UnixMilli(),
+		}
+		if tokenStorage.Scope != "" {
+			metadata["scope"] = tokenStorage.Scope
+		}
+		if tokenStorage.Domain != "" {
+			metadata["domain"] = tokenStorage.Domain
+		}
+		if tokenStorage.UID != "" {
+			metadata["uid"] = tokenStorage.UID
+		}
+		if tokenStorage.Nickname != "" {
+			metadata["nickname"] = tokenStorage.Nickname
+		}
+		if tokenStorage.Expired != "" {
+			metadata["expired"] = tokenStorage.Expired
+		}
+		if len(tokenStorage.EnabledModels) > 0 {
+			metadata["enabled_models"] = tokenStorage.EnabledModels
+		}
+		if tokenStorage.ModelsMeta != "" {
+			metadata["models_meta"] = tokenStorage.ModelsMeta
+		}
+
+		fileName := fmt.Sprintf("codebuddy-cn-%d.json", time.Now().UnixMilli())
+		label := "CodeBuddy User"
+		if nickname := strings.TrimSpace(tokenStorage.Nickname); nickname != "" {
+			label = nickname
+		}
+		record := &coreauth.Auth{
+			ID:       fileName,
+			Provider: "codebuddy-cn",
+			FileName: fileName,
+			Label:    label,
+			Storage:  tokenStorage,
+			Metadata: metadata,
+		}
+		if errGuard := guardOAuthSessionPendingForSave(state, "codebuddy-cn"); errGuard != nil {
+			return
+		}
+		savedPath, errSave := h.saveTokenRecord(ctx, record)
+		if errSave != nil {
+			log.Errorf("Failed to save authentication tokens: %v", errSave)
+			SetOAuthSessionError(state, "Failed to save authentication tokens")
+			return
+		}
+
+		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
+		fmt.Println("You can now use CodeBuddy (WorkBuddy) services through this CLI")
+		CompleteOAuthSession(state)
+	}()
+
+	response := gin.H{"status": "ok", "url": authURL, "state": state, "flow": "codebuddy-cn"}
+	c.JSON(200, response)
+}
+
+// accountUIDValue returns the account UID used for the /v3/config X-User-Id header.
+func accountUIDValue(account *codebuddyauth.AccountInfo) string {
+	if account == nil {
+		return ""
+	}
+	return account.UID
 }
 
 // CancelAuthSession cancels a pending OAuth session identified by state.

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -178,6 +178,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
+		mgmt.GET("/codebuddy-cn-auth-url", s.mgmt.RequestCodeBuddyToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)
 	}

--- a/internal/auth/codebuddy/codebuddy.go
+++ b/internal/auth/codebuddy/codebuddy.go
@@ -1,0 +1,406 @@
+// Package codebuddy provides authentication and token management for the
+// Tencent CodeBuddy (WorkBuddy) copilot service. The upstream exposes an
+// OpenAI-compatible chat completions endpoint and a state-based plugin auth
+// flow (state generation, browser authorization, state-to-token exchange,
+// refresh token rotation).
+package codebuddy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultBaseURL is the default upstream base URL of the CodeBuddy copilot API.
+	DefaultBaseURL = "https://copilot.tencent.com"
+	// DefaultDomain is the X-Domain header value used by login-state endpoints.
+	DefaultDomain = "www.codebuddy.cn"
+	// PlatformDomain is the X-Domain header value used by plugin and inference endpoints.
+	PlatformDomain = "copilot.tencent.com"
+
+	// PluginAuthStatePath is the endpoint path for generating an auth state.
+	PluginAuthStatePath = "/v2/plugin/auth/state"
+	// PluginAuthTokenPath is the endpoint path for exchanging a state for tokens.
+	PluginAuthTokenPath = "/v2/plugin/auth/token"
+	// PluginAuthTokenRefreshPath is the endpoint path for refreshing tokens.
+	PluginAuthTokenRefreshPath = "/v2/plugin/auth/token/refresh"
+	// LoginAccountPath is the endpoint path for account information.
+	LoginAccountPath = "/v2/plugin/login/account"
+	// ConfigPath is the endpoint path for the user config (available models).
+	ConfigPath = "/v3/config"
+
+	// ChatCompletionsPath is the OpenAI-compatible chat completions endpoint path.
+	ChatCompletionsPath = "/v2/chat/completions"
+
+	// AuthSourcePlugin is the X-Auth-Refresh-Source header value required by the refresh endpoint.
+	AuthSourcePlugin = "plugin"
+	// PlatformWorkBuddy is the platform query parameter used when generating an auth state.
+	PlatformWorkBuddy = "workbuddy"
+
+	// ClientUserAgent is the User-Agent expected by the CodeBuddy upstream.
+	ClientUserAgent = "WorkBuddy/5.2.5 WorkBuddy/5.2.5 CLI/2.106.4"
+
+	// defaultAccessTokenTTL is used when the upstream omits expiresIn.
+	defaultAccessTokenTTL = 24 * time.Hour
+	// pollInterval is the delay between token exchange attempts while waiting for authorization.
+	pollInterval = 3 * time.Second
+	// maxPollDuration bounds the total wait for user authorization.
+	maxPollDuration = 15 * time.Minute
+)
+
+// TokenResponse represents the token payload returned by the token and refresh
+// endpoints. CodeBuddy returns camelCase JSON fields.
+type TokenResponse struct {
+	AccessToken      string `json:"accessToken,omitempty"`
+	ExpiresIn        int64  `json:"expiresIn,omitempty"`
+	RefreshExpiresIn int64  `json:"refreshExpiresIn,omitempty"`
+	RefreshToken     string `json:"refreshToken,omitempty"`
+	TokenType        string `json:"tokenType,omitempty"`
+	SessionState     string `json:"sessionState,omitempty"`
+	// Domain is the user domain identifier returned by the token endpoint.
+	Domain string `json:"domain,omitempty"`
+	// Scope is the authorization scope returned by the token endpoint.
+	Scope string `json:"scope,omitempty"`
+}
+
+// StateResult is the data payload of the auth state response.
+type StateResult struct {
+	State   string `json:"state"`
+	AuthURL string `json:"authUrl"`
+	Domain  string `json:"domain,omitempty"`
+}
+
+// AccountInfo is the account information payload (only fields the gateway needs).
+type AccountInfo struct {
+	UID         string `json:"uid"`
+	Nickname    string `json:"nickname"`
+	Type        string `json:"type"`
+	UIN         string `json:"uin"`
+	PhoneNumber string `json:"phoneNumber"`
+}
+
+// envelope is the unified {code, msg, data} response wrapper.
+type envelope struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+// BuildAuthStateURL returns the auth state generation URL.
+func BuildAuthStateURL(baseURL string) string {
+	return effectiveBaseURL(baseURL) + PluginAuthStatePath
+}
+
+// BuildAuthTokenURL returns the state-to-token exchange URL.
+func BuildAuthTokenURL(baseURL, state string) string {
+	return effectiveBaseURL(baseURL) + PluginAuthTokenPath + "?state=" + state
+}
+
+// BuildAuthTokenRefreshURL returns the token refresh URL.
+func BuildAuthTokenRefreshURL(baseURL string) string {
+	return effectiveBaseURL(baseURL) + PluginAuthTokenRefreshPath
+}
+
+// BuildLoginAccountURL returns the account information URL.
+func BuildLoginAccountURL(baseURL, state string) string {
+	return effectiveBaseURL(baseURL) + LoginAccountPath + "?state=" + state
+}
+
+// BuildConfigURL returns the user config URL.
+func BuildConfigURL(baseURL string) string {
+	return effectiveBaseURL(baseURL) + ConfigPath
+}
+
+// BuildChatCompletionsURL returns the chat completions URL.
+func BuildChatCompletionsURL(baseURL string) string {
+	return effectiveBaseURL(baseURL) + ChatCompletionsPath
+}
+
+// effectiveBaseURL normalizes a base URL override and falls back to the default.
+func effectiveBaseURL(override string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(override), "/")
+	if trimmed == "" {
+		return DefaultBaseURL
+	}
+	return trimmed
+}
+
+// Client talks to the CodeBuddy auth endpoints.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient creates a CodeBuddy auth client. proxyURL, when non-empty, takes
+// precedence over cfg.ProxyURL.
+func NewClient(cfg *config.Config, proxyURL string) *Client {
+	client := &http.Client{}
+	effectiveProxyURL := strings.TrimSpace(proxyURL)
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+		if effectiveProxyURL == "" {
+			effectiveProxyURL = strings.TrimSpace(cfg.ProxyURL)
+		}
+	}
+	sdkCfg.ProxyURL = effectiveProxyURL
+	util.SetProxy(&sdkCfg, client)
+	return &Client{
+		httpClient: client,
+		baseURL:    DefaultBaseURL,
+	}
+}
+
+// decodeEnvelope reads an HTTP response and unwraps the {code, msg, data} envelope.
+func (c *Client) decodeEnvelope(resp *http.Response, action string) (json.RawMessage, error) {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return nil, fmt.Errorf("codebuddy %s: HTTP %d: %s", action, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy %s: read response: %w", action, err)
+	}
+	var env envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("codebuddy %s: invalid json: %w", action, err)
+	}
+	if env.Code != 0 {
+		return nil, fmt.Errorf("codebuddy %s: code=%d msg=%s", action, env.Code, env.Msg)
+	}
+	return env.Data, nil
+}
+
+// FetchState generates a fresh auth state and authorization URL.
+func (c *Client) FetchState(ctx context.Context) (*StateResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, BuildAuthStateURL(c.baseURL)+"?platform="+PlatformWorkBuddy, strings.NewReader("{}"))
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy: build state request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Domain", PlatformDomain)
+	req.Header.Set("X-No-Authorization", "true")
+	req.Header.Set("X-No-User-Id", "true")
+	req.Header.Set("X-No-Enterprise-Id", "true")
+	req.Header.Set("X-No-Department-Info", "true")
+	req.Header.Set("X-Product", "SaaS")
+	req.Header.Set("User-Agent", ClientUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy state request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy state: close body error: %v", errClose)
+		}
+	}()
+	data, err := c.decodeEnvelope(resp, "fetch state")
+	if err != nil {
+		return nil, err
+	}
+	var result StateResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("codebuddy: decode state: %w", err)
+	}
+	if strings.TrimSpace(result.State) == "" || strings.TrimSpace(result.AuthURL) == "" {
+		return nil, fmt.Errorf("codebuddy: invalid state response")
+	}
+	return &result, nil
+}
+
+// FetchToken exchanges a state for tokens. A non-zero envelope code usually
+// means the user has not finished browser authorization yet.
+func (c *Client) FetchToken(ctx context.Context, state string) (*TokenResponse, error) {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return nil, fmt.Errorf("codebuddy: state is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, BuildAuthTokenURL(c.baseURL, state), nil)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy: build token request: %w", err)
+	}
+	req.Header.Set("X-No-Authorization", "true")
+	req.Header.Set("X-No-User-Id", "true")
+	req.Header.Set("X-No-Enterprise-Id", "true")
+	req.Header.Set("X-No-Department-Info", "true")
+	req.Header.Set("X-Product", "SaaS")
+	req.Header.Set("User-Agent", ClientUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy token request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy token: close body error: %v", errClose)
+		}
+	}()
+	data, err := c.decodeEnvelope(resp, "fetch token")
+	if err != nil {
+		return nil, err
+	}
+	var token TokenResponse
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("codebuddy: decode token: %w", err)
+	}
+	if strings.TrimSpace(token.AccessToken) == "" {
+		return nil, fmt.Errorf("codebuddy: empty access token in response")
+	}
+	return &token, nil
+}
+
+// WaitForToken polls the token endpoint until the user completes browser
+// authorization or the deadline expires. This is part of credential
+// acquisition, so a bounded wait is allowed here.
+func (c *Client) WaitForToken(ctx context.Context, state string) (*TokenResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deadline := time.Now().Add(maxPollDuration)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		token, err := c.FetchToken(ctx, state)
+		if err == nil {
+			return token, nil
+		}
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("codebuddy: context cancelled: %w", ctx.Err())
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("codebuddy: timed out waiting for authorization: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("codebuddy: context cancelled: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// GetAccountInfo returns the account information for a state that has been authorized.
+func (c *Client) GetAccountInfo(ctx context.Context, accessToken, state string) (*AccountInfo, error) {
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("codebuddy: access token is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, BuildLoginAccountURL(c.baseURL, strings.TrimSpace(state)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy: build account request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-Domain", DefaultDomain)
+	req.Header.Set("X-No-User-Id", "true")
+	req.Header.Set("X-No-Enterprise-Id", "true")
+	req.Header.Set("X-No-Department-Info", "true")
+	req.Header.Set("User-Agent", ClientUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy account request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy account: close body error: %v", errClose)
+		}
+	}()
+	data, err := c.decodeEnvelope(resp, "get account")
+	if err != nil {
+		return nil, err
+	}
+	var info AccountInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("codebuddy: decode account: %w", err)
+	}
+	return &info, nil
+}
+
+// FetchConfig returns the raw data payload of the /v3/config endpoint, which
+// contains the models available to the account.
+func (c *Client) FetchConfig(ctx context.Context, accessToken, userID string) ([]byte, error) {
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("codebuddy: access token is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, BuildConfigURL(c.baseURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy: build config request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-Domain", DefaultDomain)
+	req.Header.Set("X-Product", "SaaS")
+	req.Header.Set("User-Agent", ClientUserAgent)
+	if userID = strings.TrimSpace(userID); userID != "" {
+		req.Header.Set("X-User-Id", userID)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy config request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy config: close body error: %v", errClose)
+		}
+	}()
+	return c.decodeEnvelope(resp, "get config")
+}
+
+// RefreshToken exchanges a refresh token for a new token pair.
+func (c *Client) RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return nil, fmt.Errorf("codebuddy: refresh token is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, BuildAuthTokenRefreshURL(c.baseURL), strings.NewReader("{}"))
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy: build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Domain", DefaultDomain)
+	req.Header.Set("X-Refresh-Token", refreshToken)
+	req.Header.Set("X-Auth-Refresh-Source", AuthSourcePlugin)
+	req.Header.Set("Authorization", "Bearer "+refreshToken)
+	req.Header.Set("User-Agent", ClientUserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy refresh request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy refresh: close body error: %v", errClose)
+		}
+	}()
+	data, err := c.decodeEnvelope(resp, "refresh token")
+	if err != nil {
+		return nil, err
+	}
+	var token TokenResponse
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("codebuddy: decode refresh response: %w", err)
+	}
+	if strings.TrimSpace(token.AccessToken) == "" {
+		return nil, fmt.Errorf("codebuddy: empty access token in refresh response")
+	}
+	return &token, nil
+}
+
+// ExpiresAt converts a token response into an absolute expiry timestamp.
+func (t *TokenResponse) ExpiresAt() int64 {
+	expiresIn := t.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = int64(defaultAccessTokenTTL.Seconds())
+	}
+	return time.Now().Unix() + expiresIn
+}

--- a/internal/auth/codebuddy/headers.go
+++ b/internal/auth/codebuddy/headers.go
@@ -1,0 +1,73 @@
+package codebuddy
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GenerateRequestUUID returns a random RFC 4122 v4 style UUID for the
+// X-Conversation-* / X-Request-ID headers. The official WorkBuddy client sends
+// fresh values on every request and the upstream does not correlate them.
+func GenerateRequestUUID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// GenerateHexID returns an n-byte random hex string for trace headers
+// (16-byte trace id, 8-byte span id). Values are per-request random.
+func GenerateHexID(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}
+
+// ApplyChatHeaders sets the session and identity headers the CodeBuddy chat
+// endpoint requires. Without them the upstream routes the request through the
+// strictest content-safety path and rejects otherwise harmless input.
+func ApplyChatHeaders(req *http.Request, uid string) {
+	req.Header.Set("X-Conversation-ID", GenerateRequestUUID())
+	req.Header.Set("X-Conversation-Request-ID", GenerateRequestUUID())
+	req.Header.Set("X-Conversation-Message-ID", GenerateRequestUUID())
+	req.Header.Set("X-Request-ID", GenerateRequestUUID())
+	req.Header.Set("X-Agent-Intent", "craft")
+	req.Header.Set("X-Agent-Purpose", "conversation_topic")
+	req.Header.Set("X-IDE-Type", "WorkBuddy")
+	req.Header.Set("X-IDE-Name", "WorkBuddy")
+	req.Header.Set("X-IDE-Version", "5.2.5")
+	req.Header.Set("X-Private-Data", "false")
+	req.Header.Set("X-Domain", DefaultDomain)
+	req.Header.Set("X-Product", "SaaS")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.Header.Set("User-Agent", ClientUserAgent)
+	if uid = strings.TrimSpace(uid); uid != "" {
+		req.Header.Set("X-User-Id", uid)
+	}
+	// Stainless and trace headers identify the SDK origin and tracing context.
+	// Random parts (trace/span ids) are regenerated per request.
+	req.Header.Set("x-stainless-arch", "arm64")
+	req.Header.Set("x-stainless-lang", "js")
+	req.Header.Set("x-stainless-os", "MacOS")
+	req.Header.Set("x-stainless-package-version", "6.25.0")
+	req.Header.Set("x-stainless-retry-count", "0")
+	req.Header.Set("x-stainless-runtime", "node")
+	req.Header.Set("x-stainless-runtime-version", "v22.21.1")
+	traceID := GenerateHexID(16)
+	spanID := GenerateHexID(8)
+	req.Header.Set("traceparent", "00-"+traceID+"-"+spanID+"-01")
+	req.Header.Set("b3", traceID+"-"+spanID+"-1")
+	req.Header.Set("X-B3-TraceId", traceID)
+	req.Header.Set("X-B3-SpanId", spanID)
+	req.Header.Set("X-B3-Sampled", "1")
+	req.Header.Set("X-Trace-ID", traceID)
+}

--- a/internal/auth/codebuddy/headers_test.go
+++ b/internal/auth/codebuddy/headers_test.go
@@ -1,0 +1,97 @@
+package codebuddy
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+func TestGenerateRequestUUIDFormat(t *testing.T) {
+	uuidPattern := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	for i := 0; i < 32; i++ {
+		value := GenerateRequestUUID()
+		if !uuidPattern.MatchString(value) {
+			t.Fatalf("unexpected UUID format: %q", value)
+		}
+	}
+	if GenerateRequestUUID() == GenerateRequestUUID() {
+		t.Fatal("expected unique UUIDs")
+	}
+}
+
+func TestGenerateHexIDLength(t *testing.T) {
+	if got := GenerateHexID(16); len(got) != 32 {
+		t.Fatalf("GenerateHexID(16) length = %d, want 32", len(got))
+	}
+	if got := GenerateHexID(8); len(got) != 16 {
+		t.Fatalf("GenerateHexID(8) length = %d, want 16", len(got))
+	}
+}
+
+func TestApplyChatHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://copilot.tencent.com/v2/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	ApplyChatHeaders(req, " 12345 ")
+
+	expected := map[string]string{
+		"X-Agent-Intent":          "craft",
+		"X-Agent-Purpose":         "conversation_topic",
+		"X-IDE-Type":              "WorkBuddy",
+		"X-IDE-Name":              "WorkBuddy",
+		"X-IDE-Version":           "5.2.5",
+		"X-Private-Data":          "false",
+		"X-Domain":                DefaultDomain,
+		"X-Product":               "SaaS",
+		"X-Requested-With":        "XMLHttpRequest",
+		"User-Agent":              ClientUserAgent,
+		"X-User-Id":               "12345",
+		"X-B3-Sampled":            "1",
+		"x-stainless-arch":        "arm64",
+		"x-stainless-lang":        "js",
+		"x-stainless-os":          "MacOS",
+		"x-stainless-retry-count": "0",
+	}
+	for key, want := range expected {
+		if got := req.Header.Get(key); got != want {
+			t.Errorf("header %s = %q, want %q", key, got, want)
+		}
+	}
+
+	// Random headers must be present and non-empty per request.
+	randomHeaders := []string{
+		"X-Conversation-ID",
+		"X-Conversation-Request-ID",
+		"X-Conversation-Message-ID",
+		"X-Request-ID",
+		"traceparent",
+		"b3",
+		"X-B3-TraceId",
+		"X-B3-SpanId",
+		"X-Trace-ID",
+		"x-stainless-package-version",
+		"x-stainless-runtime",
+		"x-stainless-runtime-version",
+	}
+	for _, key := range randomHeaders {
+		if req.Header.Get(key) == "" {
+			t.Errorf("header %s must be set", key)
+		}
+	}
+
+	traceID := req.Header.Get("X-B3-TraceId")
+	spanID := req.Header.Get("X-B3-SpanId")
+	if req.Header.Get("traceparent") != "00-"+traceID+"-"+spanID+"-01" {
+		t.Errorf("traceparent does not match trace/span ids")
+	}
+}
+
+func TestBuildChatCompletionsURL(t *testing.T) {
+	if got := BuildChatCompletionsURL(""); got != DefaultBaseURL+ChatCompletionsPath {
+		t.Errorf("default base URL mismatch: %q", got)
+	}
+	if got := BuildChatCompletionsURL("https://example.com/"); got != "https://example.com"+ChatCompletionsPath {
+		t.Errorf("override base URL mismatch: %q", got)
+	}
+}

--- a/internal/auth/codebuddy/models.go
+++ b/internal/auth/codebuddy/models.go
@@ -1,0 +1,160 @@
+package codebuddy
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// nonModelEntries are placeholder entries in the /v3/config model lists that
+// do not refer to a concrete model and must not be exposed as routable models.
+var nonModelEntries = map[string]bool{
+	"auto": true,
+}
+
+// IsRoutableModel reports whether the given model ID refers to a concrete
+// routable model rather than a placeholder entry such as "auto".
+func IsRoutableModel(id string) bool {
+	id = strings.TrimSpace(id)
+	return id != "" && !nonModelEntries[id]
+}
+
+// ConfigModel is a single entry in the top-level models list of /v3/config.
+type ConfigModel struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Credits            string `json:"credits"`
+	MaxInputTokens     int    `json:"maxInputTokens"`
+	MaxOutputTokens    int    `json:"maxOutputTokens"`
+	SupportsImages     bool   `json:"supportsImages"`
+	SupportsReasoning  bool   `json:"supportsReasoning"`
+	SupportsToolCall   bool   `json:"supportsToolCall"`
+	DisabledMultimodal bool   `json:"disabledMultimodal"`
+}
+
+// ConfigAgent is an agent entry whose models list also contains usable models.
+type ConfigAgent struct {
+	Name   string   `json:"name"`
+	AsTool bool     `json:"asTool"`
+	Models []string `json:"models"`
+}
+
+// configResponse is the relevant subset of the /v3/config payload.
+type configResponse struct {
+	Agents []ConfigAgent `json:"agents"`
+	Models []ConfigModel `json:"models"`
+}
+
+// ModelInfo is a parsed CodeBuddy model with billing and context metadata.
+type ModelInfo struct {
+	ID                string  `json:"id"`
+	Name              string  `json:"name"`
+	Credits           string  `json:"credits,omitempty"`
+	CreditMultiplier  float64 `json:"credit_multiplier,omitempty"`
+	MaxInputTokens    int     `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens   int     `json:"max_output_tokens,omitempty"`
+	SupportsImages    bool    `json:"supports_images,omitempty"`
+	SupportsReasoning bool    `json:"supports_reasoning,omitempty"`
+	SupportsToolCall  bool    `json:"supports_tool_call,omitempty"`
+}
+
+// parseCreditMultiplier converts a "x2.20 credits" style string into a float.
+// Empty, zero, or unparsable values return 0.
+func parseCreditMultiplier(s string) float64 {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "x")
+	s = strings.TrimSuffix(s, "credits")
+	s = strings.TrimSuffix(s, "credit")
+	s = strings.TrimSpace(s)
+	if s == "" || s == "-" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// parseConfigBody decodes a /v3/config data payload, tolerating both the plain
+// {models, agents} shape and a {"data": {...}} wrapped shape.
+func parseConfigBody(configBody []byte) (*configResponse, error) {
+	if len(configBody) == 0 {
+		return nil, nil
+	}
+	var cfg configResponse
+	if err := json.Unmarshal(configBody, &cfg); err != nil {
+		return nil, err
+	}
+	if len(cfg.Agents) == 0 && len(cfg.Models) == 0 {
+		var wrapped struct {
+			Data configResponse `json:"data"`
+		}
+		if err := json.Unmarshal(configBody, &wrapped); err == nil {
+			cfg = wrapped.Data
+		}
+	}
+	return &cfg, nil
+}
+
+// ParseModels parses the full model catalog (with billing and context
+// metadata) from a /v3/config data payload.
+func ParseModels(configBody []byte) ([]ModelInfo, error) {
+	cfg, err := parseConfigBody(configBody)
+	if err != nil || cfg == nil {
+		return nil, err
+	}
+	out := make([]ModelInfo, 0, len(cfg.Models))
+	for _, m := range cfg.Models {
+		id := strings.TrimSpace(m.ID)
+		if id == "" {
+			continue
+		}
+		out = append(out, ModelInfo{
+			ID:                id,
+			Name:              m.Name,
+			Credits:           m.Credits,
+			CreditMultiplier:  parseCreditMultiplier(m.Credits),
+			MaxInputTokens:    m.MaxInputTokens,
+			MaxOutputTokens:   m.MaxOutputTokens,
+			SupportsImages:    m.SupportsImages,
+			SupportsReasoning: m.SupportsReasoning,
+			SupportsToolCall:  m.SupportsToolCall,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// ParseEnabledModels parses the routable model IDs from a /v3/config data
+// payload. It aggregates the top-level models list and every agent models
+// list, drops placeholder entries, deduplicates, and sorts the result.
+func ParseEnabledModels(configBody []byte) ([]string, error) {
+	cfg, err := parseConfigBody(configBody)
+	if err != nil || cfg == nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	models := make([]string, 0)
+	addModel := func(name string) {
+		if !IsRoutableModel(name) {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		models = append(models, name)
+	}
+	for _, m := range cfg.Models {
+		addModel(m.ID)
+	}
+	for _, agent := range cfg.Agents {
+		for _, m := range agent.Models {
+			addModel(m)
+		}
+	}
+	sort.Strings(models)
+	return models, nil
+}

--- a/internal/auth/codebuddy/models_test.go
+++ b/internal/auth/codebuddy/models_test.go
@@ -1,0 +1,85 @@
+package codebuddy
+
+import (
+	"testing"
+)
+
+func TestParseEnabledModelsAggregatesAndFilters(t *testing.T) {
+	body := []byte(`{
+		"models": [
+			{"id": "glm-5.2", "name": "GLM 5.2", "credits": "x2.20 credits", "maxInputTokens": 200000, "maxOutputTokens": 64000, "supportsImages": true},
+			{"id": "hy3", "name": "HY3"},
+			{"id": "auto", "name": "Auto"}
+		],
+		"agents": [
+			{"name": "agent", "asTool": false, "models": ["glm-5.2", "deepseek-v4-pro", "auto", ""]}
+		]
+	}`)
+
+	models, err := ParseEnabledModels(body)
+	if err != nil {
+		t.Fatalf("ParseEnabledModels returned error: %v", err)
+	}
+	want := []string{"deepseek-v4-pro", "glm-5.2", "hy3"}
+	if len(models) != len(want) {
+		t.Fatalf("unexpected model count: got %v, want %v", models, want)
+	}
+	for i, id := range want {
+		if models[i] != id {
+			t.Errorf("models[%d] = %q, want %q", i, models[i], id)
+		}
+	}
+}
+
+func TestParseEnabledModelsSupportsDataWrapper(t *testing.T) {
+	body := []byte(`{"code":0,"msg":"ok","data":{"models":[{"id":"kimi-k2.7"}]}}`)
+	models, err := ParseEnabledModels(body)
+	if err != nil {
+		t.Fatalf("ParseEnabledModels returned error: %v", err)
+	}
+	if len(models) != 1 || models[0] != "kimi-k2.7" {
+		t.Fatalf("unexpected models: %v", models)
+	}
+}
+
+func TestParseEnabledModelsEmptyBody(t *testing.T) {
+	models, err := ParseEnabledModels(nil)
+	if err != nil {
+		t.Fatalf("ParseEnabledModels(nil) returned error: %v", err)
+	}
+	if models != nil {
+		t.Fatalf("expected nil models, got %v", models)
+	}
+}
+
+func TestParseModelsMetadata(t *testing.T) {
+	body := []byte(`{
+		"models": [
+			{"id": "glm-5.2", "name": "GLM 5.2", "credits": "x2.20 credits", "maxInputTokens": 200000, "maxOutputTokens": 64000, "supportsImages": true, "supportsReasoning": false, "supportsToolCall": true},
+			{"id": "minimax-m3", "name": "MiniMax M3", "credits": ""}
+		]
+	}`)
+
+	models, err := ParseModels(body)
+	if err != nil {
+		t.Fatalf("ParseModels returned error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("unexpected model count: %d", len(models))
+	}
+	if models[0].ID != "glm-5.2" {
+		t.Errorf("expected sorted output, first model = %q", models[0].ID)
+	}
+	if models[0].CreditMultiplier != 2.20 {
+		t.Errorf("credit multiplier = %v, want 2.20", models[0].CreditMultiplier)
+	}
+	if models[0].MaxInputTokens != 200000 || models[0].MaxOutputTokens != 64000 {
+		t.Errorf("token limits not parsed: %+v", models[0])
+	}
+	if !models[0].SupportsImages {
+		t.Errorf("supportsImages not parsed")
+	}
+	if models[1].CreditMultiplier != 0 {
+		t.Errorf("empty credits should yield zero multiplier, got %v", models[1].CreditMultiplier)
+	}
+}

--- a/internal/auth/codebuddy/record.go
+++ b/internal/auth/codebuddy/record.go
@@ -1,0 +1,52 @@
+package codebuddy
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// BuildTokenStorage assembles the token storage from an upstream token
+// response, account info, and the parsed /v3/config models. It is shared by
+// the CLI login flow and the management API login flow.
+func BuildTokenStorage(token *TokenResponse, account *AccountInfo, models []ModelInfo) *TokenStorage {
+	storage := &TokenStorage{
+		TokenType: "Bearer",
+	}
+	if token != nil {
+		storage.AccessToken = token.AccessToken
+		storage.RefreshToken = token.RefreshToken
+		if token.TokenType != "" {
+			storage.TokenType = token.TokenType
+		}
+		storage.Scope = token.Scope
+		storage.Domain = token.Domain
+		if expiresAt := token.ExpiresAt(); expiresAt > 0 {
+			storage.Expired = timeAt(expiresAt)
+		}
+	}
+	if account != nil {
+		storage.UID = account.UID
+		storage.Nickname = account.Nickname
+	}
+	if len(models) > 0 {
+		routable := make([]ModelInfo, 0, len(models))
+		ids := make([]string, 0, len(models))
+		for _, m := range models {
+			if !IsRoutableModel(m.ID) {
+				continue
+			}
+			routable = append(routable, m)
+			ids = append(ids, m.ID)
+		}
+		storage.EnabledModels = ids
+		if raw, err := json.Marshal(routable); err == nil {
+			storage.ModelsMeta = string(raw)
+		}
+	}
+	return storage
+}
+
+// timeAt formats a Unix timestamp as an RFC3339 UTC timestamp.
+func timeAt(unix int64) string {
+	return time.Unix(unix, 0).UTC().Format(time.RFC3339)
+}

--- a/internal/auth/codebuddy/sanitize.go
+++ b/internal/auth/codebuddy/sanitize.go
@@ -1,0 +1,148 @@
+package codebuddy
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// SystemPromptBlacklistRule is one system prompt rewrite rule.
+//
+// The CodeBuddy upstream content filter rejects system prompts containing
+// certain vendor identity phrases (finish_reason=content_filter). Rules were
+// derived empirically from rejected/accepted prompt pairs; a match is rewritten
+// with Replace (an empty string deletes the match).
+//
+// Find matches either a literal substring (IsRegex=false) or a regular
+// expression (IsRegex=true). Replace is always a literal replacement.
+type SystemPromptBlacklistRule struct {
+	Find    string
+	Replace string
+	IsRegex bool
+}
+
+// DefaultSystemPromptBlacklist returns the empirically derived default rule
+// set. Only the specific trigger sentences are rewritten; other occurrences of
+// the vendor names are left untouched to avoid over-rewriting.
+func DefaultSystemPromptBlacklist() []SystemPromptBlacklistRule {
+	return []SystemPromptBlacklistRule{
+		{Find: `You are Claude Code, Anthropic's official CLI for Claude\.`, Replace: "", IsRegex: true},
+		{Find: ` Codex CLI is an open source project led by OpenAI.`, Replace: "", IsRegex: false},
+		{Find: "Codex CLI", Replace: "workbuddy", IsRegex: false},
+		{Find: "PRs", Replace: "PR", IsRegex: false},
+	}
+}
+
+// SanitizeForContentFilter rewrites system messages in an OpenAI chat
+// completions payload according to the blacklist rules and returns the updated
+// body plus whether any change was made. String contents and the OpenAI
+// multi-part content array format are both supported. Nil rules fall back to
+// DefaultSystemPromptBlacklist.
+func SanitizeForContentFilter(body []byte, rules []SystemPromptBlacklistRule) ([]byte, bool, error) {
+	if len(rules) == 0 {
+		rules = DefaultSystemPromptBlacklist()
+	}
+	compiled, err := compileBlacklistRules(rules)
+	if err != nil {
+		return body, false, err
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body, false, nil
+	}
+
+	changed := false
+	for i, msg := range messages.Array() {
+		if !strings.EqualFold(msg.Get("role").String(), "system") {
+			continue
+		}
+		content := msg.Get("content")
+		path := "messages." + strconv.Itoa(i) + ".content"
+
+		if content.Type == gjson.String {
+			cleaned := applyBlacklistRules(compiled, content.String())
+			if cleaned != content.String() {
+				updated, errSet := sjson.SetBytes(body, path, cleaned)
+				if errSet != nil {
+					return body, changed, errSet
+				}
+				body = updated
+				changed = true
+			}
+			continue
+		}
+
+		if content.IsArray() {
+			raw, errDelete := sjson.DeleteBytes(body, path)
+			if errDelete != nil {
+				return body, changed, errDelete
+			}
+			parts := make([]map[string]any, 0, len(content.Array()))
+			localChanged := false
+			for _, part := range content.Array() {
+				p := map[string]any{}
+				for k, v := range part.Map() {
+					if k == "text" && v.Type == gjson.String {
+						cleaned := applyBlacklistRules(compiled, v.String())
+						if cleaned != v.String() {
+							localChanged = true
+						}
+						p["text"] = cleaned
+					} else {
+						p[k] = v.Value()
+					}
+				}
+				parts = append(parts, p)
+			}
+			if localChanged {
+				updated, errSet := sjson.SetBytes(raw, path, parts)
+				if errSet != nil {
+					return body, changed, errSet
+				}
+				body = updated
+				changed = true
+			}
+		}
+	}
+
+	return body, changed, nil
+}
+
+type compiledRule struct {
+	rule  SystemPromptBlacklistRule
+	regex *regexp.Regexp
+}
+
+func compileBlacklistRules(rules []SystemPromptBlacklistRule) ([]compiledRule, error) {
+	out := make([]compiledRule, 0, len(rules))
+	for _, r := range rules {
+		cr := compiledRule{rule: r}
+		if r.IsRegex {
+			re, err := regexp.Compile(r.Find)
+			if err != nil {
+				return nil, err
+			}
+			cr.regex = re
+		}
+		out = append(out, cr)
+	}
+	return out, nil
+}
+
+func applyBlacklistRules(rules []compiledRule, text string) string {
+	out := text
+	for _, r := range rules {
+		if r.rule.IsRegex {
+			out = r.regex.ReplaceAllString(out, r.rule.Replace)
+			continue
+		}
+		if strings.Contains(out, r.rule.Find) {
+			out = strings.ReplaceAll(out, r.rule.Find, r.rule.Replace)
+		}
+	}
+	// Trim leading/trailing whitespace only; internal structure is preserved.
+	return strings.TrimSpace(out)
+}

--- a/internal/auth/codebuddy/sanitize_test.go
+++ b/internal/auth/codebuddy/sanitize_test.go
@@ -1,0 +1,97 @@
+package codebuddy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSanitizeForContentFilterStringContent(t *testing.T) {
+	body := []byte(`{"model":"hy3","messages":[
+		{"role":"system","content":"You are Claude Code, Anthropic's official CLI for Claude.\n\nCodex CLI is an open source project led by OpenAI. Use Codex CLI to build PRs."},
+		{"role":"user","content":"hi"}
+	]}`)
+
+	sanitized, changed, err := SanitizeForContentFilter(body, nil)
+	if err != nil {
+		t.Fatalf("SanitizeForContentFilter returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected the system prompt to be rewritten")
+	}
+	system := gjson.GetBytes(sanitized, "messages.0.content").String()
+	if strings.Contains(system, "You are Claude Code") {
+		t.Errorf("vendor identity sentence still present: %q", system)
+	}
+	if strings.Contains(system, "Codex CLI") {
+		t.Errorf("'Codex CLI' still present: %q", system)
+	}
+	if strings.Contains(system, "PRs") {
+		t.Errorf("'PRs' still present: %q", system)
+	}
+	if !strings.Contains(system, "workbuddy to build PR") {
+		t.Errorf("expected rewritten text, got %q", system)
+	}
+	user := gjson.GetBytes(sanitized, "messages.1.content").String()
+	if user != "hi" {
+		t.Errorf("user message must be untouched, got %q", user)
+	}
+}
+
+func TestSanitizeForContentFilterArrayContent(t *testing.T) {
+	body := []byte(`{"messages":[
+		{"role":"system","content":[{"type":"text","text":"Codex CLI helps with PRs"},{"type":"text","text":"unchanged"}]}
+	]}`)
+
+	sanitized, changed, err := SanitizeForContentFilter(body, nil)
+	if err != nil {
+		t.Fatalf("SanitizeForContentFilter returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected the system prompt to be rewritten")
+	}
+	first := gjson.GetBytes(sanitized, "messages.0.content.0.text").String()
+	if strings.Contains(first, "Codex CLI") || strings.Contains(first, "PRs") {
+		t.Errorf("first text part not rewritten: %q", first)
+	}
+	second := gjson.GetBytes(sanitized, "messages.0.content.1.text").String()
+	if second != "unchanged" {
+		t.Errorf("second text part must be untouched, got %q", second)
+	}
+}
+
+func TestSanitizeForContentFilterNoSystemMessages(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"You are Claude Code, Anthropic's official CLI for Claude."}]}`)
+	sanitized, changed, err := SanitizeForContentFilter(body, nil)
+	if err != nil {
+		t.Fatalf("SanitizeForContentFilter returned error: %v", err)
+	}
+	if changed {
+		t.Fatal("user messages must not be rewritten")
+	}
+	if string(sanitized) != string(body) {
+		t.Fatal("body must stay unchanged when no system message matches")
+	}
+}
+
+func TestSanitizeForContentFilterCustomRules(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"system","content":"please drop SECRETWORD"}]}`)
+	sanitized, changed, err := SanitizeForContentFilter(body, []SystemPromptBlacklistRule{{Find: "SECRETWORD", Replace: "safe"}})
+	if err != nil {
+		t.Fatalf("SanitizeForContentFilter returned error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected custom rule to apply")
+	}
+	if !strings.Contains(gjson.GetBytes(sanitized, "messages.0.content").String(), "please drop safe") {
+		t.Errorf("custom rule not applied: %s", gjson.GetBytes(sanitized, "messages.0.content").String())
+	}
+}
+
+func TestSanitizeForContentFilterInvalidRegex(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"system","content":"x"}]}`)
+	if _, _, err := SanitizeForContentFilter(body, []SystemPromptBlacklistRule{{Find: "([", IsRegex: true}}); err == nil {
+		t.Fatal("expected an error for an invalid regex rule")
+	}
+}

--- a/internal/auth/codebuddy/token.go
+++ b/internal/auth/codebuddy/token.go
@@ -1,0 +1,91 @@
+package codebuddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+	log "github.com/sirupsen/logrus"
+)
+
+// TokenStorage stores OAuth credentials and account metadata for CodeBuddy.
+type TokenStorage struct {
+	// AccessToken is the bearer token used for API requests.
+	AccessToken string `json:"access_token"`
+	// RefreshToken is used to obtain a new access token.
+	RefreshToken string `json:"refresh_token"`
+	// TokenType is the token type, typically "Bearer".
+	TokenType string `json:"token_type,omitempty"`
+	// Scope is the authorization scope granted to the token.
+	Scope string `json:"scope,omitempty"`
+	// Domain is the user domain identifier returned by the token endpoint.
+	Domain string `json:"domain,omitempty"`
+	// UID is the account user id, used as the X-User-Id header value.
+	UID string `json:"uid,omitempty"`
+	// Nickname is the account display name.
+	Nickname string `json:"nickname,omitempty"`
+	// Expired is the RFC3339 timestamp when the access token expires.
+	Expired string `json:"expired,omitempty"`
+	// Type indicates the provider, always "codebuddy-cn" for this storage.
+	Type string `json:"type"`
+	// EnabledModels lists the model IDs the account can call, synced from /v3/config.
+	EnabledModels []string `json:"enabled_models,omitempty"`
+	// ModelsMeta stores the parsed model metadata JSON from /v3/config.
+	ModelsMeta string `json:"models_meta,omitempty"`
+
+	// Metadata holds arbitrary key-value pairs injected via hooks.
+	// It is not exported to JSON directly to allow flattening during serialization.
+	Metadata map[string]any `json:"-"`
+}
+
+// SetMetadata allows external callers to inject metadata into the storage before saving.
+func (ts *TokenStorage) SetMetadata(meta map[string]any) {
+	ts.Metadata = meta
+}
+
+// SaveTokenToFile serializes the token storage to a JSON file.
+func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
+	misc.LogSavingCredentials(authFilePath)
+	ts.Type = "codebuddy-cn"
+
+	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
+	if errMerge != nil {
+		return fmt.Errorf("failed to merge metadata: %w", errMerge)
+	}
+
+	f, err := os.Create(authFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create token file: %w", err)
+	}
+	defer func() {
+		if errClose := f.Close(); errClose != nil {
+			log.Errorf("codebuddy token storage: close token file error: %v", errClose)
+		}
+	}()
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+	if err = encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to write token to file: %w", err)
+	}
+	return nil
+}
+
+// IsExpired checks whether the access token is expired or close to expiring.
+func (ts *TokenStorage) IsExpired() bool {
+	if ts.Expired == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, ts.Expired)
+	if err != nil {
+		return true
+	}
+	return time.Now().After(t)
+}

--- a/internal/auth/codebuddy/token_test.go
+++ b/internal/auth/codebuddy/token_test.go
@@ -1,0 +1,137 @@
+package codebuddy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTokenStorageSaveTokenToFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "codebuddy-test.json")
+
+	storage := &TokenStorage{
+		AccessToken:   "access-1",
+		RefreshToken:  "refresh-1",
+		TokenType:     "Bearer",
+		UID:           "u-1",
+		Nickname:      "tester",
+		Expired:       "2030-01-01T00:00:00Z",
+		EnabledModels: []string{"hy3", "glm-5.2"},
+		Metadata: map[string]any{
+			"extra": "value",
+		},
+	}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved token file: %v", err)
+	}
+	var saved map[string]any
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("saved file is not valid JSON: %v", err)
+	}
+	if saved["type"] != "codebuddy-cn" {
+		t.Errorf("type = %v, want codebuddy", saved["type"])
+	}
+	if saved["access_token"] != "access-1" || saved["refresh_token"] != "refresh-1" {
+		t.Errorf("tokens not persisted: %v", saved)
+	}
+	if saved["extra"] != "value" {
+		t.Errorf("metadata not merged: %v", saved)
+	}
+	enabled, ok := saved["enabled_models"].([]any)
+	if !ok || len(enabled) != 2 {
+		t.Errorf("enabled_models not persisted: %v", saved["enabled_models"])
+	}
+}
+
+func TestTokenStorageIsExpired(t *testing.T) {
+	storage := &TokenStorage{}
+	if storage.IsExpired() {
+		t.Error("empty expiry must not be reported as expired")
+	}
+	storage.Expired = "not-a-time"
+	if !storage.IsExpired() {
+		t.Error("unparsable expiry must be reported as expired")
+	}
+	storage.Expired = "2000-01-01T00:00:00Z"
+	if !storage.IsExpired() {
+		t.Error("past expiry must be reported as expired")
+	}
+	storage.Expired = "2100-01-01T00:00:00Z"
+	if storage.IsExpired() {
+		t.Error("future expiry must not be reported as expired")
+	}
+}
+
+func TestBuildTokenStorage(t *testing.T) {
+	token := &TokenResponse{
+		AccessToken:  "a",
+		RefreshToken: "r",
+		TokenType:    "",
+		ExpiresIn:    3600,
+		Domain:       "d",
+	}
+	models := []ModelInfo{{ID: "hy3", Name: "HY3"}, {ID: "glm-5.2", Name: "GLM 5.2"}}
+	storage := BuildTokenStorage(token, &AccountInfo{UID: "u", Nickname: "n"}, models)
+
+	if storage.TokenType != "Bearer" {
+		t.Errorf("default token type = %q, want Bearer", storage.TokenType)
+	}
+	if storage.UID != "u" || storage.Nickname != "n" || storage.Domain != "d" {
+		t.Errorf("account fields not populated: %+v", storage)
+	}
+	if len(storage.EnabledModels) != 2 || storage.EnabledModels[0] != "hy3" {
+		t.Errorf("enabled models mismatch: %v", storage.EnabledModels)
+	}
+	var meta []ModelInfo
+	if err := json.Unmarshal([]byte(storage.ModelsMeta), &meta); err != nil {
+		t.Fatalf("models_meta is not valid JSON: %v", err)
+	}
+	if len(meta) != 2 || meta[0].ID != "hy3" {
+		t.Errorf("models_meta content mismatch: %s", storage.ModelsMeta)
+	}
+	if storage.Expired == "" {
+		t.Error("expired timestamp should be derived from expiresIn")
+	}
+}
+
+func TestTokenResponseExpiresAtFallback(t *testing.T) {
+	token := &TokenResponse{}
+	if token.ExpiresAt() <= 0 {
+		t.Error("missing expiresIn must fall back to a future expiry")
+	}
+}
+
+func TestBuildTokenStorageFiltersPlaceholderModels(t *testing.T) {
+	token := &TokenResponse{AccessToken: "a", RefreshToken: "r"}
+	models := []ModelInfo{
+		{ID: "glm-5.2", Name: "GLM 5.2"},
+		{ID: "auto", Name: "Auto"},
+		{ID: "hy3", Name: "HY3"},
+	}
+	storage := BuildTokenStorage(token, nil, models)
+
+	for _, id := range storage.EnabledModels {
+		if id == "auto" {
+			t.Errorf("placeholder 'auto' should not appear in enabled_models: %v", storage.EnabledModels)
+		}
+	}
+	if len(storage.EnabledModels) != 2 {
+		t.Errorf("expected 2 routable models, got %d: %v", len(storage.EnabledModels), storage.EnabledModels)
+	}
+	var meta []ModelInfo
+	if err := json.Unmarshal([]byte(storage.ModelsMeta), &meta); err != nil {
+		t.Fatalf("models_meta is not valid JSON: %v", err)
+	}
+	for _, m := range meta {
+		if m.ID == "auto" {
+			t.Errorf("placeholder 'auto' should not appear in models_meta")
+		}
+	}
+}

--- a/internal/cmd/auth_manager.go
+++ b/internal/cmd/auth_manager.go
@@ -6,7 +6,7 @@ import (
 
 // newAuthManager creates a new authentication manager instance with all supported
 // authenticators and a file-based token store. It initializes authenticators for
-// Codex, Claude, Antigravity, Kimi, and xAI providers.
+// Codex, Claude, Antigravity, Kimi, xAI, and CodeBuddy providers.
 //
 // Returns:
 //   - *sdkAuth.Manager: A configured authentication manager instance
@@ -18,6 +18,7 @@ func newAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewAntigravityAuthenticator(),
 		sdkAuth.NewKimiAuthenticator(),
 		sdkAuth.NewXAIAuthenticator(),
+		sdkAuth.NewCodeBuddyAuthenticator(),
 	)
 	return manager
 }

--- a/internal/cmd/codebuddy_login.go
+++ b/internal/cmd/codebuddy_login.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// DoCodeBuddyLogin triggers the state-based authorization flow for CodeBuddy
+// (WorkBuddy, Tencent copilot) and saves tokens. It generates an authorization
+// URL, waits for the user to complete browser authorization, and then saves
+// the exchanged tokens together with the account's available models.
+//
+// Parameters:
+//   - cfg: The application configuration containing proxy and auth directory settings
+//   - options: Login options including browser behavior settings
+func DoCodeBuddyLogin(cfg *config.Config, options *LoginOptions) {
+	if options == nil {
+		options = &LoginOptions{}
+	}
+
+	manager := newAuthManager()
+	authOpts := &sdkAuth.LoginOptions{
+		NoBrowser: options.NoBrowser,
+		Metadata:  map[string]string{},
+		Prompt:    options.Prompt,
+	}
+
+	record, savedPath, err := manager.Login(context.Background(), "codebuddy-cn", cfg, authOpts)
+	if err != nil {
+		log.Errorf("CodeBuddy CN authentication failed: %v", err)
+		return
+	}
+
+	if savedPath != "" {
+		fmt.Printf("Authentication saved to %s\n", savedPath)
+	}
+	if record != nil && record.Label != "" {
+		fmt.Printf("Authenticated as %s\n", record.Label)
+	}
+	fmt.Println("CodeBuddy CN authentication successful!")
+}

--- a/internal/runtime/executor/codebuddy_executor.go
+++ b/internal/runtime/executor/codebuddy_executor.go
@@ -1,0 +1,493 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	codebuddyauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/sjson"
+)
+
+// CodeBuddyExecutor is a stateless executor for the Tencent CodeBuddy
+// (WorkBuddy) copilot service. The upstream speaks the OpenAI chat
+// completions protocol at /v2/chat/completions and authenticates with an
+// OAuth access token obtained through the state-based plugin auth flow.
+type CodeBuddyExecutor struct {
+	cfg *config.Config
+}
+
+// NewCodeBuddyExecutor creates a new CodeBuddy executor.
+func NewCodeBuddyExecutor(cfg *config.Config) *CodeBuddyExecutor {
+	return &CodeBuddyExecutor{cfg: cfg}
+}
+
+// Identifier returns the executor identifier.
+func (e *CodeBuddyExecutor) Identifier() string { return "codebuddy-cn" }
+
+// RequestToFormat reports the upstream request format: OpenAI chat completions.
+func (e *CodeBuddyExecutor) RequestToFormat(_ cliproxyexecutor.Request, _ cliproxyexecutor.Options) sdktranslator.Format {
+	return sdktranslator.FormatOpenAI
+}
+
+// codebuddyCreds extracts the access token from an auth record. OAuth tokens
+// live in metadata; a manually provisioned token may appear in attributes.
+func codebuddyCreds(a *cliproxyauth.Auth) string {
+	if a == nil {
+		return ""
+	}
+	if a.Metadata != nil {
+		if v, ok := a.Metadata["access_token"].(string); ok && strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	if a.Attributes != nil {
+		if v := a.Attributes["access_token"]; v != "" {
+			return v
+		}
+		if v := a.Attributes["api_key"]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// codebuddyUID returns the account user id used for the X-User-Id header.
+func codebuddyUID(a *cliproxyauth.Auth) string {
+	if a == nil {
+		return ""
+	}
+	if a.Metadata != nil {
+		if v, ok := a.Metadata["uid"].(string); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	if a.Attributes != nil {
+		return strings.TrimSpace(a.Attributes["uid"])
+	}
+	return ""
+}
+
+// codebuddyBaseURL resolves the upstream base URL, allowing a per-auth override.
+func codebuddyBaseURL(a *cliproxyauth.Auth) string {
+	if a != nil && a.Attributes != nil {
+		if base := strings.TrimSpace(a.Attributes["base_url"]); base != "" {
+			return base
+		}
+	}
+	return codebuddyauth.DefaultBaseURL
+}
+
+// isCodeBuddySSEHeartbeat reports whether the SSE line is an upstream
+// keep-alive comment (": heartbeat" or "data: : heartbeat") whose payload is
+// not valid JSON and must not be forwarded to downstream clients.
+func isCodeBuddySSEHeartbeat(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	if bytes.HasPrefix(trimmed, []byte(":")) {
+		return true
+	}
+	payload, ok := bytes.CutPrefix(trimmed, []byte("data:"))
+	if !ok {
+		return false
+	}
+	return bytes.HasPrefix(bytes.TrimSpace(payload), []byte(":"))
+}
+
+// normalizeCodeBuddyUpstreamModel returns the upstream model ID by stripping
+// the CLIProxyAPI "codebuddy-" prefix and any Claude Code "[1m]" context
+// suffix while preserving a trailing thinking suffix (e.g. "(1024)").
+func normalizeCodeBuddyUpstreamModel(model string) string {
+	model = strings.TrimSpace(model)
+	parsed := thinking.ParseSuffix(model)
+	base := strings.TrimSpace(parsed.ModelName)
+	if len(base) >= 4 && strings.HasSuffix(strings.ToLower(base), "[1m]") {
+		base = base[:len(base)-len("[1m]")]
+	}
+	prefix := "codebuddy-"
+	if len(base) > len(prefix) && strings.HasPrefix(strings.ToLower(base), prefix) {
+		base = base[len(prefix):]
+	}
+	if parsed.HasSuffix {
+		return base + "(" + parsed.RawSuffix + ")"
+	}
+	return base
+}
+
+// PrepareRequest injects CodeBuddy credentials into the outgoing HTTP request.
+func (e *CodeBuddyExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	if token := codebuddyCreds(auth); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(req, attrs)
+	return nil
+}
+
+// HttpRequest injects CodeBuddy credentials into the request and executes it.
+func (e *CodeBuddyExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("codebuddy executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if err := e.PrepareRequest(httpReq, auth); err != nil {
+		return nil, err
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	return httpClient.Do(httpReq)
+}
+
+// buildCodeBuddyChatRequest translates the inbound payload into an OpenAI chat
+// completions body and prepares the upstream HTTP request with the headers the
+// CodeBuddy endpoint requires.
+func (e *CodeBuddyExecutor) buildCodeBuddyChatRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, stream bool) (*http.Request, []byte, error) {
+	from := opts.SourceFormat
+	to := sdktranslator.FormatOpenAI
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	originalPayloadSource := req.Payload
+	if len(opts.OriginalRequest) > 0 {
+		originalPayloadSource = opts.OriginalRequest
+	}
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(originalPayloadSource), stream)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(req.Payload), stream)
+
+	body, errSet := sjson.SetBytes(body, "model", normalizeCodeBuddyUpstreamModel(baseModel))
+	if errSet != nil {
+		return nil, nil, fmt.Errorf("codebuddy executor: failed to set model in payload: %w", errSet)
+	}
+
+	body, err := helps.ApplyThinkingWithSourcePayload(body, req.Payload, originalPayloadSource, req.Model, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if stream {
+		body, errSet = sjson.SetBytes(body, "stream_options.include_usage", true)
+		if errSet != nil {
+			return nil, nil, fmt.Errorf("codebuddy executor: failed to set stream_options in payload: %w", errSet)
+		}
+	}
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+
+	// The upstream content filter rejects vendor identity phrases in system
+	// prompts; rewrite them before sending.
+	if sanitized, changed, sanitizeErr := codebuddyauth.SanitizeForContentFilter(body, nil); sanitizeErr != nil {
+		log.WithError(sanitizeErr).Warn("codebuddy executor: system prompt sanitize failed, sending original payload")
+	} else if changed {
+		body = sanitized
+	}
+
+	url := codebuddyauth.BuildChatCompletionsURL(codebuddyBaseURL(auth))
+	httpReq, errNew := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if errNew != nil {
+		return nil, nil, errNew
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if stream {
+		httpReq.Header.Set("Accept", "text/event-stream")
+	} else {
+		httpReq.Header.Set("Accept", "application/json")
+	}
+	if token := codebuddyCreds(auth); token != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+	}
+	codebuddyauth.ApplyChatHeaders(httpReq, codebuddyUID(auth))
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+	return httpReq, body, nil
+}
+
+// Execute performs a non-streaming chat completion request to CodeBuddy.
+func (e *CodeBuddyExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	httpReq, body, err := e.buildCodeBuddyChatRequest(ctx, auth, req, opts, false)
+	if err != nil {
+		return resp, err
+	}
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       httpReq.URL.String(),
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy executor: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return resp, err
+	}
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return resp, err
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(data))
+
+	to := sdktranslator.FormatOpenAI
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, data, &param)
+	if responseFormat == sdktranslator.FormatOpenAIResponse {
+		out = helps.EnsureResponsesUsageDetails(out)
+	}
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+// ExecuteStream performs a streaming chat completion request to CodeBuddy.
+func (e *CodeBuddyExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	httpReq, body, err := e.buildCodeBuddyChatRequest(ctx, auth, req, opts, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       httpReq.URL.String(),
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, err)
+		return nil, err
+	}
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codebuddy executor: close response body error: %v", errClose)
+		}
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+
+	to := sdktranslator.FormatOpenAI
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("codebuddy executor: close response body error: %v", errClose)
+			}
+		}()
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 1_048_576) // 1MB
+		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, to, responseFormat, bytes.Clone(opts.OriginalRequest))
+		var param any
+		var streamUsage helps.StreamUsageBuffer
+		defer streamUsage.Publish(ctx, reporter)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			// The upstream emits keep-alive comment lines (": heartbeat") that
+			// are not JSON; strict downstream SSE parsers reject them, so drop
+			// these lines before translating.
+			if isCodeBuddySSEHeartbeat(line) {
+				continue
+			}
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			streamUsage.ObserveOpenAIStream(line)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, bytes.Clone(line), &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		doneChunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, body, []byte("[DONE]"), &param, claudeInputTokens)
+		for i := range doneChunks {
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Payload: doneChunks[i]}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+			reporter.PublishFailure(ctx, errScan)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// CountTokens estimates the token count locally; the upstream has no count endpoint.
+func (e *CodeBuddyExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+
+	from := opts.SourceFormat
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	to := sdktranslator.FormatOpenAI
+	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
+
+	translated, err := helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+
+	enc, err := helps.TokenizerForModel(baseModel)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("codebuddy executor: tokenizer init failed: %w", err)
+	}
+
+	count, err := helps.CountOpenAIChatTokens(enc, translated)
+	if err != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("codebuddy executor: token counting failed: %w", err)
+	}
+
+	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, responseFormat, count, usageJSON)
+	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+// Refresh rotates the OAuth tokens and re-syncs the account's available models.
+func (e *CodeBuddyExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	log.Debugf("codebuddy executor: refresh called")
+	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		return refreshed, err
+	}
+	if auth == nil {
+		return nil, fmt.Errorf("codebuddy executor: auth is nil")
+	}
+	refreshToken := ""
+	if auth.Metadata != nil {
+		if v, ok := auth.Metadata["refresh_token"].(string); ok {
+			refreshToken = strings.TrimSpace(v)
+		}
+	}
+	if refreshToken == "" {
+		// Nothing to refresh.
+		return auth, nil
+	}
+
+	client := codebuddyauth.NewClient(e.cfg, auth.ProxyURL)
+	token, err := client.RefreshToken(ctx, refreshToken)
+	if err != nil {
+		return nil, err
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = token.AccessToken
+	if token.RefreshToken != "" {
+		auth.Metadata["refresh_token"] = token.RefreshToken
+	}
+	if token.TokenType != "" {
+		auth.Metadata["token_type"] = token.TokenType
+	}
+	if token.Domain != "" {
+		auth.Metadata["domain"] = token.Domain
+	}
+	if expiresAt := token.ExpiresAt(); expiresAt > 0 {
+		auth.Metadata["expired"] = time.Unix(expiresAt, 0).UTC().Format(time.RFC3339)
+	}
+	auth.Metadata["type"] = "codebuddy-cn"
+	auth.Metadata["last_refresh"] = time.Now().Format(time.RFC3339)
+
+	// Re-sync the account's available models; keep the previous list on failure.
+	uid := ""
+	if v, ok := auth.Metadata["uid"].(string); ok {
+		uid = strings.TrimSpace(v)
+	}
+	if configData, cfgErr := client.FetchConfig(ctx, token.AccessToken, uid); cfgErr != nil {
+		log.WithError(cfgErr).Debugf("codebuddy executor: model config refresh failed for %s", auth.ID)
+	} else if models, parseErr := codebuddyauth.ParseModels(configData); parseErr != nil {
+		log.WithError(parseErr).Debugf("codebuddy executor: model config parse failed for %s", auth.ID)
+	} else if len(models) > 0 {
+		ids := make([]string, 0, len(models))
+		for _, m := range models {
+			ids = append(ids, m.ID)
+		}
+		auth.Metadata["enabled_models"] = ids
+		if raw, marshalErr := json.Marshal(models); marshalErr == nil {
+			auth.Metadata["models_meta"] = string(raw)
+		}
+	}
+	return auth, nil
+}

--- a/internal/runtime/executor/codebuddy_executor_test.go
+++ b/internal/runtime/executor/codebuddy_executor_test.go
@@ -1,0 +1,101 @@
+package executor
+
+import (
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestNormalizeCodeBuddyUpstreamModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain id", input: "glm-5.2", want: "glm-5.2"},
+		{name: "prefixed id", input: "codebuddy-glm-5.2", want: "glm-5.2"},
+		{name: "prefixed id uppercase", input: "CodeBuddy-HY3", want: "HY3"},
+		{name: "claude context suffix", input: "codebuddy-hy3[1m]", want: "hy3"},
+		{name: "thinking suffix preserved", input: "codebuddy-glm-5.2(1024)", want: "glm-5.2(1024)"},
+		{name: "context and thinking suffix", input: "codebuddy-glm-5.2[1m](1024)", want: "glm-5.2(1024)"},
+		{name: "double prefix trims once", input: "codebuddy-codebuddy-hy3", want: "codebuddy-hy3"},
+		{name: "bare prefix word", input: "codebuddy-", want: "codebuddy-"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := normalizeCodeBuddyUpstreamModel(testCase.input); got != testCase.want {
+				t.Errorf("normalizeCodeBuddyUpstreamModel(%q) = %q, want %q", testCase.input, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestCodeBuddyCreds(t *testing.T) {
+	if got := codebuddyCreds(nil); got != "" {
+		t.Errorf("nil auth should yield empty token, got %q", got)
+	}
+
+	metadataAuth := &cliproxyauth.Auth{Attributes: map[string]string{}, Metadata: map[string]any{"access_token": "meta-token"}}
+	if got := codebuddyCreds(metadataAuth); got != "meta-token" {
+		t.Errorf("metadata token = %q, want meta-token", got)
+	}
+
+	attrAuth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "attr-key"}, Metadata: map[string]any{}}
+	if got := codebuddyCreds(attrAuth); got != "attr-key" {
+		t.Errorf("attribute token = %q, want attr-key", got)
+	}
+}
+
+func TestCodeBuddyUID(t *testing.T) {
+	if got := codebuddyUID(nil); got != "" {
+		t.Errorf("nil auth should yield empty uid, got %q", got)
+	}
+
+	metadataAuth := &cliproxyauth.Auth{Attributes: map[string]string{}, Metadata: map[string]any{"uid": "  u-1  "}}
+	if got := codebuddyUID(metadataAuth); got != "u-1" {
+		t.Errorf("uid = %q, want u-1", got)
+	}
+
+	attrAuth := &cliproxyauth.Auth{Attributes: map[string]string{"uid": "u-2"}, Metadata: map[string]any{}}
+	if got := codebuddyUID(attrAuth); got != "u-2" {
+		t.Errorf("attribute uid = %q, want u-2", got)
+	}
+}
+
+func TestCodeBuddyBaseURL(t *testing.T) {
+	if got := codebuddyBaseURL(nil); got == "" {
+		t.Error("nil auth should fall back to the default base URL")
+	}
+
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://example.com/"}, Metadata: map[string]any{}}
+	if got := codebuddyBaseURL(auth); got != "https://example.com/" {
+		t.Errorf("base_url = %q, want https://example.com/", got)
+	}
+}
+
+func TestIsCodeBuddySSEHeartbeat(t *testing.T) {
+	heartbeats := [][]byte{
+		[]byte(": heartbeat"),
+		[]byte(": keep-alive"),
+		[]byte("data: : heartbeat"),
+		[]byte("data::heartbeat"),
+		[]byte("  : heartbeat  "),
+	}
+	for _, line := range heartbeats {
+		if !isCodeBuddySSEHeartbeat(line) {
+			t.Errorf("expected heartbeat detection for %q", line)
+		}
+	}
+	normal := [][]byte{
+		[]byte(`data: {"id":"x","choices":[]}`),
+		[]byte("data: [DONE]"),
+		[]byte("event: message_start"),
+		[]byte(""),
+	}
+	for _, line := range normal {
+		if isCodeBuddySSEHeartbeat(line) {
+			t.Errorf("unexpected heartbeat detection for %q", line)
+		}
+	}
+}

--- a/sdk/auth/codebuddy.go
+++ b/sdk/auth/codebuddy.go
@@ -1,0 +1,150 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/browser"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+// codebuddyRefreshLead is the duration before token expiry when refresh should occur.
+var codebuddyRefreshLead = time.Hour
+
+// CodeBuddyAuthenticator implements the state-based plugin auth login for
+// CodeBuddy (WorkBuddy, Tencent copilot).
+type CodeBuddyAuthenticator struct{}
+
+// NewCodeBuddyAuthenticator constructs a new CodeBuddy authenticator.
+func NewCodeBuddyAuthenticator() Authenticator {
+	return &CodeBuddyAuthenticator{}
+}
+
+// Provider returns the provider key for codebuddy.
+func (CodeBuddyAuthenticator) Provider() string {
+	return "codebuddy-cn"
+}
+
+// RefreshLead returns the duration before token expiry when refresh should occur.
+func (CodeBuddyAuthenticator) RefreshLead() *time.Duration {
+	return &codebuddyRefreshLead
+}
+
+// Login runs the CodeBuddy state-based authorization flow: generate a state,
+// open the authorization URL in a browser, then poll the token endpoint until
+// the user completes authorization.
+func (a CodeBuddyAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *LoginOptions) (*coreauth.Auth, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("cliproxy auth: configuration is required")
+	}
+	if opts == nil {
+		opts = &LoginOptions{}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	client := codebuddy.NewClient(cfg, "")
+
+	fmt.Println("Starting CodeBuddy CN (WorkBuddy) authentication...")
+	state, err := client.FetchState(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy-cn: failed to generate auth state: %w", err)
+	}
+
+	fmt.Printf("\nTo authenticate, please visit:\n%s\n\n", state.AuthURL)
+	if !opts.NoBrowser {
+		if browser.IsAvailable() {
+			if errOpen := browser.OpenURL(state.AuthURL); errOpen != nil {
+				log.Warnf("Failed to open browser automatically: %v", errOpen)
+			} else {
+				fmt.Println("Browser opened automatically.")
+			}
+		}
+	}
+
+	fmt.Println("Waiting for authorization (complete the login in the browser)...")
+	token, err := client.WaitForToken(ctx, state.State)
+	if err != nil {
+		return nil, fmt.Errorf("codebuddy-cn: %w", err)
+	}
+
+	// Account info is optional; the flow still succeeds without it.
+	account, accErr := client.GetAccountInfo(ctx, token.AccessToken, state.State)
+	if accErr != nil {
+		log.Warnf("codebuddy-cn: failed to fetch account info: %v", accErr)
+		account = nil
+	}
+
+	// Available models are optional; the executor refreshes them on token refresh.
+	var models []codebuddy.ModelInfo
+	configData, cfgErr := client.FetchConfig(ctx, token.AccessToken, accountUID(account))
+	if cfgErr != nil {
+		log.Warnf("codebuddy-cn: failed to fetch model config: %v", cfgErr)
+	} else if parsed, parseErr := codebuddy.ParseModels(configData); parseErr != nil {
+		log.Warnf("codebuddy-cn: failed to parse model config: %v", parseErr)
+	} else {
+		models = parsed
+	}
+
+	tokenStorage := codebuddy.BuildTokenStorage(token, account, models)
+
+	metadata := map[string]any{
+		"type":          "codebuddy-cn",
+		"access_token":  tokenStorage.AccessToken,
+		"refresh_token": tokenStorage.RefreshToken,
+		"token_type":    tokenStorage.TokenType,
+		"timestamp":     time.Now().UnixMilli(),
+	}
+	if tokenStorage.Scope != "" {
+		metadata["scope"] = tokenStorage.Scope
+	}
+	if tokenStorage.Domain != "" {
+		metadata["domain"] = tokenStorage.Domain
+	}
+	if tokenStorage.UID != "" {
+		metadata["uid"] = tokenStorage.UID
+	}
+	if tokenStorage.Nickname != "" {
+		metadata["nickname"] = tokenStorage.Nickname
+	}
+	if tokenStorage.Expired != "" {
+		metadata["expired"] = tokenStorage.Expired
+	}
+	if len(tokenStorage.EnabledModels) > 0 {
+		metadata["enabled_models"] = tokenStorage.EnabledModels
+	}
+	if tokenStorage.ModelsMeta != "" {
+		metadata["models_meta"] = tokenStorage.ModelsMeta
+	}
+
+	fileName := fmt.Sprintf("codebuddy-cn-%d.json", time.Now().UnixMilli())
+
+	label := "CodeBuddy CN User"
+	if nickname := strings.TrimSpace(tokenStorage.Nickname); nickname != "" {
+		label = nickname
+	}
+
+	fmt.Println("\nCodeBuddy CN authentication successful!")
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: a.Provider(),
+		FileName: fileName,
+		Label:    label,
+		Storage:  tokenStorage,
+		Metadata: metadata,
+	}, nil
+}
+
+func accountUID(account *codebuddy.AccountInfo) string {
+	if account == nil {
+		return ""
+	}
+	return account.UID
+}

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -22,6 +22,7 @@ func newDefaultAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewCodexAuthenticator(),
 		sdkAuth.NewClaudeAuthenticator(),
 		sdkAuth.NewXAIAuthenticator(),
+		sdkAuth.NewCodeBuddyAuthenticator(),
 	)
 }
 

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -208,6 +208,7 @@ func baselineExecutorAuths() []*coreauth.Auth {
 		"aistudio",
 		"antigravity",
 		"kimi",
+		"codebuddy-cn",
 		"xai",
 		"openai-compatibility",
 	}
@@ -292,6 +293,8 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(cfg))
+	case "codebuddy-cn":
+		s.coreManager.RegisterExecutor(executor.NewCodeBuddyExecutor(cfg))
 	case "xai":
 		if !forceReplace {
 			existingExecutor, hasExecutor := s.coreManager.Executor("xai")

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -2,10 +2,12 @@ package cliproxy
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
 
+	codebuddyauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codebuddy"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -143,6 +145,9 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()
+		models = applyExcludedModels(models, excluded)
+	case "codebuddy-cn":
+		models = buildCodeBuddyAuthModels(a)
 		models = applyExcludedModels(models, excluded)
 	case "xai":
 		models = registry.GetXAIModels()
@@ -795,6 +800,90 @@ func buildVertexCompatConfigModels(entry *config.VertexCompatKey) []*ModelInfo {
 		return nil
 	}
 	return buildConfigModels(entry.Models, "google", "vertex")
+}
+
+// buildCodeBuddyAuthModels builds the CodeBuddy model catalog from per-auth
+// metadata synced from the upstream /v3/config endpoint at login and refresh
+// time. Models without metadata fall back to plain ID entries.
+func buildCodeBuddyAuthModels(auth *coreauth.Auth) []*ModelInfo {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return nil
+	}
+	now := time.Now().Unix()
+	if raw, ok := auth.Metadata["models_meta"].(string); ok {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			var meta []codebuddyauth.ModelInfo
+			if err := json.Unmarshal([]byte(trimmed), &meta); err == nil && len(meta) > 0 {
+				out := make([]*ModelInfo, 0, len(meta))
+				for _, m := range meta {
+					if !codebuddyauth.IsRoutableModel(m.ID) {
+						continue
+					}
+					info := &ModelInfo{
+						ID:          m.ID,
+						Object:      "model",
+						Created:     now,
+						OwnedBy:     "codebuddy-cn",
+						Type:        "codebuddy-cn",
+						DisplayName: m.Name,
+						Name:        m.Name,
+					}
+					if m.MaxInputTokens > 0 {
+						info.ContextLength = m.MaxInputTokens
+						info.MaxContextLength = m.MaxInputTokens
+						info.InputTokenLimit = m.MaxInputTokens
+					}
+					if m.MaxOutputTokens > 0 {
+						info.MaxCompletionTokens = m.MaxOutputTokens
+						info.OutputTokenLimit = m.MaxOutputTokens
+					}
+					if m.SupportsImages {
+						info.SupportedInputModalities = append(info.SupportedInputModalities, "image")
+					}
+					out = append(out, info)
+				}
+				if len(out) > 0 {
+					return out
+				}
+			}
+		}
+	}
+	ids, ok := metadataStringSlice(auth.Metadata["enabled_models"])
+	if !ok {
+		return nil
+	}
+	out := make([]*ModelInfo, 0, len(ids))
+	for _, id := range ids {
+		if !codebuddyauth.IsRoutableModel(id) {
+			continue
+		}
+		out = append(out, &ModelInfo{
+			ID:      id,
+			Object:  "model",
+			Created: now,
+			OwnedBy: "codebuddy-cn",
+			Type:    "codebuddy-cn",
+		})
+	}
+	return out
+}
+
+// metadataStringSlice converts a JSON-decoded metadata value into a string slice.
+func metadataStringSlice(raw any) ([]string, bool) {
+	switch v := raw.(type) {
+	case []string:
+		return v, true
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	default:
+		return nil, false
+	}
 }
 
 func buildGeminiConfigModels(entry *config.GeminiKey) []*ModelInfo {

--- a/sdk/cliproxy/service_models_codebuddy_test.go
+++ b/sdk/cliproxy/service_models_codebuddy_test.go
@@ -1,0 +1,72 @@
+package cliproxy
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestBuildCodeBuddyAuthModelsFromMetadata(t *testing.T) {
+	auth := &coreauth.Auth{
+		Provider: "codebuddy-cn",
+		Metadata: map[string]any{
+			"enabled_models": []any{"hy3", "glm-5.2"},
+			"models_meta":    `[{"id":"glm-5.2","name":"GLM 5.2","max_input_tokens":200000,"max_output_tokens":64000,"supports_images":true},{"id":"hy3","name":"HY3"}]`,
+		},
+	}
+
+	models := buildCodeBuddyAuthModels(auth)
+	if len(models) != 2 {
+		t.Fatalf("unexpected model count: %d", len(models))
+	}
+	if models[0].ID != "glm-5.2" || models[0].DisplayName != "GLM 5.2" {
+		t.Errorf("first model mismatch: %+v", models[0])
+	}
+	if models[0].ContextLength != 200000 || models[0].MaxCompletionTokens != 64000 {
+		t.Errorf("context limits not mapped: %+v", models[0])
+	}
+	if len(models[0].SupportedInputModalities) != 1 || models[0].SupportedInputModalities[0] != "image" {
+		t.Errorf("input modalities not mapped: %v", models[0].SupportedInputModalities)
+	}
+	if models[1].ID != "hy3" {
+		t.Errorf("second model mismatch: %+v", models[1])
+	}
+}
+
+func TestBuildCodeBuddyAuthModelsFallsBackToIDList(t *testing.T) {
+	auth := &coreauth.Auth{
+		Provider: "codebuddy-cn",
+		Metadata: map[string]any{
+			"enabled_models": []any{"hy3", "minimax-m3"},
+		},
+	}
+
+	models := buildCodeBuddyAuthModels(auth)
+	if len(models) != 2 {
+		t.Fatalf("unexpected model count: %d", len(models))
+	}
+	if models[0].ID != "hy3" || models[0].OwnedBy != "codebuddy-cn" || models[0].Type != "codebuddy-cn" {
+		t.Errorf("fallback model mismatch: %+v", models[0])
+	}
+}
+
+func TestBuildCodeBuddyAuthModelsStringSliceMetadata(t *testing.T) {
+	auth := &coreauth.Auth{
+		Provider: "codebuddy-cn",
+		Metadata: map[string]any{
+			"enabled_models": []string{"hy3"},
+		},
+	}
+	if models := buildCodeBuddyAuthModels(auth); len(models) != 1 || models[0].ID != "hy3" {
+		t.Fatalf("string slice metadata not handled: %+v", models)
+	}
+}
+
+func TestBuildCodeBuddyAuthModelsEmptyMetadata(t *testing.T) {
+	if models := buildCodeBuddyAuthModels(nil); models != nil {
+		t.Errorf("nil auth should yield no models, got %+v", models)
+	}
+	if models := buildCodeBuddyAuthModels(&coreauth.Auth{Provider: "codebuddy-cn"}); models != nil {
+		t.Errorf("auth without metadata should yield no models, got %+v", models)
+	}
+}


### PR DESCRIPTION
## Summary
- Add CodeBuddy CN (WorkBuddy CN) as a new provider: OAuth login flow, token management/refresh, request sanitization, and model definitions under `internal/auth/codebuddy/`
- Add the CodeBuddy runtime executor (`internal/runtime/executor/codebuddy_executor.go`) and the `codebuddy_login` CLI command
- Expose the provider through `sdk/auth` and the SDK service model registry

## Testing
- Unit tests added for headers, models, sanitize, token handling, the executor, and SDK service model registration