### PR TITLE
fix(auth): use transient cooldown for HTML 404 error pages

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -835,7 +835,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								state.NextRetryAfter = next
 							}
 						case 404:
-							if disableCooling {
+							if isHTMLNotFoundResultError(result.Error) {
+								state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+								state.Unavailable = !state.NextRetryAfter.IsZero()
+							} else if disableCooling {
 								state.NextRetryAfter = time.Time{}
 							} else {
 								next := now.Add(12 * time.Hour)
@@ -1705,6 +1708,18 @@ func nextCloudflareCooldown(backoffLevel int, disableCooling bool, now time.Time
 	return next, backoffLevel
 }
 
+// An HTML 404 page is not evidence that a model is unsupported. Use the
+// transient upstream cooldown so a temporary route failure cannot suspend it
+// for twelve hours. Structured model errors and Cloudflare challenges retain
+// their existing classification.
+func isHTMLNotFoundResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != http.StatusNotFound || isModelNotFoundIdentifier(err.Code) {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Message))
+	return strings.HasPrefix(message, "<html>") || strings.HasPrefix(message, "<html ") || strings.HasPrefix(message, "<!doctype html")
+}
+
 func isRequestScopedNotFoundResultError(err *Error) bool {
 	if err == nil || statusCodeFromResult(err) != http.StatusNotFound {
 		return false
@@ -2060,7 +2075,10 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			}
 		case 404:
 			auth.StatusMessage = "not_found"
-			if disableCooling {
+			if isHTMLNotFoundResultError(resultErr) {
+				auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+				auth.Unavailable = !auth.NextRetryAfter.IsZero()
+			} else if disableCooling {
 				auth.NextRetryAfter = time.Time{}
 			} else {
 				auth.NextRetryAfter = now.Add(12 * time.Hour)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1717,7 +1717,18 @@ func isHTMLNotFoundResultError(err *Error) bool {
 		return false
 	}
 	message := strings.ToLower(strings.TrimSpace(err.Message))
-	return strings.HasPrefix(message, "<html>") || strings.HasPrefix(message, "<html ") || strings.HasPrefix(message, "<!doctype html")
+	if strings.HasPrefix(message, "<!doctype html") {
+		return true
+	}
+	if !strings.HasPrefix(message, "<html") || len(message) <= len("<html") {
+		return false
+	}
+	switch message[len("<html")] {
+	case '>', ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
 }
 
 func isRequestScopedNotFoundResultError(err *Error) bool {

--- a/sdk/cliproxy/auth/conductor_html_not_found_test.go
+++ b/sdk/cliproxy/auth/conductor_html_not_found_test.go
@@ -20,6 +20,11 @@ func TestManager_HTMLNotFoundCooldown(t *testing.T) {
 		}{
 			{"html", "<html>\n<head><title>404 Not Found</title></head></html>", time.Minute},
 			{"doctype", " \n<!DOCTYPE HTML><html><body>Not Found</body></html>", time.Minute},
+			{"newline", "<html\nlang=\"en\">Not Found</html>", time.Minute},
+			{"tab", "<html\tlang=\"en\">Not Found</html>", time.Minute},
+			{"cr", "<html\rlang=\"en\">Not Found</html>", time.Minute},
+			{"form feed", "<html\flang=\"en\">Not Found</html>", time.Minute},
+			{"not html tag", "<htmlish>not found", 12 * time.Hour},
 			{"plain", "404 page not found", 12 * time.Hour},
 			{"model", `{"error":{"code":"model_not_found","message":"model html-not-found-model was not found"}}`, 12 * time.Hour},
 		} {

--- a/sdk/cliproxy/auth/conductor_html_not_found_test.go
+++ b/sdk/cliproxy/auth/conductor_html_not_found_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestManager_HTMLNotFoundCooldown(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	previousTransient := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(0)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous); transientErrorCooldownSeconds.Store(previousTransient) })
+	for _, model := range []string{"", "html-not-found-model"} {
+		for _, tc := range []struct {
+			name, message string
+			want          time.Duration
+		}{
+			{"html", "<html>\n<head><title>404 Not Found</title></head></html>", time.Minute},
+			{"doctype", " \n<!DOCTYPE HTML><html><body>Not Found</body></html>", time.Minute},
+			{"plain", "404 page not found", 12 * time.Hour},
+			{"model", `{"error":{"code":"model_not_found","message":"model html-not-found-model was not found"}}`, 12 * time.Hour},
+		} {
+			t.Run(model+"/"+tc.name, func(t *testing.T) {
+				m := NewManager(nil, nil, nil)
+				a := &Auth{ID: "html-not-found-auth", Provider: "codex"}
+				if _, err := m.Register(context.Background(), a); err != nil {
+					t.Fatal(err)
+				}
+				before := time.Now()
+				m.MarkResult(context.Background(), Result{AuthID: a.ID, Provider: a.Provider, Model: model, Error: &Error{HTTPStatus: http.StatusNotFound, Message: tc.message}})
+				after := time.Now()
+				got, _ := m.GetByID(a.ID)
+				deadline := got.NextRetryAfter
+				if model != "" {
+					deadline = got.ModelStates[model].NextRetryAfter
+				}
+				if deadline.Before(before.Add(tc.want)) || deadline.After(after.Add(tc.want)) {
+					t.Fatalf("cooldown = %v, want %v", deadline.Sub(before), tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestApplyAuthFailureState_HTMLNotFoundPreservesLongerCooldown(t *testing.T) {
+	now := time.Date(2026, 9, 7, 0, 0, 0, 0, time.UTC)
+	want := now.Add(30 * time.Minute)
+	a := &Auth{NextRetryAfter: want}
+	applyAuthFailureState(a, &Error{HTTPStatus: 404, Message: "<html><body>Not Found</body></html>"}, nil, now, false)
+	if !a.NextRetryAfter.Equal(want) {
+		t.Fatalf("deadline = %v, want %v", a.NextRetryAfter, want)
+	}
+}
+
+func TestManager_HTMLNotFoundCooldownSettings(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous); transientErrorCooldownSeconds.Store(previousTransient) })
+	for _, tc := range []struct {
+		name     string
+		disabled bool
+		seconds  int64
+		want     time.Duration
+	}{
+		{"disabled", true, 0, 0},
+		{"transient disabled", false, -1, 0},
+		{"custom transient", false, 7, 7 * time.Second},
+	} {
+		for _, model := range []string{"", "html-not-found-model"} {
+			t.Run(tc.name+"/"+model, func(t *testing.T) {
+				quotaCooldownDisabled.Store(tc.disabled)
+				transientErrorCooldownSeconds.Store(tc.seconds)
+				m := NewManager(nil, nil, nil)
+				a := &Auth{ID: "html-settings-auth", Provider: "codex"}
+				if _, err := m.Register(context.Background(), a); err != nil {
+					t.Fatal(err)
+				}
+				before := time.Now()
+				m.MarkResult(context.Background(), Result{AuthID: a.ID, Provider: a.Provider, Model: model, Error: &Error{HTTPStatus: 404, Message: "<html><body>Not Found</body></html>"}})
+				after := time.Now()
+				got, _ := m.GetByID(a.ID)
+				deadline, unavailable := got.NextRetryAfter, got.Unavailable
+				if model != "" {
+					deadline, unavailable = got.ModelStates[model].NextRetryAfter, got.ModelStates[model].Unavailable
+				}
+				if tc.want == 0 {
+					if !deadline.IsZero() || unavailable {
+						t.Fatalf("disabled cooldown: deadline=%v unavailable=%v", deadline, unavailable)
+					}
+				} else if !unavailable || deadline.Before(before.Add(tc.want)) || deadline.After(after.Add(tc.want)) {
+					t.Fatalf("cooldown=%v unavailable=%v, want %v", deadline.Sub(before), unavailable, tc.want)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
HTML 404 pages currently trigger the same 12-hour model/credential cooldown as other 404 responses. This PR proposes using the existing configurable transient cooldown (one minute by default) for HTML pages, so a recovered upstream route can be retried sooner. This is a recovery-policy improvement: HTML alone does not prove that a failure is transient, and a persistent HTML 404 will be retried more often.

The change applies at both model and credential scope. Plain/structured 404s and explicit model-not-found codes retain their existing behavior. Cloudflare challenges keep their separate classification; disabled-cooldown settings and longer live deadlines remain respected. HTML tag-boundary matching includes space, tab, newline, carriage return, and form feed, addressing the automated review.

Related to #5476 and a narrower alternative to #5514. This proposal only changes HTML error pages, rather than every unclassified 404, and includes the current monotonic cooldown protections. Both alternatives need not be merged.

### Incident clarification

The user subsequently identified their network proxy as the cause of the reported outage and confirmed recovery. The original upstream HTTP status was not retained. A minimal request succeeded after clearing local routing state during investigation, but that did not establish the cause of the user's overall failure. This PR must not be treated as a confirmed fix for that incident. Its justification is the independently reproducible 12-hour HTML-404 cooldown and the proposed recovery-policy tradeoff, subject to maintainer agreement.

### Validation

- Regression tests demonstrate the existing 12-hour HTML/doctype cooldown at model and credential scope and the proposed one-minute behavior.
- Review regression cases for newline/tab/CR/form-feed tag boundaries fail before the follow-up and pass after it; non-HTML tag prefixes remain unchanged.
- Tests cover plain/structured 404s, custom/disabled transient cooldowns, and preservation of longer deadlines.
- `go test ./sdk/cliproxy/auth -count=1` passes.
- `go build -o test-output ./cmd/server` passes.
- Changed Go files formatted with gofmt; `git diff --check` passes.

Implemented and verified with Codex assistance.
