### PR TITLE
fix(claude): forward the per-turn-control beta requested by the caller

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -523,3 +523,42 @@ func TestApplyClaudeHeaders_StructuredHelperBetaOrderPreservedWithAdvisor(t *tes
 		t.Fatalf("helper Anthropic-Beta =\n got:  %q\n want: %q", got, helperBeta)
 	}
 }
+
+// Claude Code 2.1.261 sends a per-turn {"role":"system"} turn that carries
+// output_config, declared by per-turn-control-2026-07-01. The rebuilt baseline
+// must forward that beta when the caller asks for it, in the client's position
+// right after mid-conversation-system, while still dropping unknown betas.
+func TestApplyClaudeHeaders_PerTurnControlBetaFollowsCaller(t *testing.T) {
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", claudeCodeBeta+","+claudeMidConvSystemBeta+","+claudePerTurnControlBeta+",totally-made-up-2030-01-01")
+
+	req := newClaudeHeaderTestRequest(t, nil)
+	if err := applyClaudeHeaders(req, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil,
+		[]byte(`{"model":"claude-opus-5","messages":[{"role":"system","content":[],"output_config":{"effort":"high"}}]}`), nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", err)
+	}
+
+	got := req.Header.Get("Anthropic-Beta")
+	if !strings.Contains(got, ","+claudeMidConvSystemBeta+","+claudePerTurnControlBeta+",") {
+		t.Fatalf("Anthropic-Beta = %q, want %s right after %s", got, claudePerTurnControlBeta, claudeMidConvSystemBeta)
+	}
+	if strings.Contains(got, "totally-made-up-2030-01-01") {
+		t.Fatalf("Anthropic-Beta = %q, unknown caller beta reached upstream", got)
+	}
+
+	// count_tokens replaces the baseline with the fixed count-tokens profile; the
+	// same body is forwarded, so the beta has to survive there too.
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"system","content":[],"output_config":{"effort":"high"}}]}`)
+	countReq := httptest.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages/count_tokens", bytes.NewReader(body))
+	if err := applyClaudeHeaders(countReq, claudeOAuthAuthForBetaPolicy(), claudeRaceProbeOAuthKey, false, nil,
+		body, nil, incoming, false); err != nil {
+		t.Fatalf("applyClaudeHeaders(count_tokens) error = %v", err)
+	}
+	got = countReq.Header.Get("Anthropic-Beta")
+	if !strings.Contains(got, claudePerTurnControlBeta) {
+		t.Fatalf("count_tokens Anthropic-Beta = %q, want %s forwarded", got, claudePerTurnControlBeta)
+	}
+	if strings.Contains(got, "totally-made-up-2030-01-01") {
+		t.Fatalf("count_tokens Anthropic-Beta = %q, unknown caller beta reached upstream", got)
+	}
+}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -40,6 +40,7 @@ const (
 	claudeCodeBeta                   = "claude-code-20250219"
 	claudeContext1MBeta              = "context-1m-2025-08-07"
 	claudeMidConvSystemBeta          = "mid-conversation-system-2026-04-07"
+	claudePerTurnControlBeta         = "per-turn-control-2026-07-01"
 	claudeAdvisorToolBeta            = "advisor-tool-2026-03-01"
 	claudeAdvancedToolUseBeta        = "advanced-tool-use-2025-11-20"
 	claudeEffortBeta                 = "effort-2025-11-24"
@@ -93,6 +94,7 @@ var claudeCodeTrailingBetas = []string{
 //	 7 context-management-2025-06-27
 //	 8 prompt-caching-scope-2026-01-05
 //	 9 mid-conversation-system-2026-04-07  models accepting a role=system turn
+//	   per-turn-control-2026-07-01        requested; 2.1.261 per-turn role=system turn
 //	10 advisor-tool-2026-03-01             requests declaring advisor tools or requesting advisor beta
 //	11 advanced-tool-use-2025-11-20       requests with tools
 //	12 effort-2025-11-24                  effort-supporting models with active thinking
@@ -124,6 +126,9 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	}
 	if !claudeUsesLegacySystemReminder(body) {
 		betas = append(betas, claudeMidConvSystemBeta)
+	}
+	if requested[claudePerTurnControlBeta] {
+		betas = append(betas, claudePerTurnControlBeta)
 	}
 	if requested[claudeAdvisorToolBeta] || claudeBodyHasAdvisorTool(body) {
 		betas = append(betas, claudeAdvisorToolBeta)
@@ -852,6 +857,9 @@ func applyClaudeHeadersWithNativeProfile(
 			baseBetas = claudeCountTokensBetasForCredential(useOAuthBetas)
 			if advisorNeeded {
 				baseBetas = withClaudeAdvisorToolBeta(baseBetas)
+			}
+			if requestedMap[claudePerTurnControlBeta] {
+				baseBetas += "," + claudePerTurnControlBeta
 			}
 		}
 	}


### PR DESCRIPTION
## Defect

Claude Code 2.1.261 sends a per-turn `{"role":"system","content":[],"output_config":{...}}` turn inside `messages`, declared by the `per-turn-control-2026-07-01` beta. `claudeCodeCLIBetas` rebuilds the `Anthropic-Beta` header from the 2.1.258 baseline, which has no entry for that beta, so the turn is forwarded while its beta is stripped and Anthropic rejects the request:

```
400 invalid_request_error: messages.3.output_config: Extra inputs are not permitted
```

Measured on a gateway serving 2.1.261 clients: 77 such rejections across 4 sessions in 12 h (one session retried 67 times).

## Mechanism

On the direct-Anthropic rebuild path (`!preserveCallerFingerprint`) caller betas only reach upstream through the known-beta flags in `claudeCodeCLIBetas`; unknown betas are dropped by design (`TestClaudeCodeCLIBetas_MatchesObservedClientMatrix`, "unknown caller beta is not smuggled into the baseline"). `per-turn-control-2026-07-01` was unknown.

## Fix

One constant, and forward it when the caller requests it, in the position the client uses (right after `mid-conversation-system-2026-04-07`). Unknown betas are still dropped.

## Check

- `TestApplyClaudeHeaders_PerTurnControlBetaFollowsCaller`: fails on the previous baseline, passes with this change, and asserts an unknown caller beta still does not reach the upstream header.
- Replay of a captured 2.1.261 request carrying the per-turn turn and the client's 12 betas, through a single OAuth credential: 400 (message above) on `dev` @ fa01468e, 200 on `dev` + this commit.
- Side effect observed while replaying: forwarding the beta changes Anthropic's prompt-cache identity for histories that already contain `role: system` turns (one cache miss, +15 tokens on a 320k-token prefix). The native client sends the beta itself, so this matches what unproxied sessions already get.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `per-turn-control-2026-07-01` beta capability when requested by callers.
  - Preserves the expected ordering of supported beta capabilities in requests.

- **Tests**
  - Added coverage verifying per-turn control handling and filtering of unknown beta capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
