### PR TITLE
fix(responses): preserve custom tool identity when namespaces are omitted

### DIFF
--- a/internal/translator/openai/openai/responses/custom_tool_namespace_recovery_test.go
+++ b/internal/translator/openai/openai/responses/custom_tool_namespace_recovery_test.go
@@ -1,0 +1,92 @@
+package responses
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const namespaceRecoveryRequest = `{"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"},{"type":"function","name":"wait"}]}]}]}`
+
+func TestCustomToolNamespaceRecoveryPreservesStreamAndNonStream(t *testing.T) {
+	for _, name := range []string{"functions__exec", "exec"} {
+		t.Run(name, func(t *testing.T) {
+			request := []byte(namespaceRecoveryRequest)
+			args := `{"input":"text(\"测试\\n\");"}`
+			call := fmt.Sprintf(`{"index":0,"id":"call_fixture","type":"function","function":{"name":%q,"arguments":%q}}`, name, args)
+			raw := fmt.Sprintf(`{"id":"fixture","choices":[{"index":0,"message":{"tool_calls":[%s]},"finish_reason":"tool_calls"}]}`, call)
+			response := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "fixture", request, nil, []byte(raw), nil)
+			assertRecoveredCustomCall(t, gjson.GetBytes(response, "output.0"), true)
+			var state any
+			counts := map[string]int{}
+			for _, line := range []string{
+				fmt.Sprintf(`data: {"id":"fixture","choices":[{"index":0,"delta":{"tool_calls":[%s]},"finish_reason":"tool_calls"}]}`, call),
+				"data: [DONE]",
+			} {
+				for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "fixture", request, nil, []byte(line), &state) {
+					event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+					counts[event]++
+					switch event {
+					case "response.output_item.added", "response.output_item.done":
+						assertRecoveredCustomCall(t, data.Get("item"), event == "response.output_item.done")
+					case "response.completed":
+						assertRecoveredCustomCall(t, data.Get("response.output.0"), true)
+					default:
+						if strings.HasPrefix(event, "response.function_call_arguments.") {
+							t.Fatalf("custom call downgraded: %s", chunk)
+						}
+					}
+				}
+			}
+			for _, event := range []string{"response.output_item.added", "response.output_item.done", "response.completed", "response.custom_tool_call_input.done"} {
+				if counts[event] != 1 {
+					t.Fatalf("%s count = %d", event, counts[event])
+				}
+			}
+		})
+	}
+}
+
+func assertRecoveredCustomCall(t *testing.T, item gjson.Result, withInput bool) {
+	t.Helper()
+	for key, want := range map[string]string{"type": "custom_tool_call", "name": "exec", "namespace": "functions", "call_id": "call_fixture"} {
+		if got := item.Get(key).String(); got != want {
+			t.Fatalf("%s = %q, want %q; item=%s", key, got, want, item)
+		}
+	}
+	if withInput && item.Get("input").String() != "text(\"测试\\n\");" {
+		t.Fatalf("input changed: %s", item)
+	}
+	if item.Get("arguments").Exists() {
+		t.Fatal("custom call retained JSON arguments")
+	}
+}
+
+func TestCustomToolReplayPreservesNamespaceAndResultPair(t *testing.T) {
+	for _, namespace := range []string{`,"namespace":"functions"`, ""} {
+		request := strings.TrimSuffix(namespaceRecoveryRequest, "]}") + fmt.Sprintf(`,{"type":"custom_tool_call","name":"exec"%s,"call_id":"call_fixture","input":"text(1);"},{"type":"custom_tool_call_output","call_id":"call_fixture","output":[{"type":"input_text","text":"1"}]}]}`, namespace)
+		body := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("fixture", []byte(request), false)
+		if got := gjson.GetBytes(body, "messages.0.tool_calls.0.function.name").String(); got != "functions__exec" {
+			t.Fatalf("replay name %q: %s", got, body)
+		}
+		if got := gjson.GetBytes(body, "messages.1.tool_call_id").String(); got != "call_fixture" {
+			t.Fatalf("result pair lost: %s", body)
+		}
+	}
+}
+
+func TestNamespaceRecoveryDoesNotGuessAmbiguousOrOverrideExactNames(t *testing.T) {
+	for _, tt := range []struct{ request, name, want string }{
+		{namespaceRecoveryRequest, "wait", "functions__wait"},
+		{namespaceRecoveryRequest, "unknown", "unknown"},
+		{`{"tools":[{"type":"function","name":"exec"},{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}]}`, "exec", "exec"},
+		{`{"tools":[{"type":"namespace","name":"first","tools":[{"type":"custom","name":"exec"}]},{"type":"namespace","name":"second","tools":[{"type":"custom","name":"exec"}]}]}`, "exec", "exec"},
+	} {
+		if got := canonicalResponsesToolName([]byte(tt.request), tt.name); got != tt.want {
+			t.Fatalf("got %q, want %q", got, tt.want)
+		}
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -245,6 +245,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					functionName := name.String()
 					if namespace := strings.TrimSpace(item.Get("namespace").String()); namespace != "" {
 						functionName = qualifyResponsesNamespaceToolName(namespace, functionName)
+					} else {
+						functionName = canonicalResponsesToolName(inputRawJSON, functionName)
 					}
 					toolCall, _ = sjson.SetBytes(toolCall, "function.name", functionName)
 				}
@@ -287,7 +289,13 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				// converting custom tool definitions.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 				toolCall, _ = sjson.SetBytes(toolCall, "id", item.Get("call_id").String())
-				toolCall, _ = sjson.SetBytes(toolCall, "function.name", item.Get("name").String())
+				functionName := item.Get("name").String()
+				if namespace := item.Get("namespace").String(); namespace != "" {
+					functionName = qualifyResponsesNamespaceToolName(namespace, functionName)
+				} else {
+					functionName = canonicalResponsesToolName(inputRawJSON, functionName)
+				}
+				toolCall, _ = sjson.SetBytes(toolCall, "function.name", functionName)
 				wrappedArgs, _ := sjson.SetBytes([]byte(`{"input":""}`), "input", item.Get("input").String())
 				toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", string(wrappedArgs))
 				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -341,7 +341,8 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			return
 		}
 		callID := st.FuncCallIDs[key]
-		name := st.FuncNames[key]
+		name := canonicalResponsesToolName(requestForNamespace, st.FuncNames[key])
+		st.FuncNames[key] = name
 		if !force && (callID == "" || name == "") {
 			return
 		}
@@ -938,7 +939,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 							// function_call item stays usable for Codex round-trips.
 							callID = fmt.Sprintf("call_%s_%d_%d", id, choice.Get("index").Int(), tcIndex.Int())
 						}
-						name := tc.Get("function.name").String()
+						name := canonicalResponsesToolName(requestForNamespace, tc.Get("function.name").String())
 						args := tc.Get("function.arguments").String()
 						toolStatus := "completed"
 						if isIncomplete {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -298,6 +298,36 @@ func resolveResponsesQualifiedToolIdentity(root gjson.Result, qualifiedName stri
 	return name, namespace, found
 }
 
+// canonicalResponsesToolName restores an omitted namespace only when the current
+// request declares exactly one matching local name. Exact emitted names win;
+// ambiguous names remain unresolved rather than being dispatched to another tool.
+func canonicalResponsesToolName(requestRawJSON []byte, name string) string {
+	root := gjson.ParseBytes(requestRawJSON)
+	if _, _, found := resolveResponsesQualifiedToolIdentity(root, name); found {
+		return name
+	}
+	seen := make(map[string]struct{})
+	candidate := ""
+	ambiguous := false
+	walkResponsesToolDeclarations(root, func(declaration responsesToolDeclaration) bool {
+		if _, duplicate := seen[declaration.chatName]; duplicate {
+			return true
+		}
+		seen[declaration.chatName] = struct{}{}
+		if declaration.localName == name {
+			if candidate != "" {
+				ambiguous = true
+			}
+			candidate = declaration.chatName
+		}
+		return true
+	})
+	if candidate != "" && !ambiguous {
+		return candidate
+	}
+	return name
+}
+
 func splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON []byte, qualifiedName string) (name, namespace string) {
 	qualifiedName = strings.TrimSpace(qualifiedName)
 	if qualifiedName == "" {


### PR DESCRIPTION
A Responses client can declare `functions.exec` as a custom tool, then receive a Chat Completions call named `exec` instead of the flattened `functions__exec`. Reverse translation currently classifies that short name as an ordinary function call, so a client expecting freeform tool input rejects it. Custom-call history replay also drops the namespace, which can encourage subsequent responses to reuse the short name.

Preserve qualified tool names during history replay. For streamed and non-streamed responses, resolve a short name only when the current request's tool declarations identify exactly one matching tool. Exact emitted names retain precedence; ambiguous and unknown names remain unchanged. The restored custom call preserves its input, namespace, call id and event type. The implementation has no provider, model or tool-name allowlist and works with both top-level declarations and Responses Lite `additional_tools`.

Validation on upstream `main` (`5208aec7`):
- `go test ./internal/translator/openai/openai/responses ./internal/runtime/executor ./sdk/cliproxy/auth`
- `go build -o ../cpa-upstream-tool-identity-build ./cmd/server`
- `git diff upstream/main...HEAD --check`

Regression coverage includes qualified and omitted namespaces, streaming/non-streaming event identity, Unicode input preservation, replay/result pairing, exact-name precedence and ambiguous/unknown names. The same translation patch was also exercised in a separate integration build with a native Responses client and real compatibility-provider custom-tool execution; that integration build is not part of this PR.

This is one standalone commit against upstream main. No account routing preset, credentials, private state, local service configuration or unrelated integration commits are included.

Upstream automation retargeted this PR to `dev`; the diff remains one standalone commit and four files. The build passed. `translator-path-guard` disallows changes under `internal/translator/**` and requests a maintainer issue; tracking implementation adoption in #5560.
