### PR TITLE
fix(codex): default output_config.format strict to false

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -434,9 +434,13 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 		if n := format.Get("name").String(); n != "" {
 			name = n
 		}
-		strict := true
-		if s := format.Get("strict"); s.Exists() && s.Type == gjson.False {
-			strict = false
+		// Default to non-strict: OpenAI strict mode requires "required" to list
+		// every property, which breaks upstream schemas carrying optional fields
+		// (e.g. Claude Code hook evaluator schemas). Only enable strict when the
+		// client explicitly requests it.
+		strict := false
+		if s := format.Get("strict"); s.Exists() && s.Type == gjson.True {
+			strict = true
 		}
 		translatedFormat := []byte(`{"type":"json_schema","name":"","strict":true,"schema":{}}`)
 		translatedFormat, _ = sjson.SetBytes(translatedFormat, "name", name)

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -805,11 +805,40 @@ func TestConvertClaudeRequestToCodex_OutputConfigFormat(t *testing.T) {
 		if got := root.Get("text.format.name").String(); got != "cli_proxy_structured_output" {
 			t.Errorf("expected text.format.name to be 'cli_proxy_structured_output', got %q", got)
 		}
-		if got := root.Get("text.format.strict").Bool(); !got {
-			t.Errorf("expected text.format.strict to be true, got %v", got)
+		if got := root.Get("text.format.strict").Bool(); got {
+			t.Errorf("expected text.format.strict to default to false, got %v", got)
 		}
 		if got := root.Get("text.format.schema.properties.answer.type").String(); got != "string" {
 			t.Errorf("expected schema.properties.answer.type to be 'string', got %q", got)
+		}
+	})
+
+	t.Run("Valid json_schema format with explicit strict true", func(t *testing.T) {
+		payload := []byte(`{
+			"model": "gpt-5.4",
+			"messages": [
+				{"role": "user", "content": "hello"}
+			],
+			"output_config": {
+				"format": {
+					"type": "json_schema",
+					"name": "strict_schema",
+					"strict": true,
+					"schema": {
+						"type": "object"
+					}
+				}
+			}
+		}`)
+
+		translated := ConvertClaudeRequestToCodex("gpt-5.4", payload, false)
+		root := gjson.ParseBytes(translated)
+
+		if got := root.Get("text.format.name").String(); got != "strict_schema" {
+			t.Errorf("expected text.format.name to be 'strict_schema', got %q", got)
+		}
+		if got := root.Get("text.format.strict").Bool(); !got {
+			t.Errorf("expected text.format.strict to be true, got %v", got)
 		}
 	})
 


### PR DESCRIPTION
## Problem

Claude→Codex translation hardcodes `strict: true` when mapping Claude `output_config.format` to Codex Responses `text.format` (`internal/translator/codex/claude/codex_claude_request.go`).

OpenAI strict structured outputs require `required` to list **every** key in `properties`. Any client schema with an optional property is therefore rejected upstream with:

```
400 Invalid schema for response_format 'cli_proxy_structured_output': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'impossible'.
```

Real-world trigger: Claude Code's prompt-hook evaluator (used by the built-in stop-condition/goal hook and by plugins) sends a JSON schema with an **optional** `impossible` field. Every turn end, Claude Code calls the hook evaluator through the proxy, and every call 400s. This makes any goal-style / prompt-hook workflow unusable through CLIProxyAPI — reported in #5565.

Clients that genuinely want strict mode can still pass `strict: true` explicitly; those are unaffected by this change.

## Fix

- Default `strict` to `false` and only set `true` when the client explicitly sends `"strict": true`.
- Updated/added translator tests:
  - default (no `strict` in payload) → `text.format.strict == false`
  - explicit `"strict": true` → `text.format.strict == true`
  - explicit `"strict": false` → unchanged behavior

## Testing

```
go test ./internal/translator/codex/claude/ -count=1   # ok
go build -o cli-proxy-api ./cmd/server                  # ok
```

Verified end-to-end locally: Claude Code goal stop-hook evaluator calls through the proxy no longer 400.

Fixes #5565

🤖 Generated with [Claude Code](https://claude.com/claude-code)