### PR TITLE
fix(openai): preserve local prewarm context during compact replay

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -328,6 +328,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 	var lastRequest []byte
 	lastResponseOutput := []byte("[]")
 	lastResponseID := ""
+	localPrewarmResponseID := ""
 	var lastResponsePendingToolCallIDs []string
 	pinnedAuthID := ""
 	// Preserve independent upstream auth affinity when a downstream session switches providers.
@@ -495,7 +496,11 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		var requestJSON []byte
 		var updatedLastRequest []byte
 		var errMsg *interfaces.ErrorMessage
-		if nativeWebsocketPassthrough {
+		previousResponseID := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String())
+		if localPrewarmResponseID != "" && previousResponseID == localPrewarmResponseID && lastResponseID != localPrewarmResponseID {
+			// A consumed local ID cannot refer to a later HTTP transcript or an upstream socket.
+			errMsg = responsesWebsocketPreviousResponseNotFoundError()
+		} else if nativeWebsocketPassthrough {
 			requestJSON, errMsg = normalizeResponsesWebsocketPassthroughRequest(payload, requestModelName)
 		} else if len(lastRequest) == 0 && strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != "" {
 			errMsg = responsesWebsocketPreviousResponseNotFoundError()
@@ -506,6 +511,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				lastResponseOutput,
 				lastResponseID,
 				lastResponsePendingToolCallIDs,
+				localPrewarmResponseID,
 				false,
 				allowCompactionReplayBypass,
 			)
@@ -545,12 +551,14 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			lastRequest = updatedLastRequest
 			lastResponseOutput = []byte("[]")
-			lastResponseID = ""
 			lastResponsePendingToolCallIDs = nil
-			if errWrite := writeResponsesWebsocketSyntheticPrewarm(c, writer, requestJSON, wsTimelineLog, passthroughSessionID); errWrite != nil {
+			responseID, errWrite := writeResponsesWebsocketSyntheticPrewarm(c, writer, requestJSON, wsTimelineLog, passthroughSessionID)
+			if errWrite != nil {
 				wsTerminateErr = errWrite
 				return
 			}
+			localPrewarmResponseID = responseID
+			lastResponseID = responseID
 			continue
 		}
 

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -559,6 +559,11 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			}
 			localPrewarmResponseID = responseID
 			lastResponseID = responseID
+			// Local prewarm replaces any previous native response chain. Rebuild its
+			// continuation before establishing the next upstream transport.
+			upstreamMode = responsesWebsocketUpstreamModeHTTP
+			upstreamWebsocketAuthID = ""
+			passthroughModelName = ""
 			continue
 		}
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
@@ -28,10 +28,10 @@ func writeResponsesWebsocketSyntheticPrewarm(
 	requestJSON []byte,
 	wsTimelineLog websocketTimelineAppender,
 	sessionID string,
-) error {
+) (string, error) {
 	payloads, errPayloads := syntheticResponsesWebsocketPrewarmPayloads(requestJSON)
 	if errPayloads != nil {
-		return errPayloads
+		return "", errPayloads
 	}
 	for i := 0; i < len(payloads); i++ {
 		markAPIResponseTimestamp(c)
@@ -49,10 +49,10 @@ func writeResponsesWebsocketSyntheticPrewarm(
 				websocketPayloadEventType(payloads[i]),
 				errWrite,
 			)
-			return errWrite
+			return "", errWrite
 		}
 	}
-	return nil
+	return gjson.GetBytes(payloads[0], "response.id").String(), nil
 }
 
 func syntheticResponsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, error) {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -24,10 +24,10 @@ func normalizeResponsesWebsocketRequestWithMode(rawJSON []byte, lastRequest []by
 }
 
 func normalizeResponsesWebsocketRequestWithLastResponseID(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
-	return normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON, lastRequest, lastResponseOutput, lastResponseID, nil, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+	return normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON, lastRequest, lastResponseOutput, lastResponseID, nil, "", allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
 }
 
-func normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
+func normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, localPrewarmResponseID string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
 	requestType := strings.TrimSpace(gjson.GetBytes(rawJSON, "type").String())
 	switch requestType {
 	case wsRequestTypeCreate:
@@ -35,10 +35,10 @@ func normalizeResponsesWebsocketRequestWithIncrementalState(rawJSON []byte, last
 		if len(lastRequest) == 0 {
 			return normalizeResponseCreateRequest(rawJSON)
 		}
-		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, localPrewarmResponseID, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
 	case wsRequestTypeAppend:
 		// log.Infof("responses websocket: response.append request")
-		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
+		return normalizeResponseSubsequentRequest(rawJSON, lastRequest, lastResponseOutput, lastResponseID, lastResponsePendingToolCallIDs, localPrewarmResponseID, allowIncrementalInputWithPreviousResponseID, allowCompactionReplayBypass)
 	default:
 		return nil, lastRequest, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -67,7 +67,7 @@ func normalizeResponseCreateRequest(rawJSON []byte) ([]byte, []byte, *interfaces
 	return normalized, bytes.Clone(normalized), nil
 }
 
-func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
+func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, lastResponseOutput []byte, lastResponseID string, lastResponsePendingToolCallIDs []string, localPrewarmResponseID string, allowIncrementalInputWithPreviousResponseID bool, allowCompactionReplayBypass bool) ([]byte, []byte, *interfaces.ErrorMessage) {
 	if len(lastRequest) == 0 {
 		return nil, lastRequest, &interfaces.ErrorMessage{
 			StatusCode: http.StatusBadRequest,
@@ -83,18 +83,33 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 
+	// The last request still holds the complete prewarm until an upstream turn succeeds.
+	// Only the ID actually issued on this connection establishes that incremental base.
+	localPrewarmContinuation := localPrewarmResponseID != "" && lastResponseID == localPrewarmResponseID
+	if localPrewarmContinuation {
+		previousResponseID := strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String())
+		if previousResponseID != "" && previousResponseID != localPrewarmResponseID {
+			return nil, lastRequest, responsesWebsocketPreviousResponseNotFoundError()
+		}
+		if previousResponseID == "" && strings.TrimSpace(gjson.GetBytes(rawJSON, "type").String()) == wsRequestTypeCreate {
+			// A fresh create replaces the prewarm, including changed or removed tools.
+			normalized := normalizeResponseTranscriptReplacement(rawJSON, lastRequest)
+			return normalized, bytes.Clone(normalized), nil
+		}
+	}
+
 	// Compaction can cause clients to replace local websocket history with a new
 	// compact transcript on the next `response.create`. When the input already
 	// contains historical model output items, treating it as an incremental append
 	// duplicates stale turn-state and can leave late orphaned function_call items.
-	if shouldReplaceWebsocketTranscript(rawJSON, nextInput) {
+	if !localPrewarmContinuation && shouldReplaceWebsocketTranscript(rawJSON, nextInput) {
 		normalized := normalizeResponseTranscriptReplacement(rawJSON, lastRequest)
 		return normalized, bytes.Clone(normalized), nil
 	}
 
 	// Websocket v2 mode uses response.create with previous_response_id + incremental input.
 	// Do not expand it into a full input transcript; upstream expects the incremental payload.
-	if allowIncrementalInputWithPreviousResponseID {
+	if allowIncrementalInputWithPreviousResponseID && !localPrewarmContinuation {
 		prev := strings.TrimSpace(gjson.GetBytes(rawJSON, "previous_response_id").String())
 		if prev == "" {
 			if !inputSatisfiesPendingToolCalls(nextInput, lastResponsePendingToolCallIDs) {
@@ -132,12 +147,14 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 	// function_call / function_call_output pairings.
 	// See: https://github.com/router-for-me/CLIProxyAPI/issues/2207
 	var mergedInput []byte
-	if allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
+	if !localPrewarmContinuation && allowCompactionReplayBypass && inputContainsFullTranscript(nextInput) {
 		log.Infof("responses websocket: full transcript detected, skipping stale merge (input items=%d)", len(nextInput.Array()))
 		mergedInput = []byte(nextInput.Raw)
 	} else {
 		appendInputRaw := nextInput.Raw
-		if inputContainsFullTranscript(nextInput) {
+		// A prewarm continuation can itself contain compact history. Preserve both
+		// that history and the input prefix the upstream has never received.
+		if !localPrewarmContinuation && inputContainsFullTranscript(nextInput) {
 			appendInputRaw = inputWithoutCompactionItems(nextInput)
 		}
 
@@ -169,6 +186,11 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
+	if localPrewarmContinuation && !gjson.GetBytes(normalized, "tools").Exists() {
+		if tools := gjson.GetBytes(lastRequest, "tools"); tools.Exists() {
+			normalized, _ = sjson.SetRawBytes(normalized, "tools", []byte(tools.Raw))
+		}
+	}
 	var errSet error
 	normalized, errSet = sjson.SetRawBytes(normalized, "input", mergedInput)
 	if errSet != nil {

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests_memory_test.go
@@ -258,7 +258,7 @@ func TestNormalizeResponseSubsequentRequestDetachesSourceBuffers(t *testing.T) {
 	lastResponseOutput := []byte(`[{"type":"message","id":"msg-2","role":"assistant","content":[{"type":"output_text","text":"response sentinel"}]}]`)
 	raw := []byte(`{"type":"response.create","input":[{"type":"message","id":"msg-3","role":"user","content":"append sentinel"}]}`)
 
-	normalized, next, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+	normalized, next, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, "", false, false)
 	if errMessage != nil {
 		t.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
 	}
@@ -349,7 +349,7 @@ func BenchmarkNormalizeResponseSubsequentRequestTranscripts(b *testing.B) {
 			b.SetBytes(int64(len(lastRequest) + len(lastResponseOutput) + len(raw)))
 			b.ReportAllocs()
 			for b.Loop() {
-				normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, false, false)
+				normalized, _, errMessage := normalizeResponseSubsequentRequest(raw, lastRequest, lastResponseOutput, "", nil, "", false, false)
 				if errMessage != nil {
 					b.Fatalf("normalizeResponseSubsequentRequest() error = %v", errMessage.Error)
 				}

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -4558,6 +4558,126 @@ func TestResponsesWebsocketLocalPrewarmContext(t *testing.T) {
 	}
 }
 
+func TestResponsesWebsocketLocalPrewarmResetsNativeTransport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const nativeModel = "prewarm-switch-native"
+	const httpModel = "prewarm-switch-http"
+	const prefix = `{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"type":"message","role":"developer","content":"Use the execution tool for shell commands."}`
+	const delta = `{"type":"compaction","encrypted_content":"opaque-summary"},{"type":"message","role":"user","content":"Run pwd."}`
+	for _, tc := range []struct {
+		name  string
+		model string
+	}{
+		{name: "return to native model", model: nativeModel},
+		{name: "continue HTTP without explicit model"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nativeExecutor := &websocketDirectCaptureExecutor{provider: "codex"}
+			httpExecutor := &websocketDirectCaptureExecutor{provider: "xai"}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(nativeExecutor)
+			manager.RegisterExecutor(httpExecutor)
+			for _, setup := range []struct {
+				auth  *coreauth.Auth
+				model string
+			}{
+				{auth: &coreauth.Auth{ID: "auth-prewarm-switch-native", Provider: "codex", Status: coreauth.StatusActive, Attributes: map[string]string{"websockets": "true"}}, model: nativeModel},
+				{auth: &coreauth.Auth{ID: "auth-prewarm-switch-http", Provider: "xai", Status: coreauth.StatusActive}, model: httpModel},
+			} {
+				if _, errRegister := manager.Register(context.Background(), setup.auth); errRegister != nil {
+					t.Fatalf("register auth: %v", errRegister)
+				}
+				registry.GetGlobalRegistry().RegisterClient(setup.auth.ID, setup.auth.Provider, []*registry.ModelInfo{{ID: setup.model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(setup.auth.ID) })
+			}
+			h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+			router := gin.New()
+			router.GET("/v1/responses", h.ResponsesWebsocket)
+			server := httptest.NewServer(router)
+			defer server.Close()
+			conn, _, errDial := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", nil)
+			if errDial != nil {
+				t.Fatalf("dial websocket: %v", errDial)
+			}
+			defer func() {
+				if errClose := conn.Close(); errClose != nil {
+					t.Errorf("close websocket: %v", errClose)
+				}
+			}()
+			exchange := func(request string) []byte {
+				t.Helper()
+				if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(request)); errWrite != nil {
+					t.Fatalf("write websocket request: %v", errWrite)
+				}
+				for {
+					_, payload, errRead := conn.ReadMessage()
+					if errRead != nil {
+						t.Fatalf("read websocket response: %v", errRead)
+					}
+					switch gjson.GetBytes(payload, "type").String() {
+					case wsEventTypeError:
+						t.Fatalf("unexpected websocket error: %s", payload)
+					case wsEventTypeCompleted:
+						return payload
+					}
+				}
+			}
+			exchange(fmt.Sprintf(`{"type":"response.create","model":%q,"input":[{"type":"message","role":"user","content":"Start the native conversation."}]}`, nativeModel))
+			prewarm := exchange(fmt.Sprintf(`{"type":"response.create","model":%q,"generate":false,"input":[%s]}`, httpModel, prefix))
+			prewarmID := gjson.GetBytes(prewarm, "response.id").String()
+			if !strings.HasPrefix(prewarmID, "resp_prewarm_") {
+				t.Fatalf("expected local prewarm response: %s", prewarm)
+			}
+			if len(nativeExecutor.Payloads()) != 1 || len(httpExecutor.Payloads()) != 0 {
+				t.Fatal("local prewarm unexpectedly reached an upstream executor")
+			}
+
+			modelField := ""
+			targetExecutor, wantCalls := httpExecutor, 1
+			if tc.model != "" {
+				modelField = fmt.Sprintf(`,"model":%q`, tc.model)
+				targetExecutor, wantCalls = nativeExecutor, 2
+			}
+			completed := exchange(fmt.Sprintf(`{"type":"response.create"%s,"previous_response_id":%q,"input":[%s]}`, modelField, prewarmID, delta))
+			payloads := targetExecutor.Payloads()
+			if len(payloads) != wantCalls {
+				t.Fatalf("upstream calls = %d, want %d", len(payloads), wantCalls)
+			}
+			forwarded := payloads[wantCalls-1]
+			if gjson.GetBytes(forwarded, "previous_response_id").Exists() || gjson.GetBytes(forwarded, "generate").Exists() {
+				t.Errorf("local prewarm metadata leaked upstream: %s", forwarded)
+			}
+			assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(forwarded, "input").Raw), "["+prefix+","+delta+"]")
+
+			// After reconstruction, subsequent turns must use the newly established transport.
+			const nextUser = `{"type":"message","role":"user","content":"Run whoami."}`
+			nextResponseID := gjson.GetBytes(completed, "response.id").String()
+			exchange(fmt.Sprintf(`{"type":"response.create","previous_response_id":%q,"input":[%s]}`, nextResponseID, nextUser))
+			payloads = targetExecutor.Payloads()
+			if len(payloads) != wantCalls+1 {
+				t.Fatalf("upstream calls after next turn = %d, want %d", len(payloads), wantCalls+1)
+			}
+			next := payloads[wantCalls]
+			wantNextInput := "[" + nextUser + "]"
+			if tc.model == nativeModel {
+				if got := gjson.GetBytes(next, "previous_response_id").String(); got != nextResponseID {
+					t.Fatalf("native continuation ID = %q, want %q", got, nextResponseID)
+				}
+				flags := nativeExecutor.RequiredUpstreamWebsocketFlags()
+				if flags[1] || !flags[2] {
+					t.Fatalf("native websocket requirements = %v, want [false false true]", flags)
+				}
+			} else {
+				if gjson.GetBytes(next, "previous_response_id").Exists() {
+					t.Fatalf("HTTP continuation forwarded a response ID: %s", next)
+				}
+				wantNextInput = "[" + prefix + "," + delta + "," + gjson.GetBytes(completed, "response.output.0").Raw + "," + nextUser + "]"
+			}
+			assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(next, "input").Raw), wantNextInput)
+		})
+	}
+}
+
 func TestNormalizeResponsesWebsocketLocalPrewarmTools(t *testing.T) {
 	const prewarmID = "resp_prewarm_test"
 	const tools = `[{"type":"function","name":"exec","parameters":{"type":"object"}}]`

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -1500,7 +1500,7 @@ func TestNormalizeResponsesWebsocketRequestInjectsPreviousResponseIDWhenPendingO
 	lastResponseOutput := []byte(`[]`)
 	raw := []byte(`{"type":"response.create","input":[{"type":"function_call_output","call_id":"call-1","id":"tool-out-1"}]}`)
 
-	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(raw, lastRequest, lastResponseOutput, "resp-1", []string{"call-1"}, true, false)
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(raw, lastRequest, lastResponseOutput, "resp-1", []string{"call-1"}, "", true, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
@@ -1520,7 +1520,7 @@ func TestNormalizeResponsesWebsocketRequestSkipsPreviousResponseIDWhenPendingOut
 	]`)
 	raw := []byte(`{"type":"response.create","input":[{"type":"message","role":"user","id":"summary-1","content":"compacted summary"}]}`)
 
-	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(raw, lastRequest, lastResponseOutput, "resp-1", []string{"call-1"}, true, false)
+	normalized, next, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(raw, lastRequest, lastResponseOutput, "resp-1", []string{"call-1"}, "", true, false)
 	if errMsg != nil {
 		t.Fatalf("unexpected error: %v", errMsg.Error)
 	}
@@ -1887,6 +1887,7 @@ func TestRestoreResponsesWebsocketCompletionOutputReconcilesConflictingToolCall(
 		completedOutput,
 		"resp-1",
 		[]string{"call-1"},
+		"",
 		false,
 		false,
 	)
@@ -4402,6 +4403,192 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 	input := gjson.GetBytes(forwarded, "input").Array()
 	if len(input) != 1 || input[0].Get("id").String() != "msg-1" {
 		t.Fatalf("unexpected forwarded input: %s", forwarded)
+	}
+}
+
+func TestResponsesWebsocketLocalPrewarmContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const tools = `{"type":"additional_tools","role":"developer","tools":[{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}]}`
+	const instructions = `{"type":"message","role":"developer","content":[{"type":"input_text","text":"Use the execution tool for shell commands."}]}`
+	const prefix = tools + "," + instructions
+	const user = `{"type":"message","role":"user","content":[{"type":"input_text","text":"Run pwd."}]}`
+	const compact = `{"type":"compaction","id":"compact-1","encrypted_content":"opaque-summary"}`
+	const replacementTools = `{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"new_exec"}]}`
+	const emptyTools = `{"type":"additional_tools","role":"developer","tools":[]}`
+	for _, tc := range []struct {
+		name      string
+		input     string
+		reference bool
+		native    bool
+		append    bool
+		checkIDs  bool
+	}{
+		{name: "ordinary increment", input: user, reference: true},
+		{name: "compaction increment", input: compact + "," + user, reference: true, checkIDs: true},
+		{name: "compaction summary increment", input: `{"type":"compaction_summary","encrypted_content":"opaque-summary"},` + user, reference: true},
+		{name: "native websocket", input: compact + "," + user, reference: true, native: true},
+		{name: "full compact replay", input: prefix + "," + compact + "," + user},
+		{name: "replace tools", input: replacementTools + "," + instructions + "," + user},
+		{name: "clear tools", input: emptyTools + "," + instructions + "," + user},
+		{name: "remove tools", input: instructions + "," + user},
+		{name: "empty create"},
+		{name: "legacy append", input: compact + "," + user, append: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &websocketDirectCaptureExecutor{}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			modelName := "local-prewarm-model"
+			auth := &coreauth.Auth{ID: "auth-local-prewarm", Provider: "codex", Status: coreauth.StatusActive, Attributes: map[string]string{"websockets": strconv.FormatBool(tc.native)}}
+			if _, err := manager.Register(context.Background(), auth); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelName}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager))
+			router := gin.New()
+			router.GET("/v1/responses", h.ResponsesWebsocket)
+			server := httptest.NewServer(router)
+			defer server.Close()
+			wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
+			conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				t.Fatalf("dial websocket: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+			exchange := func(socket *websocket.Conn, request string) []byte {
+				t.Helper()
+				if errWrite := socket.WriteMessage(websocket.TextMessage, []byte(request)); errWrite != nil {
+					t.Fatalf("write websocket request: %v", errWrite)
+				}
+				for {
+					_, event, errRead := socket.ReadMessage()
+					if errRead != nil {
+						t.Fatalf("read websocket response: %v", errRead)
+					}
+					if eventType := gjson.GetBytes(event, "type").String(); eventType == wsEventTypeCompleted || eventType == wsEventTypeError {
+						return event
+					}
+				}
+			}
+			prewarm := exchange(conn, fmt.Sprintf(`{"type":"response.create","model":%q,"generate":false,"input":[%s]}`, modelName, prefix))
+			prewarmID := gjson.GetBytes(prewarm, "response.id").String()
+			if prewarmID == "" {
+				t.Fatalf("missing prewarm response ID: %s", prewarm)
+			}
+			prewarmCalls := 0
+			if tc.native {
+				prewarmCalls = 1
+			}
+			if payloads := executor.Payloads(); len(payloads) != prewarmCalls {
+				t.Fatalf("upstream prewarm calls = %d, want %d", len(payloads), prewarmCalls)
+			} else if tc.native {
+				assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(payloads[0], "input").Raw), "["+prefix+"]")
+			}
+
+			if tc.checkIDs {
+				// A similar-looking ID must not borrow this connection's prewarm.
+				unknown := exchange(conn, `{"type":"response.create","previous_response_id":"resp_prewarm_other-connection","input":[`+compact+","+user+`]}`)
+				if got := gjson.GetBytes(unknown, "error.code").String(); got != "previous_response_not_found" {
+					t.Fatalf("unknown prewarm error = %q: %s", got, unknown)
+				}
+				reconn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+				if errDial != nil {
+					t.Fatalf("reconnect websocket: %v", errDial)
+				}
+				defer func() { _ = reconn.Close() }()
+				missing := exchange(reconn, fmt.Sprintf(`{"type":"response.create","model":%q,"previous_response_id":%q,"input":[%s]}`, modelName, prewarmID, user))
+				if got := gjson.GetBytes(missing, "error.code").String(); got != "previous_response_not_found" {
+					t.Fatalf("reconnect prewarm error = %q: %s", got, missing)
+				}
+				if got := len(executor.Payloads()); got != 0 {
+					t.Fatalf("invalid continuations reached upstream: %d calls", got)
+				}
+			}
+
+			requestType := wsRequestTypeCreate
+			if tc.append {
+				requestType = wsRequestTypeAppend
+			}
+			previous := ""
+			if tc.reference {
+				previous = fmt.Sprintf(`,"previous_response_id":%q`, prewarmID)
+			}
+			response := exchange(conn, fmt.Sprintf(`{"type":%q%s,"input":[%s]}`, requestType, previous, tc.input))
+			if got := gjson.GetBytes(response, "type").String(); got != wsEventTypeCompleted {
+				t.Fatalf("continuation response type = %q: %s", got, response)
+			}
+			payloads := executor.Payloads()
+			if len(payloads) != prewarmCalls+1 {
+				t.Fatalf("upstream calls = %d, want %d", len(payloads), prewarmCalls+1)
+			}
+			forwarded := payloads[len(payloads)-1]
+			wantInput := tc.input
+			if (tc.reference || tc.append) && !tc.native {
+				wantInput = prefix + "," + tc.input
+			}
+			assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(forwarded, "input").Raw), "["+wantInput+"]")
+			if tc.native {
+				if got := gjson.GetBytes(forwarded, "previous_response_id").String(); got != prewarmID {
+					t.Fatalf("upstream prewarm chain = %q, want %q", got, prewarmID)
+				}
+			} else if gjson.GetBytes(forwarded, "previous_response_id").Exists() || gjson.GetBytes(forwarded, "generate").Exists() {
+				t.Fatalf("local prewarm metadata leaked upstream: %s", forwarded)
+			}
+			if tc.checkIDs {
+				// Successful reconstruction becomes the canonical base of the next HTTP turn.
+				nextResponseID := gjson.GetBytes(response, "response.id").String()
+				exchange(conn, fmt.Sprintf(`{"type":"response.create","previous_response_id":%q,"input":[%s]}`, nextResponseID, user))
+				payloads = executor.Payloads()
+				if len(payloads) != 2 {
+					t.Fatalf("upstream calls after next turn = %d, want 2", len(payloads))
+				}
+				output := gjson.GetBytes(response, "response.output").Raw
+				wantNextInput := "[" + wantInput + "," + strings.TrimSuffix(strings.TrimPrefix(output, "["), "]") + "," + user + "]"
+				assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(payloads[1], "input").Raw), wantNextInput)
+				stale := exchange(conn, fmt.Sprintf(`{"type":"response.create","previous_response_id":%q,"input":[%s]}`, prewarmID, user))
+				if got := gjson.GetBytes(stale, "error.code").String(); got != "previous_response_not_found" {
+					t.Fatalf("consumed prewarm error = %q: %s", got, stale)
+				}
+				if got := len(executor.Payloads()); got != 2 {
+					t.Fatalf("consumed local prewarm reached upstream: %d calls", got)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesWebsocketLocalPrewarmTools(t *testing.T) {
+	const prewarmID = "resp_prewarm_test"
+	const tools = `[{"type":"function","name":"exec","parameters":{"type":"object"}}]`
+	lastRequest := []byte(`{"model":"test-model","instructions":"Use tools.","tools":` + tools + `,"input":[]}`)
+	for _, tc := range []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "omitted", want: tools},
+		{name: "cleared", field: `,"tools":[]`, want: `[]`},
+		{name: "replaced", field: `,"tools":[{"type":"function","name":"new_exec"}]`, want: `[{"type":"function","name":"new_exec"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte(`{"type":"response.create","previous_response_id":"resp_prewarm_test","input":[{"type":"compaction","encrypted_content":"summary"}]` + tc.field + `}`)
+			// Local IDs must be expanded even if transport capabilities change after prewarm.
+			normalized, next, errMsg := normalizeResponsesWebsocketRequestWithIncrementalState(raw, lastRequest, []byte("[]"), prewarmID, nil, prewarmID, true, false)
+			if errMsg != nil {
+				t.Fatalf("normalize prewarm continuation: %v", errMsg.Error)
+			}
+			assertJSONSemanticallyEqual(t, []byte(gjson.GetBytes(normalized, "tools").Raw), tc.want)
+			if got := gjson.GetBytes(normalized, "input.0.type").String(); got != "compaction" {
+				t.Fatalf("compaction item was lost: %s", normalized)
+			}
+			if gjson.GetBytes(normalized, "previous_response_id").Exists() {
+				t.Fatalf("local prewarm ID leaked upstream: %s", normalized)
+			}
+			if !bytes.Equal(next, normalized) {
+				t.Fatal("canonical request differs from the reconstructed request")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
A locally synthesized WebSocket prewarm can lose the tools and base instructions required to resume a compacted Codex conversation. This change reconstructs the first continuation from the prewarm actually issued on that socket, before applying compact-transcript replacement heuristics.

## Reproduction

With a Codex HTTP/SSE upstream, a Responses Lite client sends:

1. `response.create` with `generate: false` and `input: [additional_tools, developer_message]`.
2. CLIProxyAPI returns a local `resp_prewarm_*` response without sending the prewarm upstream.
3. The client references that response ID and sends `input: [compaction, user_message]`, omitting the prefix it already supplied.

Previously, the presence of `compaction` or `compaction_summary` made the normalizer treat the delta as a complete transcript. It discarded the prewarm input and removed the local response ID, so the upstream received only `[compaction, user_message]`.

The upstream now receives `[additional_tools, developer_message, compaction, user_message]`, and that reconstructed input becomes the canonical state for subsequent HTTP turns.

## Changes

- Retain the synthetic response ID on the connection and match continuations against it; do not infer ownership from an ID prefix.
- Preserve the complete prewarm input and the continuation's compaction items. Reuse the existing input merger.
- Treat a new `response.create` without a previous response ID as a replacement, preserving tool updates, explicit empty tool lists, and removed tools. Keep legacy `response.append` behavior.
- Preserve omitted top-level tools for a local prewarm continuation while honoring explicit overrides.
- Reject unknown prewarm references and consumed local IDs. Native upstream WebSocket prewarming keeps its own response chain.
- Reset stale native transport mode, auth binding, and model fallback when a prewarm is handled locally. Both returning to the native model and continuing with the HTTP model rebuild the local prefix before selecting the next transport.

## Related reports

Related to #5380. The regression test supplies the payload-level evidence requested there for the local-prewarm/compact-continuation path.

Related to #5420, which addresses inherited `additional_tools` on transcript replacement. This change also preserves the prewarm's developer messages and uses the locally issued response ID to distinguish a continuation from a fresh full request.

The transport reset also addresses the [Codex review on the original revision](https://github.com/router-for-me/CLIProxyAPI/pull/5566#discussion_r3943633974).

## Validation

- Local WebSocket/capture-executor regression tests cover ordinary and compact continuations, both compact item types, full replacement, tool replacement/clearing/removal, empty input, native WS passthrough, unknown IDs, reconnects, retries after rejected requests, and canonical state after the first successful continuation.
- Top-level tool tests cover omission, clearing, and replacement.
- `TestResponsesWebsocketLocalPrewarmResetsNativeTransport` covers native WS → local HTTP prewarm → native WS, and native WS → local HTTP prewarm → HTTP with an omitted model. Both cases failed before the transport reset and pass after it; subsequent turns also retain the correct native or HTTP continuation behavior.
- All tests in `sdk/api/handlers/openai` passed, including the new regressions.
- `go test ./...` was run on Windows: 91 packages passed; the only failing test was `TestXAIExecutorExecuteVideosCreate` (`ttft = 0s, want positive duration`). This assertion failure also reproduces on unmodified `dev` (`fa01468e`).
- `go build -o <temporary-output> ./cmd/server` passed.

The tests use synthetic payloads and a capture executor; they do not require credentials or call a live model.