### PR TITLE
fix(auth): preserve forced cooldowns across in-flight successes

### DIFF
--- a/internal/store/postgres_cooldown_store_test.go
+++ b/internal/store/postgres_cooldown_store_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -169,13 +170,18 @@ func TestPostgresCooldownStateStore_SaveLoad(t *testing.T) {
 	nextRetry := time.Date(2026, time.March, 15, 12, 0, 0, 0, time.UTC)
 	records := []cliproxyauth.CooldownStateRecord{
 		{
-			Provider:       "codex",
-			AuthID:         "account-1",
-			Model:          "gpt-test",
-			Status:         string(cliproxyauth.StatusError),
-			NextRetryAfter: nextRetry,
-			Reason:         "rate limited",
-			UpdatedAt:      nextRetry.Add(-time.Minute),
+			Provider: "codex", AuthID: "account-1", NextRetryAfter: nextRetry,
+			LastFailureScope: "model", UpdatedAt: nextRetry.Add(-time.Minute),
+		},
+		{
+			Provider:            "codex",
+			AuthID:              "account-1",
+			Model:               "gpt-test",
+			Status:              string(cliproxyauth.StatusError),
+			NextRetryAfter:      nextRetry,
+			ForcedCooldownUntil: nextRetry.Add(-30 * time.Second),
+			Reason:              "rate limited",
+			UpdatedAt:           nextRetry.Add(-time.Minute),
 		},
 	}
 	if errSave := cooldownStore.Save(context.Background(), records); errSave != nil {
@@ -185,6 +191,8 @@ func TestPostgresCooldownStateStore_SaveLoad(t *testing.T) {
 	if errLoad != nil {
 		t.Fatalf("Load() error = %v", errLoad)
 	}
+	// Neither the query nor the map-backed test driver guarantees row order.
+	sort.Slice(loaded, func(i, j int) bool { return loaded[i].Model < loaded[j].Model })
 	if !reflect.DeepEqual(loaded, records) {
 		t.Fatalf("Load() = %#v, want %#v", loaded, records)
 	}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -310,7 +310,6 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 
 	now := time.Now()
 	authLevelRecords := make([]CooldownStateRecord, 0)
-	modelRecordsByAuth := make(map[string][]CooldownStateRecord)
 	snapshotsByID := make(map[string]*Auth)
 
 	m.mu.Lock()
@@ -319,17 +318,14 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 			authLevelRecords = append(authLevelRecords, record)
 			continue
 		}
-		if m.restoreCooldownRecordLocked(record, now, false) {
-			authID := strings.TrimSpace(record.AuthID)
-			modelRecordsByAuth[authID] = append(modelRecordsByAuth[authID], record)
-			if auth := m.auths[authID]; auth != nil {
+		if m.restoreCooldownRecordLocked(record, now) {
+			if auth := m.auths[strings.TrimSpace(record.AuthID)]; auth != nil {
 				snapshotsByID[auth.ID] = auth.Clone()
 			}
 		}
 	}
 	for _, record := range authLevelRecords {
-		isAggregate := isModelAggregateCooldownRecord(record, modelRecordsByAuth[strings.TrimSpace(record.AuthID)])
-		if m.restoreCooldownRecordLocked(record, now, isAggregate) {
+		if m.restoreCooldownRecordLocked(record, now) {
 			if auth := m.auths[strings.TrimSpace(record.AuthID)]; auth != nil {
 				snapshotsByID[auth.ID] = auth.Clone()
 			}
@@ -346,24 +342,7 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 	return nil
 }
 
-// Aggregate auth records combine the earliest model deadline with the last
-// model error. Inspect the loaded records, not unrelated runtime model history.
-func isModelAggregateCooldownRecord(record CooldownStateRecord, models []CooldownStateRecord) bool {
-	if record.Quota.Reason == "credential_quota" {
-		return false
-	}
-	var earliest time.Time
-	matchingError := false
-	for _, model := range models {
-		if earliest.IsZero() || model.NextRetryAfter.Before(earliest) {
-			earliest = model.NextRetryAfter
-		}
-		matchingError = matchingError || cooldownErrorEqual(record.LastError, model.LastError)
-	}
-	return !earliest.IsZero() && earliest.Equal(record.NextRetryAfter) && matchingError
-}
-
-func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time, isModelAggregate bool) bool {
+func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time) bool {
 	authID := strings.TrimSpace(record.AuthID)
 	if authID == "" || record.NextRetryAfter.IsZero() || !record.NextRetryAfter.After(now) {
 		return false
@@ -378,12 +357,10 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	}
 	reason := strings.TrimSpace(record.Reason)
 	model := strings.TrimSpace(record.Model)
+	// Error history is not cooldown provenance: legacy aggregates can retain a
+	// removed model's forced error. Restore only an explicitly persisted forced
+	// deadline; field-absent legacy records keep their ordinary recovery rules.
 	forcedUntil := record.ForcedCooldownUntil
-	// Older sidecars only had the error marker. Do not reinterpret a model
-	// aggregate as an independent auth-level forced cooldown.
-	if forcedUntil.IsZero() && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown && !isModelAggregate {
-		forcedUntil = record.NextRetryAfter
-	}
 	quota := record.Quota
 	if quota.Exceeded && quota.NextRecoverAt.IsZero() {
 		quota.NextRecoverAt = record.NextRetryAfter
@@ -416,6 +393,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 			auth.StatusMessage = reason
 		}
 		auth.LastError = cloneError(record.LastError)
+		auth.lastFailureScope = record.LastFailureScope
 		return true
 	}
 
@@ -696,6 +674,7 @@ func cooldownStateRecordEqual(a, b CooldownStateRecord) bool {
 		a.Model != b.Model ||
 		a.Status != b.Status ||
 		a.Reason != b.Reason ||
+		a.LastFailureScope != b.LastFailureScope ||
 		!a.NextRetryAfter.Equal(b.NextRetryAfter) ||
 		!a.ForcedCooldownUntil.Equal(b.ForcedCooldownUntil) ||
 		!a.UpdatedAt.Equal(b.UpdatedAt) ||
@@ -736,6 +715,7 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 		Reason:              cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
 		Quota:               cooldownFieldsOf(auth.Quota),
 		LastError:           cloneError(auth.LastError),
+		LastFailureScope:    auth.lastFailureScope,
 		UpdatedAt:           auth.UpdatedAt,
 	}, true
 }
@@ -819,6 +799,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				// Retain active credential-scoped cooldown
 			} else if modelKey != "" {
 				recoverAggregate := modelStatesOwnAvailability(auth, now) || auth.ForcedCooldownUntil.After(now)
+				credentialFailure := !recoverAggregate && auth.lastFailureScope == cooldownFailureScopeCredential &&
+					(auth.NextRetryAfter.After(now) || (auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(now)))
 				state := ensureModelState(auth, modelKey)
 				modelState = state
 				recoverModelStateOnSuccess(state, now)
@@ -827,10 +809,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 				if recoverAggregate {
 					recoverAggregatedAvailability(auth, now)
-				} else {
+				} else if !credentialFailure {
 					updateAggregatedAvailability(auth, now)
 				}
-				if !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
+				if !credentialFailure && !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
 					auth.LastError = nil
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
@@ -855,6 +837,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
+					auth.lastFailureScope = cooldownFailureScopeModel
 					prevModelRetryAfter := state.NextRetryAfter
 					var forcedRetryAfter time.Time
 					if result.Error != nil {
@@ -1358,6 +1341,11 @@ func modelStateIsClean(state *ModelState) bool {
 	return true
 }
 
+const (
+	cooldownFailureScopeModel      = "model"
+	cooldownFailureScopeCredential = "credential"
+)
+
 // Model recovery may replace a derived summary, but must not clear a separate
 // credential failure. Check the pre-recovery state, before changing its models.
 func modelStatesOwnAvailability(auth *Auth, now time.Time) bool {
@@ -1368,9 +1356,15 @@ func modelStatesOwnAvailability(auth *Auth, now time.Time) bool {
 	if !auth.NextRetryAfter.After(now) && (!auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.After(now)) {
 		return true
 	}
+	if auth.lastFailureScope == cooldownFailureScopeCredential {
+		return false
+	}
 	var earliest time.Time
 	var latestModelQuota time.Time
-	matchingError := auth.LastError == nil
+	// New result paths record their source explicitly. A removed model may no
+	// longer supply a matching LastError, but its auth summary is still derived.
+	// Unknown legacy provenance retains the existing ordinary recovery checks.
+	matchingError := auth.LastError == nil || auth.lastFailureScope == cooldownFailureScopeModel
 	for _, state := range auth.ModelStates {
 		if state == nil {
 			continue
@@ -1534,6 +1528,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
 	auth.ForcedCooldownUntil = time.Time{}
+	auth.lastFailureScope = ""
 	auth.UpdatedAt = now
 }
 
@@ -2178,6 +2173,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	auth.Unavailable = true
 	auth.Status = StatusError
 	auth.UpdatedAt = now
+	auth.lastFailureScope = cooldownFailureScopeCredential
 	if resultErr != nil {
 		auth.LastError = cloneError(resultErr)
 		if resultErr.Message != "" {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -357,6 +357,12 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	}
 	reason := strings.TrimSpace(record.Reason)
 	model := strings.TrimSpace(record.Model)
+	forcedUntil := record.ForcedCooldownUntil
+	// Older sidecars only had the error marker. An aggregate auth record must
+	// not turn a restored model cooldown into an auth-level forced cooldown.
+	if forcedUntil.IsZero() && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown && (model != "" || len(auth.ModelStates) == 0) {
+		forcedUntil = record.NextRetryAfter
+	}
 	quota := record.Quota
 	if quota.Exceeded && quota.NextRecoverAt.IsZero() {
 		quota.NextRecoverAt = record.NextRetryAfter
@@ -366,6 +372,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 		auth.Unavailable = true
 		auth.Status = StatusError
 		auth.NextRetryAfter = record.NextRetryAfter
+		auth.ForcedCooldownUntil = forcedUntil
 		applyCooldownFields(&auth.Quota, quota)
 		auth.Quota = mergeQuotaObservation(auth.Quota, quota)
 		auth.Generation++
@@ -379,13 +386,14 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 
 	state := ensureModelState(auth, model)
 	mergeModelState(state, &ModelState{
-		Unavailable:    true,
-		Status:         StatusError,
-		StatusMessage:  reason,
-		NextRetryAfter: record.NextRetryAfter,
-		Quota:          quota,
-		LastError:      cloneError(record.LastError),
-		UpdatedAt:      updatedAt,
+		Unavailable:         true,
+		Status:              StatusError,
+		StatusMessage:       reason,
+		NextRetryAfter:      record.NextRetryAfter,
+		ForcedCooldownUntil: forcedUntil,
+		Quota:               quota,
+		LastError:           cloneError(record.LastError),
+		UpdatedAt:           updatedAt,
 	})
 	auth.Generation++
 	auth.UpdatedAt = updatedAt
@@ -398,9 +406,10 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		return false
 	}
 	changed := false
-	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
+	if auth.Unavailable || !auth.NextRetryAfter.IsZero() || !auth.ForcedCooldownUntil.IsZero() || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
 		auth.Unavailable = false
 		auth.NextRetryAfter = time.Time{}
+		auth.ForcedCooldownUntil = time.Time{}
 		applyCooldownFields(&auth.Quota, QuotaState{})
 		auth.UpdatedAt = now
 		changed = true
@@ -409,9 +418,10 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		if state == nil {
 			continue
 		}
-		if state.Unavailable || !state.NextRetryAfter.IsZero() || state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
+		if state.Unavailable || !state.NextRetryAfter.IsZero() || !state.ForcedCooldownUntil.IsZero() || state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
 			state.Unavailable = false
 			state.NextRetryAfter = time.Time{}
+			state.ForcedCooldownUntil = time.Time{}
 			applyCooldownFields(&state.Quota, QuotaState{})
 			state.UpdatedAt = now
 			changed = true
@@ -652,6 +662,7 @@ func cooldownStateRecordEqual(a, b CooldownStateRecord) bool {
 		a.Status != b.Status ||
 		a.Reason != b.Reason ||
 		!a.NextRetryAfter.Equal(b.NextRetryAfter) ||
+		!a.ForcedCooldownUntil.Equal(b.ForcedCooldownUntil) ||
 		!a.UpdatedAt.Equal(b.UpdatedAt) ||
 		!cooldownQuotaEqual(a.Quota, b.Quota) {
 		return false
@@ -681,15 +692,16 @@ func authCooldownStateRecord(auth *Auth, now time.Time) (CooldownStateRecord, bo
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
-		Provider:       strings.TrimSpace(auth.Provider),
-		AuthID:         auth.ID,
-		AuthFile:       cooldownAuthFile(auth),
-		Status:         "cooling",
-		NextRetryAfter: auth.NextRetryAfter,
-		Reason:         cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
-		Quota:          cooldownFieldsOf(auth.Quota),
-		LastError:      cloneError(auth.LastError),
-		UpdatedAt:      auth.UpdatedAt,
+		Provider:            strings.TrimSpace(auth.Provider),
+		AuthID:              auth.ID,
+		AuthFile:            cooldownAuthFile(auth),
+		Status:              "cooling",
+		NextRetryAfter:      auth.NextRetryAfter,
+		ForcedCooldownUntil: auth.ForcedCooldownUntil,
+		Reason:              cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError),
+		Quota:               cooldownFieldsOf(auth.Quota),
+		LastError:           cloneError(auth.LastError),
+		UpdatedAt:           auth.UpdatedAt,
 	}, true
 }
 
@@ -699,16 +711,17 @@ func modelCooldownStateRecord(auth *Auth, model string, state *ModelState, now t
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
-		Provider:       strings.TrimSpace(auth.Provider),
-		AuthID:         auth.ID,
-		AuthFile:       cooldownAuthFile(auth),
-		Model:          model,
-		Status:         "cooling",
-		NextRetryAfter: state.NextRetryAfter,
-		Reason:         cooldownReason(state.StatusMessage, state.Quota, state.LastError),
-		Quota:          cooldownFieldsOf(state.Quota),
-		LastError:      cloneError(state.LastError),
-		UpdatedAt:      state.UpdatedAt,
+		Provider:            strings.TrimSpace(auth.Provider),
+		AuthID:              auth.ID,
+		AuthFile:            cooldownAuthFile(auth),
+		Model:               model,
+		Status:              "cooling",
+		NextRetryAfter:      state.NextRetryAfter,
+		ForcedCooldownUntil: state.ForcedCooldownUntil,
+		Reason:              cooldownReason(state.StatusMessage, state.Quota, state.LastError),
+		Quota:               cooldownFieldsOf(state.Quota),
+		LastError:           cloneError(state.LastError),
+		UpdatedAt:           state.UpdatedAt,
 	}, true
 }
 
@@ -772,9 +785,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
 				modelState = state
-				// A success from an already in-flight request must not undo an
-				// explicit cooldown before its deadline.
-				if !hasActiveForcedCooldown(state.LastError, state.NextRetryAfter, now) {
+				// Success heals ordinary failures but cannot clear an explicit
+				// cooldown before its own deadline.
+				if state.ForcedCooldownUntil.After(now) {
+					state.NextRetryAfter = state.ForcedCooldownUntil
+					state.Unavailable = true
+					state.Status = StatusError
+					applyCooldownFields(&state.Quota, QuotaState{})
+				} else {
 					resetModelState(state, now)
 				}
 				updateAggregatedAvailability(auth, now)
@@ -783,16 +801,20 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
 				}
-			} else if !hasActiveForcedCooldown(auth.LastError, auth.NextRetryAfter, now) {
+			} else if auth.ForcedCooldownUntil.After(now) {
+				auth.NextRetryAfter = auth.ForcedCooldownUntil
+				auth.Unavailable = true
+				auth.Status = StatusError
+				applyCooldownFields(&auth.Quota, QuotaState{})
+			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
 		} else {
 			if modelKey != "" {
 				if !shouldSkipCredentialCooldown(result.Error) {
 					state := ensureModelState(auth, modelKey)
-					preserveForcedCooldown := hasActiveForcedCooldown(state.LastError, state.NextRetryAfter, now)
 					disableCooling := m.cooldownDisabledForAuth(auth)
-					if preserveForcedCooldown || (result.Error != nil && result.Error.Code == ErrorCodeForceCooldown) {
+					if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 						disableCooling = false
 					}
 					modelState = state
@@ -802,11 +824,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					prevModelRetryAfter := state.NextRetryAfter
 					if result.Error != nil {
 						state.LastError = cloneError(result.Error)
-						if preserveForcedCooldown {
-							state.LastError.Code = ErrorCodeForceCooldown
-						}
 						state.StatusMessage = result.Error.Message
-						auth.LastError = cloneError(state.LastError)
+						auth.LastError = cloneError(result.Error)
 						auth.StatusMessage = result.Error.Message
 					}
 
@@ -924,10 +943,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						state.NextRetryAfter = now.Add(transientErrorCooldown)
 						state.Unavailable = true
 					}
-					// Later failures cannot shorten a live deadline. A zero write
-					// can clear ordinary cooldowns, but not an explicit action.
-					if (preserveForcedCooldown || !state.NextRetryAfter.IsZero()) && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
+					// Capture this action's deadline before merging ordinary cooldowns.
+					state.ForcedCooldownUntil = extendForcedCooldown(state.ForcedCooldownUntil, state.NextRetryAfter, result.Error)
+					// Later failures only extend ordinary live cooldowns. Explicit
+					// actions remain a floor even when ordinary cooling is disabled.
+					if !state.NextRetryAfter.IsZero() && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
 						state.NextRetryAfter = prevModelRetryAfter
+						state.Unavailable = true
+					}
+					if state.ForcedCooldownUntil.After(now) && state.ForcedCooldownUntil.After(state.NextRetryAfter) {
+						state.NextRetryAfter = state.ForcedCooldownUntil
 						state.Unavailable = true
 					}
 					auth.Status = StatusError
@@ -1118,11 +1143,12 @@ func mergeModelState(target, source *ModelState) *ModelState {
 		fallback = target
 	}
 	merged := ModelState{
-		Status:         preferred.Status,
-		StatusMessage:  preferred.StatusMessage,
-		Unavailable:    target.Unavailable || source.Unavailable,
-		NextRetryAfter: target.NextRetryAfter,
-		LastError:      cloneError(preferred.LastError),
+		Status:              preferred.Status,
+		StatusMessage:       preferred.StatusMessage,
+		Unavailable:         target.Unavailable || source.Unavailable,
+		NextRetryAfter:      target.NextRetryAfter,
+		ForcedCooldownUntil: target.ForcedCooldownUntil,
+		LastError:           cloneError(preferred.LastError),
 		Quota: QuotaState{
 			Exceeded:      target.Quota.Exceeded || source.Quota.Exceeded,
 			Reason:        preferred.Quota.Reason,
@@ -1135,6 +1161,9 @@ func mergeModelState(target, source *ModelState) *ModelState {
 	merged.Quota = mergeQuotaObservation(merged.Quota, preferred.Quota)
 	if source.NextRetryAfter.After(merged.NextRetryAfter) {
 		merged.NextRetryAfter = source.NextRetryAfter
+	}
+	if source.ForcedCooldownUntil.After(merged.ForcedCooldownUntil) {
+		merged.ForcedCooldownUntil = source.ForcedCooldownUntil
 	}
 	if source.Quota.NextRecoverAt.After(merged.Quota.NextRecoverAt) {
 		merged.Quota.NextRecoverAt = source.Quota.NextRecoverAt
@@ -1163,10 +1192,12 @@ func mergeModelState(target, source *ModelState) *ModelState {
 	return target
 }
 
-// Explicit cooldown actions retain their deadline even if an older request
-// succeeds. Ordinary cooldowns still use the existing success-based recovery.
-func hasActiveForcedCooldown(lastError *Error, nextRetryAfter, now time.Time) bool {
-	return lastError != nil && lastError.Code == ErrorCodeForceCooldown && nextRetryAfter.After(now)
+// Only explicit actions can extend the success-resistant cooldown deadline.
+func extendForcedCooldown(current, next time.Time, resultErr *Error) time.Time {
+	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && next.After(current) {
+		return next
+	}
+	return current
 }
 
 func resetModelState(state *ModelState, now time.Time) {
@@ -1177,6 +1208,7 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.Status = StatusActive
 	state.StatusMessage = ""
 	state.NextRetryAfter = time.Time{}
+	state.ForcedCooldownUntil = time.Time{}
 	state.LastError = nil
 	applyCooldownFields(&state.Quota, QuotaState{})
 	state.UpdatedAt = now
@@ -1258,7 +1290,7 @@ func modelStateIsClean(state *ModelState) bool {
 	if state.Status != StatusActive {
 		return false
 	}
-	if state.Unavailable || state.StatusMessage != "" || !state.NextRetryAfter.IsZero() || state.LastError != nil {
+	if state.Unavailable || state.StatusMessage != "" || !state.NextRetryAfter.IsZero() || !state.ForcedCooldownUntil.IsZero() || state.LastError != nil {
 		return false
 	}
 	if state.Quota.Exceeded || state.Quota.Reason != "" || !state.Quota.NextRecoverAt.IsZero() || state.Quota.BackoffLevel != 0 {
@@ -1389,6 +1421,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.BackoffLevel = 0
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
+	auth.ForcedCooldownUntil = time.Time{}
 	auth.UpdatedAt = now
 }
 
@@ -2023,10 +2056,6 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
-	preserveForcedCooldown := hasActiveForcedCooldown(auth.LastError, auth.NextRetryAfter, now)
-	if preserveForcedCooldown {
-		disableCooling = false
-	}
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
@@ -2038,9 +2067,6 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	auth.UpdatedAt = now
 	if resultErr != nil {
 		auth.LastError = cloneError(resultErr)
-		if preserveForcedCooldown {
-			auth.LastError.Code = ErrorCodeForceCooldown
-		}
 		if resultErr.Message != "" {
 			auth.StatusMessage = resultErr.Message
 		}
@@ -2119,13 +2145,18 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.Unavailable = !auth.NextRetryAfter.IsZero()
 		}
 	}
-	// A zero write can clear ordinary cooldowns, but not an explicit action.
-	if (preserveForcedCooldown || !auth.NextRetryAfter.IsZero()) && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
+	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
+		auth.NextRetryAfter = now.Add(transientErrorCooldown)
+		auth.Unavailable = true
+	}
+	// Capture this action's deadline before merging ordinary cooldowns.
+	auth.ForcedCooldownUntil = extendForcedCooldown(auth.ForcedCooldownUntil, auth.NextRetryAfter, resultErr)
+	if !auth.NextRetryAfter.IsZero() && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
 		auth.NextRetryAfter = prevAuthRetryAfter
 		auth.Unavailable = true
 	}
-	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
-		auth.NextRetryAfter = now.Add(transientErrorCooldown)
+	if auth.ForcedCooldownUntil.After(now) && auth.ForcedCooldownUntil.After(auth.NextRetryAfter) {
+		auth.NextRetryAfter = auth.ForcedCooldownUntil
 		auth.Unavailable = true
 	}
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -818,14 +818,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			if auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 				// Retain active credential-scoped cooldown
 			} else if modelKey != "" {
+				recoverAggregate := modelStatesOwnAvailability(auth, now) || auth.ForcedCooldownUntil.After(now)
 				state := ensureModelState(auth, modelKey)
 				modelState = state
 				recoverModelStateOnSuccess(state, now)
 				if auth.ForcedCooldownUntil.After(now) {
 					auth.NextRetryAfter = auth.ForcedCooldownUntil
-					applyCooldownFields(&auth.Quota, QuotaState{})
 				}
-				updateAggregatedAvailability(auth, now)
+				if recoverAggregate {
+					recoverAggregatedAvailability(auth, now)
+				} else {
+					updateAggregatedAvailability(auth, now)
+				}
 				if !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
 					auth.LastError = nil
 					auth.StatusMessage = ""
@@ -1352,6 +1356,52 @@ func modelStateIsClean(state *ModelState) bool {
 		return false
 	}
 	return true
+}
+
+// Model recovery may replace a derived summary, but must not clear a separate
+// credential failure. Check the pre-recovery state, before changing its models.
+func modelStatesOwnAvailability(auth *Auth, now time.Time) bool {
+	if auth == nil || len(auth.ModelStates) == 0 || auth.ForcedCooldownUntil.After(now) ||
+		(auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now)) {
+		return false
+	}
+	if !auth.NextRetryAfter.After(now) && (!auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.After(now)) {
+		return true
+	}
+	var earliest time.Time
+	var latestModelQuota time.Time
+	matchingError := auth.LastError == nil
+	for _, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		matchingError = matchingError || cooldownErrorEqual(auth.LastError, state.LastError)
+		if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(latestModelQuota) {
+			latestModelQuota = state.Quota.NextRecoverAt
+		}
+		if state.Unavailable && state.NextRetryAfter.After(now) && (earliest.IsZero() || state.NextRetryAfter.Before(earliest)) {
+			earliest = state.NextRetryAfter
+		}
+	}
+	// A credential quota can predate the model errors that supplied the current
+	// retry deadline and LastError. Do not treat its independent window as derived.
+	if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(now) && auth.Quota.NextRecoverAt.After(latestModelQuota) {
+		return false
+	}
+	if !auth.Unavailable && auth.NextRetryAfter.IsZero() {
+		return true
+	}
+	return !earliest.IsZero() && earliest.Equal(auth.NextRetryAfter) && matchingError
+}
+
+// Failure aggregation is monotonic. Recovery instead derives quota fields
+// afresh, so an old aggregate cannot outlive the remaining model cooldowns.
+func recoverAggregatedAvailability(auth *Auth, now time.Time) {
+	if auth == nil || (auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now)) {
+		return
+	}
+	applyCooldownFields(&auth.Quota, QuotaState{})
+	updateAggregatedAvailability(auth, now)
 }
 
 func updateAggregatedAvailability(auth *Auth, now time.Time) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -310,6 +310,7 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 
 	now := time.Now()
 	authLevelRecords := make([]CooldownStateRecord, 0)
+	modelRecordsByAuth := make(map[string][]CooldownStateRecord)
 	snapshotsByID := make(map[string]*Auth)
 
 	m.mu.Lock()
@@ -318,14 +319,17 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 			authLevelRecords = append(authLevelRecords, record)
 			continue
 		}
-		if m.restoreCooldownRecordLocked(record, now) {
-			if auth := m.auths[strings.TrimSpace(record.AuthID)]; auth != nil {
+		if m.restoreCooldownRecordLocked(record, now, false) {
+			authID := strings.TrimSpace(record.AuthID)
+			modelRecordsByAuth[authID] = append(modelRecordsByAuth[authID], record)
+			if auth := m.auths[authID]; auth != nil {
 				snapshotsByID[auth.ID] = auth.Clone()
 			}
 		}
 	}
 	for _, record := range authLevelRecords {
-		if m.restoreCooldownRecordLocked(record, now) {
+		isAggregate := isModelAggregateCooldownRecord(record, modelRecordsByAuth[strings.TrimSpace(record.AuthID)])
+		if m.restoreCooldownRecordLocked(record, now, isAggregate) {
 			if auth := m.auths[strings.TrimSpace(record.AuthID)]; auth != nil {
 				snapshotsByID[auth.ID] = auth.Clone()
 			}
@@ -342,7 +346,24 @@ func (m *Manager) RestoreCooldownStates(ctx context.Context) error {
 	return nil
 }
 
-func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time) bool {
+// Aggregate auth records combine the earliest model deadline with the last
+// model error. Inspect the loaded records, not unrelated runtime model history.
+func isModelAggregateCooldownRecord(record CooldownStateRecord, models []CooldownStateRecord) bool {
+	if record.Quota.Reason == "credential_quota" {
+		return false
+	}
+	var earliest time.Time
+	matchingError := false
+	for _, model := range models {
+		if earliest.IsZero() || model.NextRetryAfter.Before(earliest) {
+			earliest = model.NextRetryAfter
+		}
+		matchingError = matchingError || cooldownErrorEqual(record.LastError, model.LastError)
+	}
+	return !earliest.IsZero() && earliest.Equal(record.NextRetryAfter) && matchingError
+}
+
+func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now time.Time, isModelAggregate bool) bool {
 	authID := strings.TrimSpace(record.AuthID)
 	if authID == "" || record.NextRetryAfter.IsZero() || !record.NextRetryAfter.After(now) {
 		return false
@@ -358,9 +379,9 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	reason := strings.TrimSpace(record.Reason)
 	model := strings.TrimSpace(record.Model)
 	forcedUntil := record.ForcedCooldownUntil
-	// Older sidecars only had the error marker. An aggregate auth record must
-	// not turn a restored model cooldown into an auth-level forced cooldown.
-	if forcedUntil.IsZero() && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown && (model != "" || len(auth.ModelStates) == 0) {
+	// Older sidecars only had the error marker. Do not reinterpret a model
+	// aggregate as an independent auth-level forced cooldown.
+	if forcedUntil.IsZero() && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown && !isModelAggregate {
 		forcedUntil = record.NextRetryAfter
 	}
 	quota := record.Quota
@@ -792,11 +813,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					state.Unavailable = true
 					state.Status = StatusError
 					applyCooldownFields(&state.Quota, QuotaState{})
+					state.UpdatedAt = now
 				} else {
 					resetModelState(state, now)
 				}
 				updateAggregatedAvailability(auth, now)
-				if !hasModelError(auth, now) {
+				if !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
 					auth.LastError = nil
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
@@ -822,6 +844,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					state.Status = StatusError
 					state.UpdatedAt = now
 					prevModelRetryAfter := state.NextRetryAfter
+					var forcedRetryAfter time.Time
 					if result.Error != nil {
 						state.LastError = cloneError(result.Error)
 						state.StatusMessage = result.Error.Message
@@ -878,7 +901,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 										cooldown = minQuotaCooldownFloor
 									}
 									next = now.Add(cooldown)
+									forcedRetryAfter = next
 								} else {
+									forcedQuota := state.Quota
+									forcedQuota.NextRecoverAt = state.ForcedCooldownUntil
+									forcedRetryAfter, _ = quotaCooldownAfterFailure(forcedQuota, now)
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								}
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
@@ -943,8 +970,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						state.NextRetryAfter = now.Add(transientErrorCooldown)
 						state.Unavailable = true
 					}
-					// Capture this action's deadline before merging ordinary cooldowns.
-					state.ForcedCooldownUntil = extendForcedCooldown(state.ForcedCooldownUntil, state.NextRetryAfter, result.Error)
+					// The 429 candidate is captured before quota-window merging too.
+					if forcedRetryAfter.IsZero() {
+						forcedRetryAfter = state.NextRetryAfter
+					}
+					state.ForcedCooldownUntil = extendForcedCooldown(state.ForcedCooldownUntil, forcedRetryAfter, result.Error)
 					// Later failures only extend ordinary live cooldowns. Explicit
 					// actions remain a floor even when ordinary cooling is disabled.
 					if !state.NextRetryAfter.IsZero() && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
@@ -1305,6 +1335,13 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 	}
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		auth.Unavailable = true
+		return
+	}
+	if auth.ForcedCooldownUntil.After(now) {
+		auth.Unavailable = true
+		if auth.NextRetryAfter.Before(auth.ForcedCooldownUntil) {
+			auth.NextRetryAfter = auth.ForcedCooldownUntil
+		}
 		return
 	}
 	if len(auth.ModelStates) == 0 {
@@ -2053,6 +2090,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		return
 	}
 	prevAuthRetryAfter := auth.NextRetryAfter
+	var forcedRetryAfter time.Time
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
@@ -2124,7 +2162,11 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 						cooldown = minQuotaCooldownFloor
 					}
 					next = now.Add(cooldown)
+					forcedRetryAfter = next
 				} else {
+					forcedQuota := auth.Quota
+					forcedQuota.NextRecoverAt = auth.ForcedCooldownUntil
+					forcedRetryAfter, _ = quotaCooldownAfterFailure(forcedQuota, now)
 					next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				}
 				if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
@@ -2149,8 +2191,11 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)
 		auth.Unavailable = true
 	}
-	// Capture this action's deadline before merging ordinary cooldowns.
-	auth.ForcedCooldownUntil = extendForcedCooldown(auth.ForcedCooldownUntil, auth.NextRetryAfter, resultErr)
+	// The 429 candidate is captured before quota-window merging too.
+	if forcedRetryAfter.IsZero() {
+		forcedRetryAfter = auth.NextRetryAfter
+	}
+	auth.ForcedCooldownUntil = extendForcedCooldown(auth.ForcedCooldownUntil, forcedRetryAfter, resultErr)
 	if !auth.NextRetryAfter.IsZero() && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
 		auth.NextRetryAfter = prevAuthRetryAfter
 		auth.Unavailable = true

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -772,24 +772,29 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
 				modelState = state
-				resetModelState(state, now)
+				// A success from an already in-flight request must not undo an
+				// explicit cooldown before its deadline.
+				if !hasActiveForcedCooldown(state.LastError, state.NextRetryAfter, now) {
+					resetModelState(state, now)
+				}
 				updateAggregatedAvailability(auth, now)
 				if !hasModelError(auth, now) {
 					auth.LastError = nil
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
 				}
-			} else {
+			} else if !hasActiveForcedCooldown(auth.LastError, auth.NextRetryAfter, now) {
 				clearAuthStateOnSuccess(auth, now)
 			}
 		} else {
 			if modelKey != "" {
 				if !shouldSkipCredentialCooldown(result.Error) {
+					state := ensureModelState(auth, modelKey)
+					preserveForcedCooldown := hasActiveForcedCooldown(state.LastError, state.NextRetryAfter, now)
 					disableCooling := m.cooldownDisabledForAuth(auth)
-					if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
+					if preserveForcedCooldown || (result.Error != nil && result.Error.Code == ErrorCodeForceCooldown) {
 						disableCooling = false
 					}
-					state := ensureModelState(auth, modelKey)
 					modelState = state
 					state.Unavailable = true
 					state.Status = StatusError
@@ -797,8 +802,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					prevModelRetryAfter := state.NextRetryAfter
 					if result.Error != nil {
 						state.LastError = cloneError(result.Error)
+						if preserveForcedCooldown {
+							state.LastError.Code = ErrorCodeForceCooldown
+						}
 						state.StatusMessage = result.Error.Message
-						auth.LastError = cloneError(result.Error)
+						auth.LastError = cloneError(state.LastError)
 						auth.StatusMessage = result.Error.Message
 					}
 
@@ -916,11 +924,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						state.NextRetryAfter = now.Add(transientErrorCooldown)
 						state.Unavailable = true
 					}
-					// A later failure only extends a still-live cooldown; it never
-					// shortens one. A deliberate zero write (disableCooling) still
-					// clears the deadline.
-					if !state.NextRetryAfter.IsZero() && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
+					// Later failures cannot shorten a live deadline. A zero write
+					// can clear ordinary cooldowns, but not an explicit action.
+					if (preserveForcedCooldown || !state.NextRetryAfter.IsZero()) && prevModelRetryAfter.After(state.NextRetryAfter) && prevModelRetryAfter.After(now) {
 						state.NextRetryAfter = prevModelRetryAfter
+						state.Unavailable = true
 					}
 					auth.Status = StatusError
 					updateAggregatedAvailability(auth, now)
@@ -1153,6 +1161,12 @@ func mergeModelState(target, source *ModelState) *ModelState {
 	}
 	*target = merged
 	return target
+}
+
+// Explicit cooldown actions retain their deadline even if an older request
+// succeeds. Ordinary cooldowns still use the existing success-based recovery.
+func hasActiveForcedCooldown(lastError *Error, nextRetryAfter, now time.Time) bool {
+	return lastError != nil && lastError.Code == ErrorCodeForceCooldown && nextRetryAfter.After(now)
 }
 
 func resetModelState(state *ModelState, now time.Time) {
@@ -2009,6 +2023,10 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
+	preserveForcedCooldown := hasActiveForcedCooldown(auth.LastError, auth.NextRetryAfter, now)
+	if preserveForcedCooldown {
+		disableCooling = false
+	}
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
@@ -2020,6 +2038,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	auth.UpdatedAt = now
 	if resultErr != nil {
 		auth.LastError = cloneError(resultErr)
+		if preserveForcedCooldown {
+			auth.LastError.Code = ErrorCodeForceCooldown
+		}
 		if resultErr.Message != "" {
 			auth.StatusMessage = resultErr.Message
 		}
@@ -2098,10 +2119,10 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.Unavailable = !auth.NextRetryAfter.IsZero()
 		}
 	}
-	// A later failure only extends a still-live credential cooldown; a
-	// deliberate zero write (disableCooling) still clears it.
-	if !auth.NextRetryAfter.IsZero() && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
+	// A zero write can clear ordinary cooldowns, but not an explicit action.
+	if (preserveForcedCooldown || !auth.NextRetryAfter.IsZero()) && prevAuthRetryAfter.After(auth.NextRetryAfter) && prevAuthRetryAfter.After(now) {
 		auth.NextRetryAfter = prevAuthRetryAfter
+		auth.Unavailable = true
 	}
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
 		auth.NextRetryAfter = now.Add(transientErrorCooldown)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -390,9 +390,23 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	}
 
 	if model == "" {
+		nextRetry := record.NextRetryAfter
+		// Restore can run while requests are active. An older auth snapshot or
+		// model aggregate must not shorten a live credential-level action.
+		if auth.ForcedCooldownUntil.After(now) {
+			if auth.ForcedCooldownUntil.After(forcedUntil) {
+				forcedUntil = auth.ForcedCooldownUntil
+			}
+			if auth.NextRetryAfter.After(nextRetry) {
+				nextRetry = auth.NextRetryAfter
+			}
+		}
+		if forcedUntil.After(nextRetry) {
+			nextRetry = forcedUntil
+		}
 		auth.Unavailable = true
 		auth.Status = StatusError
-		auth.NextRetryAfter = record.NextRetryAfter
+		auth.NextRetryAfter = nextRetry
 		auth.ForcedCooldownUntil = forcedUntil
 		applyCooldownFields(&auth.Quota, quota)
 		auth.Quota = mergeQuotaObservation(auth.Quota, quota)
@@ -806,16 +820,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else if modelKey != "" {
 				state := ensureModelState(auth, modelKey)
 				modelState = state
-				// Success heals ordinary failures but cannot clear an explicit
-				// cooldown before its own deadline.
-				if state.ForcedCooldownUntil.After(now) {
-					state.NextRetryAfter = state.ForcedCooldownUntil
-					state.Unavailable = true
-					state.Status = StatusError
-					applyCooldownFields(&state.Quota, QuotaState{})
-					state.UpdatedAt = now
-				} else {
-					resetModelState(state, now)
+				recoverModelStateOnSuccess(state, now)
+				if auth.ForcedCooldownUntil.After(now) {
+					auth.NextRetryAfter = auth.ForcedCooldownUntil
+					applyCooldownFields(&auth.Quota, QuotaState{})
 				}
 				updateAggregatedAvailability(auth, now)
 				if !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
@@ -1228,6 +1236,23 @@ func extendForcedCooldown(current, next time.Time, resultErr *Error) time.Time {
 		return next
 	}
 	return current
+}
+
+// Request and token-refresh success heal ordinary failures, but cannot remove
+// an explicit cooldown before its own deadline.
+func recoverModelStateOnSuccess(state *ModelState, now time.Time) {
+	if state == nil {
+		return
+	}
+	if !state.ForcedCooldownUntil.After(now) {
+		resetModelState(state, now)
+		return
+	}
+	state.NextRetryAfter = state.ForcedCooldownUntil
+	state.Unavailable = true
+	state.Status = StatusError
+	applyCooldownFields(&state.Quota, QuotaState{})
+	state.UpdatedAt = now
 }
 
 func resetModelState(state *ModelState, now time.Time) {

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_aggregate_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_aggregate_test.go
@@ -1,0 +1,354 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManager_ForcedCooldownRecoveryAggregates(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, recovery := range []string{"success", "refresh", "refresh_helper"} {
+		for _, priorQuota := range []bool{false, true} {
+			name := recovery + "/ordinary_401"
+			if priorQuota {
+				name = recovery + "/prior_ordinary_quota"
+			}
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "aggregate-model")
+				store := NewFileCooldownStateStore(t.TempDir())
+				m.SetCooldownStateStore(store)
+				if priorQuota {
+					ordinary := 2 * time.Hour
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "aggregate-model", RetryAfter: &ordinary, Error: &Error{HTTPStatus: http.StatusTooManyRequests}})
+				}
+				forced := 10 * time.Minute
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "aggregate-model", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+				if !priorQuota || recovery != "success" {
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "aggregate-model", Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired token"}})
+				}
+				before, _ := m.GetByID(auth.ID)
+				deadline := before.ModelStates["aggregate-model"].ForcedCooldownUntil
+				var snapshot *Auth
+				switch recovery {
+				case "refresh_helper":
+					snapshot = before.Clone()
+					resumed := clearUnauthorizedModelStates(snapshot, time.Now())
+					if len(resumed) != 0 {
+						t.Error("a still-forced model must not be reported as immediately resumed")
+					}
+				case "refresh":
+					m.RegisterExecutor(&unauthorizedRefreshExecutor{id: auth.Provider})
+					if _, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, ""); errRefresh != nil {
+						t.Fatal(errRefresh)
+					}
+					snapshot, _ = m.GetByID(auth.ID)
+				default:
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "aggregate-model", Success: true})
+					snapshot, _ = m.GetByID(auth.ID)
+				}
+				assertRecoveredForcedAggregate(t, snapshot, "aggregate-model", deadline)
+				if recovery == "refresh_helper" {
+					return
+				}
+				if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "aggregate-model", cliproxyexecutor.Options{}, nil); picked != nil || errPick == nil {
+					t.Error("scheduler reused the forced model before its deadline")
+				}
+				assertForcedAggregateSchedulerExpiry(t, m, auth, "aggregate-model", deadline)
+				records, errLoad := store.Load(ctx)
+				if errLoad != nil {
+					t.Fatal(errLoad)
+				}
+				if len(records) != 2 {
+					t.Fatalf("expected auth and model cooldown records, got %d", len(records))
+				}
+				for _, record := range records {
+					if !record.NextRetryAfter.Equal(deadline) || record.Quota.Exceeded || !record.Quota.NextRecoverAt.IsZero() {
+						t.Errorf("persisted stale aggregate: model=%q next=%v quota=%v", record.Model, record.NextRetryAfter, record.Quota.NextRecoverAt)
+					}
+				}
+				restored, _ := newCooldownMonotonicManager(t, "aggregate-model")
+				restored.SetCooldownStateStore(store)
+				if errRestore := restored.RestoreCooldownStates(ctx); errRestore != nil {
+					t.Fatal(errRestore)
+				}
+				afterRestore, _ := restored.GetByID(auth.ID)
+				assertRecoveredForcedAggregate(t, afterRestore, "aggregate-model", deadline)
+				assertForcedAggregateSchedulerExpiry(t, restored, auth, "aggregate-model", deadline)
+			})
+		}
+	}
+}
+
+func assertForcedAggregateSchedulerExpiry(t *testing.T, m *Manager, auth *Auth, model string, deadline time.Time) {
+	t.Helper()
+	m.scheduler.mu.Lock()
+	defer m.scheduler.mu.Unlock()
+	provider := m.scheduler.providers[auth.Provider]
+	if provider == nil {
+		t.Fatal("scheduler has no provider state")
+	}
+	for _, selectedModel := range []string{model, ""} {
+		shard := provider.ensureModelLocked(selectedModel, time.Now())
+		entry := shard.entries[auth.ID]
+		if entry == nil || entry.state == scheduledStateReady || !entry.nextRetryAt.Equal(deadline) {
+			t.Errorf("scheduler model=%q did not retain exactly the forced deadline", selectedModel)
+		}
+		shard.promoteExpiredLocked(deadline.Add(time.Second))
+		if entry == nil || entry.state != scheduledStateReady {
+			t.Errorf("scheduler model=%q retained stale aggregate after forced expiry", selectedModel)
+		}
+	}
+}
+
+func assertRecoveredForcedAggregate(t *testing.T, auth *Auth, model string, deadline time.Time) {
+	t.Helper()
+	state := auth.ModelStates[model]
+	if state == nil || !state.ForcedCooldownUntil.Equal(deadline) || !state.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("recovered model lost its forced deadline: %+v", state)
+	}
+	if !auth.ForcedCooldownUntil.IsZero() {
+		t.Error("model recovery widened the forced cooldown to credential scope")
+	}
+	if !auth.NextRetryAfter.Equal(deadline) || auth.Quota.Exceeded || !auth.Quota.NextRecoverAt.IsZero() {
+		t.Errorf("auth retained stale aggregate: next=%v quota=%v; want next=%v, no quota", auth.NextRetryAfter, auth.Quota.NextRecoverAt, deadline)
+	}
+	for _, selectedModel := range []string{model, ""} {
+		if blocked, _, _ := isAuthBlockedForModel(auth, selectedModel, time.Now()); !blocked {
+			t.Errorf("selection model=%q bypassed an active forced cooldown", selectedModel)
+		}
+		if blocked, _, next := isAuthBlockedForModel(auth, selectedModel, deadline.Add(time.Second)); blocked {
+			t.Errorf("selection model=%q retained stale cooldown after forced expiry: %v", selectedModel, next)
+		}
+	}
+}
+
+func TestManager_ForcedCooldownRefreshKeepsConcurrentState(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, mutation := range []string{"sibling", "same_model", "credential_forced", "credential_quota", "reset"} {
+		t.Run(mutation, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "refresh-model", "sibling-model")
+			forced := 10 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "refresh-model", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "refresh-model", Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired token"}})
+			before, _ := m.GetByID(auth.ID)
+			deadline := before.ModelStates["refresh-model"].ForcedCooldownUntil
+			executor := &aggregateBlockingRefreshExecutor{unauthorizedRefreshExecutor: unauthorizedRefreshExecutor{id: auth.Provider}, started: make(chan struct{}), release: make(chan struct{})}
+			m.RegisterExecutor(executor)
+			done := make(chan error, 1)
+			go func() {
+				_, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, "")
+				done <- errRefresh
+			}()
+			<-executor.started
+			longer := 20 * time.Minute
+			result := Result{AuthID: auth.ID, Provider: auth.Provider, Model: "sibling-model", RetryAfter: &longer, Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "new quota"}}
+			switch mutation {
+			case "same_model":
+				result.Model = "refresh-model"
+				result.Error = &Error{HTTPStatus: http.StatusNotFound, Message: "new model error"}
+			case "credential_forced":
+				result.Model = ""
+				result.Error.Code = ErrorCodeForceCooldown
+			case "credential_quota":
+				result.CredentialScope = true
+			case "reset":
+				if _, _, errReset := m.ResetQuota(ctx, auth.ID); errReset != nil {
+					t.Error(errReset)
+				}
+			}
+			if mutation != "reset" {
+				m.MarkResult(ctx, result)
+			}
+			concurrent, _ := m.GetByID(auth.ID)
+			close(executor.release)
+			if errRefresh := <-done; errRefresh != nil {
+				t.Fatal(errRefresh)
+			}
+			after, _ := m.GetByID(auth.ID)
+			if mutation == "reset" {
+				if blocked, _, _ := isAuthBlockedForModel(after, "", time.Now()); blocked {
+					t.Error("refresh resurrected a reset aggregate cooldown")
+				}
+				return
+			}
+			if mutation == "sibling" {
+				if !after.NextRetryAfter.Equal(deadline) || !after.Quota.NextRecoverAt.Equal(concurrent.ModelStates["sibling-model"].Quota.NextRecoverAt) {
+					t.Error("refresh did not rebuild aggregate from healed and concurrent model states")
+				}
+				if blocked, _, _ := isAuthBlockedForModel(after, "refresh-model", deadline.Add(time.Second)); blocked {
+					t.Error("sibling quota widened the recovered model cooldown")
+				}
+			}
+			if mutation == "credential_forced" && !after.ForcedCooldownUntil.Equal(concurrent.ForcedCooldownUntil) {
+				t.Error("refresh cleared a concurrent credential forced action")
+			}
+			if mutation == "credential_quota" && (!after.Quota.NextRecoverAt.Equal(concurrent.Quota.NextRecoverAt) || after.Quota.Reason != "credential_quota") {
+				t.Error("refresh cleared a concurrent credential quota")
+			}
+			blockedModel := result.Model
+			if blocked, _, _ := isAuthBlockedForModel(after, blockedModel, deadline.Add(time.Second)); !blocked {
+				t.Error("refresh cleared a concurrent error before its own deadline")
+			}
+		})
+	}
+}
+
+type aggregateBlockingRefreshExecutor struct {
+	unauthorizedRefreshExecutor
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *aggregateBlockingRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	close(e.started)
+	select {
+	case <-e.release:
+		return e.unauthorizedRefreshExecutor.Refresh(ctx, auth)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestManager_ForcedCooldownRefreshAggregateBoundaries(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, boundary := range []string{"ordinary_recovery", "expired_force", "credential_forced", "credential_quota", "credential_ordinary_quota", "credential_ordinary_401", "disabled", "delete_ordinary_model", "delete_forced_model", "nil_forced_model", "clear_forced_model"} {
+		t.Run(boundary, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "boundary-model")
+			store := NewFileCooldownStateStore(t.TempDir())
+			m.SetCooldownStateStore(store)
+			forced := 10 * time.Minute
+			if boundary != "ordinary_recovery" && boundary != "delete_ordinary_model" {
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "boundary-model", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "boundary-model", Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "same unauthorized text"}})
+			longer := 20 * time.Minute
+			if boundary == "credential_forced" || boundary == "credential_quota" || boundary == "credential_ordinary_quota" || boundary == "credential_ordinary_401" {
+				result := Result{AuthID: auth.ID, Provider: auth.Provider, RetryAfter: &longer, Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "credential quota"}}
+				if boundary == "credential_forced" {
+					result.Error.Code = ErrorCodeForceCooldown
+				} else if boundary == "credential_quota" {
+					result.Model = "boundary-model"
+					result.CredentialScope = true
+				} else if boundary == "credential_ordinary_401" {
+					result.Error = &Error{HTTPStatus: http.StatusUnauthorized, Message: "same unauthorized text"}
+				}
+				m.MarkResult(ctx, result)
+			}
+			m.mu.Lock()
+			current := m.auths[auth.ID]
+			observed := time.Now()
+			current.Quota.Signals = map[string]string{"X-Codex-Plan-Type": "test-plan"}
+			current.Quota.ObservedAt = observed
+			current.ModelStates["boundary-model"].Quota.Signals = map[string]string{"X-Codex-Plan-Type": "model-plan"}
+			current.ModelStates["boundary-model"].Quota.ObservedAt = observed
+			if boundary == "expired_force" {
+				current.ModelStates["boundary-model"].ForcedCooldownUntil = time.Now().Add(-time.Minute)
+			}
+			m.mu.Unlock()
+			before, _ := m.GetByID(auth.ID)
+			updated := before.Clone()
+			updated.LastError = nil
+			updated.Status = StatusActive
+			updated.Unavailable = false
+			clearUnauthorizedModelStates(updated, time.Now())
+			switch boundary {
+			case "disabled":
+				updated.Disabled = true
+				updated.Status = StatusDisabled
+			case "delete_ordinary_model", "delete_forced_model":
+				delete(updated.ModelStates, "boundary-model")
+			case "nil_forced_model":
+				updated.ModelStates["boundary-model"] = nil
+			case "clear_forced_model":
+				resetModelState(updated.ModelStates["boundary-model"], time.Now())
+			}
+			if _, errUpdate := m.UpdateRefreshedAuth(ctx, before, updated); errUpdate != nil {
+				t.Fatal(errUpdate)
+			}
+			after, _ := m.GetByID(auth.ID)
+			if !reflect.DeepEqual(after.Quota.Signals, before.Quota.Signals) || !after.Quota.ObservedAt.Equal(observed) {
+				t.Error("aggregate recovery discarded passive quota observations")
+			}
+			switch boundary {
+			case "ordinary_recovery", "expired_force", "delete_ordinary_model":
+				if blocked, _, _ := isAuthBlockedForModel(after, "", time.Now()); blocked || after.LastError != nil || after.Status != StatusActive {
+					t.Error("model recovery left stale credential availability or error status")
+				}
+				records, errLoad := store.Load(ctx)
+				if errLoad != nil || len(records) != 0 {
+					t.Errorf("recovery did not remove persisted cooldowns: records=%d error=%v", len(records), errLoad)
+				}
+				if boundary == "delete_ordinary_model" && len(after.ModelStates) != 0 {
+					t.Error("refresh replacement resurrected a deleted ordinary model state")
+				}
+			case "delete_forced_model", "nil_forced_model", "clear_forced_model":
+				deadline := before.ModelStates["boundary-model"].ForcedCooldownUntil
+				assertRecoveredForcedAggregate(t, after, "boundary-model", deadline)
+				assertForcedAggregateSchedulerExpiry(t, m, auth, "boundary-model", deadline)
+			case "disabled":
+				if !after.Disabled || after.Status != StatusDisabled {
+					t.Error("aggregate recovery re-enabled a disabled credential")
+				}
+			default:
+				if !after.NextRetryAfter.Equal(before.NextRetryAfter) || !reflect.DeepEqual(cooldownFieldsOf(after.Quota), cooldownFieldsOf(before.Quota)) || !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) {
+					t.Error("model recovery changed an independent credential cooldown")
+				}
+			}
+		})
+	}
+}
+
+func TestManager_ForcedCooldownRefreshPreservesEarlierCredentialQuota(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, recovery := range []string{"refresh", "success"} {
+		t.Run(recovery, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "earlier-quota-model")
+			store := NewFileCooldownStateStore(t.TempDir())
+			m.SetCooldownStateStore(store)
+			credentialQuota := 2 * time.Hour
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, RetryAfter: &credentialQuota, Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "credential rate limit"}})
+			forced := 10 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "earlier-quota-model", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "earlier-quota-model", Error: &Error{HTTPStatus: http.StatusUnauthorized}})
+			before, _ := m.GetByID(auth.ID)
+			if recovery == "refresh" {
+				m.RegisterExecutor(&unauthorizedRefreshExecutor{id: auth.Provider})
+				if _, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, ""); errRefresh != nil {
+					t.Fatal(errRefresh)
+				}
+			} else {
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "earlier-quota-model", Success: true})
+			}
+			after, _ := m.GetByID(auth.ID)
+			if !after.Quota.NextRecoverAt.Equal(before.Quota.NextRecoverAt) || !after.Quota.Exceeded {
+				t.Error("model recovery cleared a credential quota that was not derived from the model")
+			}
+			restored, _ := newCooldownMonotonicManager(t, "earlier-quota-model")
+			restored.SetCooldownStateStore(store)
+			if errRestore := restored.RestoreCooldownStates(ctx); errRestore != nil {
+				t.Fatal(errRestore)
+			}
+			afterRestore, _ := restored.GetByID(auth.ID)
+			if !afterRestore.Quota.NextRecoverAt.Equal(before.Quota.NextRecoverAt) || !afterRestore.Quota.Exceeded {
+				t.Error("restoration lost the independent credential quota after model recovery")
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_aggregate_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_aggregate_test.go
@@ -2,13 +2,141 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
+
+func TestManager_ForcedCooldownRecoveryAfterRegistryRemoval(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+	for _, recovery := range []string{"success", "refresh"} {
+		for _, lifecycle := range []string{"live", "restore_before_recovery", "replacement_before_recovery", "refresh_error_before_recovery"} {
+			t.Run(recovery+"/"+lifecycle, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "ordinary-a", "removed-b", "unrelated-c")
+				store := NewFileCooldownStateStore(t.TempDir())
+				m.SetCooldownStateStore(store)
+				ordinary := 2 * time.Hour
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "ordinary-a", RetryAfter: &ordinary, Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "ordinary A quota"}})
+				forced := 10 * time.Minute
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "ordinary-a", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests, Message: "forced A quota"}})
+				if recovery == "refresh" {
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "ordinary-a", Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired A token"}})
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "removed-b", Error: &Error{HTTPStatus: http.StatusNotFound, Message: "removed model B"}})
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "ordinary-a"}, {ID: "unrelated-c"}})
+				m.ReconcileRegistryModelStates(ctx, auth.ID)
+				snapshot, _ := m.GetByID(auth.ID)
+				if _, exists := snapshot.ModelStates["removed-b"]; exists {
+					t.Fatal("registry removal did not remove model B")
+				}
+				deadline := snapshot.ModelStates["ordinary-a"].ForcedCooldownUntil
+				switch lifecycle {
+				case "restore_before_recovery":
+					m, _ = newCooldownMonotonicManager(t, "ordinary-a", "unrelated-c")
+					m.SetCooldownStateStore(store)
+					if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+						t.Fatal(errRestore)
+					}
+				case "replacement_before_recovery":
+					if _, errUpdate := m.Update(ctx, &Auth{ID: auth.ID, Provider: auth.Provider}); errUpdate != nil {
+						t.Fatal(errUpdate)
+					}
+				case "refresh_error_before_recovery":
+					m.RegisterExecutor(&aggregateFailingRefreshExecutor{unauthorizedRefreshExecutor{id: auth.Provider}})
+					if _, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, ""); errRefresh == nil {
+						t.Fatal("expected the diagnostic token-refresh failure")
+					}
+				}
+				if recovery == "refresh" {
+					m.RegisterExecutor(&unauthorizedRefreshExecutor{id: auth.Provider})
+					if _, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, ""); errRefresh != nil {
+						t.Fatal(errRefresh)
+					}
+				} else {
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "ordinary-a", Success: true})
+				}
+				snapshot, _ = m.GetByID(auth.ID)
+				assertRecoveredForcedAggregate(t, snapshot, "ordinary-a", deadline)
+				assertForcedAggregateSchedulerExpiry(t, m, auth, "ordinary-a", deadline)
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "unrelated-c", time.Now()); blocked {
+					t.Error("model recovery blocked an unrelated model")
+				}
+				restarted, _ := newCooldownMonotonicManager(t, "ordinary-a", "unrelated-c")
+				restarted.SetCooldownStateStore(store)
+				if errRestore := restarted.RestoreCooldownStates(ctx); errRestore != nil {
+					t.Fatal(errRestore)
+				}
+				snapshot, _ = restarted.GetByID(auth.ID)
+				assertRecoveredForcedAggregate(t, snapshot, "ordinary-a", deadline)
+				assertForcedAggregateSchedulerExpiry(t, restarted, auth, "ordinary-a", deadline)
+			})
+		}
+	}
+}
+
+type aggregateFailingRefreshExecutor struct{ unauthorizedRefreshExecutor }
+
+func (e *aggregateFailingRefreshExecutor) Refresh(context.Context, *Auth) (*Auth, error) {
+	return nil, errors.New("test token-refresh failure")
+}
+
+func TestManager_ForcedCooldownRecoveryKeepsSameErrorCredentialFailure(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+	for _, restored := range []bool{false, true} {
+		name := "live"
+		if restored {
+			name = "restored"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "same-error-model")
+			store := NewFileCooldownStateStore(t.TempDir())
+			m.SetCooldownStateStore(store)
+			forced := 10 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "same-error-model", RetryAfter: &forced, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			ordinaryError := &Error{HTTPStatus: http.StatusUnauthorized, Message: "same unauthorized error"}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "same-error-model", Error: ordinaryError})
+			// Two result paths can produce the same error and deadline. Use the
+			// real credential failure helper's clock argument to make them exact.
+			m.mu.Lock()
+			current := m.auths[auth.ID]
+			state := current.ModelStates["same-error-model"]
+			deadline := state.ForcedCooldownUntil
+			credentialDeadline := state.NextRetryAfter
+			applyAuthFailureState(current, ordinaryError, nil, state.UpdatedAt, false)
+			m.mu.Unlock()
+			m.PersistCooldownStates(ctx)
+			if restored {
+				m, _ = newCooldownMonotonicManager(t, "same-error-model")
+				m.SetCooldownStateStore(store)
+				if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+					t.Fatal(errRestore)
+				}
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "same-error-model", Success: true})
+			snapshot, _ := m.GetByID(auth.ID)
+			if !snapshot.NextRetryAfter.Equal(credentialDeadline) {
+				t.Error("matching error/deadline caused recovery to clear an independent credential failure")
+			}
+			if blocked, _, next := isAuthBlockedForModel(snapshot, "", deadline.Add(time.Second)); !blocked || !next.Equal(credentialDeadline) {
+				t.Error("empty-model selection lost the independent credential deadline")
+			}
+			if blocked, _, _ := isAuthBlockedForModel(snapshot, "", credentialDeadline.Add(time.Second)); blocked {
+				t.Error("selection retained the credential error after its own expiry")
+			}
+		})
+	}
+}
 
 func TestManager_ForcedCooldownRecoveryAggregates(t *testing.T) {
 	previousDisabled := quotaCooldownDisabled.Load()

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_lifecycle_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_lifecycle_test.go
@@ -1,0 +1,375 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManager_ForcedCooldownSurvivesAuthUpdates(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"", "lifecycle-model"} {
+		for _, mode := range []string{"replace_fresh", "replace_stale_clean", "replace_stale_forced", "prepare", "refresh"} {
+			t.Run("model="+model+"/"+mode, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "lifecycle-model", "other-model")
+				store := NewFileCooldownStateStore(t.TempDir())
+				m.SetCooldownStateStore(store)
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "lifecycle-model", Success: true})
+				base, _ := m.GetByID(auth.ID)
+				retry := 10 * time.Minute
+				forced := Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests, Message: "explicit quota"}}
+				m.MarkResult(ctx, forced)
+				staleForced, _ := m.GetByID(auth.ID)
+				retry = 20 * time.Minute
+				m.MarkResult(ctx, forced)
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: &Error{HTTPStatus: http.StatusNotFound, Message: "later ordinary failure"}})
+				before := forcedCooldownTestState(t, m, auth.ID, model)
+				incoming := base.Clone()
+				if mode == "replace_fresh" {
+					incoming = &Auth{ID: auth.ID, Provider: auth.Provider, Status: StatusActive}
+				} else if mode == "replace_stale_forced" {
+					incoming = staleForced
+				}
+				incoming.Metadata = map[string]any{"notes": "updated note"}
+				var errUpdate error
+				switch mode {
+				case "prepare":
+					_, errUpdate = m.UpdatePreparedAuth(ctx, base, incoming)
+				case "refresh":
+					_, errUpdate = m.UpdateRefreshedAuth(ctx, base, incoming)
+				default:
+					_, errUpdate = m.Update(ctx, incoming)
+				}
+				if errUpdate != nil {
+					t.Fatal(errUpdate)
+				}
+				after := forcedCooldownTestState(t, m, auth.ID, model)
+				if !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || !after.NextRetryAfter.Equal(before.NextRetryAfter) || !after.Unavailable {
+					t.Errorf("auth update lost the latest cooldown: forced=%v next=%v unavailable=%v; want forced=%v next=%v", after.ForcedCooldownUntil, after.NextRetryAfter, after.Unavailable, before.ForcedCooldownUntil, before.NextRetryAfter)
+				}
+				snapshot, _ := m.GetByID(auth.ID)
+				if snapshot.Metadata["notes"] != "updated note" {
+					t.Error("cooldown preservation discarded the configuration update")
+				}
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "other-model", time.Now()); blocked != (model == "") {
+					t.Errorf("auth update changed cooldown scope: other model blocked=%v", blocked)
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+				after = forcedCooldownTestState(t, m, auth.ID, model)
+				if !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || !after.NextRetryAfter.Equal(before.ForcedCooldownUntil) {
+					t.Error("success after auth update did not retain exactly the forced deadline")
+				}
+				if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "lifecycle-model", cliproxyexecutor.Options{}, nil); picked != nil || errPick == nil {
+					t.Error("scheduler selected the credential after auth replacement and success")
+				}
+				records, errLoad := store.Load(ctx)
+				if errLoad != nil {
+					t.Fatal(errLoad)
+				}
+				found := false
+				for _, record := range records {
+					found = found || (record.Model == model && record.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil))
+				}
+				if !found {
+					t.Error("auth update lost the persisted forced cooldown")
+				}
+			})
+		}
+	}
+}
+
+func TestManager_ForcedCooldownSurvivesUnauthorizedRefresh(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"", "refresh-model"} {
+		for _, forced := range []bool{false, true} {
+			name := "ordinary"
+			if forced {
+				name = "forced"
+			}
+			t.Run("model="+model+"/"+name, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "refresh-model", "other-model")
+				m.RegisterExecutor(&unauthorizedRefreshExecutor{id: auth.Provider})
+				if forced {
+					retry := 10 * time.Minute
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired token"}})
+				before := forcedCooldownTestState(t, m, auth.ID, model)
+				if _, errRefresh := m.refreshAuthForRequest(ctx, auth.ID, ""); errRefresh != nil {
+					t.Fatal(errRefresh)
+				}
+				after := forcedCooldownTestState(t, m, auth.ID, model)
+				if forced && (!after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || !after.Unavailable) {
+					t.Error("successful token refresh cleared an active explicit cooldown")
+				}
+				if !forced && model != "" && (after.Unavailable || !after.NextRetryAfter.IsZero()) {
+					t.Error("ordinary model 401 did not recover after token refresh")
+				}
+			})
+		}
+	}
+}
+
+func TestManager_ForcedCooldownResetThenStaleUpdate(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"", "reset-model"} {
+		for _, mode := range []string{"replace", "prepare", "refresh"} {
+			t.Run("model="+model+"/"+mode, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "reset-model", "other-model")
+				retry := 10 * time.Minute
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+				stale, _ := m.GetByID(auth.ID)
+				if _, _, errReset := m.ResetQuota(ctx, auth.ID); errReset != nil {
+					t.Fatal(errReset)
+				}
+				var errUpdate error
+				switch mode {
+				case "prepare":
+					_, errUpdate = m.UpdatePreparedAuth(ctx, stale, stale.Clone())
+				case "refresh":
+					_, errUpdate = m.UpdateRefreshedAuth(ctx, stale, stale.Clone())
+				default:
+					_, errUpdate = m.Update(ctx, stale.Clone())
+				}
+				if errUpdate != nil {
+					t.Fatal(errUpdate)
+				}
+				snapshot, _ := m.GetByID(auth.ID)
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "reset-model", time.Now()); blocked {
+					t.Error("stale auth update resurrected an explicitly reset cooldown")
+				}
+				if snapshot.LastError != nil || snapshot.Status != StatusActive {
+					t.Error("stale auth update resurrected the reset error status")
+				}
+			})
+		}
+	}
+}
+
+func TestManager_ForcedCooldownRestoreDoesNotShortenLiveState(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, aggregate := range []bool{false, true} {
+		name := "older_auth_record"
+		if aggregate {
+			name = "model_aggregate"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "restore-live-model", "other-model")
+			retry := 20 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			before, _ := m.GetByID(auth.ID)
+			old := CooldownStateRecord{AuthID: auth.ID, Provider: auth.Provider, NextRetryAfter: time.Now().Add(10 * time.Minute), LastError: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway}}
+			if !aggregate {
+				old.ForcedCooldownUntil = old.NextRetryAfter
+			}
+			records := []CooldownStateRecord{old}
+			if aggregate {
+				old.Model = "restore-live-model"
+				records = append(records, old)
+			}
+			store := NewFileCooldownStateStore(t.TempDir())
+			if errSave := store.Save(ctx, records); errSave != nil {
+				t.Fatal(errSave)
+			}
+			m.SetCooldownStateStore(store)
+			if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+				t.Fatal(errRestore)
+			}
+			after, _ := m.GetByID(auth.ID)
+			if !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || after.NextRetryAfter.Before(before.ForcedCooldownUntil) {
+				t.Error("loading an older sidecar shortened a live credential forced cooldown")
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Success: true})
+			after, _ = m.GetByID(auth.ID)
+			if blocked, _, next := isAuthBlockedForModel(after, "other-model", time.Now()); !blocked || next.Before(before.ForcedCooldownUntil) {
+				t.Error("restoration and success unblocked the credential too early")
+			}
+		})
+	}
+}
+
+func TestManager_ForcedCooldownLifecycleReleaseBoundaries(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"", "boundary-model"} {
+		for _, action := range []string{"expire", "reset", "disable", "disable_status", "disable_cooling", "remove"} {
+			t.Run("model="+model+"/"+action, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "boundary-model", "other-model")
+				retry := 10 * time.Minute
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+				fresh := &Auth{ID: auth.ID, Provider: auth.Provider, Status: StatusActive}
+				switch action {
+				case "expire":
+					m.mu.Lock()
+					current := m.auths[auth.ID]
+					past := time.Now().Add(-time.Minute)
+					current.ForcedCooldownUntil, current.NextRetryAfter, current.Quota.NextRecoverAt = past, past, past
+					for _, state := range current.ModelStates {
+						state.ForcedCooldownUntil, state.NextRetryAfter, state.Quota.NextRecoverAt = past, past, past
+					}
+					m.mu.Unlock()
+				case "reset":
+					if _, _, errReset := m.ResetQuota(ctx, auth.ID); errReset != nil {
+						t.Fatal(errReset)
+					}
+				case "disable", "disable_status":
+					disabled := fresh.Clone()
+					disabled.Disabled = action == "disable"
+					if action == "disable_status" {
+						disabled.Status = StatusDisabled
+					}
+					if _, errUpdate := m.Update(ctx, disabled); errUpdate != nil {
+						t.Fatal(errUpdate)
+					}
+				case "disable_cooling":
+					m.SetConfig(&internalconfig.Config{DisableCooling: true})
+					m.SetConfig(&internalconfig.Config{})
+				case "remove":
+					m.Remove(ctx, auth.ID)
+					if _, errRegister := m.Register(ctx, fresh); errRegister != nil {
+						t.Fatal(errRegister)
+					}
+				}
+				if _, errUpdate := m.Update(ctx, fresh); errUpdate != nil {
+					t.Fatal(errUpdate)
+				}
+				snapshot, _ := m.GetByID(auth.ID)
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "boundary-model", time.Now()); blocked {
+					t.Error("auth update retained a cooldown after its release boundary")
+				}
+				if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "boundary-model", cliproxyexecutor.Options{}, nil); picked == nil || errPick != nil {
+					t.Errorf("scheduler did not release the credential: %v", errPick)
+				}
+			})
+		}
+	}
+}
+
+func TestManager_ForcedCooldownConcurrentReplacementAndResults(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"", "concurrent-model"} {
+		t.Run("model="+model, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "concurrent-model", "other-model")
+			retry := 20 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			deadline := forcedCooldownTestState(t, m, auth.ID, model).ForcedCooldownUntil
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for worker := range 4 {
+				wg.Go(func() {
+					<-start
+					for range 20 {
+						switch worker {
+						case 0:
+							_, errUpdate := m.Update(ctx, &Auth{ID: auth.ID, Provider: auth.Provider, Status: StatusActive})
+							if errUpdate != nil {
+								t.Error(errUpdate)
+							}
+						case 1:
+							base, _ := m.GetByID(auth.ID)
+							if _, errUpdate := m.UpdatePreparedAuth(ctx, base, base.Clone()); errUpdate != nil {
+								t.Error(errUpdate)
+							}
+						case 2:
+							m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+						case 3:
+							m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: &Error{HTTPStatus: http.StatusNotFound}})
+						}
+					}
+				})
+			}
+			close(start)
+			wg.Wait()
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+			state := forcedCooldownTestState(t, m, auth.ID, model)
+			if !state.ForcedCooldownUntil.Equal(deadline) || !state.NextRetryAfter.Equal(deadline) {
+				t.Error("concurrent auth updates and results changed the explicit deadline")
+			}
+		})
+	}
+}
+
+func TestManager_ForcedCooldownSurvivesRegistryReconciliation(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	ctx := context.Background()
+	m, auth := newCooldownMonotonicManager(t, "removed-model", "kept-model")
+	m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "removed-model", Error: &Error{HTTPStatus: http.StatusNotFound}})
+	retry := 10 * time.Minute
+	m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+	before, _ := m.GetByID(auth.ID)
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "kept-model"}})
+	m.ReconcileRegistryModelStates(ctx, auth.ID)
+	after, _ := m.GetByID(auth.ID)
+	if !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || !after.Unavailable || after.Status != StatusError || after.LastError == nil {
+		t.Error("model reconciliation cleared active credential-level cooldown state")
+	}
+	if _, exists := after.ModelStates["removed-model"]; exists {
+		t.Error("forced credential cooldown prevented obsolete model cleanup")
+	}
+}
+
+func TestManager_ForcedCooldownCrossScopeSuccess(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, ordinaryModel := range []string{"", "healed-model"} {
+		t.Run("ordinary_model="+ordinaryModel, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "healed-model", "still-cooling-model")
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: ordinaryModel, Error: &Error{HTTPStatus: http.StatusNotFound}})
+			retry := 10 * time.Minute
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, RetryAfter: &retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+			before, _ := m.GetByID(auth.ID)
+			// A separate failed model must retain its own ordinary cooldown.
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "still-cooling-model", Error: &Error{HTTPStatus: http.StatusNotFound}})
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "healed-model", Success: true})
+			after, _ := m.GetByID(auth.ID)
+			if !after.NextRetryAfter.Equal(before.ForcedCooldownUntil) || after.Quota.Exceeded {
+				t.Error("model success retained ordinary credential cooldown beyond the explicit deadline")
+			}
+			afterForcedExpiry := before.ForcedCooldownUntil.Add(time.Second)
+			if blocked, _, _ := isAuthBlockedForModel(after, "healed-model", afterForcedExpiry); blocked {
+				t.Error("healed model remained blocked after the credential forced deadline")
+			}
+			if blocked, _, _ := isAuthBlockedForModel(after, "still-cooling-model", afterForcedExpiry); !blocked {
+				t.Error("success cleared a different model's ordinary cooldown")
+			}
+		})
+	}
+}
+
+func TestAuthCloneEmptyRuntimeMapsAreIndependent(t *testing.T) {
+	auth := &Auth{Attributes: map[string]string{}, Metadata: map[string]any{}, ModelStates: map[string]*ModelState{}}
+	snapshot := auth.Clone()
+	snapshot.Attributes["test"] = "value"
+	snapshot.Metadata["test"] = "value"
+	snapshot.ModelStates["test"] = &ModelState{}
+	if len(auth.Attributes) != 0 || len(auth.Metadata) != 0 || len(auth.ModelStates) != 0 {
+		t.Error("mutating a cloned empty map changed the original auth snapshot")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_migration_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_migration_test.go
@@ -1,0 +1,245 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManager_ForcedCooldownLegacyMigration(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+	for _, fixture := range []string{"cooldown_v1_stale_forced_error.json", "cooldown_v1_ambiguous_quota.json"} {
+		t.Run(fixture, func(t *testing.T) {
+			testForcedCooldownLegacyMigration(t, fixture)
+		})
+	}
+}
+
+func testForcedCooldownLegacyMigration(t *testing.T, fixture string) {
+	t.Helper()
+	ctx := context.Background()
+	// Captured from upstream 934fb7928c42a8dd0aeaf39a321bef6601b55eb6:
+	// A ordinary 404 or 429, B forced 502, B success, then registry removal of B.
+	// The old writer keeps B's error on A's aggregate deadline. Only timestamps
+	// are rebased below; do not replace this with a hand-built aggregate record.
+	// The quota fixture is also byte-identical to a genuine credential-level
+	// forced failure following A's quota: the old format cannot identify scope.
+	data, errRead := os.ReadFile(filepath.Join("testdata", fixture))
+	if errRead != nil {
+		t.Fatal(errRead)
+	}
+	var document map[string]any
+	if errDecode := json.Unmarshal(data, &document); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	anchor, errTime := time.Parse(time.RFC3339Nano, document["updated_at"].(string))
+	if errTime != nil {
+		t.Fatal(errTime)
+	}
+	shiftCooldownFixtureTimes(t, document, time.Now().UTC().Sub(anchor))
+	data, errEncode := json.Marshal(document)
+	if errEncode != nil {
+		t.Fatal(errEncode)
+	}
+	dir := t.TempDir()
+	if errWrite := os.WriteFile(filepath.Join(dir, "legacy.cds"), data, 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	store := NewFileCooldownStateStore(dir)
+	records, errLoad := store.Load(ctx)
+	if errLoad != nil || len(records) != 2 {
+		t.Fatalf("load captured legacy records: count=%d error=%v", len(records), errLoad)
+	}
+	deadline := records[0].NextRetryAfter
+	quota := records[0].Quota
+	// The first restore reads the old file, the second reads the new writer's
+	// migrated file. Neither may promote the stale error into a forced action.
+	for restart := 0; restart < 2; restart++ {
+		m, auth := newCooldownMonotonicManager(t, "ordinary-a", "unrelated-c")
+		m.SetCooldownStateStore(store)
+		if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+			t.Fatal(errRestore)
+		}
+		snapshot, _ := m.GetByID(auth.ID)
+		if !snapshot.ForcedCooldownUntil.IsZero() || !snapshot.ModelStates["ordinary-a"].ForcedCooldownUntil.IsZero() {
+			t.Error("legacy error history was promoted into a forced action")
+		}
+		if !snapshot.NextRetryAfter.Equal(deadline) || !snapshot.ModelStates["ordinary-a"].NextRetryAfter.Equal(deadline) {
+			t.Error("migration discarded the ordinary cooldown deadline")
+		}
+		if !cooldownQuotaEqual(snapshot.Quota, quota) || !cooldownQuotaEqual(snapshot.ModelStates["ordinary-a"].Quota, quota) {
+			t.Error("migration changed the legacy quota state")
+		}
+		if blocked, _, _ := isAuthBlockedForModel(snapshot, "ordinary-a", time.Now()); !blocked {
+			t.Error("migration cleared the ordinary model cooldown before recovery")
+		}
+		if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "unrelated-c", cliproxyexecutor.Options{}, nil); errPick != nil || picked == nil {
+			t.Errorf("migration blocked an unrelated model: %v", errPick)
+		}
+		records, errLoad = store.Load(ctx)
+		if errLoad != nil || len(records) != 2 {
+			t.Fatalf("migration dropped persisted ordinary cooldowns: count=%d error=%v", len(records), errLoad)
+		}
+		if restart == 1 {
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "ordinary-a", Success: true})
+			snapshot, _ = m.GetByID(auth.ID)
+			for _, model := range []string{"ordinary-a", "unrelated-c", ""} {
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, model, time.Now()); blocked {
+					t.Errorf("legacy ordinary recovery still blocks model=%q", model)
+				}
+			}
+			records, errLoad = store.Load(ctx)
+			if errLoad != nil || len(records) != 0 {
+				t.Errorf("ordinary recovery did not remove persisted cooldowns: count=%d error=%v", len(records), errLoad)
+			}
+		}
+	}
+}
+
+func shiftCooldownFixtureTimes(t *testing.T, value any, delta time.Duration) {
+	t.Helper()
+	switch current := value.(type) {
+	case []any:
+		for _, item := range current {
+			shiftCooldownFixtureTimes(t, item, delta)
+		}
+	case map[string]any:
+		for key, item := range current {
+			switch key {
+			case "next_retry_after", "next_recover_at", "updated_at", "observed_at":
+				stamp, errTime := time.Parse(time.RFC3339Nano, item.(string))
+				if errTime != nil {
+					t.Fatal(errTime)
+				}
+				if !stamp.IsZero() {
+					current[key] = stamp.Add(delta).Format(time.RFC3339Nano)
+				}
+			default:
+				shiftCooldownFixtureTimes(t, item, delta)
+			}
+		}
+	}
+}
+
+// Keep legacy fixtures genuinely field-absent even after the new writer starts
+// serializing an explicit zero. Current records must use the real store writer.
+func writeLegacyCooldownRecords(t *testing.T, dir string, records []CooldownStateRecord) {
+	t.Helper()
+	for _, record := range records {
+		if !record.ForcedCooldownUntil.IsZero() || record.LastFailureScope != "" {
+			t.Fatal("cannot encode explicit cooldown provenance as a legacy fixture")
+		}
+	}
+	data, errEncode := json.Marshal(records)
+	if errEncode != nil {
+		t.Fatal(errEncode)
+	}
+	var raw []map[string]json.RawMessage
+	if errDecode := json.Unmarshal(data, &raw); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	for _, record := range raw {
+		delete(record, "forced_cooldown_until")
+	}
+	data, errEncode = json.Marshal(struct {
+		Version int                          `json:"version"`
+		Records []map[string]json.RawMessage `json:"records"`
+	}{Version: 1, Records: raw})
+	if errEncode != nil {
+		t.Fatal(errEncode)
+	}
+	if errWrite := os.WriteFile(filepath.Join(dir, "legacy.cds"), data, 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+}
+
+func TestManager_ForcedCooldownExplicitWireDeadline(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+	for _, scope := range []string{"model", "credential"} {
+		for _, deadlineKind := range []string{"zero", "expired", "active"} {
+			for _, errorKind := range []string{"forced", "ordinary", "absent"} {
+				t.Run(scope+"/"+deadlineKind+"/"+errorKind, func(t *testing.T) {
+					ctx := context.Background()
+					m, auth := newCooldownMonotonicManager(t, "wire-model", "other-model")
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "wire-model", Success: true})
+					store := NewFileCooldownStateStore(t.TempDir())
+					m.SetCooldownStateStore(store)
+					now := time.Now().UTC()
+					forced := time.Time{}
+					if deadlineKind == "active" {
+						forced = now.Add(10 * time.Minute)
+					} else if deadlineKind == "expired" {
+						forced = now.Add(-time.Minute)
+					}
+					record := CooldownStateRecord{AuthID: auth.ID, Provider: auth.Provider, NextRetryAfter: now.Add(2 * time.Hour), ForcedCooldownUntil: forced, UpdatedAt: now}
+					if scope == "model" {
+						record.Model = "wire-model"
+					}
+					if errorKind != "absent" {
+						record.LastError = &Error{HTTPStatus: http.StatusNotFound, Message: "ordinary error"}
+						if errorKind == "forced" {
+							record.LastError = &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway}
+						}
+					}
+					if errSave := store.Save(ctx, []CooldownStateRecord{record}); errSave != nil {
+						t.Fatal(errSave)
+					}
+					data, errRead := os.ReadFile(filepath.Join(store.dir, auth.ID+".cds"))
+					if errRead != nil {
+						t.Fatal(errRead)
+					}
+					var wire struct {
+						Records []map[string]json.RawMessage `json:"records"`
+					}
+					if errDecode := json.Unmarshal(data, &wire); errDecode != nil {
+						t.Fatal(errDecode)
+					}
+					if len(wire.Records) != 1 || len(wire.Records[0]["forced_cooldown_until"]) == 0 {
+						t.Fatal("writer omitted the explicit forced deadline, including its zero case")
+					}
+					if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+						t.Fatal(errRestore)
+					}
+					state := forcedCooldownTestState(t, m, auth.ID, record.Model)
+					if !state.ForcedCooldownUntil.Equal(forced) || !state.NextRetryAfter.Equal(record.NextRetryAfter) {
+						t.Error("restore inferred or altered a deadline from diagnostic error history")
+					}
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "wire-model", Success: true})
+					state = forcedCooldownTestState(t, m, auth.ID, record.Model)
+					if deadlineKind == "active" {
+						if !state.ForcedCooldownUntil.Equal(forced) || !state.NextRetryAfter.Equal(forced) || !state.Unavailable {
+							t.Error("success did not retain exactly the explicit active deadline")
+						}
+					} else if state.Unavailable || !state.NextRetryAfter.IsZero() || state.ForcedCooldownUntil.After(now) {
+						t.Error("success retained a zero/expired forced action or ordinary deadline")
+					}
+					restarted, _ := newCooldownMonotonicManager(t, "wire-model", "other-model")
+					restarted.SetCooldownStateStore(store)
+					if errRestore := restarted.RestoreCooldownStates(ctx); errRestore != nil {
+						t.Fatal(errRestore)
+					}
+					snapshot, _ := restarted.GetByID(auth.ID)
+					for _, model := range []string{"wire-model", "other-model", ""} {
+						wantBlocked := deadlineKind == "active" && (scope == "credential" || model != "other-model")
+						if blocked, _, _ := isAuthBlockedForModel(snapshot, model, now); blocked != wantBlocked {
+							t.Errorf("post-restart model=%q blocked=%v, want=%v", model, blocked, wantBlocked)
+						}
+						if blocked, _, _ := isAuthBlockedForModel(snapshot, model, now.Add(11*time.Minute)); blocked {
+							t.Errorf("post-restart model=%q blocked beyond explicit deadline", model)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
@@ -478,20 +478,22 @@ func TestManager_ForcedCooldownLegacySidecars(t *testing.T) {
 			store := NewFileCooldownStateStore(t.TempDir())
 			m.SetCooldownStateStore(store)
 			deadline := time.Now().Add(10 * time.Minute)
-			// This is the old JSON shape: no independent forced deadline.
-			if errSave := store.Save(ctx, []CooldownStateRecord{{
+			// Error-only legacy records retain ordinary recovery semantics.
+			writeLegacyCooldownRecords(t, store.dir, []CooldownStateRecord{{
 				AuthID: auth.ID, Provider: auth.Provider, Model: model,
 				NextRetryAfter: deadline, LastError: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway},
-			}}); errSave != nil {
-				t.Fatal(errSave)
-			}
+			}})
 			if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
 				t.Fatal(errRestore)
 			}
-			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
 			state := forcedCooldownTestState(t, m, auth.ID, model)
-			if !state.Unavailable || !state.NextRetryAfter.Equal(deadline) || !state.ForcedCooldownUntil.Equal(deadline) {
-				t.Fatalf("legacy forced cooldown was lost: %+v", state)
+			if !state.Unavailable || !state.NextRetryAfter.Equal(deadline) || !state.ForcedCooldownUntil.IsZero() {
+				t.Fatalf("legacy ordinary cooldown was lost or promoted: %+v", state)
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+			state = forcedCooldownTestState(t, m, auth.ID, model)
+			if state.Unavailable || !state.NextRetryAfter.IsZero() || !state.ForcedCooldownUntil.IsZero() {
+				t.Fatalf("legacy ordinary cooldown did not recover on success: %+v", state)
 			}
 		})
 	}
@@ -560,6 +562,11 @@ func TestManager_ForcedCooldownMergeAndRecordEquality(t *testing.T) {
 	if cooldownStateRecordEqual(a, b) {
 		t.Fatal("forced-only deadline change would not trigger persistence")
 	}
+	b = a
+	b.LastFailureScope = cooldownFailureScopeModel
+	if cooldownStateRecordEqual(a, b) {
+		t.Fatal("failure provenance change would not trigger persistence")
+	}
 }
 
 func TestManager_ForcedCooldownLegacyAuthWithModelHistory(t *testing.T) {
@@ -614,33 +621,28 @@ func TestManager_ForcedCooldownLegacyAuthWithModelHistory(t *testing.T) {
 					}
 					records = append(records, modelRecord)
 				}
-				if errSave := store.Save(ctx, records); errSave != nil {
-					t.Fatal(errSave)
-				}
+				writeLegacyCooldownRecords(t, store.dir, records)
 				if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
 					t.Fatal(errRestore)
 				}
 				snapshot, _ := m.GetByID(auth.ID)
-				wantForced := !tc.aggregate || tc.credential429
-				if wantForced && !snapshot.ForcedCooldownUntil.Equal(deadline) {
-					t.Errorf("model history suppressed genuine legacy auth cooldown: got=%v want=%v", snapshot.ForcedCooldownUntil, deadline)
-				} else if !wantForced && !snapshot.ForcedCooldownUntil.IsZero() {
-					t.Errorf("model aggregate became auth-level forced cooldown: %v", snapshot.ForcedCooldownUntil)
+				if !snapshot.ForcedCooldownUntil.IsZero() || !snapshot.NextRetryAfter.Equal(deadline) {
+					t.Errorf("legacy auth deadline was discarded or promoted: forced=%v next=%v", snapshot.ForcedCooldownUntil, snapshot.NextRetryAfter)
 				}
-				if blocked, _, _ := isAuthBlockedForModel(snapshot, "history-model", time.Now()); blocked != wantForced {
-					t.Errorf("history model blocked=%v, want=%v", blocked, wantForced)
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "history-model", time.Now()); blocked != tc.credential429 {
+					t.Errorf("history model blocked=%v, want=%v", blocked, tc.credential429)
 				}
-				if wantForced && !isCredentialBlocked(snapshot, 3, time.Now()) {
-					t.Error("scheduler did not recognize the credential-wide forced cooldown")
+				if tc.credential429 && !isCredentialBlocked(snapshot, 3, time.Now()) {
+					t.Error("scheduler did not recognize the legacy credential quota")
 				}
 				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: successModel, Success: true})
 				snapshot, _ = m.GetByID(auth.ID)
-				if wantForced {
-					if !snapshot.ForcedCooldownUntil.Equal(deadline) || !snapshot.Unavailable || snapshot.NextRetryAfter.Before(deadline) {
-						t.Errorf("success cleared restored auth cooldown: forced=%v next=%v unavailable=%v", snapshot.ForcedCooldownUntil, snapshot.NextRetryAfter, snapshot.Unavailable)
+				if tc.credential429 {
+					if !snapshot.ForcedCooldownUntil.IsZero() || !snapshot.Unavailable || snapshot.Quota.Reason != "credential_quota" || !snapshot.Quota.NextRecoverAt.Equal(deadline) {
+						t.Errorf("success changed the legacy credential quota: %+v", snapshot.Quota)
 					}
 					if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "history-model", cliproxyexecutor.Options{}, nil); errPick == nil || picked != nil {
-						t.Error("scheduler selected a credential with an active auth-level forced cooldown")
+						t.Error("scheduler selected a credential with an active legacy credential quota")
 					}
 				}
 			})

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
@@ -167,7 +167,7 @@ func testForcedCooldownInFlightSuccess(t *testing.T, mode string, status int, co
 	}
 	after, _ := m.GetByID(auth.ID)
 	stateAfter := after.ModelStates[model]
-	if stateAfter == nil || !stateAfter.Unavailable || !stateAfter.NextRetryAfter.Equal(deadline) {
+	if stateAfter == nil || !stateAfter.Unavailable || !stateAfter.NextRetryAfter.Equal(deadline) || !stateAfter.ForcedCooldownUntil.Equal(deadline) {
 		t.Errorf("in-flight success cleared forced cooldown: %+v", stateAfter)
 	}
 	if after.Success != 1 || after.Failed != 1 {
@@ -176,7 +176,7 @@ func testForcedCooldownInFlightSuccess(t *testing.T, mode string, status int, co
 	records, errLoad := store.Load(ctx)
 	found := false
 	for _, record := range records {
-		if record.Model == model && record.NextRetryAfter.Equal(deadline) && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown {
+		if record.Model == model && record.NextRetryAfter.Equal(deadline) && record.ForcedCooldownUntil.Equal(deadline) && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown {
 			found = true
 		}
 	}
@@ -248,8 +248,10 @@ func TestManager_ForcedCooldownRecoveryBoundaries(t *testing.T) {
 					m.mu.Lock()
 					current := m.auths[auth.ID]
 					current.NextRetryAfter = time.Now().Add(-time.Second)
+					current.ForcedCooldownUntil = current.NextRetryAfter
 					if model != "" {
 						current.ModelStates[model].NextRetryAfter = current.NextRetryAfter
+						current.ModelStates[model].ForcedCooldownUntil = current.NextRetryAfter
 					}
 					m.mu.Unlock()
 				}
@@ -276,7 +278,11 @@ func TestManager_ForcedCooldownRecoveryBoundaries(t *testing.T) {
 				}
 				wantRetained := !tc.ordinary && !tc.expired && !tc.manualReset
 				if wantRetained {
-					if !unavailable || !next.Equal(deadline) || lastError == nil || lastError.Code != ErrorCodeForceCooldown {
+					wantCode := ErrorCodeForceCooldown
+					if tc.secondFailure {
+						wantCode = ""
+					}
+					if !unavailable || !next.Equal(deadline) || lastError == nil || lastError.Code != wantCode {
 						t.Fatalf("forced cooldown not retained: unavailable=%v next=%v lastError=%v", unavailable, next, lastError)
 					}
 					if blocked, _, _ := isAuthBlockedForModel(after, "recovery-model", deadline.Add(time.Second)); blocked {
@@ -305,5 +311,246 @@ func TestManager_ForcedCooldownRecoveryBoundaries(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestManager_ForcedCooldownKeepsOrdinaryDeadlinesSeparate(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousDisabled)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, scope := range []string{"model", "credential"} {
+		for _, tc := range []struct {
+			name     string
+			status   int
+			reversed bool
+		}{
+			{name: "forced_then_404", status: http.StatusNotFound},
+			{name: "forced_then_401", status: http.StatusUnauthorized},
+			{name: "forced_then_429", status: http.StatusTooManyRequests},
+			{name: "404_then_forced", status: http.StatusNotFound, reversed: true},
+		} {
+			for _, restore := range []bool{false, true} {
+				for _, expired := range []bool{false, true} {
+					name := scope + "/" + tc.name
+					if restore {
+						name += "/restored"
+					} else {
+						name += "/live"
+					}
+					if expired {
+						name += "/after_forced_expiry"
+					} else {
+						name += "/during_forced_cooldown"
+					}
+					t.Run(name, func(t *testing.T) {
+						SetQuotaCooldownDisabled(false)
+						SetTransientErrorCooldownSeconds(600)
+						ctx := context.Background()
+						m, auth := newCooldownMonotonicManager(t, "separate-deadlines")
+						model := "separate-deadlines"
+						if scope == "credential" {
+							model = ""
+						}
+						store := NewFileCooldownStateStore(t.TempDir())
+						m.SetCooldownStateStore(store)
+						forced := Result{
+							AuthID: auth.ID, Provider: auth.Provider, Model: model,
+							Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway, Message: "server_is_overloaded"},
+						}
+						ordinaryRetry := 2 * time.Hour
+						ordinary := Result{
+							AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &ordinaryRetry,
+							Error: &Error{HTTPStatus: tc.status, Message: "ordinary upstream failure"},
+						}
+						beforeForce := time.Now()
+						if tc.reversed {
+							m.MarkResult(ctx, ordinary)
+							m.MarkResult(ctx, forced)
+						} else {
+							m.MarkResult(ctx, forced)
+							m.MarkResult(ctx, ordinary)
+						}
+						state := forcedCooldownTestState(t, m, auth.ID, model)
+						forcedUntil := state.ForcedCooldownUntil
+						if forcedUntil.Before(beforeForce.Add(10*time.Minute)) || forcedUntil.After(time.Now().Add(10*time.Minute)) {
+							t.Fatalf("forced deadline inherited an ordinary duration: %v", forcedUntil.Sub(beforeForce))
+						}
+						if !state.NextRetryAfter.After(forcedUntil.Add(19 * time.Minute)) {
+							t.Fatalf("ordinary cooldown was lost before success: %+v", state)
+						}
+						if !tc.reversed && (state.LastError == nil || state.LastError.Code != "" || state.LastError.HTTPStatus != tc.status) {
+							t.Fatalf("ordinary error was relabeled as forced: %+v", state.LastError)
+						}
+						if ordinary.Error.Code != "" {
+							t.Fatal("caller-owned ordinary error was mutated")
+						}
+
+						if expired {
+							// Expire only the explicit action, leaving the longer ordinary
+							// deadline live. No wall-clock waiting is needed.
+							m.mu.Lock()
+							current := m.auths[auth.ID]
+							if model == "" {
+								current.ForcedCooldownUntil = time.Now().Add(-time.Second)
+							} else {
+								current.ModelStates[model].ForcedCooldownUntil = time.Now().Add(-time.Second)
+							}
+							m.mu.Unlock()
+							m.persistCooldownStates(ctx)
+						}
+						if restore {
+							restored := NewManager(nil, nil, nil)
+							restored.SetCooldownStateStore(store)
+							if _, errRegister := restored.Register(ctx, auth); errRegister != nil {
+								t.Fatal(errRegister)
+							}
+							if errRestore := restored.RestoreCooldownStates(ctx); errRestore != nil {
+								t.Fatal(errRestore)
+							}
+							m = restored
+							if model != "" {
+								snapshot, _ := m.GetByID(auth.ID)
+								if !snapshot.ForcedCooldownUntil.IsZero() {
+									t.Fatal("model cooldown was promoted into an auth-level forced deadline")
+								}
+							}
+						}
+						m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+						state = forcedCooldownTestState(t, m, auth.ID, model)
+						if expired {
+							if state.Unavailable || !state.NextRetryAfter.IsZero() || !state.ForcedCooldownUntil.IsZero() || state.LastError != nil {
+								t.Fatalf("success did not heal ordinary cooldown after forced expiry: %+v", state)
+							}
+						} else if !state.Unavailable || !state.NextRetryAfter.Equal(forcedUntil) || !state.ForcedCooldownUntil.Equal(forcedUntil) || state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
+							t.Fatalf("success should retain only the original forced deadline: %+v", state)
+						}
+						if _, _, errReset := m.ResetQuota(ctx, auth.ID); errReset != nil {
+							t.Fatal(errReset)
+						}
+						state = forcedCooldownTestState(t, m, auth.ID, model)
+						if state.Unavailable || !state.NextRetryAfter.IsZero() || !state.ForcedCooldownUntil.IsZero() {
+							t.Fatalf("manual reset left cooldown state behind: %+v", state)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func forcedCooldownTestState(t *testing.T, m *Manager, authID, model string) *ModelState {
+	t.Helper()
+	auth, ok := m.GetByID(authID)
+	if !ok || auth == nil {
+		t.Fatal("auth missing")
+	}
+	if model != "" {
+		state := auth.ModelStates[model]
+		if state == nil {
+			t.Fatal("model state missing")
+		}
+		return state
+	}
+	return &ModelState{
+		Unavailable: auth.Unavailable, NextRetryAfter: auth.NextRetryAfter,
+		ForcedCooldownUntil: auth.ForcedCooldownUntil, LastError: auth.LastError, Quota: auth.Quota,
+	}
+}
+
+func TestManager_ForcedCooldownLegacySidecars(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, model := range []string{"legacy-model", ""} {
+		t.Run("model="+model, func(t *testing.T) {
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "legacy-model")
+			store := NewFileCooldownStateStore(t.TempDir())
+			m.SetCooldownStateStore(store)
+			deadline := time.Now().Add(10 * time.Minute)
+			// This is the old JSON shape: no independent forced deadline.
+			if errSave := store.Save(ctx, []CooldownStateRecord{{
+				AuthID: auth.ID, Provider: auth.Provider, Model: model,
+				NextRetryAfter: deadline, LastError: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway},
+			}}); errSave != nil {
+				t.Fatal(errSave)
+			}
+			if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+				t.Fatal(errRestore)
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+			state := forcedCooldownTestState(t, m, auth.ID, model)
+			if !state.Unavailable || !state.NextRetryAfter.Equal(deadline) || !state.ForcedCooldownUntil.Equal(deadline) {
+				t.Fatalf("legacy forced cooldown was lost: %+v", state)
+			}
+		})
+	}
+}
+
+func TestManager_ForcedCooldownOnlyExplicitActionsExtendDeadline(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousDisabled)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, model := range []string{"forced-extensions", ""} {
+		t.Run("model="+model, func(t *testing.T) {
+			SetQuotaCooldownDisabled(false)
+			SetTransientErrorCooldownSeconds(600)
+			ctx := context.Background()
+			m, auth := newCooldownMonotonicManager(t, "forced-extensions")
+			result := Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway}}
+			m.MarkResult(ctx, result)
+			first := forcedCooldownTestState(t, m, auth.ID, model).ForcedCooldownUntil
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: &Error{HTTPStatus: http.StatusNotFound}})
+			SetTransientErrorCooldownSeconds(15)
+			m.MarkResult(ctx, result)
+			state := forcedCooldownTestState(t, m, auth.ID, model)
+			if !state.ForcedCooldownUntil.Equal(first) {
+				t.Fatalf("shorter explicit action inherited the ordinary 12h deadline: %+v", state)
+			}
+			longer := 2 * time.Hour
+			result.Error = &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}
+			result.RetryAfter = &longer
+			before := time.Now()
+			m.MarkResult(ctx, result)
+			state = forcedCooldownTestState(t, m, auth.ID, model)
+			if state.ForcedCooldownUntil.Before(before.Add(longer)) || state.ForcedCooldownUntil.After(time.Now().Add(longer)) {
+				t.Fatalf("longer explicit action did not establish its own 2h deadline: %+v", state)
+			}
+			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+			after := forcedCooldownTestState(t, m, auth.ID, model)
+			if !after.Unavailable || !after.NextRetryAfter.Equal(state.ForcedCooldownUntil) {
+				t.Fatalf("success did not retain only the explicit deadline: %+v", after)
+			}
+		})
+	}
+}
+
+func TestManager_ForcedCooldownMergeAndRecordEquality(t *testing.T) {
+	now := time.Now()
+	forcedUntil := now.Add(10 * time.Minute)
+	ordinaryUntil := now.Add(12 * time.Hour)
+	forced := &ModelState{Unavailable: true, NextRetryAfter: forcedUntil, ForcedCooldownUntil: forcedUntil}
+	ordinary := &ModelState{Unavailable: true, NextRetryAfter: ordinaryUntil, UpdatedAt: now}
+	for _, reversed := range []bool{false, true} {
+		target, source := forced.Clone(), ordinary.Clone()
+		if reversed {
+			target, source = source, target
+		}
+		merged := mergeModelState(target, source)
+		if !merged.NextRetryAfter.Equal(ordinaryUntil) || !merged.ForcedCooldownUntil.Equal(forcedUntil) {
+			t.Fatalf("merge conflated ordinary and forced deadlines: %+v", merged)
+		}
+	}
+	a := CooldownStateRecord{NextRetryAfter: ordinaryUntil, ForcedCooldownUntil: forcedUntil}
+	b := a
+	b.ForcedCooldownUntil = forcedUntil.Add(time.Minute)
+	if cooldownStateRecordEqual(a, b) {
+		t.Fatal("forced-only deadline change would not trigger persistence")
 	}
 }

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
@@ -1,0 +1,309 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestManager_ForcedCooldownSurvivesInFlightSuccess(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetQuotaCooldownDisabled(false)
+	SetTransientErrorCooldownSeconds(600)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousDisabled)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, mode := range []string{"execute", "stream", "count"} {
+		for _, tc := range []struct {
+			name   string
+			status int
+			code   string
+			action string
+		}{
+			{"502", http.StatusBadGateway, "server_is_overloaded", RequestScopedActionStopAndCooldown},
+			{"503", http.StatusServiceUnavailable, "server_is_overloaded", RequestScopedActionStopAndCooldown},
+			{"429", http.StatusTooManyRequests, "rate_limit_exceeded", RequestScopedActionStopAndCooldown},
+			{"continue", http.StatusBadGateway, "server_is_overloaded", RequestScopedActionContinueAndCooldown},
+		} {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				testForcedCooldownInFlightSuccess(t, mode, tc.status, tc.code, tc.action)
+			})
+		}
+	}
+}
+
+func testForcedCooldownInFlightSuccess(t *testing.T, mode string, status int, code, action string) {
+	t.Helper()
+	const model = "forced-cooldown-model"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 1)
+	store := NewFileCooldownStateStore(t.TempDir())
+	m.SetCooldownStateStore(store)
+	auth := &Auth{
+		ID: "forced-cooldown-auth", Provider: "codex", Status: StatusActive,
+		Metadata: map[string]any{
+			"request_scoped_errors": []internalconfig.RequestScopedErrorRule{{
+				Status: status, Match: []string{code}, Action: action,
+			}},
+		},
+	}
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}, {ID: "other-model"}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, errRegister := m.Register(ctx, auth); errRegister != nil {
+		t.Fatal(errRegister)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	finishSuccess := func() { releaseOnce.Do(func() { close(release) }) }
+	defer finishSuccess()
+	var calls atomic.Int32
+	mock := mockCustomErrorExecutor{
+		identifier: "codex",
+		executeFn: func(ctx context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			calls.Add(1)
+			cliproxyexecutor.MarkUpstreamAttempt(ctx)
+			switch string(req.Payload) {
+			case "pending-success":
+				close(started)
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return cliproxyexecutor.Response{}, ctx.Err()
+				}
+			case "overload":
+				retryAfter := 10 * time.Minute
+				return cliproxyexecutor.Response{}, customStatusError{
+					code: status, retryAfter: &retryAfter,
+					msg: `{"error":{"code":"` + code + `"}}`,
+				}
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+		},
+	}
+	mock.countFn = mock.executeFn
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex", mockCustomErrorExecutor: mock,
+		streamFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			resp, errExec := mock.Execute(ctx, auth, req, opts)
+			if errExec != nil {
+				return nil, errExec
+			}
+			chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+			chunks <- cliproxyexecutor.StreamChunk{Payload: resp.Payload}
+			close(chunks)
+			return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+		},
+	})
+	invoke := func(payload string) error {
+		req := cliproxyexecutor.Request{Model: model, Payload: []byte(payload)}
+		switch mode {
+		case "stream":
+			stream, errStream := m.ExecuteStream(ctx, []string{"codex"}, req, cliproxyexecutor.Options{})
+			if errStream != nil {
+				return errStream
+			}
+			var errChunk error
+			for chunk := range stream.Chunks {
+				if chunk.Err != nil {
+					errChunk = chunk.Err
+				}
+			}
+			return errChunk
+		case "count":
+			_, errCount := m.ExecuteCount(ctx, []string{"codex"}, req, cliproxyexecutor.Options{})
+			return errCount
+		default:
+			_, errExec := m.Execute(ctx, []string{"codex"}, req, cliproxyexecutor.Options{})
+			return errExec
+		}
+	}
+
+	successDone := make(chan error, 1)
+	var pending sync.WaitGroup
+	pending.Add(1)
+	defer func() {
+		finishSuccess()
+		cancel()
+		pending.Wait()
+	}()
+	go func() {
+		defer pending.Done()
+		successDone <- invoke("pending-success")
+	}()
+	select {
+	case <-started:
+	case errEarly := <-successDone:
+		t.Fatalf("pending request exited before executor entry: %v", errEarly)
+	}
+	errExec := invoke("overload")
+	if statusCodeFromError(errExec) != status {
+		t.Fatalf("overload error = %v, want HTTP %d", errExec, status)
+	}
+	before, _ := m.GetByID(auth.ID)
+	stateBefore := before.ModelStates[model]
+	if stateBefore == nil || stateBefore.LastError == nil || stateBefore.LastError.Code != ErrorCodeForceCooldown || time.Until(stateBefore.NextRetryAfter) < 9*time.Minute {
+		t.Fatalf("failure did not establish the configured forced cooldown: %+v", stateBefore)
+	}
+	deadline := stateBefore.NextRetryAfter
+	t.Logf("after HTTP %d: cooling until %s", status, deadline.Format(time.RFC3339Nano))
+
+	finishSuccess()
+	if errSuccess := <-successDone; errSuccess != nil {
+		t.Fatalf("in-flight success failed: %v", errSuccess)
+	}
+	after, _ := m.GetByID(auth.ID)
+	stateAfter := after.ModelStates[model]
+	if stateAfter == nil || !stateAfter.Unavailable || !stateAfter.NextRetryAfter.Equal(deadline) {
+		t.Errorf("in-flight success cleared forced cooldown: %+v", stateAfter)
+	}
+	if after.Success != 1 || after.Failed != 1 {
+		t.Errorf("success/failure accounting changed: success=%d failed=%d", after.Success, after.Failed)
+	}
+	records, errLoad := store.Load(ctx)
+	found := false
+	for _, record := range records {
+		if record.Model == model && record.NextRetryAfter.Equal(deadline) && record.LastError != nil && record.LastError.Code == ErrorCodeForceCooldown {
+			found = true
+		}
+	}
+	if errLoad != nil || !found {
+		t.Errorf("persisted cooldown lost after in-flight success: records=%v error=%v", records, errLoad)
+	}
+	errRetry := invoke("")
+	if errRetry == nil || calls.Load() != 2 {
+		t.Errorf("new request reused cooling credential: calls=%d error=%v", calls.Load(), errRetry)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(after, "other-model", time.Now()); blocked {
+		t.Error("forced model cooldown blocked an unrelated model")
+	}
+}
+
+func TestManager_ForcedCooldownRecoveryBoundaries(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousDisabled)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, scope := range []string{"model", "credential"} {
+		for _, tc := range []struct {
+			name          string
+			ordinary      bool
+			expired       bool
+			manualReset   bool
+			secondFailure bool
+			disable       bool
+			transient     int
+		}{
+			{name: "active"},
+			{name: "expired", expired: true},
+			{name: "ordinary", ordinary: true},
+			{name: "manual_reset", manualReset: true},
+			{name: "intervening_failure", secondFailure: true, transient: 15},
+			{name: "intervening_failure_cooling_disabled", secondFailure: true, disable: true, transient: -1},
+		} {
+			t.Run(scope+"/"+tc.name, func(t *testing.T) {
+				SetQuotaCooldownDisabled(false)
+				SetTransientErrorCooldownSeconds(600)
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "recovery-model")
+				store := NewFileCooldownStateStore(t.TempDir())
+				m.SetCooldownStateStore(store)
+				model := "recovery-model"
+				if scope == "credential" {
+					model = ""
+				}
+				code := ErrorCodeForceCooldown
+				if tc.ordinary {
+					code = ""
+				}
+				m.MarkResult(ctx, Result{
+					AuthID: auth.ID, Provider: auth.Provider, Model: model,
+					Error: &Error{Code: code, HTTPStatus: http.StatusBadGateway, Message: "server_is_overloaded"},
+				})
+				before, _ := m.GetByID(auth.ID)
+				deadline := before.NextRetryAfter
+				if model != "" {
+					deadline = before.ModelStates[model].NextRetryAfter
+				}
+				if !deadline.After(time.Now()) {
+					t.Fatal("initial cooldown was not established")
+				}
+				if tc.expired {
+					// Advance only the stored deadline; do not wait in real time.
+					m.mu.Lock()
+					current := m.auths[auth.ID]
+					current.NextRetryAfter = time.Now().Add(-time.Second)
+					if model != "" {
+						current.ModelStates[model].NextRetryAfter = current.NextRetryAfter
+					}
+					m.mu.Unlock()
+				}
+				if tc.secondFailure {
+					SetQuotaCooldownDisabled(tc.disable)
+					SetTransientErrorCooldownSeconds(tc.transient)
+					secondErr := &Error{HTTPStatus: http.StatusInternalServerError, Message: "later failure"}
+					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Error: secondErr})
+					if secondErr.Code != "" {
+						t.Error("MarkResult mutated the caller's error")
+					}
+				}
+				if tc.manualReset {
+					if _, _, errReset := m.ResetQuota(ctx, auth.ID); errReset != nil {
+						t.Fatal(errReset)
+					}
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+				after, _ := m.GetByID(auth.ID)
+				unavailable, next, lastError := after.Unavailable, after.NextRetryAfter, after.LastError
+				if model != "" {
+					state := after.ModelStates[model]
+					unavailable, next, lastError = state.Unavailable, state.NextRetryAfter, state.LastError
+				}
+				wantRetained := !tc.ordinary && !tc.expired && !tc.manualReset
+				if wantRetained {
+					if !unavailable || !next.Equal(deadline) || lastError == nil || lastError.Code != ErrorCodeForceCooldown {
+						t.Fatalf("forced cooldown not retained: unavailable=%v next=%v lastError=%v", unavailable, next, lastError)
+					}
+					if blocked, _, _ := isAuthBlockedForModel(after, "recovery-model", deadline.Add(time.Second)); blocked {
+						t.Error("credential remains blocked after the forced deadline")
+					}
+					// disable-cooling also disables sidecar persistence by design.
+					if tc.disable {
+						return
+					}
+					// A restored sidecar must retain the forced marker and deadline.
+					restored := NewManager(nil, nil, nil)
+					restored.SetCooldownStateStore(store)
+					if _, errRegister := restored.Register(ctx, auth); errRegister != nil {
+						t.Fatal(errRegister)
+					}
+					if errRestore := restored.RestoreCooldownStates(ctx); errRestore != nil {
+						t.Fatal(errRestore)
+					}
+					restored.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+					restoredAuth, _ := restored.GetByID(auth.ID)
+					if blocked, _, _ := isAuthBlockedForModel(restoredAuth, "recovery-model", time.Now()); !blocked {
+						t.Error("restored forced cooldown was cleared by success")
+					}
+				} else if unavailable || !next.IsZero() || lastError != nil {
+					t.Fatalf("expected normal recovery: unavailable=%v next=%v lastError=%v", unavailable, next, lastError)
+				}
+			})
+		}
+	}
+}

--- a/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
+++ b/sdk/cliproxy/auth/conductor_forced_cooldown_success_test.go
@@ -323,14 +323,16 @@ func TestManager_ForcedCooldownKeepsOrdinaryDeadlinesSeparate(t *testing.T) {
 	})
 	for _, scope := range []string{"model", "credential"} {
 		for _, tc := range []struct {
-			name     string
-			status   int
-			reversed bool
+			name         string
+			status       int
+			forcedStatus int
+			reversed     bool
 		}{
 			{name: "forced_then_404", status: http.StatusNotFound},
 			{name: "forced_then_401", status: http.StatusUnauthorized},
 			{name: "forced_then_429", status: http.StatusTooManyRequests},
 			{name: "404_then_forced", status: http.StatusNotFound, reversed: true},
+			{name: "429_then_forced_429", status: http.StatusTooManyRequests, forcedStatus: http.StatusTooManyRequests, reversed: true},
 		} {
 			for _, restore := range []bool{false, true} {
 				for _, expired := range []bool{false, true} {
@@ -359,6 +361,11 @@ func TestManager_ForcedCooldownKeepsOrdinaryDeadlinesSeparate(t *testing.T) {
 						forced := Result{
 							AuthID: auth.ID, Provider: auth.Provider, Model: model,
 							Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway, Message: "server_is_overloaded"},
+						}
+						if tc.forcedStatus != 0 {
+							forced.Error.HTTPStatus = tc.forcedStatus
+							forcedRetry := 10 * time.Minute
+							forced.RetryAfter = &forcedRetry
 						}
 						ordinaryRetry := 2 * time.Hour
 						ordinary := Result{
@@ -552,5 +559,150 @@ func TestManager_ForcedCooldownMergeAndRecordEquality(t *testing.T) {
 	b.ForcedCooldownUntil = forcedUntil.Add(time.Minute)
 	if cooldownStateRecordEqual(a, b) {
 		t.Fatal("forced-only deadline change would not trigger persistence")
+	}
+}
+
+func TestManager_ForcedCooldownLegacyAuthWithModelHistory(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	for _, tc := range []struct {
+		name            string
+		modelRecords    bool
+		aggregate       bool
+		credential429   bool
+		sameDeadline    bool
+		differentSource bool
+	}{
+		{name: "clean_history"},
+		{name: "unrelated_model_sidecar", modelRecords: true},
+		{name: "same_deadline_different_error", modelRecords: true, sameDeadline: true},
+		{name: "matching_model_aggregate", modelRecords: true, aggregate: true},
+		{name: "aggregate_deadline_and_error_from_different_models", modelRecords: true, aggregate: true, differentSource: true},
+		{name: "credential_quota", modelRecords: true, aggregate: true, credential429: true},
+	} {
+		for _, successModel := range []string{"", "history-model"} {
+			t.Run(tc.name+"/success_model="+successModel, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "history-model", "sidecar-model", "earlier-model")
+				// Real model history exists before loading the auth-level sidecar.
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: "history-model", Success: true})
+				store := NewFileCooldownStateStore(t.TempDir())
+				m.SetCooldownStateStore(store)
+				deadline := time.Now().Add(10 * time.Minute)
+				failure := &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusBadGateway, Message: "legacy forced cooldown"}
+				authRecord := CooldownStateRecord{AuthID: auth.ID, Provider: auth.Provider, NextRetryAfter: deadline, LastError: failure}
+				if tc.credential429 {
+					authRecord.Quota = QuotaState{Exceeded: true, Reason: "credential_quota", NextRecoverAt: deadline}
+				}
+				records := []CooldownStateRecord{authRecord}
+				if tc.modelRecords {
+					modelRecord := authRecord
+					modelRecord.Model = "sidecar-model"
+					if !tc.aggregate {
+						if !tc.sameDeadline {
+							modelRecord.NextRetryAfter = deadline.Add(time.Hour)
+						}
+						modelRecord.LastError = &Error{HTTPStatus: http.StatusNotFound, Message: "unrelated model failure"}
+					}
+					if tc.differentSource {
+						modelRecord.NextRetryAfter = deadline.Add(time.Hour)
+						earlier := authRecord
+						earlier.Model = "earlier-model"
+						earlier.LastError = &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusServiceUnavailable, Message: "earlier model failure"}
+						records = append(records, earlier)
+					}
+					records = append(records, modelRecord)
+				}
+				if errSave := store.Save(ctx, records); errSave != nil {
+					t.Fatal(errSave)
+				}
+				if errRestore := m.RestoreCooldownStates(ctx); errRestore != nil {
+					t.Fatal(errRestore)
+				}
+				snapshot, _ := m.GetByID(auth.ID)
+				wantForced := !tc.aggregate || tc.credential429
+				if wantForced && !snapshot.ForcedCooldownUntil.Equal(deadline) {
+					t.Errorf("model history suppressed genuine legacy auth cooldown: got=%v want=%v", snapshot.ForcedCooldownUntil, deadline)
+				} else if !wantForced && !snapshot.ForcedCooldownUntil.IsZero() {
+					t.Errorf("model aggregate became auth-level forced cooldown: %v", snapshot.ForcedCooldownUntil)
+				}
+				if blocked, _, _ := isAuthBlockedForModel(snapshot, "history-model", time.Now()); blocked != wantForced {
+					t.Errorf("history model blocked=%v, want=%v", blocked, wantForced)
+				}
+				if wantForced && !isCredentialBlocked(snapshot, 3, time.Now()) {
+					t.Error("scheduler did not recognize the credential-wide forced cooldown")
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: successModel, Success: true})
+				snapshot, _ = m.GetByID(auth.ID)
+				if wantForced {
+					if !snapshot.ForcedCooldownUntil.Equal(deadline) || !snapshot.Unavailable || snapshot.NextRetryAfter.Before(deadline) {
+						t.Errorf("success cleared restored auth cooldown: forced=%v next=%v unavailable=%v", snapshot.ForcedCooldownUntil, snapshot.NextRetryAfter, snapshot.Unavailable)
+					}
+					if picked, errPick := m.scheduler.pickSingle(ctx, auth.Provider, "history-model", cliproxyexecutor.Options{}, nil); errPick == nil || picked != nil {
+						t.Error("scheduler selected a credential with an active auth-level forced cooldown")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestManager_ForcedCooldown429RetryAfterBoundaries(t *testing.T) {
+	previousDisabled := quotaCooldownDisabled.Load()
+	SetQuotaCooldownDisabled(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisabled) })
+	zero, negative, longer := time.Duration(0), -time.Minute, 3*time.Hour
+	for _, model := range []string{"quota-window-model", ""} {
+		for _, tc := range []struct {
+			name  string
+			retry *time.Duration
+			want  time.Duration
+		}{
+			{name: "zero_floor", retry: &zero, want: minQuotaCooldownFloor},
+			{name: "negative_floor", retry: &negative, want: minQuotaCooldownFloor},
+			{name: "absent_retry_after", want: quotaBackoffBase * (1 << 6)},
+			{name: "longer_explicit_window", retry: &longer, want: longer},
+		} {
+			t.Run("model="+model+"/"+tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				m, auth := newCooldownMonotonicManager(t, "quota-window-model")
+				ordinaryRetry := 2 * time.Hour
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: &ordinaryRetry, Error: &Error{HTTPStatus: http.StatusTooManyRequests}})
+				ordinaryUntil := forcedCooldownTestState(t, m, auth.ID, model).NextRetryAfter
+				// Use an established backoff level so the no-header window remains
+				// comfortably live without relying on sub-second test timing.
+				m.mu.Lock()
+				if model == "" {
+					m.auths[auth.ID].Quota.BackoffLevel = 6
+				} else {
+					m.auths[auth.ID].ModelStates[model].Quota.BackoffLevel = 6
+				}
+				m.mu.Unlock()
+				forced := Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, RetryAfter: tc.retry, Error: &Error{Code: ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}}
+				before := time.Now()
+				m.MarkResult(ctx, forced)
+				state := forcedCooldownTestState(t, m, auth.ID, model)
+				deadline := state.ForcedCooldownUntil
+				if deadline.Before(before.Add(tc.want)) || deadline.After(time.Now().Add(tc.want)) {
+					t.Fatalf("forced 429 deadline = %v, want its own %v window", deadline.Sub(before), tc.want)
+				}
+				if tc.want < ordinaryRetry && (!state.NextRetryAfter.Equal(ordinaryUntil) || !state.Quota.NextRecoverAt.Equal(ordinaryUntil)) {
+					t.Fatalf("ordinary quota window shortened before success: %+v", state)
+				}
+				if tc.retry == nil {
+					m.MarkResult(ctx, forced)
+					state = forcedCooldownTestState(t, m, auth.ID, model)
+					if !state.ForcedCooldownUntil.Equal(deadline) || state.Quota.BackoffLevel != 6 {
+						t.Fatalf("in-flight no-header failure escalated the active window: %+v", state)
+					}
+				}
+				m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: auth.Provider, Model: model, Success: true})
+				state = forcedCooldownTestState(t, m, auth.ID, model)
+				if !state.Unavailable || !state.NextRetryAfter.Equal(deadline) || state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
+					t.Fatalf("success retained more than the forced 429 window: %+v", state)
+				}
+			})
+		}
 	}
 }

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -105,12 +105,13 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	auth.Generation = 1
 	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
+	schedulerSnapshot := authClone.Clone()
 	m.mu.Unlock()
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	}
 	if m.scheduler != nil {
-		m.scheduler.upsertAuth(authClone.Clone())
+		m.scheduler.upsertAuth(schedulerSnapshot)
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
@@ -220,18 +221,22 @@ func (m *Manager) updateInternal(ctx context.Context, base, auth *Auth, mode upd
 	now := time.Now()
 	auth.UpdatedAt = now
 	cooldownStateChanged := normalizeModelStates(auth)
+	if mode == updateModeReplace && !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
+		cooldownStateChanged = preserveForcedCooldownsOnReplacement(auth, existing, now) || cooldownStateChanged
+	}
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		cooldownStateChanged = clearCooldownStateForAuth(auth, now) || cooldownStateChanged
 	}
 	auth.EnsureIndex()
 	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
+	schedulerSnapshot := authClone.Clone()
 	m.mu.Unlock()
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
 		m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 	}
 	if m.scheduler != nil {
-		m.scheduler.upsertAuth(authClone.Clone())
+		m.scheduler.upsertAuth(schedulerSnapshot)
 	}
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
@@ -240,6 +245,61 @@ func (m *Manager) updateInternal(ctx context.Context, base, auth *Auth, mode upd
 		m.persistCooldownStates(context.Background())
 	}
 	return auth.Clone(), nil
+}
+
+// Configuration replacements can contain no runtime state, or an older snapshot.
+// The manager owns forced cooldowns: preserve current deadlines, including a
+// concurrent extension or reset, without restoring deadlines from the caller.
+func preserveForcedCooldownsOnReplacement(auth, current *Auth, now time.Time) bool {
+	authChanged := current.ForcedCooldownUntil.After(now) || !auth.ForcedCooldownUntil.IsZero()
+	var states map[string]*ModelState
+	modelsChanged := false
+	copyCurrentModel := func(model string) {
+		if !modelsChanged {
+			states = make(map[string]*ModelState, len(auth.ModelStates))
+			for key, state := range auth.ModelStates {
+				states[key] = state
+			}
+		}
+		incoming := states[model]
+		state := current.ModelStates[model].Clone()
+		if state == nil {
+			state = &ModelState{}
+			resetModelState(state, now)
+		}
+		if incoming != nil {
+			state.Quota = mergeQuotaObservation(state.Quota, incoming.Quota)
+			if incoming.Status == StatusDisabled {
+				state.Status = StatusDisabled
+			}
+		}
+		states[model] = state
+		modelsChanged = true
+	}
+	for model, state := range auth.ModelStates {
+		if state != nil && !state.ForcedCooldownUntil.IsZero() {
+			copyCurrentModel(model)
+		}
+	}
+	for model, state := range current.ModelStates {
+		if state != nil && state.ForcedCooldownUntil.After(now) {
+			copyCurrentModel(model)
+		}
+	}
+	if authChanged || modelsChanged {
+		auth.ForcedCooldownUntil = current.ForcedCooldownUntil
+		auth.NextRetryAfter = current.NextRetryAfter
+		auth.Unavailable = current.Unavailable
+		auth.Status = current.Status
+		auth.StatusMessage = current.StatusMessage
+		auth.LastError = cloneError(current.LastError)
+		auth.Quota = mergeQuotaObservation(current.Quota.Clone(), auth.Quota)
+	}
+	if modelsChanged {
+		auth.ModelStates = states
+		updateAggregatedAvailability(auth, now)
+	}
+	return authChanged || modelsChanged
 }
 
 // Remove deletes an auth from runtime state without persisting.

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -206,7 +206,7 @@ func (m *Manager) updateInternal(ctx context.Context, base, auth *Auth, mode upd
 		auth.Generation++
 	}
 	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
-		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+		if mode != updateModeRefresh && len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
 			auth.ModelStates = existing.ModelStates
 		}
 		if existing.Quota.Exceeded && existing.Quota.Reason == "credential_quota" && existing.Quota.NextRecoverAt.After(time.Now()) {
@@ -226,6 +226,12 @@ func (m *Manager) updateInternal(ctx context.Context, base, auth *Auth, mode upd
 	}
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		cooldownStateChanged = clearCooldownStateForAuth(auth, now) || cooldownStateChanged
+	}
+	if mode == updateModeRefresh && m.cooldownStore != nil {
+		cooldownStateChanged = !cooldownStateRecordsEqual(
+			m.cooldownStateRecordsForAuthLocked(existing, now),
+			m.cooldownStateRecordsForAuthLocked(auth, now),
+		) || cooldownStateChanged
 	}
 	auth.EnsureIndex()
 	authClone := auth.Clone()

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -299,6 +299,7 @@ func preserveForcedCooldownsOnReplacement(auth, current *Auth, now time.Time) bo
 		auth.Status = current.Status
 		auth.StatusMessage = current.StatusMessage
 		auth.LastError = cloneError(current.LastError)
+		auth.lastFailureScope = current.lastFailureScope
 		auth.Quota = mergeQuotaObservation(current.Quota.Clone(), auth.Quota)
 	}
 	if modelsChanged {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -365,6 +365,8 @@ func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 	if auth == nil || len(auth.ModelStates) == 0 {
 		return nil
 	}
+	recoverAggregate := modelStatesOwnAvailability(auth, now)
+	changed := false
 	var resumed []string
 	for model, state := range auth.ModelStates {
 		if state == nil || state.LastError == nil {
@@ -374,12 +376,13 @@ func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 			continue
 		}
 		recoverModelStateOnSuccess(state, now)
+		changed = true
 		if !state.Unavailable {
 			resumed = append(resumed, model)
 		}
 	}
-	if len(resumed) > 0 {
-		updateAggregatedAvailability(auth, now)
+	if changed && recoverAggregate {
+		recoverAggregatedAvailability(auth, now)
 	}
 	return resumed
 }

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -373,8 +373,10 @@ func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 		if state.LastError.StatusCode() != http.StatusUnauthorized && !strings.EqualFold(state.LastError.Code, "unauthorized") {
 			continue
 		}
-		resetModelState(state, now)
-		resumed = append(resumed, model)
+		recoverModelStateOnSuccess(state, now)
+		if !state.Unavailable {
+			resumed = append(resumed, model)
+		}
 	}
 	if len(resumed) > 0 {
 		updateAggregatedAvailability(auth, now)

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -307,7 +307,7 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 				auth.ModelStates = candidateAuth.ModelStates
 				if candidateChanged {
 					updateAggregatedAvailability(auth, now)
-					if !hasModelError(auth, now) {
+					if !auth.ForcedCooldownUntil.After(now) && !hasModelError(auth, now) {
 						auth.LastError = nil
 						auth.StatusMessage = ""
 						auth.Status = StatusActive

--- a/sdk/cliproxy/auth/cooldown_state.go
+++ b/sdk/cliproxy/auth/cooldown_state.go
@@ -17,16 +17,19 @@ import (
 
 // CooldownStateRecord is a persisted runtime cooldown snapshot for one auth/model pair.
 type CooldownStateRecord struct {
-	Provider            string     `json:"provider,omitempty"`
-	AuthID              string     `json:"auth_id"`
-	AuthFile            string     `json:"-"`
-	Model               string     `json:"model,omitempty"`
-	Status              string     `json:"status,omitempty"`
-	NextRetryAfter      time.Time  `json:"next_retry_after"`
-	ForcedCooldownUntil time.Time  `json:"forced_cooldown_until,omitzero"`
+	Provider       string    `json:"provider,omitempty"`
+	AuthID         string    `json:"auth_id"`
+	AuthFile       string    `json:"-"`
+	Model          string    `json:"model,omitempty"`
+	Status         string    `json:"status,omitempty"`
+	NextRetryAfter time.Time `json:"next_retry_after"`
+	// Always persist the authoritative value, including zero (no forced action).
+	// Readers must not infer a missing legacy deadline from LastError.
+	ForcedCooldownUntil time.Time  `json:"forced_cooldown_until"`
 	Reason              string     `json:"reason,omitempty"`
 	Quota               QuotaState `json:"quota,omitempty"`
 	LastError           *Error     `json:"last_error,omitempty"`
+	LastFailureScope    string     `json:"last_failure_scope,omitempty"`
 	UpdatedAt           time.Time  `json:"updated_at"`
 }
 

--- a/sdk/cliproxy/auth/cooldown_state.go
+++ b/sdk/cliproxy/auth/cooldown_state.go
@@ -17,16 +17,17 @@ import (
 
 // CooldownStateRecord is a persisted runtime cooldown snapshot for one auth/model pair.
 type CooldownStateRecord struct {
-	Provider       string     `json:"provider,omitempty"`
-	AuthID         string     `json:"auth_id"`
-	AuthFile       string     `json:"-"`
-	Model          string     `json:"model,omitempty"`
-	Status         string     `json:"status,omitempty"`
-	NextRetryAfter time.Time  `json:"next_retry_after"`
-	Reason         string     `json:"reason,omitempty"`
-	Quota          QuotaState `json:"quota,omitempty"`
-	LastError      *Error     `json:"last_error,omitempty"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	Provider            string     `json:"provider,omitempty"`
+	AuthID              string     `json:"auth_id"`
+	AuthFile            string     `json:"-"`
+	Model               string     `json:"model,omitempty"`
+	Status              string     `json:"status,omitempty"`
+	NextRetryAfter      time.Time  `json:"next_retry_after"`
+	ForcedCooldownUntil time.Time  `json:"forced_cooldown_until,omitzero"`
+	Reason              string     `json:"reason,omitempty"`
+	Quota               QuotaState `json:"quota,omitempty"`
+	LastError           *Error     `json:"last_error,omitempty"`
+	UpdatedAt           time.Time  `json:"updated_at"`
 }
 
 // CooldownStateStore persists runtime cooldown state independently from auth tokens.

--- a/sdk/cliproxy/auth/metadata_merge.go
+++ b/sdk/cliproxy/auth/metadata_merge.go
@@ -58,6 +58,7 @@ func MergeRefreshedAuth(base, current, updated *Auth) *Auth {
 	if base != nil && current.RegistrationEpoch != base.RegistrationEpoch {
 		return merged
 	}
+	now := time.Now()
 
 	// 1. Refresh Lifecycle Timestamps
 	if !updated.LastRefreshedAt.IsZero() {
@@ -128,6 +129,7 @@ func MergeRefreshedAuth(base, current, updated *Auth) *Auth {
 	}
 
 	// 3. ModelStates: three-way merge to preserve concurrent cooldown/quota
+	modelsChanged := false
 	var baseModels map[string]*ModelState
 	if base != nil {
 		baseModels = base.ModelStates
@@ -144,7 +146,25 @@ func MergeRefreshedAuth(base, current, updated *Auth) *Auth {
 			changedByUser := !reflect.DeepEqual(baseState, currentState)
 
 			if changedByExecutor && !changedByUser {
-				merged.ModelStates[model] = updState
+				next := updState.Clone()
+				// Token refresh can heal ordinary errors, but executor cleanup
+				// is not an explicit reset of a manager-owned forced action.
+				if currentState != nil && currentState.ForcedCooldownUntil.After(now) {
+					if next == nil {
+						next = currentState.Clone()
+						recoverModelStateOnSuccess(next, now)
+					}
+					next.ForcedCooldownUntil = currentState.ForcedCooldownUntil
+					if next.NextRetryAfter.Before(next.ForcedCooldownUntil) {
+						next.NextRetryAfter = next.ForcedCooldownUntil
+					}
+					next.Unavailable = true
+					if next.Status != StatusDisabled {
+						next.Status = StatusError
+					}
+				}
+				merged.ModelStates[model] = next
+				modelsChanged = true
 			}
 		}
 		if baseModels != nil {
@@ -152,11 +172,28 @@ func MergeRefreshedAuth(base, current, updated *Auth) *Auth {
 				if _, inUpdated := updated.ModelStates[model]; !inUpdated {
 					if currentState, ok := current.ModelStates[model]; ok {
 						if reflect.DeepEqual(baseState, currentState) {
-							delete(merged.ModelStates, model)
+							if currentState != nil && currentState.ForcedCooldownUntil.After(now) {
+								next := currentState.Clone()
+								recoverModelStateOnSuccess(next, now)
+								merged.ModelStates[model] = next
+							} else {
+								delete(merged.ModelStates, model)
+							}
+							modelsChanged = true
 						}
 					}
 				}
 			}
+		}
+	}
+	// Recompute from the final three-way model merge, not the executor's stale
+	// aggregate. Independent credential cooldowns remain owned by current.
+	if modelsChanged && !finalDisabled && modelStatesOwnAvailability(current, now) {
+		recoverAggregatedAvailability(merged, now)
+		if !hasModelError(merged, now) {
+			merged.LastError = nil
+			merged.StatusMessage = ""
+			merged.Status = StatusActive
 		}
 	}
 

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -718,6 +718,9 @@ func isCredentialBlocked(auth *Auth, supportedModelCount int, now time.Time) boo
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		return true
 	}
+	if auth.ForcedCooldownUntil.After(now) {
+		return true
+	}
 	if len(auth.ModelStates) == 0 {
 		return auth.Unavailable || auth.Quota.Exceeded || (!auth.NextRetryAfter.IsZero() && auth.NextRetryAfter.After(now))
 	}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -834,6 +834,13 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
 		return true, blockReasonCooldown, auth.Quota.NextRecoverAt
 	}
+	if auth.ForcedCooldownUntil.After(now) {
+		next := auth.NextRetryAfter
+		if next.Before(auth.ForcedCooldownUntil) {
+			next = auth.ForcedCooldownUntil
+		}
+		return availabilityBlock(true, auth.Quota.Exceeded, next, auth.Quota.NextRecoverAt, now)
+	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			modelKey := canonicalModelKey(model)

--- a/sdk/cliproxy/auth/testdata/cooldown_v1_ambiguous_quota.json
+++ b/sdk/cliproxy/auth/testdata/cooldown_v1_ambiguous_quota.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "auth_id": "auth-monotonic-ordinary-a",
+  "provider": "claude",
+  "updated_at": "2026-09-07T13:26:47.566998575Z",
+  "records": [
+    {
+      "provider": "claude",
+      "auth_id": "auth-monotonic-ordinary-a",
+      "status": "cooling",
+      "next_retry_after": "2026-09-07T23:26:47.565815694+08:00",
+      "reason": "quota",
+      "quota": {
+        "exceeded": true,
+        "reason": "quota",
+        "next_recover_at": "2026-09-07T23:26:47.565815694+08:00",
+        "observed_at": "0001-01-01T00:00:00Z"
+      },
+      "last_error": {
+        "code": "force_cooldown",
+        "message": "server_is_overloaded",
+        "retryable": false,
+        "http_status": 502
+      },
+      "updated_at": "2026-09-07T21:26:47.566965805+08:00"
+    },
+    {
+      "provider": "claude",
+      "auth_id": "auth-monotonic-ordinary-a",
+      "model": "ordinary-a",
+      "status": "cooling",
+      "next_retry_after": "2026-09-07T23:26:47.565815694+08:00",
+      "reason": "quota",
+      "quota": {
+        "exceeded": true,
+        "reason": "quota",
+        "next_recover_at": "2026-09-07T23:26:47.565815694+08:00",
+        "observed_at": "0001-01-01T00:00:00Z"
+      },
+      "last_error": {
+        "message": "ordinary A quota",
+        "retryable": false,
+        "http_status": 429
+      },
+      "updated_at": "2026-09-07T21:26:47.565815694+08:00"
+    }
+  ]
+}

--- a/sdk/cliproxy/auth/testdata/cooldown_v1_stale_forced_error.json
+++ b/sdk/cliproxy/auth/testdata/cooldown_v1_stale_forced_error.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "auth_id": "auth-monotonic-ordinary-a",
+  "provider": "claude",
+  "updated_at": "2026-09-07T13:18:15.372127413Z",
+  "records": [
+    {
+      "provider": "claude",
+      "auth_id": "auth-monotonic-ordinary-a",
+      "status": "cooling",
+      "next_retry_after": "2026-09-08T09:18:15.370660326+08:00",
+      "reason": "forced B failure",
+      "quota": {
+        "exceeded": false,
+        "next_recover_at": "0001-01-01T00:00:00Z",
+        "observed_at": "0001-01-01T00:00:00Z"
+      },
+      "last_error": {
+        "code": "force_cooldown",
+        "message": "forced B failure",
+        "retryable": false,
+        "http_status": 502
+      },
+      "updated_at": "2026-09-07T21:18:15.372090123+08:00"
+    },
+    {
+      "provider": "claude",
+      "auth_id": "auth-monotonic-ordinary-a",
+      "model": "ordinary-a",
+      "status": "cooling",
+      "next_retry_after": "2026-09-08T09:18:15.370660326+08:00",
+      "reason": "ordinary A failure",
+      "quota": {
+        "exceeded": false,
+        "next_recover_at": "0001-01-01T00:00:00Z",
+        "observed_at": "0001-01-01T00:00:00Z"
+      },
+      "last_error": {
+        "message": "ordinary A failure",
+        "retryable": false,
+        "http_status": 404
+      },
+      "updated_at": "2026-09-07T21:18:15.370660326+08:00"
+    }
+  ]
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -92,6 +92,8 @@ type Auth struct {
 	NextRefreshAfter time.Time `json:"next_refresh_after"`
 	// NextRetryAfter is the earliest time a retry should retrigger.
 	NextRetryAfter time.Time `json:"next_retry_after"`
+	// ForcedCooldownUntil is the explicit cooldown deadline, independent of ordinary failures.
+	ForcedCooldownUntil time.Time `json:"forced_cooldown_until,omitzero"`
 	// ModelStates tracks per-model runtime availability data.
 	ModelStates map[string]*ModelState `json:"model_states,omitempty"`
 
@@ -212,6 +214,8 @@ type ModelState struct {
 	Unavailable bool `json:"unavailable"`
 	// NextRetryAfter defines the per-model retry time.
 	NextRetryAfter time.Time `json:"next_retry_after"`
+	// ForcedCooldownUntil is the explicit cooldown deadline, independent of ordinary failures.
+	ForcedCooldownUntil time.Time `json:"forced_cooldown_until,omitzero"`
 	// LastError records the latest error observed for this model.
 	LastError *Error `json:"last_error,omitempty"`
 	// Quota retains quota information if this model hit rate limits.

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -94,6 +94,9 @@ type Auth struct {
 	NextRetryAfter time.Time `json:"next_retry_after"`
 	// ForcedCooldownUntil is the explicit cooldown deadline, independent of ordinary failures.
 	ForcedCooldownUntil time.Time `json:"forced_cooldown_until,omitzero"`
+	// lastFailureScope identifies the result path that last wrote cooldown
+	// state, independently of later diagnostics or removed model history.
+	lastFailureScope string
 	// ModelStates tracks per-model runtime availability data.
 	ModelStates map[string]*ModelState `json:"model_states,omitempty"`
 

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -295,19 +295,19 @@ func (a *Auth) Clone() *Auth {
 	}
 	copyAuth := *a
 	copyAuth.Quota = a.Quota.Clone()
-	if len(a.Attributes) > 0 {
+	if a.Attributes != nil {
 		copyAuth.Attributes = make(map[string]string, len(a.Attributes))
 		for key, value := range a.Attributes {
 			copyAuth.Attributes[key] = value
 		}
 	}
-	if len(a.Metadata) > 0 {
+	if a.Metadata != nil {
 		copyAuth.Metadata = make(map[string]any, len(a.Metadata))
 		for key, value := range a.Metadata {
 			copyAuth.Metadata[key] = value
 		}
 	}
-	if len(a.ModelStates) > 0 {
+	if a.ModelStates != nil {
 		copyAuth.ModelStates = make(map[string]*ModelState, len(a.ModelStates))
 		for key, state := range a.ModelStates {
 			copyAuth.ModelStates[key] = state.Clone()

--- a/sdk/cliproxy/service_forced_cooldown_test.go
+++ b/sdk/cliproxy/service_forced_cooldown_test.go
@@ -1,0 +1,46 @@
+package cliproxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestService_ForcedCooldownSurvivesWatcherReplacement(t *testing.T) {
+	ctx := context.Background()
+	service := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+	const authID = "watcher-forced-cooldown"
+	t.Cleanup(func() { GlobalModelRegistry().UnregisterClient(authID) })
+	fresh := func() *coreauth.Auth {
+		return &coreauth.Auth{ID: authID, Provider: "claude", Status: coreauth.StatusActive, Metadata: map[string]any{"disable_cooling": false}}
+	}
+	service.applyCoreAuthAddOrUpdate(ctx, fresh())
+	models := GlobalModelRegistry().GetModelsForClient(authID)
+	if len(models) == 0 {
+		t.Fatal("fixture did not register models")
+	}
+	model := models[0].ID
+	service.coreManager.MarkResult(ctx, coreauth.Result{AuthID: authID, Provider: "claude", Model: model, Success: true})
+	retry := 10 * time.Minute
+	service.coreManager.MarkResult(ctx, coreauth.Result{AuthID: authID, Provider: "claude", RetryAfter: &retry, Error: &coreauth.Error{Code: coreauth.ErrorCodeForceCooldown, HTTPStatus: http.StatusTooManyRequests}})
+	before, _ := service.coreManager.GetByID(authID)
+	prepared := service.prepareCoreAuthForModelRegistration(ctx, fresh())
+	if prepared == nil || !prepared.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) {
+		t.Error("watcher preparation lost the credential forced deadline")
+	}
+	service.completeModelRegistrationForAuth(ctx, prepared)
+	service.coreManager.MarkResult(ctx, coreauth.Result{AuthID: authID, Provider: "claude", Model: model, Success: true})
+	after, _ := service.coreManager.GetByID(authID)
+	if !after.ForcedCooldownUntil.Equal(before.ForcedCooldownUntil) || !after.Unavailable {
+		t.Error("watcher replacement and model registration cleared the forced cooldown")
+	}
+	selector := &coreauth.FillFirstSelector{}
+	if selected, errPick := selector.Pick(ctx, "claude", model, cliproxyexecutor.Options{}, []*coreauth.Auth{after}); selected != nil || errPick == nil {
+		t.Error("selector reused the credential after a watcher replacement")
+	}
+}


### PR DESCRIPTION
## Summary

- Track `ForcedCooldownUntil` separately from ordinary retry/quota deadlines, for model-level and auth-level results. Only explicit cooldown actions can extend this success-resistant deadline.
- Let success and token-refresh recovery heal ordinary failures while retaining an active explicit action. Capture forced 429 retry-after/backoff candidates before merging previous ordinary quota windows.
- Preserve manager-owned forced state across watcher/configuration replacements, three-way refresh merges, registry reconciliation, and older snapshot restores. Keep reset, disable, removal, expiration, and existing credential-quota boundaries.
- Rebuild derived availability/quota summaries after recovery. Persist the last failure's model/credential source so removed model history or identical error text cannot misidentify a new summary. This provenance does not create or extend a forced action.
- Restore forced deadlines only from the explicit persisted field, including an authoritative zero. Field-absent legacy records retain ordinary cooldown/quota recovery semantics; they are not promoted using `LastError`.

No configuration defaults, retry policies, translators, or provider request formats are changed.

## Reproduction

Reproduced on upstream `dev` at `934fb7928c42a8dd0aeaf39a321bef6601b55eb6`, using a fake executor and channels, without live provider requests:

1. Request A starts and remains in flight.
2. Request B returns HTTP 502 with `server_is_overloaded`, matches `stop-and-cooldown`, and establishes a configured 600-second cooldown.
3. Request A succeeds before that deadline.
4. Request C is submitted immediately afterward.

Previously, A reset the model state, removed its persisted cooldown, and allowed C to reach the executor. The patch retains the explicit deadline and persisted state; C is rejected locally, with two executor calls in total.

The initial regression test (available in `b651e9ea9f`) was run against unmodified upstream before implementing the fix:

```sh
go test -buildvcs=false ./sdk/cliproxy/auth \
  -run '^TestManager_ForcedCooldownSurvivesInFlightSuccess/execute/502$' \
  -count=1 -timeout=90s -v
```

It failed with the expected assertions: the in-flight success cleared the forced cooldown, the persisted records were empty, and the next request made a third executor call.

## Legacy migration policy

The latest review exposed ambiguous legacy records. An ordinary model A cooldown plus a recovered/removed forced model B can leave an auth record with A's deadline and B's stale error. Promoting that error into an auth-level forced action incorrectly blocks unrelated models.

An upstream-writer reproduction also produced byte-identical cooldown records for two different histories: that stale aggregate, and A's ordinary quota followed by a genuine credential-level forced error. The equality includes errors, quota fields, reasons, and timestamps. The old format therefore cannot reliably recover the missing forced scope or deadline.

This revision removes the inference fallback rather than adding another classifier:

- An explicitly persisted `ForcedCooldownUntil` is authoritative. The writer includes its zero value as well as active/expired values.
- Field-absent records retain their ordinary `NextRetryAfter` and quota fields, including `credential_quota`, without acquiring success-resistant protection. A true old forced record can consequently recover on success, as it could before this PR. This deliberate compatibility policy supersedes the earlier inferred legacy migration described in previous review replies.
- Already-live explicit forced deadlines remain protected when an older snapshot is restored.

Two checked-in fixtures were generated by the original upstream writer; tests rebase only their timestamps and exercise both initial restoration and a second restart after migration.

## Coverage and verification

Regression coverage includes:

- `Execute`, `ExecuteStream`, and `ExecuteCount`; 502/503/429; `stop-and-cooldown` and `continue-and-cooldown`; channel-controlled in-flight completion and actual selector/executor behavior.
- Model/auth scope, ordinary-before-forced and forced-before-ordinary ordering, explicit/no-header 429 backoff, repeated shorter/longer actions, expiry, reset, file restoration, and independent deadline merging.
- Watcher preparation/model registration, fresh/stale replacements, concurrent extensions/resets, token refresh, final three-way merge, executor model cleanup, passive quota observations, and clone/scheduler snapshot isolation.
- Named-model and empty-model selection, scheduler promotion at the explicit deadline, and persisted auth/model records after recovery.
- Removed model B leaving a stale error while model A recovers, through live state, restart, replacement, and intervening refresh diagnostics. A matching-error/matching-deadline credential control ensures independent credential failures are retained.
- Genuine field-absent legacy fixtures, two-restart migration, and an 18-case explicit wire-field matrix: model/auth scope, zero/expired/active deadlines, and forced/ordinary/missing error history. File and PostgreSQL-store JSON round trips cover the new fields.

Ordering and expiry assertions use channels or explicit timestamps, not sleeps. The initial 429 regression supplies a ten-minute retry-after; the patch does not make every 429 last 600 seconds.

Passed locally on the final patch with Go 1.26.4, Linux/amd64:

```sh
go test -buildvcs=false ./... -count=1 -timeout=300s
CGO_ENABLED=1 go test -buildvcs=false -race -shuffle=on \
  ./sdk/cliproxy/auth ./sdk/cliproxy \
  -count=10 -timeout=300s
CGO_ENABLED=1 go test -buildvcs=false -race -shuffle=on \
  ./sdk/cliproxy/auth ./sdk/cliproxy ./internal/store \
  -run 'TestManager_ForcedCooldown|TestService_ForcedCooldown|TestAuthCloneEmptyRuntimeMaps|TestPostgresCooldownStateStore' \
  -count=30 -timeout=180s
go vet -buildvcs=false ./...
go build -buildvcs=false -o /dev/null ./cmd/server/
```

The two listed race runs have zero failed tests and zero race warnings. Formatting and complete-diff whitespace checks also pass.

Related to #5501 and #5519. The existing monotonic-deadline fix handles later failures; this PR addresses later success clearing an explicit cooldown.