### PR TITLE
feat(api): add /readyz and /metrics so liveness is not readiness

### DIFF
--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// evaluateReadiness reports whether the process has a usable provider credential
+// or is intentionally running without local credentials (Home / empty config).
+// It uses cached auth state only and never issues live upstream calls.
+func evaluateReadiness(cfg *config.Config, manager *auth.Manager) (ready bool, reason string, usable int, total int) {
+	if manager != nil {
+		for _, entry := range manager.List() {
+			total++
+			if authIsUsable(entry) {
+				usable++
+			}
+		}
+	}
+	if usable > 0 {
+		return true, "ok", usable, total
+	}
+	if cfg != nil && cfg.Home.Enabled {
+		return true, "ok", usable, total
+	}
+	if total == 0 && !hasConfiguredProviderCredentials(cfg) {
+		return true, "ok", usable, total
+	}
+	return false, "no_usable_auth", usable, total
+}
+
+func authIsUsable(entry *auth.Auth) bool {
+	if entry == nil || entry.Disabled || entry.Unavailable {
+		return false
+	}
+	switch entry.Status {
+	case auth.StatusError, auth.StatusDisabled, auth.StatusPending:
+		return false
+	default:
+		return true
+	}
+}
+
+func hasConfiguredProviderCredentials(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if len(cfg.OpenAICompatibility) > 0 || len(cfg.GeminiKey) > 0 || len(cfg.ClaudeKey) > 0 ||
+		len(cfg.CodexKey) > 0 || len(cfg.XAIKey) > 0 || len(cfg.VertexCompatAPIKey) > 0 ||
+		len(cfg.InteractionsKey) > 0 {
+		return true
+	}
+	return false
+}
+
+func (s *Server) handleReadyz(c *gin.Context) {
+	var manager *auth.Manager
+	if s != nil && s.handlers != nil {
+		manager = s.handlers.AuthManager
+	}
+	var cfg *config.Config
+	if s != nil {
+		cfg = s.cfg
+	}
+	ready, reason, usable, total := evaluateReadiness(cfg, manager)
+	status := http.StatusOK
+	if !ready {
+		status = http.StatusServiceUnavailable
+	}
+	if c.Request.Method == http.MethodHead {
+		c.Status(status)
+		return
+	}
+	c.JSON(status, gin.H{
+		"status":      reason,
+		"ready":       ready,
+		"usable_auth": usable,
+		"total_auth":  total,
+	})
+}
+
+func (s *Server) handleMetrics(c *gin.Context) {
+	var manager *auth.Manager
+	if s != nil && s.handlers != nil {
+		manager = s.handlers.AuthManager
+	}
+	c.Header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	c.String(http.StatusOK, renderPrometheusMetrics(manager))
+}
+
+func renderPrometheusMetrics(manager *auth.Manager) string {
+	statusCounts := map[string]int{
+		string(auth.StatusUnknown):    0,
+		string(auth.StatusActive):     0,
+		string(auth.StatusPending):    0,
+		string(auth.StatusRefreshing): 0,
+		string(auth.StatusError):      0,
+		string(auth.StatusDisabled):   0,
+	}
+	unavailable := 0
+	if manager != nil {
+		for _, entry := range manager.List() {
+			if entry == nil {
+				continue
+			}
+			key := string(entry.Status)
+			if key == "" {
+				key = string(auth.StatusUnknown)
+			}
+			statusCounts[key]++
+			if entry.Unavailable {
+				unavailable++
+			}
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("# HELP cliproxy_auth_status Number of auth entries by lifecycle status.\n")
+	b.WriteString("# TYPE cliproxy_auth_status gauge\n")
+	statusKeys := make([]string, 0, len(statusCounts))
+	for key := range statusCounts {
+		statusKeys = append(statusKeys, key)
+	}
+	sort.Strings(statusKeys)
+	for _, key := range statusKeys {
+		fmt.Fprintf(&b, "cliproxy_auth_status{status=%q} %d\n", key, statusCounts[key])
+	}
+	b.WriteString("# HELP cliproxy_auth_unavailable Number of auth entries marked unavailable.\n")
+	b.WriteString("# TYPE cliproxy_auth_unavailable gauge\n")
+	fmt.Fprintf(&b, "cliproxy_auth_unavailable %d\n", unavailable)
+
+	success, errorsByStatus := auth.SnapshotUpstreamMetrics()
+	b.WriteString("# HELP cliproxy_upstream_requests_total Upstream execution results by outcome.\n")
+	b.WriteString("# TYPE cliproxy_upstream_requests_total counter\n")
+	fmt.Fprintf(&b, "cliproxy_upstream_requests_total{result=%q} %d\n", "success", success)
+	b.WriteString("# HELP cliproxy_upstream_errors_total Upstream execution errors by HTTP status.\n")
+	b.WriteString("# TYPE cliproxy_upstream_errors_total counter\n")
+	errorStatuses := make([]string, 0, len(errorsByStatus))
+	for status := range errorsByStatus {
+		errorStatuses = append(errorStatuses, status)
+	}
+	sort.Strings(errorStatuses)
+	for _, status := range errorStatuses {
+		fmt.Fprintf(&b, "cliproxy_upstream_errors_total{status=%q} %d\n", status, errorsByStatus[status])
+	}
+	return b.String()
+}

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -15,10 +15,11 @@ import (
 // or is intentionally running without local credentials (Home / empty config).
 // It uses cached auth state only and never issues live upstream calls.
 func evaluateReadiness(cfg *config.Config, manager *auth.Manager) (ready bool, reason string, usable int, total int) {
+	requireWeight := readinessRequiresPositiveWeight(cfg)
 	if manager != nil {
 		for _, entry := range manager.List() {
 			total++
-			if authIsUsable(entry) {
+			if authIsUsable(entry, requireWeight) {
 				usable++
 			}
 		}
@@ -35,16 +36,23 @@ func evaluateReadiness(cfg *config.Config, manager *auth.Manager) (ready bool, r
 	return false, "no_usable_auth", usable, total
 }
 
-func authIsUsable(entry *auth.Auth) bool {
-	if entry == nil || entry.Disabled || entry.Unavailable {
+func readinessRequiresPositiveWeight(cfg *config.Config) bool {
+	if cfg == nil {
 		return false
 	}
-	switch entry.Status {
-	case auth.StatusError, auth.StatusDisabled, auth.StatusPending:
+	return strings.EqualFold(strings.TrimSpace(cfg.Routing.Strategy), "weighted-round-robin")
+}
+
+// authIsUsable mirrors scheduler admission: availability/selection predicates,
+// plus positive weight when routing.strategy is weighted-round-robin.
+func authIsUsable(entry *auth.Auth, requirePositiveWeight bool) bool {
+	if !auth.IsSelectableCredential(entry) {
 		return false
-	default:
-		return true
 	}
+	if requirePositiveWeight && !auth.HasPositiveCredentialWeight(entry) {
+		return false
+	}
+	return true
 }
 
 func hasConfiguredProviderCredentials(cfg *config.Config) bool {

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -40,7 +40,14 @@ func readinessRequiresPositiveWeight(cfg *config.Config) bool {
 	if cfg == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(cfg.Routing.Strategy), "weighted-round-robin")
+	// Match sdk/cliproxy normalizedRoutingRuntimeState aliases so readiness
+	// agrees with the weighted selector the runtime actually installs.
+	switch strings.ToLower(strings.TrimSpace(cfg.Routing.Strategy)) {
+	case "weighted-round-robin", "weightedroundrobin", "wrr":
+		return true
+	default:
+		return false
+	}
 }
 
 // authIsUsable mirrors scheduler admission: availability/selection predicates,

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestEvaluateReadiness_EmptyConfigIsReady(t *testing.T) {
+	ready, reason, usable, total := evaluateReadiness(&config.Config{}, auth.NewManager(nil, nil, nil))
+	if !ready || reason != "ok" || usable != 0 || total != 0 {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+}
+
+func TestEvaluateReadiness_ConfiguredProviderWithoutAuthIsNotReady(t *testing.T) {
+	cfg := &config.Config{
+		OpenAICompatibility: []config.OpenAICompatibility{{
+			Name:    "example",
+			BaseURL: "https://example.invalid/v1",
+		}},
+	}
+	ready, reason, _, _ := evaluateReadiness(cfg, auth.NewManager(nil, nil, nil))
+	if ready || reason != "no_usable_auth" {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q, want not ready", ready, reason)
+	}
+}
+
+func TestEvaluateReadiness_HomeEnabledWithoutLocalAuthIsReady(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Home.Enabled = true
+	ready, reason, _, _ := evaluateReadiness(cfg, auth.NewManager(nil, nil, nil))
+	if !ready || reason != "ok" {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q, want ready with Home enabled", ready, reason)
+	}
+}
+
+func TestEvaluateReadiness_AllAuthsUnusableIsNotReady(t *testing.T) {
+	manager := auth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &auth.Auth{
+		ID:          "broken.json",
+		Provider:    "codex",
+		Status:      auth.StatusError,
+		Unavailable: true,
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	ready, reason, usable, total := evaluateReadiness(&config.Config{}, manager)
+	if ready || reason != "no_usable_auth" || usable != 0 || total != 1 {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+}
+
+func TestEvaluateReadiness_ActiveAuthIsReady(t *testing.T) {
+	manager := auth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &auth.Auth{
+		ID:       "ok.json",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	ready, reason, usable, total := evaluateReadiness(&config.Config{}, manager)
+	if !ready || reason != "ok" || usable != 1 || total != 1 {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+}
+
+func TestReadyzAndMetricsRoutes(t *testing.T) {
+	auth.ResetUpstreamMetricsForTest()
+
+	server := newTestServer(t)
+	t.Run("readyz empty is 200", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("readyz status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+		var resp struct {
+			Ready  bool   `json:"ready"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("parse readyz: %v", err)
+		}
+		if !resp.Ready || resp.Status != "ok" {
+			t.Fatalf("readyz body = %+v", resp)
+		}
+	})
+
+	t.Run("readyz HEAD", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodHead, "/readyz", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("HEAD readyz status = %d, want %d", rr.Code, http.StatusOK)
+		}
+		if rr.Body.Len() != 0 {
+			t.Fatalf("HEAD readyz body = %q, want empty", rr.Body.String())
+		}
+	})
+
+	t.Run("readyz 503 when only error auths exist", func(t *testing.T) {
+		if _, err := server.handlers.AuthManager.Register(context.Background(), &auth.Auth{
+			ID:          "dead.json",
+			Provider:    "openai-compatibility",
+			Status:      auth.StatusError,
+			Unavailable: true,
+		}); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("readyz status = %d, want %d body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+		}
+	})
+
+	t.Run("healthz stays 200 while readyz is 503", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("healthz status = %d, want %d", rr.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("metrics includes auth gauges and upstream counters", func(t *testing.T) {
+		server.handlers.AuthManager.MarkResult(context.Background(), auth.Result{
+			AuthID:   "dead.json",
+			Provider: "openai-compatibility",
+			Success:  false,
+			Error:    &auth.Error{HTTPStatus: http.StatusPaymentRequired, Message: "quota"},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("metrics status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+		body := rr.Body.String()
+		for _, want := range []string{
+			"cliproxy_auth_status",
+			`cliproxy_auth_status{status="error"}`,
+			"cliproxy_auth_unavailable",
+			`cliproxy_upstream_errors_total{status="402"}`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("metrics missing %q:\n%s", want, body)
+			}
+		}
+	})
+}

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -72,6 +72,44 @@ func TestEvaluateReadiness_ActiveAuthIsReady(t *testing.T) {
 	}
 }
 
+func TestEvaluateReadiness_StatusErrorStillSelectableWhenAvailable(t *testing.T) {
+	manager := auth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &auth.Auth{
+		ID:       "partial.json",
+		Provider: "codex",
+		Status:   auth.StatusError, // parent lifecycle error after model-scoped failure
+		// Unavailable left false because another model remains selectable.
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	ready, reason, usable, total := evaluateReadiness(&config.Config{}, manager)
+	if !ready || reason != "ok" || usable != 1 || total != 1 {
+		t.Fatalf("evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+}
+
+func TestEvaluateReadiness_ZeroWeightExcludedUnderWeightedStrategy(t *testing.T) {
+	manager := auth.NewManager(nil, nil, nil)
+	if _, err := manager.Register(context.Background(), &auth.Auth{
+		ID:         "zero.json",
+		Provider:   "codex",
+		Status:     auth.StatusActive,
+		Attributes: map[string]string{auth.AttributeWeight: "0"},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	cfg := &config.Config{Routing: config.RoutingConfig{Strategy: "weighted-round-robin"}}
+	ready, reason, usable, total := evaluateReadiness(cfg, manager)
+	if ready || reason != "no_usable_auth" || usable != 0 || total != 1 {
+		t.Fatalf("weighted evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+	// Non-weighted strategies still admit zero-weight credentials.
+	ready, reason, usable, total = evaluateReadiness(&config.Config{Routing: config.RoutingConfig{Strategy: "round-robin"}}, manager)
+	if !ready || reason != "ok" || usable != 1 || total != 1 {
+		t.Fatalf("round-robin evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	}
+}
+
 func TestReadyzAndMetricsRoutes(t *testing.T) {
 	auth.ResetUpstreamMetricsForTest()
 

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -98,13 +98,15 @@ func TestEvaluateReadiness_ZeroWeightExcludedUnderWeightedStrategy(t *testing.T)
 	}); err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	cfg := &config.Config{Routing: config.RoutingConfig{Strategy: "weighted-round-robin"}}
-	ready, reason, usable, total := evaluateReadiness(cfg, manager)
-	if ready || reason != "no_usable_auth" || usable != 0 || total != 1 {
-		t.Fatalf("weighted evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
+	for _, strategy := range []string{"weighted-round-robin", "weightedroundrobin", "wrr", "WRR", "WeightedRoundRobin"} {
+		cfg := &config.Config{Routing: config.RoutingConfig{Strategy: strategy}}
+		ready, reason, usable, total := evaluateReadiness(cfg, manager)
+		if ready || reason != "no_usable_auth" || usable != 0 || total != 1 {
+			t.Fatalf("strategy %q evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", strategy, ready, reason, usable, total)
+		}
 	}
 	// Non-weighted strategies still admit zero-weight credentials.
-	ready, reason, usable, total = evaluateReadiness(&config.Config{Routing: config.RoutingConfig{Strategy: "round-robin"}}, manager)
+	ready, reason, usable, total := evaluateReadiness(&config.Config{Routing: config.RoutingConfig{Strategy: "round-robin"}}, manager)
 	if !ready || reason != "ok" || usable != 1 || total != 1 {
 		t.Fatalf("round-robin evaluateReadiness() = ready=%t reason=%q usable=%d total=%d", ready, reason, usable, total)
 	}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -50,6 +50,9 @@ func (s *Server) setupRoutes() {
 	}
 	s.engine.GET("/healthz", healthzHandler)
 	s.engine.HEAD("/healthz", healthzHandler)
+	s.engine.GET("/readyz", s.handleReadyz)
+	s.engine.HEAD("/readyz", s.handleReadyz)
+	s.engine.GET("/metrics", s.handleMetrics)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)

--- a/internal/client/codex/live/sideband.go
+++ b/internal/client/codex/live/sideband.go
@@ -450,6 +450,7 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 	}
 
 	upstream, handshakeResponse, errDial := dialUpstream(selected)
+	auth.RecordDirectHttpUpstreamResult(selected, handshakeResponse, errDial)
 	if errDial != nil {
 		handshakeStatus := clienterror.HTTPStatusFromErrorOr(errDial, http.StatusBadGateway)
 		if handshakeResponse != nil && handshakeResponse.StatusCode > 0 {

--- a/internal/client/codex/live/websocket.go
+++ b/internal/client/codex/live/websocket.go
@@ -126,6 +126,7 @@ func (h *Handler) HandleDirectWebsocket(c *gin.Context) {
 	}
 
 	upstream, handshakeResponse, errDial := dialUpstream(selected)
+	auth.RecordDirectHttpUpstreamResult(selected, handshakeResponse, errDial)
 	if errDial != nil {
 		status := clienterror.HTTPStatusFromErrorOr(errDial, http.StatusBadGateway)
 		helpConfig := h.currentConfig()

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -753,6 +753,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		}
 	}
+	recordUpstreamResult(result)
 	modelKey := canonicalModelKey(result.Model)
 
 	var authSnapshot *Auth

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1046,6 +1046,9 @@ func (m *Manager) recordAvailabilityNeutralResult(ctx context.Context, result Re
 	if result.AuthID == "" {
 		return
 	}
+	// Availability-neutral paths (e.g. Responses Compact, Claude count_tokens 404)
+	// bypass MarkResult but are still real upstream attempts.
+	recordUpstreamResult(result)
 
 	var authSnapshot *Auth
 	m.mu.Lock()

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1032,6 +1032,8 @@ func (m *Manager) reportHomeResult(ctx context.Context, result Result, auth *Aut
 	if m == nil || result.AuthID == "" {
 		return
 	}
+	// Home outcomes bypass MarkResult; count them here once for all execution paths.
+	recordUpstreamResult(result)
 	var snapshot *Auth
 	if auth != nil {
 		snapshot = auth.Clone()

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -2004,6 +2004,8 @@ func (m *Manager) NewHttpRequest(ctx context.Context, auth *Auth, method, target
 }
 
 // HttpRequest injects provider credentials into the supplied HTTP request and executes it.
+// Direct callers (Alpha Search, Codex live/realtime) bypass Execute/MarkResult, so outcomes
+// are recorded here for the shared upstream metrics observer.
 func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
 	if m == nil {
 		return nil, &Error{Code: "provider_not_found", Message: "manager is nil"}
@@ -2022,7 +2024,9 @@ func (m *Manager) HttpRequest(ctx context.Context, auth *Auth, req *http.Request
 	if exec == nil {
 		return nil, &Error{Code: "provider_not_found", Message: "executor not registered for provider: " + providerKey}
 	}
-	return exec.HttpRequest(ctx, auth, req)
+	resp, err := exec.HttpRequest(ctx, auth, req)
+	recordDirectHttpUpstreamResult(auth, resp, err)
+	return resp, err
 }
 
 func ensureCanonicalSessionMetadata(metadata map[string]any, headers http.Header, payload []byte) map[string]any {

--- a/sdk/cliproxy/auth/readiness.go
+++ b/sdk/cliproxy/auth/readiness.go
@@ -1,0 +1,22 @@
+package auth
+
+import "time"
+
+// IsSelectableCredential reports whether a credential could be selected for a
+// model-agnostic request under the same availability rules as the scheduler.
+// Parent lifecycle StatusError alone does not make a credential unusable when
+// updateAggregatedAvailability left Unavailable false (another model remains
+// selectable).
+func IsSelectableCredential(a *Auth) bool {
+	if a == nil {
+		return false
+	}
+	blocked, _, _ := isAuthBlockedForModel(a, "", time.Now())
+	return !blocked
+}
+
+// HasPositiveCredentialWeight reports whether weighted-round-robin routing
+// would admit this credential (weight > 0). Unset weight defaults to 1.
+func HasPositiveCredentialWeight(a *Auth) bool {
+	return authWeight(a) > 0
+}

--- a/sdk/cliproxy/auth/upstream_metrics.go
+++ b/sdk/cliproxy/auth/upstream_metrics.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	upstreamSuccessCount atomic.Int64
+	upstreamErrorCounts  sync.Map // status label -> *atomic.Int64
+)
+
+func recordUpstreamResult(result Result) {
+	if result.Success {
+		upstreamSuccessCount.Add(1)
+		return
+	}
+	status := "unknown"
+	if result.Error != nil && result.Error.HTTPStatus > 0 {
+		status = strconv.Itoa(result.Error.HTTPStatus)
+	}
+	value, _ := upstreamErrorCounts.LoadOrStore(status, &atomic.Int64{})
+	counter, _ := value.(*atomic.Int64)
+	if counter != nil {
+		counter.Add(1)
+	}
+}
+
+// SnapshotUpstreamMetrics returns process-wide upstream success and error counts.
+func SnapshotUpstreamMetrics() (success int64, errorsByStatus map[string]int64) {
+	success = upstreamSuccessCount.Load()
+	errorsByStatus = make(map[string]int64)
+	upstreamErrorCounts.Range(func(key, value any) bool {
+		label, _ := key.(string)
+		counter, _ := value.(*atomic.Int64)
+		if label == "" || counter == nil {
+			return true
+		}
+		errorsByStatus[label] = counter.Load()
+		return true
+	})
+	return success, errorsByStatus
+}
+
+// ResetUpstreamMetricsForTest clears process-wide upstream counters. Tests only.
+func ResetUpstreamMetricsForTest() {
+	upstreamSuccessCount.Store(0)
+	upstreamErrorCounts.Range(func(key, _ any) bool {
+		upstreamErrorCounts.Delete(key)
+		return true
+	})
+}

--- a/sdk/cliproxy/auth/upstream_metrics.go
+++ b/sdk/cliproxy/auth/upstream_metrics.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -25,6 +27,33 @@ func recordUpstreamResult(result Result) {
 	if counter != nil {
 		counter.Add(1)
 	}
+}
+
+// recordDirectHttpUpstreamResult counts Manager.HttpRequest outcomes that never
+// flow through MarkResult / reportHomeResult / recordAvailabilityNeutralResult
+// (for example /v1/alpha/search via codexAlphaSearch).
+func recordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) {
+	if auth == nil || strings.TrimSpace(auth.ID) == "" {
+		return
+	}
+	result := Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+	}
+	switch {
+	case err != nil:
+		result.Error = resultErrorFromError(err)
+	case resp == nil:
+		result.Error = &Error{Message: "nil http response"}
+	case resp.StatusCode >= http.StatusBadRequest:
+		result.Error = &Error{
+			HTTPStatus: resp.StatusCode,
+			Message:    resp.Status,
+		}
+	default:
+		result.Success = true
+	}
+	recordUpstreamResult(result)
 }
 
 // SnapshotUpstreamMetrics returns process-wide upstream success and error counts.

--- a/sdk/cliproxy/auth/upstream_metrics.go
+++ b/sdk/cliproxy/auth/upstream_metrics.go
@@ -29,10 +29,16 @@ func recordUpstreamResult(result Result) {
 	}
 }
 
-// recordDirectHttpUpstreamResult counts Manager.HttpRequest outcomes that never
-// flow through MarkResult / reportHomeResult / recordAvailabilityNeutralResult
-// (for example /v1/alpha/search via codexAlphaSearch).
-func recordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) {
+// RecordDirectHttpUpstreamResult counts direct HTTP / WebSocket handshake
+// outcomes that never flow through MarkResult / reportHomeResult /
+// recordAvailabilityNeutralResult (for example /v1/alpha/search via
+// codexAlphaSearch, and Codex Realtime / sideband dials that call
+// PrepareHttpRequest + DialContext outside Manager.HttpRequest).
+//
+// When both err and resp are set (gorilla websocket dials often return a
+// rejected handshake response alongside the dial error), prefer the HTTP
+// status from resp so /metrics reflects the upstream status code.
+func RecordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) {
 	if auth == nil || strings.TrimSpace(auth.ID) == "" {
 		return
 	}
@@ -42,7 +48,14 @@ func recordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) 
 	}
 	switch {
 	case err != nil:
-		result.Error = resultErrorFromError(err)
+		if resp != nil && resp.StatusCode >= http.StatusBadRequest {
+			result.Error = &Error{
+				HTTPStatus: resp.StatusCode,
+				Message:    resp.Status,
+			}
+		} else {
+			result.Error = resultErrorFromError(err)
+		}
 	case resp == nil:
 		result.Error = &Error{Message: "nil http response"}
 	case resp.StatusCode >= http.StatusBadRequest:
@@ -54,6 +67,11 @@ func recordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) 
 		result.Success = true
 	}
 	recordUpstreamResult(result)
+}
+
+// recordDirectHttpUpstreamResult is kept as an unexported alias for in-package callers.
+func recordDirectHttpUpstreamResult(auth *Auth, resp *http.Response, err error) {
+	RecordDirectHttpUpstreamResult(auth, resp, err)
 }
 
 // SnapshotUpstreamMetrics returns process-wide upstream success and error counts.

--- a/sdk/cliproxy/auth/upstream_metrics_test.go
+++ b/sdk/cliproxy/auth/upstream_metrics_test.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestUpstreamMetricsResultPaths(t *testing.T) {
+	for _, path := range []string{"local", "home", "ephemeral"} {
+		t.Run(path, func(t *testing.T) {
+			ResetUpstreamMetricsForTest()
+			t.Cleanup(ResetUpstreamMetricsForTest)
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "metrics-auth"}
+			report := func(result Result) {
+				switch path {
+				case "local":
+					m.recordExecutionResult(context.Background(), result, auth, false)
+				case "home":
+					m.reportHomeResult(context.Background(), result, auth)
+				case "ephemeral":
+					m.recordExecutionResult(context.Background(), result, auth, true)
+				}
+			}
+			report(Result{AuthID: auth.ID, Success: true})
+			report(Result{AuthID: auth.ID, Error: &Error{HTTPStatus: 429}})
+			report(Result{AuthID: auth.ID, Error: &Error{HTTPStatus: 503}})
+			report(Result{AuthID: auth.ID})
+			report(Result{Success: true}) // Invalid results must not be counted.
+			success, failures := SnapshotUpstreamMetrics()
+			if success != 1 || len(failures) != 3 || failures["429"] != 1 || failures["503"] != 1 || failures["unknown"] != 1 {
+				t.Fatalf("metrics = %d, %v; want exactly one success and one of each error", success, failures)
+			}
+			if auth.Success != 0 || auth.Failed != 0 {
+				t.Fatal("reporting mutated supplied auth")
+			}
+		})
+	}
+}
+
+func TestUpstreamMetricsHomeExecution(t *testing.T) {
+	for _, path := range []string{"execute", "stream", "stream-error"} {
+		t.Run(path, func(t *testing.T) {
+			ResetUpstreamMetricsForTest()
+			t.Cleanup(ResetUpstreamMetricsForTest)
+			m := NewManager(nil, nil, nil)
+			m.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			registry := executionregistry.New()
+			m.PublishHomeDispatch(homeExecutionDispatcher{}, registry, 1)
+			if path == "execute" {
+				m.RegisterExecutor(&homeExecutionExecutor{})
+				if _, err := m.Execute(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "test"}, cliproxyexecutor.Options{}); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+				chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("ok")}
+				if path == "stream-error" {
+					chunks <- cliproxyexecutor.StreamChunk{Err: &Error{HTTPStatus: 503, Message: "upstream failed"}}
+				}
+				close(chunks)
+				m.RegisterExecutor(&homeExecutionStreamExecutor{chunks: chunks})
+				stream, err := m.ExecuteStream(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "test"}, cliproxyexecutor.Options{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for range stream.Chunks {
+				}
+			}
+			if err := registry.Drain(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			success, failures := SnapshotUpstreamMetrics()
+			if path == "stream-error" {
+				if success != 0 || len(failures) != 1 || failures["503"] != 1 {
+					t.Fatalf("metrics = %d, %v; want one 503", success, failures)
+				}
+			} else if success != 1 || len(failures) != 0 {
+				t.Fatalf("metrics = %d, %v; want one success", success, failures)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/upstream_metrics_test.go
+++ b/sdk/cliproxy/auth/upstream_metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestUpstreamMetricsResultPaths(t *testing.T) {
-	for _, path := range []string{"local", "home", "ephemeral"} {
+	for _, path := range []string{"local", "home", "ephemeral", "availability-neutral"} {
 		t.Run(path, func(t *testing.T) {
 			ResetUpstreamMetricsForTest()
 			t.Cleanup(ResetUpstreamMetricsForTest)
@@ -24,6 +24,8 @@ func TestUpstreamMetricsResultPaths(t *testing.T) {
 					m.reportHomeResult(context.Background(), result, auth)
 				case "ephemeral":
 					m.recordExecutionResult(context.Background(), result, auth, true)
+				case "availability-neutral":
+					m.recordAvailabilityNeutralResult(context.Background(), result)
 				}
 			}
 			report(Result{AuthID: auth.ID, Success: true})

--- a/sdk/cliproxy/auth/upstream_metrics_test.go
+++ b/sdk/cliproxy/auth/upstream_metrics_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -153,5 +154,47 @@ func TestUpstreamMetricsHttpRequest(t *testing.T) {
 	success, failures := SnapshotUpstreamMetrics()
 	if success != 1 || failures["429"] != 1 || failures["502"] != 1 || len(failures) != 2 {
 		t.Fatalf("metrics = %d, %v; want 1 success, 429=1, 502=1", success, failures)
+	}
+}
+
+func TestRecordDirectHttpUpstreamResultWebsocketHandshake(t *testing.T) {
+	ResetUpstreamMetricsForTest()
+	t.Cleanup(ResetUpstreamMetricsForTest)
+
+	authOK := &Auth{ID: "realtime-auth", Provider: "codex"}
+
+	// Successful upgrade (101 Switching Protocols) must count as success.
+	RecordDirectHttpUpstreamResult(authOK, &http.Response{
+		StatusCode: http.StatusSwitchingProtocols,
+		Status:     http.StatusText(http.StatusSwitchingProtocols),
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil)
+
+	// Rejected handshake: gorilla dial returns err + response; prefer HTTP status.
+	RecordDirectHttpUpstreamResult(authOK, &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Status:     http.StatusText(http.StatusUnauthorized),
+		Body:       io.NopCloser(strings.NewReader(`{"error":"unauthorized"}`)),
+		Header:     make(http.Header),
+	}, errors.New("websocket: bad handshake"))
+
+	RecordDirectHttpUpstreamResult(authOK, &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     http.StatusText(http.StatusTooManyRequests),
+		Body:       io.NopCloser(strings.NewReader(`{"error":"rate_limited"}`)),
+		Header:     make(http.Header),
+	}, errors.New("websocket: bad handshake"))
+
+	// Transport-only failure with no handshake response.
+	RecordDirectHttpUpstreamResult(authOK, nil, &Error{HTTPStatus: http.StatusBadGateway, Message: "dial tcp: connection refused"})
+
+	// Empty auth ID must be ignored.
+	RecordDirectHttpUpstreamResult(&Auth{ID: "  ", Provider: "codex"}, &http.Response{StatusCode: http.StatusOK}, nil)
+	RecordDirectHttpUpstreamResult(nil, &http.Response{StatusCode: http.StatusOK}, nil)
+
+	success, failures := SnapshotUpstreamMetrics()
+	if success != 1 || failures["401"] != 1 || failures["429"] != 1 || failures["502"] != 1 || len(failures) != 3 {
+		t.Fatalf("metrics = %d, %v; want 1 success, 401=1, 429=1, 502=1", success, failures)
 	}
 }

--- a/sdk/cliproxy/auth/upstream_metrics_test.go
+++ b/sdk/cliproxy/auth/upstream_metrics_test.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -85,5 +88,70 @@ func TestUpstreamMetricsHomeExecution(t *testing.T) {
 				t.Fatalf("metrics = %d, %v; want one success", success, failures)
 			}
 		})
+	}
+}
+
+type directHTTPMetricsExecutor struct {
+	status int
+	err    error
+}
+
+func (*directHTTPMetricsExecutor) Identifier() string { return "codex" }
+func (*directHTTPMetricsExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (*directHTTPMetricsExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (*directHTTPMetricsExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+func (*directHTTPMetricsExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *directHTTPMetricsExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return &http.Response{
+		StatusCode: e.status,
+		Status:     http.StatusText(e.status),
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestUpstreamMetricsHttpRequest(t *testing.T) {
+	ResetUpstreamMetricsForTest()
+	t.Cleanup(ResetUpstreamMetricsForTest)
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "alpha-search-auth", Provider: "codex"}
+	m.RegisterExecutor(&directHTTPMetricsExecutor{status: http.StatusOK})
+
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/alpha/search", strings.NewReader(`{"query":"x"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := m.HttpRequest(context.Background(), auth, req)
+	if err != nil {
+		t.Fatalf("HttpRequest success path: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	m.RegisterExecutor(&directHTTPMetricsExecutor{status: http.StatusTooManyRequests})
+	resp, err = m.HttpRequest(context.Background(), auth, req)
+	if err != nil {
+		t.Fatalf("HttpRequest 429 path: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	m.RegisterExecutor(&directHTTPMetricsExecutor{err: &Error{HTTPStatus: http.StatusBadGateway, Message: "dial failed"}})
+	_, err = m.HttpRequest(context.Background(), auth, req)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+
+	success, failures := SnapshotUpstreamMetrics()
+	if success != 1 || failures["429"] != 1 || failures["502"] != 1 || len(failures) != 2 {
+		t.Fatalf("metrics = %d, %v; want 1 success, 429=1, 502=1", success, failures)
 	}
 }


### PR DESCRIPTION
## Summary
Adds `/readyz` and `/metrics` so liveness is not mistaken for readiness, and upstream health is observable.

Fixes #5575

## Test plan
- [ ] Unit tests for health/readyz and upstream metrics
- [ ] Manual: with no auth, readyz is not ready; with healthy auth, ready
