### PR TITLE
fix(claude): forward per-turn-control and mid-conversation-tool-changes betas when the caller requests them

### DIFF
--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -50,6 +50,8 @@ const (
 	claudeExtendedCacheTTLBeta       = "extended-cache-ttl-2025-04-11"
 	claudeCacheDiagnosisBeta         = "cache-diagnosis-2026-04-07"
 	claudeRedactThinkingBeta         = "redact-thinking-2026-02-12"
+	claudePerTurnControlBeta         = "per-turn-control-2026-07-01"
+	claudeMidConvToolChangesBeta     = "mid-conversation-tool-changes-2026-07-01"
 )
 
 // claudeCodeCLIConstantBetas are the betas Claude Code sends on every
@@ -74,6 +76,8 @@ var claudeCodeTrailingBetas = []string{
 	claudeServerSideFallbackBeta,
 	claudeFallbackCreditBeta,
 	claudeStructuredOutputsBeta,
+	claudePerTurnControlBeta,
+	claudeMidConvToolChangesBeta,
 }
 
 // claudeCodeCLIBetas assembles the Anthropic-Beta baseline the way Claude Code

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -7975,6 +7975,21 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 				"fallback-credit-2026-06-01,extended-cache-ttl-2025-04-11",
 		},
 		{
+			name: "per-turn-control and mid-conversation-tool-changes are forwarded when the caller requests them",
+			body: `{"model":"claude-fable-5-1"}`,
+			requested: map[string]bool{
+				claudePerTurnControlBeta:     true,
+				claudeMidConvToolChangesBeta: true,
+			},
+			want: constants + ",mid-conversation-system-2026-04-07,effort-2025-11-24," +
+				"per-turn-control-2026-07-01,mid-conversation-tool-changes-2026-07-01",
+		},
+		{
+			name: "per-turn-control is not injected when the caller did not request it",
+			body: `{"model":"claude-fable-5-1"}`,
+			want: constants + ",mid-conversation-system-2026-04-07,effort-2025-11-24",
+		},
+		{
 			name:      "disabled thinking omits effort beta even if requested",
 			body:      `{"model":"claude-sonnet-5","thinking":{"type":"disabled"}}`,
 			requested: map[string]bool{"effort-2025-11-24": true},


### PR DESCRIPTION
## Problem

Claude Code 2.1.261 (measured via the Agent SDK entrypoint `sdk-ts`, i.e. T3 Code) attaches `output_config` to mid-conversation `role: "system"` messages and declares `per-turn-control-2026-07-01` in its `Anthropic-Beta` header:

```
Anthropic-Beta: claude-code-20250219,context-1m-2025-08-07,...,mid-conversation-system-2026-04-07,per-turn-control-2026-07-01,mid-conversation-tool-changes-2026-07-01,...
```

`claudeCodeCLIBetas` rebuilds the beta list from scratch and has no knowledge of either 2026-07-01 beta, so the upstream request keeps the `output_config` field on the system message but loses the beta that permits it. Anthropic rejects it:

```
HTTP 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.4.output_config: Extra inputs are not permitted"}}
```

The client retries and the session sits on "thinking" indefinitely. Reproduced on v7.2.147 and v7.2.151 (and current `dev`, where `claudeCodeTrailingBetas` is unchanged).

## Verification

Same body (a `user` turn followed by a `system` turn carrying `output_config: {"effort": "high"}`), OAuth credential:

| route | result |
|---|---|
| direct to api.anthropic.com, with `per-turn-control-2026-07-01` | 200 |
| direct to api.anthropic.com, without it | 400 `messages.1.output_config: Extra inputs are not permitted` |
| through v7.2.151 unpatched | 400 (same message) |
| through v7.2.151 with this change | 200 |

## Change

Two constants added to `claudeCodeTrailingBetas`. That list is consumed by the loop that appends a beta **only if the caller requested it** (`requested[beta]`), so nothing is injected on its own: clients that do not send these betas keep a byte-identical header. Two cases added to `TestClaudeCodeCLIBetas_MatchesObservedClientMatrix` (forwarded when requested, absent when not). `go test ./internal/runtime/executor/...` passes.
