### PR TITLE
fix(antigravity): default to short connections and harden connection pool lifecycle (#5494)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -300,6 +300,10 @@ codex:
 #   sensitive-words:             # optional: words to obfuscate with zero-width characters in system instructions
 #     - "API"
 #     - "proxy"
+#   connection-pool:             # optional: upstream HTTP connection pool settings
+#     enabled: false             # whether to enable connection pooling (default: false; set to true to enable connection pooling)
+#     idle-conn-timeout: "30s"   # idle keep-alive timeout (default: 30s, capped at 210s)
+#     max-idle-conns-per-host: 2 # max idle connections per host per credential (default: 2)
 
 # xAI provider behavior.
 xai:

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/access"
@@ -11,6 +12,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/managementasset"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -110,6 +112,10 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 	}
 
 	applySignatureCacheConfig(oldCfg, cfg)
+
+	if oldCfg != nil && !reflect.DeepEqual(oldCfg.Antigravity.ConnectionPool, cfg.Antigravity.ConnectionPool) {
+		executor.ResetAntigravityTransports()
+	}
 
 	if s.handlers != nil && s.handlers.AuthManager != nil {
 		s.handlers.AuthManager.SetRetryConfig(cfg.RequestRetry, time.Duration(cfg.MaxRetryInterval)*time.Second, cfg.MaxRetryCredentials)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
@@ -31,6 +32,7 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	"gopkg.in/yaml.v3"
 )
 
 type codexSearchCaptureExecutor struct {
@@ -2587,5 +2589,53 @@ func TestInteractionsRouteRegistered(t *testing.T) {
 	server.engine.ServeHTTP(rr, req)
 	if rr.Code == http.StatusNotFound {
 		t.Fatalf("status = %d, want route registered; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpdateClientsContext_AntigravityConnectionPoolPurgesTransports(t *testing.T) {
+	server := newTestServer(t)
+
+	enabled := true
+	disabled := false
+
+	cfg1 := *server.cfg
+	cfg1.Antigravity.ConnectionPool.Enabled = &enabled
+	cfg1.Antigravity.ConnectionPool.IdleConnTimeout = "30s"
+	server.oldConfigYaml, _ = yaml.Marshal(&cfg1)
+
+	// Pre-populate the cache before reload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	testAuth := &auth.Auth{
+		ID:         "hot-reload-test-auth",
+		Provider:   "antigravity",
+		Attributes: map[string]string{"base_url": srv.URL},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "proj",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	exec := executor.NewAntigravityExecutor(&cfg1)
+	req := httptest.NewRequest(http.MethodGet, srv.URL, nil)
+	_, _ = exec.HttpRequest(context.Background(), testAuth, req)
+
+	if executor.AntigravityTransportsLen() == 0 {
+		t.Fatal("expected Antigravity transports to be cached before hot reload")
+	}
+
+	cfg2 := cfg1
+	cfg2.Antigravity.ConnectionPool.Enabled = &disabled
+	cfg2.Antigravity.ConnectionPool.IdleConnTimeout = "10s"
+
+	if ok := server.UpdateClientsContext(context.Background(), &cfg2); !ok {
+		t.Fatal("UpdateClientsContext returned false")
+	}
+
+	if got := executor.AntigravityTransportsLen(); got != 0 {
+		t.Fatalf("AntigravityTransportsLen() after reload = %d, want 0", got)
 	}
 }

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -30,6 +30,27 @@ func TestParseConfigBytes_AntigravitySensitiveWords(t *testing.T) {
 	}
 }
 
+func TestParseConfigBytes_AntigravityConnectionPool(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte(`antigravity:
+  connection-pool:
+    enabled: false
+    idle-conn-timeout: "15s"
+    max-idle-conns-per-host: 4
+`))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	if cfg.Antigravity.ConnectionPool.Enabled == nil || *cfg.Antigravity.ConnectionPool.Enabled != false {
+		t.Fatalf("Enabled = %v, want false", cfg.Antigravity.ConnectionPool.Enabled)
+	}
+	if cfg.Antigravity.ConnectionPool.IdleConnTimeout != "15s" {
+		t.Fatalf("IdleConnTimeout = %q, want 15s", cfg.Antigravity.ConnectionPool.IdleConnTimeout)
+	}
+	if cfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost == nil || *cfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost != 4 {
+		t.Fatalf("MaxIdleConnsPerHost = %v, want 4", cfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost)
+	}
+}
+
 func TestCloneForRuntimeDeepCopiesConfig(t *testing.T) {
 	cfg := sampleCloneRuntimeConfig()
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -141,6 +141,24 @@ type XAIConfig struct {
 type AntigravityConfig struct {
 	// SensitiveWords is a list of words to obfuscate with zero-width characters in system instructions.
 	SensitiveWords []string `yaml:"sensitive-words,omitempty" json:"sensitive-words,omitempty"`
+
+	// ConnectionPool configures upstream HTTP connection pooling behavior for Antigravity.
+	ConnectionPool AntigravityConnectionPoolConfig `yaml:"connection-pool,omitempty" json:"connection-pool,omitempty"`
+}
+
+// AntigravityConnectionPoolConfig controls upstream HTTP/1.1 connection pooling behavior for Antigravity.
+type AntigravityConnectionPoolConfig struct {
+	// Enabled controls whether upstream connection pooling is enabled.
+	// Defaults to false (short-lived connection mode). Set to true to enable connection pooling.
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+
+	// IdleConnTimeout specifies how long an idle connection stays in the pool before expiring.
+	// Defaults to "30s". Capped at 210s to prevent exceeding Google Frontend (GFE) 240s cutoff.
+	IdleConnTimeout string `yaml:"idle-conn-timeout,omitempty" json:"idle-conn-timeout,omitempty"`
+
+	// MaxIdleConnsPerHost specifies the maximum number of idle connections to retain per host per credential.
+	// Defaults to 2.
+	MaxIdleConnsPerHost *int `yaml:"max-idle-conns-per-host,omitempty" json:"max-idle-conns-per-host,omitempty"`
 }
 
 // CodexConfig configures provider-wide Codex request behavior.

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -98,19 +98,24 @@ const (
 	// it only causes pool thrashing.
 	antigravityTransportCacheCapacity = 8192
 
-	// antigravityMaxIdleConnsPerHost mirrors the value that
-	// cloud.google.com/go/auth/httptransport and google.golang.org/api/transport/http
-	// set on their base transport, which is the stack the native Antigravity client
-	// uses. Both raise Go's DefaultMaxIdleConnsPerHost of 2 to 100 because the low
-	// default forces concurrent requests to re-handshake instead of reusing pooled
-	// connections.
-	antigravityMaxIdleConnsPerHost = 100
+	// antigravityDefaultMaxIdleConnsPerHost sets the default number of idle connections
+	// to retain per host per credential when connection pooling is enabled.
+	// Matches Go's DefaultMaxIdleConnsPerHost (2) and the native Antigravity binary.
+	antigravityDefaultMaxIdleConnsPerHost = 2
 
-	// antigravityIdleConnTimeout keeps pooled connections usable far longer than Go's
-	// 90s default. Captured native traffic reuses a connection after idle gaps with a
-	// p90 of roughly six minutes, and a 90s timeout would discard about an eighth of
-	// the reuses the native client actually performs.
-	antigravityIdleConnTimeout = 10 * time.Minute
+	// antigravityMaxAllowedMaxIdleConnsPerHost is the hard upper bound on MaxIdleConnsPerHost (100).
+	// Prevents unbounded connection pool expansion in multi-credential environments.
+	antigravityMaxAllowedMaxIdleConnsPerHost = 100
+
+	// antigravityDefaultIdleConnTimeout is the default idle connection timeout (30 seconds).
+	// Kept strictly far below Google Frontend (GFE / ESF) 240-second cutoff to prevent
+	// client-side reuse of half-closed connections that cause connection resets.
+	antigravityDefaultIdleConnTimeout = 30 * time.Second
+
+	// antigravityMaxAllowedIdleConnTimeout is the hard upper bound on IdleConnTimeout (210 seconds).
+	// Kept strictly below Google Frontend (GFE / ESF) 240.0-second HTTP/1.1 idle keep-alive cutoff
+	// with a 30-second safety margin to eliminate timer race conditions.
+	antigravityMaxAllowedIdleConnTimeout = 210 * time.Second
 
 	// antigravityAnonymousTransportScope is the pool scope for auth objects that carry
 	// no identity at all. Reaching it means the auth has no ID, no source path and no
@@ -119,6 +124,97 @@ const (
 	// connection pool, and the goroutines managing it, on every call.
 	antigravityAnonymousTransportScope = "anonymous"
 )
+
+type antigravityPoolSettings struct {
+	shortMode           bool
+	idleConnTimeout     time.Duration
+	maxIdleConnsPerHost int
+}
+
+func resolveAntigravityPoolSettings(cfg *config.Config) antigravityPoolSettings {
+	// By default, upstream connection pooling is disabled (shortMode = true, maxIdleConnsPerHost = -1)
+	// to prevent socket buildup and stale connection errors across rotating credentials.
+	settings := antigravityPoolSettings{
+		shortMode:           true,
+		maxIdleConnsPerHost: -1,
+		idleConnTimeout:     0,
+	}
+	if cfg == nil {
+		return settings
+	}
+
+	// Pooling is active ONLY when explicitly enabled: true
+	if cfg.Antigravity.ConnectionPool.Enabled == nil || !*cfg.Antigravity.ConnectionPool.Enabled {
+		return settings
+	}
+
+	// Enabled is true: initialize default pool settings
+	settings.shortMode = false
+	settings.idleConnTimeout = antigravityDefaultIdleConnTimeout
+	settings.maxIdleConnsPerHost = antigravityDefaultMaxIdleConnsPerHost
+
+	rawTimeout := strings.TrimSpace(cfg.Antigravity.ConnectionPool.IdleConnTimeout)
+	if rawTimeout != "" {
+		d, err := time.ParseDuration(rawTimeout)
+		if err != nil {
+			log.Warnf("antigravity executor: invalid idle-conn-timeout %q: %v, using default %v", rawTimeout, err, antigravityDefaultIdleConnTimeout)
+		} else {
+			if d <= 0 {
+				settings.shortMode = true
+				settings.maxIdleConnsPerHost = -1
+				return settings
+			}
+			if d > antigravityMaxAllowedIdleConnTimeout {
+				d = antigravityMaxAllowedIdleConnTimeout
+			}
+			settings.idleConnTimeout = d
+		}
+	}
+
+	if cfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost != nil {
+		val := *cfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost
+		if val < 0 {
+			settings.shortMode = true
+			settings.maxIdleConnsPerHost = -1
+			return settings
+		}
+		if val > antigravityMaxAllowedMaxIdleConnsPerHost {
+			val = antigravityMaxAllowedMaxIdleConnsPerHost
+		}
+		settings.maxIdleConnsPerHost = val
+	}
+
+	if settings.maxIdleConnsPerHost < 0 {
+		settings.shortMode = true
+	}
+
+	return settings
+}
+
+// ResetAntigravityTransports purges all cached Antigravity connection pools and closes their idle connections.
+// Used during configuration hot-reloads to ensure updated pool parameters apply immediately.
+func ResetAntigravityTransports() {
+	antigravityTransports.Purge()
+}
+
+// AntigravityTransportsLen reports the current number of cached Antigravity transports.
+func AntigravityTransportsLen() int {
+	return antigravityTransports.Len()
+}
+
+// closeAntigravityAuthIdleTransports closes and removes all idle connections for the given auth.
+func closeAntigravityAuthIdleTransports(auth *cliproxyauth.Auth) {
+	if auth == nil {
+		return
+	}
+	scope := antigravityTransportScope(auth)
+	if scope == "" || scope == antigravityAnonymousTransportScope {
+		return
+	}
+	antigravityTransports.CloseMatching(func(key antigravityTransportKey) bool {
+		return key.credential == scope
+	})
+}
 
 // antigravityTransportKey identifies one connection pool. At most one of proxy and
 // base is set: proxy for a credential-scoped proxy pool, base for a transport handed
@@ -136,7 +232,7 @@ func defaultAntigravityBaseTransport() *http.Transport {
 	return &http.Transport{}
 }
 
-func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
+func cloneTransportWithHTTP11(base *http.Transport, cfgs ...*config.Config) *http.Transport {
 	if base == nil {
 		return nil
 	}
@@ -153,39 +249,69 @@ func cloneTransportWithHTTP11(base *http.Transport) *http.Transport {
 	// Native Antigravity sends no ALPN extension. With HTTP/2 disabled above,
 	// an empty NextProtos keeps the wire shape aligned while using HTTP/1.1.
 	clone.TLSClientConfig.NextProtos = nil
-	applyAntigravityPoolLimits(clone)
+	applyAntigravityPoolLimits(clone, cfgs...)
 	return clone
 }
 
-// applyAntigravityPoolLimits widens the connection pool so keep-alive actually
-// survives concurrency and idle periods. Limits are only ever raised, so an
-// operator-supplied base transport with a larger pool keeps its own settings.
-func applyAntigravityPoolLimits(transport *http.Transport) {
+// applyAntigravityPoolLimits configures connection pool parameters for Antigravity.
+// Default: IdleConnTimeout=30s, MaxIdleConnsPerHost=2.
+// IdleConnTimeout is strictly capped at 240s (antigravityMaxAllowedIdleConnTimeout)
+// matching the Google Frontend (GFE / ESF) HTTP/1.1 idle cutoff.
+// If short-lived connection mode is configured, MaxIdleConnsPerHost is set to -1
+// so idle connections are closed immediately upon request completion.
+func applyAntigravityPoolLimits(transport *http.Transport, cfgs ...*config.Config) {
 	if transport == nil {
 		return
 	}
-	// Go treats 0 as DefaultMaxIdleConnsPerHost (2) and a negative value as "never pool
-	// an idle connection". Raise the default and smaller positive values, but leave a
-	// negative value alone so an operator can still disable pooling outright.
-	if transport.MaxIdleConnsPerHost >= 0 && transport.MaxIdleConnsPerHost < antigravityMaxIdleConnsPerHost {
-		transport.MaxIdleConnsPerHost = antigravityMaxIdleConnsPerHost
+	var cfg *config.Config
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
 	}
-	// MaxIdleConns caps the pool across all hosts. Leaving it below the per-host limit
-	// would silently throttle Antigravity, which talks to a single host at a time.
-	// Zero means unlimited, so it must not be lowered.
+	settings := resolveAntigravityPoolSettings(cfg)
+	if settings.shortMode {
+		transport.MaxIdleConnsPerHost = -1
+		transport.DisableKeepAlives = false
+		transport.IdleConnTimeout = 0
+		return
+	}
+
+	// If the operator base transport already disabled pooling (< 0), honor it.
+	if transport.MaxIdleConnsPerHost < 0 {
+		return
+	}
+
+	// Go treats 0 as DefaultMaxIdleConnsPerHost (2). Ensure at least configured/default limit.
+	if transport.MaxIdleConnsPerHost < settings.maxIdleConnsPerHost {
+		transport.MaxIdleConnsPerHost = settings.maxIdleConnsPerHost
+	}
+
+	// MaxIdleConns caps the pool across all hosts.
 	if transport.MaxIdleConns > 0 && transport.MaxIdleConns < transport.MaxIdleConnsPerHost {
 		transport.MaxIdleConns = transport.MaxIdleConnsPerHost
 	}
-	// Zero already means "never expire idle connections", which is strictly longer.
-	if transport.IdleConnTimeout > 0 && transport.IdleConnTimeout < antigravityIdleConnTimeout {
-		transport.IdleConnTimeout = antigravityIdleConnTimeout
+
+	// Apply IdleConnTimeout:
+	// If the config explicitly specified a timeout, apply settings.idleConnTimeout.
+	// If config did not specify a timeout:
+	// - if base transport already has a timeout > 0, preserve it (capped at 240s).
+	// - otherwise, apply default 30s.
+	rawTimeout := ""
+	if cfg != nil {
+		rawTimeout = strings.TrimSpace(cfg.Antigravity.ConnectionPool.IdleConnTimeout)
+	}
+	if rawTimeout != "" {
+		transport.IdleConnTimeout = settings.idleConnTimeout
+	} else if transport.IdleConnTimeout == 0 || transport.IdleConnTimeout == 90*time.Second {
+		transport.IdleConnTimeout = settings.idleConnTimeout
+	} else if transport.IdleConnTimeout > antigravityMaxAllowedIdleConnTimeout {
+		transport.IdleConnTimeout = antigravityMaxAllowedIdleConnTimeout
 	}
 }
 
 // antigravityHTTP11Transport returns the HTTP/1.1 pool shared by every request that
 // uses the same credential and the same base transport. The base is either the
 // process default or a transport provided through the request context.
-func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport) *http.Transport {
+func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport, cfgs ...*config.Config) *http.Transport {
 	if base == nil {
 		return nil
 	}
@@ -194,14 +320,14 @@ func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport) *
 		base:       base,
 	}
 	transport, errGet := antigravityTransports.Get(key, func() (*http.Transport, error) {
-		return cloneTransportWithHTTP11(base), nil
+		return cloneTransportWithHTTP11(base, cfgs...), nil
 	})
 	if errGet != nil {
 		// Defensive only: the builder above cannot fail. Never return nil here, because a
 		// nil Transport makes http.Client fall back to http.DefaultTransport, which
 		// advertises h2 over ALPN and would break the Antigravity wire fingerprint.
 		log.Debugf("antigravity executor: cache HTTP/1.1 transport failed: %v", errGet)
-		return cloneTransportWithHTTP11(base)
+		return cloneTransportWithHTTP11(base, cfgs...)
 	}
 	return transport
 }
@@ -210,7 +336,7 @@ func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport) *
 // one proxy setting, or nil when the proxy setting cannot be turned into a
 // transport. Keying on the normalized proxy string rather than on a prebuilt
 // transport keeps one pool per credential and proxy instead of one per request.
-func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string) *http.Transport {
+func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string, cfgs ...*config.Config) *http.Transport {
 	proxyURL = strings.TrimSpace(proxyURL)
 	if proxyURL == "" {
 		return nil
@@ -227,7 +353,7 @@ func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string)
 		if base == nil {
 			return nil, fmt.Errorf("antigravity executor: proxy setting produced no transport")
 		}
-		return cloneTransportWithHTTP11(base), nil
+		return cloneTransportWithHTTP11(base, cfgs...), nil
 	})
 	if errGet != nil {
 		// The caller falls back to NewProxyAwareHTTPClient, which reports the failure
@@ -293,7 +419,7 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 	// credential-scoped proxy transport only here so other providers keep their
 	// existing lifecycle and different OAuth identities remain isolated.
 	if proxyURL := antigravityProxyURL(cfg, auth); proxyURL != "" {
-		if transport := antigravityProxiedHTTP11Transport(auth, proxyURL); transport != nil {
+		if transport := antigravityProxiedHTTP11Transport(auth, proxyURL, cfg); transport != nil {
 			return &http.Client{Transport: transport, Timeout: timeout}
 		}
 		// Fall through so NewProxyAwareHTTPClient reports the failure and applies the
@@ -303,7 +429,7 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
 	// Direct requests share an HTTP/1.1 pool only within the selected credential.
 	if client.Transport == nil {
-		client.Transport = antigravityHTTP11Transport(auth, antigravityBaseTransport)
+		client.Transport = antigravityHTTP11Transport(auth, antigravityBaseTransport, cfg)
 		return client
 	}
 
@@ -321,7 +447,7 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 		// Antigravity fingerprint, so substitute the process base transport.
 		transport = antigravityBaseTransport
 	}
-	client.Transport = antigravityHTTP11Transport(auth, transport)
+	client.Transport = antigravityHTTP11Transport(auth, transport, cfg)
 	return client
 }
 

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -154,6 +154,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 		decision := decideAntigravity429(bodyBytes)
 		switch decision.kind {
 		case antigravity429DecisionShortCooldownSwitchAuth:
+			closeAntigravityAuthIdleTransports(auth)
 			if decision.retryAfter != nil && *decision.retryAfter > 0 && !antigravityCoolingDisabled(auth, e.cfg) {
 				if errMarkCooldown := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), *decision.retryAfter); errMarkCooldown != nil {
 					err = homeKVUnavailableStatusErr(errMarkCooldown)
@@ -162,6 +163,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 				log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown", *decision.retryAfter, baseModel)
 			}
 		case antigravity429DecisionFullQuotaExhausted:
+			closeAntigravityAuthIdleTransports(auth)
 			if useCredits && antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) && !antigravityCoolingDisabled(auth, e.cfg) {
 				markAntigravityCreditsPermanentlyDisabled(auth)
 			}
@@ -364,6 +366,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 
 			switch decision.kind {
 			case antigravity429DecisionShortCooldownSwitchAuth:
+				closeAntigravityAuthIdleTransports(auth)
 				if decision.retryAfter != nil && *decision.retryAfter > 0 && !antigravityCoolingDisabled(auth, e.cfg) {
 					if errMarkCooldown := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), *decision.retryAfter); errMarkCooldown != nil {
 						err = homeKVUnavailableStatusErr(errMarkCooldown)
@@ -372,6 +375,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 					log.Debugf("antigravity executor: short quota cooldown (%s) for model %s, recorded cooldown", *decision.retryAfter, baseModel)
 				}
 			case antigravity429DecisionFullQuotaExhausted:
+				closeAntigravityAuthIdleTransports(auth)
 				if useCredits && antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) && !antigravityCoolingDisabled(auth, e.cfg) {
 					markAntigravityCreditsPermanentlyDisabled(auth)
 				}

--- a/internal/runtime/executor/antigravity_executor_keepalive_test.go
+++ b/internal/runtime/executor/antigravity_executor_keepalive_test.go
@@ -63,7 +63,15 @@ func TestAntigravityExecuteStreamReusesUpstreamConnection(t *testing.T) {
 	}))
 	defer server.Close()
 
-	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	enabledPool := true
+	exec := NewAntigravityExecutor(&config.Config{
+		RequestRetry: 1,
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledPool,
+			},
+		},
+	})
 	auth := &cliproxyauth.Auth{
 		ID:         "antigravity-keepalive-auth",
 		Provider:   "antigravity",
@@ -135,7 +143,15 @@ func TestAntigravityCountTokensReusesUpstreamConnection(t *testing.T) {
 	}))
 	defer server.Close()
 
-	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	enabledCountPool := true
+	exec := NewAntigravityExecutor(&config.Config{
+		RequestRetry: 1,
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledCountPool,
+			},
+		},
+	})
 	auth := &cliproxyauth.Auth{
 		ID:         "antigravity-counttokens-auth",
 		Provider:   "antigravity",
@@ -198,7 +214,14 @@ func TestAntigravityHTTPRequestReusesUpstreamConnection(t *testing.T) {
 	}))
 	defer server.Close()
 
-	exec := NewAntigravityExecutor(&config.Config{})
+	enabledHTTPPool := true
+	exec := NewAntigravityExecutor(&config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledHTTPPool,
+			},
+		},
+	})
 	auth := &cliproxyauth.Auth{
 		ID:       "antigravity-http-request-auth",
 		Provider: "antigravity",
@@ -339,6 +362,66 @@ func TestAntigravityHTTPRequestConcurrentSessionsStayIsolated(t *testing.T) {
 	for err := range errs {
 		if err != nil {
 			t.Error(err)
+		}
+	}
+}
+
+// TestAntigravityDefaultConfigDisablesPoolingAndClosesConnections verifies that by default
+// (no connection-pool configuration, or enabled: false), connection pooling is disabled.
+// Every request uses a new connection, and the wire request never emits Connection: close.
+func TestAntigravityDefaultConfigDisablesPoolingAndClosesConnections(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	var connectionHeaders []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		connectionHeaders = append(connectionHeaders, r.Header.Get("Connection"))
+		mu.Unlock()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	// Default config has ConnectionPool.Enabled = nil, which defaults to false (disabled)
+	exec := NewAntigravityExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "antigravity-default-short-auth",
+		Provider: "antigravity",
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	const requests = 4
+	for i := 0; i < requests; i++ {
+		req, errRequest := http.NewRequest(http.MethodPost, server.URL, nil)
+		if errRequest != nil {
+			t.Fatalf("request %d: NewRequest() error = %v", i, errRequest)
+		}
+		resp, errDo := exec.HttpRequest(context.Background(), auth, req)
+		if errDo != nil {
+			t.Fatalf("request %d: HttpRequest() error = %v", i, errDo)
+		}
+		_ = resp.Body.Close()
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	headers := append([]string(nil), connectionHeaders...)
+	mu.Unlock()
+
+	// With pooling disabled by default, every request opens a fresh connection
+	if distinct != requests {
+		t.Fatalf("default disabled pool: expected %d distinct connections, got %d", requests, distinct)
+	}
+
+	// Must never leak Connection: close header to upstream
+	for i, h := range headers {
+		if strings.Contains(strings.ToLower(h), "close") {
+			t.Fatalf("request %d leaked Connection: close header: %q", i, h)
 		}
 	}
 }

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -161,6 +161,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 
 			switch decision.kind {
 			case antigravity429DecisionShortCooldownSwitchAuth:
+				closeAntigravityAuthIdleTransports(auth)
 				if decision.retryAfter != nil && *decision.retryAfter > 0 && !antigravityCoolingDisabled(auth, e.cfg) {
 					if errMarkCooldown := markAntigravityShortCooldownRequired(ctx, auth, baseModel, time.Now(), *decision.retryAfter); errMarkCooldown != nil {
 						err = homeKVUnavailableStatusErr(errMarkCooldown)
@@ -169,6 +170,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 					log.Debugf("antigravity executor: short quota cooldown (%s) for model %s recorded", *decision.retryAfter, baseModel)
 				}
 			case antigravity429DecisionFullQuotaExhausted:
+				closeAntigravityAuthIdleTransports(auth)
 				if useCredits && antigravityHasExplicitCreditsBalanceExhaustedReason(bodyBytes) && !antigravityCoolingDisabled(auth, e.cfg) {
 					markAntigravityCreditsPermanentlyDisabled(auth)
 				}

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -142,6 +142,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 
 	sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
 	if httpResp.StatusCode == http.StatusTooManyRequests {
+		closeAntigravityAuthIdleTransports(auth)
 		if retryAfter, parseErr := helps.ParseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {
 			sErr.retryAfter = retryAfter
 		}

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
 func antigravityAuthWithProxy(proxyURL string) *cliproxyauth.Auth {
@@ -40,17 +42,32 @@ func antigravityAuthWithIDAndProxy(id, proxyURL string) *cliproxyauth.Auth {
 // every proxied Antigravity request created a new transport, so no keep-alive connection
 // was ever reused and every request paid a full TCP + TLS handshake.
 func TestNewAntigravityHTTPClientSharesTransport(t *testing.T) {
+	enabled := true
+	poolCfg := func(sdkCfg ...config.SDKConfig) *config.Config {
+		cfg := &config.Config{
+			Antigravity: config.AntigravityConfig{
+				ConnectionPool: config.AntigravityConnectionPoolConfig{
+					Enabled: &enabled,
+				},
+			},
+		}
+		if len(sdkCfg) > 0 {
+			cfg.SDKConfig = sdkCfg[0]
+		}
+		return cfg
+	}
+
 	cases := []struct {
 		name string
 		cfg  *config.Config
 		auth *cliproxyauth.Auth
 	}{
-		{"direct", &config.Config{}, antigravityAuthWithProxy("")},
-		{"auth http proxy", &config.Config{}, antigravityAuthWithProxy("http://127.0.0.1:18080")},
-		{"auth socks5 proxy", &config.Config{}, antigravityAuthWithProxy("socks5://127.0.0.1:18081")},
+		{"direct", poolCfg(), antigravityAuthWithProxy("")},
+		{"auth http proxy", poolCfg(), antigravityAuthWithProxy("http://127.0.0.1:18080")},
+		{"auth socks5 proxy", poolCfg(), antigravityAuthWithProxy("socks5://127.0.0.1:18081")},
 		{
 			"config proxy",
-			&config.Config{SDKConfig: config.SDKConfig{ProxyURL: "http://127.0.0.1:18082"}},
+			poolCfg(config.SDKConfig{ProxyURL: "http://127.0.0.1:18082"}),
 			antigravityAuthWithProxy(""),
 		},
 	}
@@ -80,59 +97,85 @@ func TestNewAntigravityHTTPClientSharesTransport(t *testing.T) {
 			if len(transport.TLSClientConfig.NextProtos) != 0 {
 				t.Fatalf("Antigravity must omit ALPN like the native client, got %v", transport.TLSClientConfig.NextProtos)
 			}
-			// Go's DefaultMaxIdleConnsPerHost of 2 would force concurrent sessions on one
-			// credential to re-handshake. The native Antigravity stack raises it to 100.
-			if transport.MaxIdleConnsPerHost < antigravityMaxIdleConnsPerHost {
-				t.Fatalf("MaxIdleConnsPerHost = %d, want >= %d", transport.MaxIdleConnsPerHost, antigravityMaxIdleConnsPerHost)
+			// Native Antigravity uses DefaultMaxIdleConnsPerHost of 2.
+			if transport.MaxIdleConnsPerHost < antigravityDefaultMaxIdleConnsPerHost {
+				t.Fatalf("MaxIdleConnsPerHost = %d, want >= %d", transport.MaxIdleConnsPerHost, antigravityDefaultMaxIdleConnsPerHost)
 			}
 			if transport.MaxIdleConns > 0 && transport.MaxIdleConns < transport.MaxIdleConnsPerHost {
 				t.Fatalf("MaxIdleConns = %d must not throttle MaxIdleConnsPerHost = %d", transport.MaxIdleConns, transport.MaxIdleConnsPerHost)
 			}
-			if transport.IdleConnTimeout > 0 && transport.IdleConnTimeout < antigravityIdleConnTimeout {
-				t.Fatalf("IdleConnTimeout = %v, want >= %v", transport.IdleConnTimeout, antigravityIdleConnTimeout)
+			if transport.IdleConnTimeout > 0 && transport.IdleConnTimeout < antigravityDefaultIdleConnTimeout {
+				t.Fatalf("IdleConnTimeout = %v, want >= %v", transport.IdleConnTimeout, antigravityDefaultIdleConnTimeout)
+			}
+			if transport.IdleConnTimeout > antigravityMaxAllowedIdleConnTimeout {
+				t.Fatalf("IdleConnTimeout = %v exceeds GFE cutoff %v", transport.IdleConnTimeout, antigravityMaxAllowedIdleConnTimeout)
 			}
 		})
 	}
 }
 
-// TestAntigravityPoolLimitsOnlyWiden guards that an operator-supplied base transport
-// with a larger pool keeps its own settings, and that "unlimited" sentinels are not
-// narrowed into finite limits.
-func TestAntigravityPoolLimitsOnlyWiden(t *testing.T) {
+// TestAntigravityPoolLimitsGuardsDefaultAndGFECutoff guards that Antigravity pool
+// limits defaults to 30s timeout, 2 idle conns per host, and hard-caps idle timeout at 240s
+// when connection pooling is enabled.
+func TestAntigravityPoolLimitsGuardsDefaultAndGFECutoff(t *testing.T) {
+	enabled := true
+	poolCfg := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabled,
+			},
+		},
+	}
+
 	wide := &http.Transport{
 		MaxIdleConns:        512,
 		MaxIdleConnsPerHost: 256,
 		IdleConnTimeout:     time.Hour,
 	}
-	applyAntigravityPoolLimits(wide)
-	if wide.MaxIdleConnsPerHost != 256 || wide.MaxIdleConns != 512 || wide.IdleConnTimeout != time.Hour {
-		t.Fatalf("wider pool settings must be preserved, got perHost=%d total=%d idle=%v",
-			wide.MaxIdleConnsPerHost, wide.MaxIdleConns, wide.IdleConnTimeout)
+	applyAntigravityPoolLimits(wide, poolCfg)
+	// Larger connection limits are kept, but IdleConnTimeout MUST be hard-capped at 240s
+	// to avoid exceeding the Google Frontend (GFE / ESF) 240-second cutoff.
+	if wide.MaxIdleConnsPerHost != 256 || wide.MaxIdleConns != 512 {
+		t.Fatalf("larger connection limits must be preserved, got perHost=%d total=%d",
+			wide.MaxIdleConnsPerHost, wide.MaxIdleConns)
+	}
+	if wide.IdleConnTimeout != antigravityMaxAllowedIdleConnTimeout {
+		t.Fatalf("IdleConnTimeout = %v, want capped at %v", wide.IdleConnTimeout, antigravityMaxAllowedIdleConnTimeout)
 	}
 
-	// Zero means unlimited for both MaxIdleConns and IdleConnTimeout.
+	// Zero idle timeout (unlimited in Go) must be capped to safe default so it doesn't cause GFE RSTs.
 	unlimited := &http.Transport{MaxIdleConns: 0, IdleConnTimeout: 0}
-	applyAntigravityPoolLimits(unlimited)
+	applyAntigravityPoolLimits(unlimited, poolCfg)
 	if unlimited.MaxIdleConns != 0 {
 		t.Fatalf("MaxIdleConns = %d, want 0 (unlimited) to stay unlimited", unlimited.MaxIdleConns)
 	}
-	if unlimited.IdleConnTimeout != 0 {
-		t.Fatalf("IdleConnTimeout = %v, want 0 (never expire) to stay unlimited", unlimited.IdleConnTimeout)
+	if unlimited.IdleConnTimeout != antigravityDefaultIdleConnTimeout {
+		t.Fatalf("IdleConnTimeout = %v, want default %v", unlimited.IdleConnTimeout, antigravityDefaultIdleConnTimeout)
 	}
 
 	// A negative MaxIdleConnsPerHost is how an operator disables idle pooling; Go never
 	// pools a connection in that case, so the intent must survive.
 	disabled := &http.Transport{MaxIdleConnsPerHost: -1}
-	applyAntigravityPoolLimits(disabled)
+	applyAntigravityPoolLimits(disabled, poolCfg)
 	if disabled.MaxIdleConnsPerHost != -1 {
 		t.Fatalf("MaxIdleConnsPerHost = %d, want -1 (pooling disabled) to be preserved", disabled.MaxIdleConnsPerHost)
 	}
 
-	// Go's zero value means DefaultMaxIdleConnsPerHost (2), which must be raised.
+	// Go's zero value defaults to 2 and 30s when enabled.
 	defaulted := &http.Transport{}
-	applyAntigravityPoolLimits(defaulted)
-	if defaulted.MaxIdleConnsPerHost != antigravityMaxIdleConnsPerHost {
-		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", defaulted.MaxIdleConnsPerHost, antigravityMaxIdleConnsPerHost)
+	applyAntigravityPoolLimits(defaulted, poolCfg)
+	if defaulted.MaxIdleConnsPerHost != antigravityDefaultMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", defaulted.MaxIdleConnsPerHost, antigravityDefaultMaxIdleConnsPerHost)
+	}
+	if defaulted.IdleConnTimeout != antigravityDefaultIdleConnTimeout {
+		t.Fatalf("IdleConnTimeout = %v, want %v", defaulted.IdleConnTimeout, antigravityDefaultIdleConnTimeout)
+	}
+
+	// When cfg is nil (or default enabled: false), short mode is applied: MaxIdleConnsPerHost = -1
+	defaultDisabled := &http.Transport{}
+	applyAntigravityPoolLimits(defaultDisabled)
+	if defaultDisabled.MaxIdleConnsPerHost != -1 {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want -1 when pooling is disabled by default", defaultDisabled.MaxIdleConnsPerHost)
 	}
 
 	applyAntigravityPoolLimits(nil) // must not panic
@@ -187,7 +230,17 @@ func TestAntigravityConcurrentRequestsReusePooledConnections(t *testing.T) {
 	defer srv.Close()
 
 	auth := antigravityAuthWithIDAndProxy("concurrent-reuse", "")
-	client := &http.Client{Transport: antigravityHTTP11Transport(auth, http.DefaultTransport.(*http.Transport))}
+	enabledPool := true
+	maxIdle := 100
+	poolCfg := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled:             &enabledPool,
+				MaxIdleConnsPerHost: &maxIdle,
+			},
+		},
+	}
+	client := &http.Client{Transport: antigravityHTTP11Transport(auth, http.DefaultTransport.(*http.Transport), poolCfg)}
 
 	const (
 		waves      = 3
@@ -228,6 +281,70 @@ func TestAntigravityConcurrentRequestsReusePooledConnections(t *testing.T) {
 	if distinct > perWave {
 		t.Fatalf("%d waves of %d concurrent requests opened %d connections, want at most %d (unpooled worst case is %d)",
 			waves, perWave, distinct, perWave, totalConns)
+	}
+}
+
+// TestAntigravityConcurrentRequestsDefaultPoolLimitsToTwo verifies that when pooling is enabled
+// without specifying max-idle-conns-per-host, it defaults to 2 (matching Go's default and official agy).
+func TestAntigravityConcurrentRequestsDefaultPoolLimitsToTwo(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]struct{}{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr] = struct{}{}
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	auth := antigravityAuthWithIDAndProxy("concurrent-default-2", "")
+	enabledPool := true
+	poolCfg := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledPool,
+			},
+		},
+	}
+	client := &http.Client{Transport: antigravityHTTP11Transport(auth, http.DefaultTransport.(*http.Transport), poolCfg)}
+
+	const (
+		waves      = 3
+		perWave    = 8
+		totalConns = waves * perWave
+	)
+	for wave := 0; wave < waves; wave++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(perWave)
+		for i := 0; i < perWave; i++ {
+			go func() {
+				defer wg.Done()
+				<-start
+				resp, errDo := client.Get(srv.URL)
+				if errDo != nil {
+					t.Error(errDo)
+					return
+				}
+				if _, errDrain := io.Copy(io.Discard, resp.Body); errDrain != nil {
+					t.Error(errDrain)
+				}
+				if errClose := resp.Body.Close(); errClose != nil {
+					t.Error(errClose)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	mu.Unlock()
+	// With default limit of 2, only 2 survive each wave, so later waves open new conns: distinct > perWave
+	if distinct <= perWave || distinct > totalConns {
+		t.Fatalf("expected distinct connections between %d and %d for default limit of 2, got %d",
+			perWave+1, totalConns, distinct)
 	}
 }
 
@@ -535,7 +652,14 @@ func TestAntigravityProxiedRequestsReuseOneConnection(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cfg := &config.Config{}
+	enabled := true
+	cfg := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabled,
+			},
+		},
+	}
 	auth := antigravityAuthWithProxy(srv.URL)
 	const requests = 8
 	for i := 0; i < requests; i++ {
@@ -556,5 +680,311 @@ func TestAntigravityProxiedRequestsReuseOneConnection(t *testing.T) {
 	mu.Unlock()
 	if distinct != 1 {
 		t.Fatalf("expected %d requests to share one connection, got %d connections", requests, distinct)
+	}
+}
+
+// TestAntigravityPoolConfigIdleTimeoutCustomAndCap verifies that custom idle-conn-timeout
+// is honored (e.g. 10s, 30s) and hard-capped at 210s when configured higher (e.g. 10m),
+// and that connection pool is disabled by default (enabled: false).
+func TestAntigravityPoolConfigIdleTimeoutCustomAndCap(t *testing.T) {
+	enabledTrue := true
+	enabledFalse := false
+	excessiveMaxIdle := 1000000
+	negativeMaxIdle := -5
+
+	cases := []struct {
+		name        string
+		cfg         *config.Config
+		wantTimeout time.Duration
+		wantShort   bool
+		wantMaxIdle int
+	}{
+		{
+			name:      "default config disables pooling (enabled: false by default)",
+			cfg:       &config.Config{},
+			wantShort: true,
+		},
+		{
+			name: "explicit enabled false activates short mode",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled: &enabledFalse,
+					},
+				},
+			},
+			wantShort: true,
+		},
+		{
+			name: "enabled true defaults to 30s",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled: &enabledTrue,
+					},
+				},
+			},
+			wantTimeout: 30 * time.Second,
+		},
+		{
+			name: "enabled true with custom 15s via connection-pool struct",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "15s",
+					},
+				},
+			},
+			wantTimeout: 15 * time.Second,
+		},
+		{
+			name: "enabled true with custom 45s via connection-pool struct",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "45s",
+					},
+				},
+			},
+			wantTimeout: 45 * time.Second,
+		},
+		{
+			name: "enabled true with 10m timeout hard-capped at 210s GFE cutoff",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "10m",
+					},
+				},
+			},
+			wantTimeout: 210 * time.Second,
+		},
+		{
+			name: "enabled true with 500s timeout hard-capped at 210s GFE cutoff",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "500s",
+					},
+				},
+			},
+			wantTimeout: 210 * time.Second,
+		},
+		{
+			name: "enabled true with 0s timeout activates short mode",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "0s",
+					},
+				},
+			},
+			wantShort: true,
+		},
+		{
+			name: "enabled true with invalid timeout string falls back to 30s default",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:         &enabledTrue,
+						IdleConnTimeout: "invalid-timeout",
+					},
+				},
+			},
+			wantTimeout: 30 * time.Second,
+		},
+		{
+			name: "enabled true with negative max-idle activates short mode",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:             &enabledTrue,
+						MaxIdleConnsPerHost: &negativeMaxIdle,
+					},
+				},
+			},
+			wantShort: true,
+		},
+		{
+			name: "enabled true with excessive max-idle capped at 100",
+			cfg: &config.Config{
+				Antigravity: config.AntigravityConfig{
+					ConnectionPool: config.AntigravityConnectionPoolConfig{
+						Enabled:             &enabledTrue,
+						MaxIdleConnsPerHost: &excessiveMaxIdle,
+					},
+				},
+			},
+			wantTimeout: 30 * time.Second,
+			wantMaxIdle: 100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := antigravityAuthWithIDAndProxy("cfg-test-"+tc.name, "")
+			client := newAntigravityHTTPClient(context.Background(), tc.cfg, auth, 0)
+			transport, ok := client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("expected *http.Transport, got %T", client.Transport)
+			}
+			if tc.wantShort {
+				if transport.MaxIdleConnsPerHost != -1 {
+					t.Fatalf("MaxIdleConnsPerHost = %d, want -1 for short mode", transport.MaxIdleConnsPerHost)
+				}
+				if transport.DisableKeepAlives {
+					t.Fatal("DisableKeepAlives must be false to avoid adding Connection: close header")
+				}
+			} else {
+				if transport.IdleConnTimeout != tc.wantTimeout {
+					t.Fatalf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, tc.wantTimeout)
+				}
+				if tc.wantMaxIdle > 0 && transport.MaxIdleConnsPerHost != tc.wantMaxIdle {
+					t.Fatalf("MaxIdleConnsPerHost = %d, want %d", transport.MaxIdleConnsPerHost, tc.wantMaxIdle)
+				}
+			}
+		})
+	}
+}
+
+// TestAntigravityShortModeNeverAdvertisesConnectionCloseAndDisconnects verifies that
+// in short mode (MaxIdleConnsPerHost=-1), repeated requests do not reuse connections,
+// but the HTTP wire request never leaks "Connection: close".
+func TestAntigravityShortModeNeverAdvertisesConnectionCloseAndDisconnects(t *testing.T) {
+	var mu sync.Mutex
+	remotes := map[string]int{}
+	var connectionHeaders []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		remotes[r.RemoteAddr]++
+		connectionHeaders = append(connectionHeaders, r.Header.Get("Connection"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	auth := antigravityAuthWithProxy(srv.URL)
+
+	const requests = 4
+	for i := 0; i < requests; i++ {
+		client := newAntigravityHTTPClient(context.Background(), cfg, auth, 0)
+		req, errReq := http.NewRequest(http.MethodGet, "http://antigravity.invalid/v1internal:streamGenerateContent", nil)
+		if errReq != nil {
+			t.Fatalf("NewRequest() error = %v", errReq)
+		}
+		resp, errDo := client.Do(req)
+		if errDo != nil {
+			t.Fatalf("request %d error = %v", i, errDo)
+		}
+		_ = resp.Body.Close()
+	}
+
+	mu.Lock()
+	distinct := len(remotes)
+	headers := append([]string(nil), connectionHeaders...)
+	mu.Unlock()
+
+	// In short mode, every request should use a fresh connection
+	if distinct != requests {
+		t.Fatalf("short mode: expected %d distinct connections, got %d", requests, distinct)
+	}
+	// Crucial: wire request must not leak "Connection: close"
+	for i, h := range headers {
+		if strings.Contains(strings.ToLower(h), "close") {
+			t.Fatalf("request %d leaked Connection: close header: %q", i, h)
+		}
+	}
+}
+
+// TestCloseAntigravityAuthIdleTransportsEvictsIdlePool verifies that calling
+// closeAntigravityAuthIdleTransports cleans up cached transports for that auth.
+func TestCloseAntigravityAuthIdleTransportsEvictsIdlePool(t *testing.T) {
+	auth := antigravityAuthWithIDAndProxy("auth-to-close", "")
+	cfg := &config.Config{}
+
+	client := newAntigravityHTTPClient(context.Background(), cfg, auth, 0)
+	if client.Transport == nil {
+		t.Fatal("expected transport to be initialized")
+	}
+
+	scope := antigravityTransportScope(auth)
+	key := antigravityTransportKey{credential: scope, base: antigravityBaseTransport}
+
+	// Verify it's cached
+	if !antigravityTransports.Contains(key) {
+		t.Fatal("expected transport to be in cache")
+	}
+
+	// Trigger close
+	closeAntigravityAuthIdleTransports(auth)
+
+	// Verify it's removed from cache
+	if antigravityTransports.Contains(key) {
+		t.Fatal("expected transport to be removed from cache after closeAntigravityAuthIdleTransports")
+	}
+}
+
+// TestAntigravityCountTokens429EvictsIdleTransports verifies that a 429 during count_tokens
+// evicts cached transports for that auth.
+func TestAntigravityCountTokens429EvictsIdleTransports(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}`))
+	}))
+	defer srv.Close()
+
+	auth := &cliproxyauth.Auth{
+		ID:         "auth-tokens-429-evict",
+		Provider:   "antigravity",
+		Attributes: map[string]string{"base_url": srv.URL},
+		Metadata: map[string]any{
+			"access_token": "token",
+			"project_id":   "project-1",
+			"expired":      time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	enabledPool := true
+	cfg := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledPool,
+			},
+		},
+	}
+	exec := NewAntigravityExecutor(cfg)
+
+	// Build client to populate cache
+	client := newAntigravityHTTPClient(context.Background(), cfg, auth, 0)
+	if client.Transport == nil {
+		t.Fatal("expected transport to be initialized")
+	}
+
+	scope := antigravityTransportScope(auth)
+	key := antigravityTransportKey{credential: scope, base: antigravityBaseTransport}
+	if !antigravityTransports.Contains(key) {
+		t.Fatal("expected transport to be in cache before count_tokens")
+	}
+
+	// Trigger CountTokens which returns 429
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	_, _ = exec.CountTokens(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-3.6-flash-high",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	})
+
+	// Verify transport is evicted
+	if antigravityTransports.Contains(key) {
+		t.Fatal("expected transport to be evicted after 429 in CountTokens")
 	}
 }

--- a/internal/runtime/executor/helps/transport_cache.go
+++ b/internal/runtime/executor/helps/transport_cache.go
@@ -63,41 +63,60 @@ func (c *TransportCache[K]) Get(key K, build func() (*http.Transport, error)) (*
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if element, ok := c.items[key]; ok {
 		c.order.MoveToFront(element)
-		return element.Value.(*transportCacheEntry[K]).transport, nil
+		transport := element.Value.(*transportCacheEntry[K]).transport
+		c.mu.Unlock()
+		return transport, nil
 	}
 
 	transport, errBuild := build()
 	if errBuild != nil {
+		c.mu.Unlock()
 		return nil, errBuild
 	}
 	if transport == nil {
+		c.mu.Unlock()
 		return nil, errors.New("transport cache: build returned no transport")
 	}
 
+	// Double check in case key was populated while build was running
+	if element, ok := c.items[key]; ok {
+		c.order.MoveToFront(element)
+		existing := element.Value.(*transportCacheEntry[K]).transport
+		c.mu.Unlock()
+		transport.CloseIdleConnections()
+		return existing, nil
+	}
+
 	c.items[key] = c.order.PushFront(&transportCacheEntry[K]{key: key, transport: transport})
-	c.evictLocked()
+	evicted := c.evictLocked()
+	c.mu.Unlock()
+
+	for _, t := range evicted {
+		t.CloseIdleConnections()
+	}
 	return transport, nil
 }
 
-// evictLocked drops least recently used entries until the cache fits its capacity.
+// evictLocked drops least recently used entries until the cache fits its capacity,
+// returning a slice of evicted transports to be closed outside the lock.
 // Closing idle connections is what actually releases the evicted pool; in-flight
 // requests still holding the transport are unaffected because CloseIdleConnections
 // only reaps connections that are currently idle.
-func (c *TransportCache[K]) evictLocked() {
+func (c *TransportCache[K]) evictLocked() []*http.Transport {
+	var evicted []*http.Transport
 	for c.order.Len() > c.capacity {
 		oldest := c.order.Back()
 		if oldest == nil {
-			return
+			break
 		}
 		c.order.Remove(oldest)
 		entry := oldest.Value.(*transportCacheEntry[K])
 		delete(c.items, entry.key)
-		entry.transport.CloseIdleConnections()
+		evicted = append(evicted, entry.transport)
 	}
+	return evicted
 }
 
 // Len reports how many transports the cache currently holds.
@@ -110,16 +129,79 @@ func (c *TransportCache[K]) Len() int {
 	return c.order.Len()
 }
 
+// Contains reports whether key exists in the cache.
+func (c *TransportCache[K]) Contains(key K) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.items[key]
+	return ok
+}
+
+// CloseKey removes the transport cached under key (if present) and closes its idle connections.
+// Returns true if the entry was found and closed.
+func (c *TransportCache[K]) CloseKey(key K) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	element, ok := c.items[key]
+	if !ok {
+		c.mu.Unlock()
+		return false
+	}
+	c.order.Remove(element)
+	delete(c.items, key)
+	transport := element.Value.(*transportCacheEntry[K]).transport
+	c.mu.Unlock()
+
+	transport.CloseIdleConnections()
+	return true
+}
+
+// CloseMatching removes and closes idle connections for every cached transport whose key
+// satisfies predicate. Returns the number of closed transports.
+func (c *TransportCache[K]) CloseMatching(predicate func(key K) bool) int {
+	if c == nil || predicate == nil {
+		return 0
+	}
+	c.mu.Lock()
+	var toClose []*http.Transport
+	var next *list.Element
+	for element := c.order.Front(); element != nil; element = next {
+		next = element.Next()
+		entry := element.Value.(*transportCacheEntry[K])
+		if predicate(entry.key) {
+			c.order.Remove(element)
+			delete(c.items, entry.key)
+			toClose = append(toClose, entry.transport)
+		}
+	}
+	c.mu.Unlock()
+
+	for _, t := range toClose {
+		t.CloseIdleConnections()
+	}
+	return len(toClose)
+}
+
 // Purge drops every entry and closes the idle connections it was holding.
 func (c *TransportCache[K]) Purge() {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	var toClose []*http.Transport
 	for element := c.order.Front(); element != nil; element = element.Next() {
-		element.Value.(*transportCacheEntry[K]).transport.CloseIdleConnections()
+		toClose = append(toClose, element.Value.(*transportCacheEntry[K]).transport)
 	}
 	c.order.Init()
 	c.items = make(map[K]*list.Element, c.capacity)
+	c.mu.Unlock()
+
+	for _, t := range toClose {
+		t.CloseIdleConnections()
+	}
 }

--- a/internal/runtime/executor/helps/transport_cache_test.go
+++ b/internal/runtime/executor/helps/transport_cache_test.go
@@ -3,6 +3,7 @@ package helps
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 )
@@ -168,5 +169,94 @@ func TestNewTransportCacheDefaultsCapacity(t *testing.T) {
 		if cache.capacity != DefaultTransportCacheCapacity {
 			t.Fatalf("NewTransportCache(%d).capacity = %d, want %d", capacity, cache.capacity, DefaultTransportCacheCapacity)
 		}
+	}
+}
+
+func TestTransportCacheCloseKeyAndCloseMatching(t *testing.T) {
+	cache := NewTransportCache[cacheKey](8)
+	build := func() (*http.Transport, error) { return &http.Transport{}, nil }
+
+	cache.Get(cacheKey{"auth-1", "p1"}, build)
+	cache.Get(cacheKey{"auth-1", "p2"}, build)
+	cache.Get(cacheKey{"auth-2", "p1"}, build)
+	if got := cache.Len(); got != 3 {
+		t.Fatalf("Len() = %d, want 3", got)
+	}
+
+	// Close non-existent key
+	if closed := cache.CloseKey(cacheKey{"auth-nonexistent", ""}); closed {
+		t.Fatal("expected CloseKey on missing entry to return false")
+	}
+
+	// Close specific key
+	if closed := cache.CloseKey(cacheKey{"auth-2", "p1"}); !closed {
+		t.Fatal("expected CloseKey on existing entry to return true")
+	}
+	if got := cache.Len(); got != 2 {
+		t.Fatalf("Len() after CloseKey = %d, want 2", got)
+	}
+
+	// Close matching all auth-1
+	closedCount := cache.CloseMatching(func(key cacheKey) bool {
+		return key.scope == "auth-1"
+	})
+	if closedCount != 2 {
+		t.Fatalf("CloseMatching closed %d entries, want 2", closedCount)
+	}
+	if got := cache.Len(); got != 0 {
+		t.Fatalf("Len() after CloseMatching = %d, want 0", got)
+	}
+
+	// Nil cache safety
+	var nilCache *TransportCache[cacheKey]
+	if nilCache.CloseKey(cacheKey{}) {
+		t.Fatal("expected CloseKey on nil cache to return false")
+	}
+	if nilCache.CloseMatching(func(cacheKey) bool { return true }) != 0 {
+		t.Fatal("expected CloseMatching on nil cache to return 0")
+	}
+}
+
+func TestTransportCacheEvictionClosesIdleConnections(t *testing.T) {
+	cache := NewTransportCache[cacheKey](2)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	build := func() (*http.Transport, error) {
+		return &http.Transport{}, nil
+	}
+
+	// Fill 2 entries
+	t1, err1 := cache.Get(cacheKey{"auth-1", ""}, build)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	_, err2 := cache.Get(cacheKey{"auth-2", ""}, build)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+
+	// Make request with t1 to establish an idle connection
+	c1 := &http.Client{Transport: t1}
+	resp, errReq := c1.Get(srv.URL)
+	if errReq != nil {
+		t.Fatal(errReq)
+	}
+	_ = resp.Body.Close()
+
+	// Push 3rd entry: t1 should be evicted and its idle connections closed
+	_, err3 := cache.Get(cacheKey{"auth-3", ""}, build)
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+
+	if cache.Contains(cacheKey{"auth-1", ""}) {
+		t.Fatal("expected auth-1 to be evicted from cache")
+	}
+	if !cache.Contains(cacheKey{"auth-2", ""}) || !cache.Contains(cacheKey{"auth-3", ""}) {
+		t.Fatal("expected auth-2 and auth-3 to remain in cache")
 	}
 }

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -108,6 +108,31 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if !reflect.DeepEqual(oldCfg.Antigravity.SensitiveWords, newCfg.Antigravity.SensitiveWords) {
 		changes = append(changes, fmt.Sprintf("antigravity.sensitive-words: %d -> %d", len(oldCfg.Antigravity.SensitiveWords), len(newCfg.Antigravity.SensitiveWords)))
 	}
+	oldEnabled := "<nil>"
+	if oldCfg.Antigravity.ConnectionPool.Enabled != nil {
+		oldEnabled = fmt.Sprintf("%t", *oldCfg.Antigravity.ConnectionPool.Enabled)
+	}
+	newEnabled := "<nil>"
+	if newCfg.Antigravity.ConnectionPool.Enabled != nil {
+		newEnabled = fmt.Sprintf("%t", *newCfg.Antigravity.ConnectionPool.Enabled)
+	}
+	if oldEnabled != newEnabled {
+		changes = append(changes, fmt.Sprintf("antigravity.connection-pool.enabled: %s -> %s", oldEnabled, newEnabled))
+	}
+	if oldCfg.Antigravity.ConnectionPool.IdleConnTimeout != newCfg.Antigravity.ConnectionPool.IdleConnTimeout {
+		changes = append(changes, fmt.Sprintf("antigravity.connection-pool.idle-conn-timeout: %q -> %q", oldCfg.Antigravity.ConnectionPool.IdleConnTimeout, newCfg.Antigravity.ConnectionPool.IdleConnTimeout))
+	}
+	oldMaxIdle := "<nil>"
+	if oldCfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost != nil {
+		oldMaxIdle = fmt.Sprintf("%d", *oldCfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost)
+	}
+	newMaxIdle := "<nil>"
+	if newCfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost != nil {
+		newMaxIdle = fmt.Sprintf("%d", *newCfg.Antigravity.ConnectionPool.MaxIdleConnsPerHost)
+	}
+	if oldMaxIdle != newMaxIdle {
+		changes = append(changes, fmt.Sprintf("antigravity.connection-pool.max-idle-conns-per-host: %s -> %s", oldMaxIdle, newMaxIdle))
+	}
 
 	if oldCfg.Codex.IdentityConfuse != newCfg.Codex.IdentityConfuse {
 		changes = append(changes, fmt.Sprintf("codex.identity-confuse: %t -> %t", oldCfg.Codex.IdentityConfuse, newCfg.Codex.IdentityConfuse))

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -338,6 +338,8 @@ func TestBuildConfigChangeDetails_RedactsEndpointURLs(t *testing.T) {
 }
 
 func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
+	oldPoolEnabled := false
+	newPoolEnabled := true
 	oldCfg := &config.Config{
 		Port:                          1000,
 		AuthDir:                       "/old",
@@ -352,10 +354,16 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		MaxRetryInterval:              1,
 		WebsocketAuth:                 false,
 		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: false, SwitchPreviewModel: false, AntigravityCredits: false},
-		Antigravity:                   config.AntigravityConfig{SensitiveWords: []string{"old-word"}},
-		ClaudeKey:                     []config.ClaudeKey{{APIKey: "c1"}},
-		CodexKey:                      []config.CodexKey{{APIKey: "x1"}},
-		RemoteManagement:              config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
+		Antigravity: config.AntigravityConfig{
+			SensitiveWords: []string{"old-word"},
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled:         &oldPoolEnabled,
+				IdleConnTimeout: "30s",
+			},
+		},
+		ClaudeKey:        []config.ClaudeKey{{APIKey: "c1"}},
+		CodexKey:         []config.CodexKey{{APIKey: "x1"}},
+		RemoteManagement: config.RemoteManagement{DisableControlPanel: false, PanelGitHubRepository: "old/repo", SecretKey: "keep"},
 		SDKConfig: sdkconfig.SDKConfig{
 			RequestLog:                 false,
 			ProxyURL:                   "http://old-proxy",
@@ -378,8 +386,14 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 		MaxRetryInterval:              3,
 		WebsocketAuth:                 true,
 		QuotaExceeded:                 config.QuotaExceeded{SwitchProject: true, SwitchPreviewModel: true, AntigravityCredits: true},
-		Antigravity:                   config.AntigravityConfig{SensitiveWords: []string{"new-word-1", "new-word-2"}},
-		XAI:                           config.XAIConfig{InjectXSearch: true},
+		Antigravity: config.AntigravityConfig{
+			SensitiveWords: []string{"new-word-1", "new-word-2"},
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled:         &newPoolEnabled,
+				IdleConnTimeout: "10s",
+			},
+		},
+		XAI: config.XAIConfig{InjectXSearch: true},
 		ClaudeKey: []config.ClaudeKey{
 			{APIKey: "c1", BaseURL: "http://new", ProxyURL: "http://p", Headers: map[string]string{"H": "1"}, ExcludedModels: []string{"a"}},
 			{APIKey: "c2"},
@@ -428,6 +442,8 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "quota-exceeded.switch-preview-model: false -> true")
 	expectContains(t, details, "quota-exceeded.antigravity-credits: false -> true")
 	expectContains(t, details, "antigravity.sensitive-words: 1 -> 2")
+	expectContains(t, details, "antigravity.connection-pool.enabled: false -> true")
+	expectContains(t, details, `antigravity.connection-pool.idle-conn-timeout: "30s" -> "10s"`)
 	expectContains(t, details, "xai.inject-x-search: false -> true")
 	expectContains(t, details, "api-keys count: 1 -> 2")
 	expectContains(t, details, "claude-api-key count: 1 -> 2")


### PR DESCRIPTION
## Summary
Fixes #5494.

In environments rotating across multiple Antigravity credentials (e.g., 30+ accounts), thousands of idle TCP connections accumulated on proxy servers. Because previous commits (`c33a33e14` and `516ec3a00`) unilaterally expanded connection pool settings (`MaxIdleConnsPerHost = 100`, `IdleConnTimeout = 10m`), rotating credentials retained idle connections until Google Frontend (GFE 4 / ESF) quietly closed them with a TCP `FIN` after exactly 240.0s. Subsequent requests reusing these half-closed connections failed with `connection reset by peer` or `unexpected EOF`, triggering cascading failover storms and proxy socket exhaustion.

This PR re-architects Antigravity connection management to default to **short-lived connections** (zero idle sockets accumulated on rotation) while providing a hardened, bounded connection pool for operators who explicitly opt in.

## Changes
1. **Configuration Schema (`antigravity.connection-pool`)**:
   ```yaml
   antigravity:
     connection-pool:
       enabled: false             # default: false (short mode; set to true to enable pooling)
       idle-conn-timeout: "30s"   # default: 30s, capped at 210s
       max-idle-conns-per-host: 2 # default: 2 (matches Go DefaultMaxIdleConnsPerHost & native agy)
   ```
   - Defaults to `enabled: false`. In multi-credential gateways, connection reuse across rotated credentials is statistically zero; short mode eliminates idle socket buildup completely.
   - Clean boolean schema with zero ambiguity.

2. **Wire Fingerprint Preservation**:
   - Short mode is implemented via `MaxIdleConnsPerHost = -1` while maintaining `DisableKeepAlives = false`.
   - Go's `net/http` transport closes the connection immediately upon response body completion via TCP `FIN` without advertising `Connection: close` in outbound HTTP request headers, maintaining 100% parity with native Antigravity CLI (`agy`) wire fingerprints.

3. **GFE 240s Keep-Alive Safety Hard-Cap**:
   - When pooling is explicitly enabled (`enabled: true`), `idle-conn-timeout` is hard-capped at **210s** (`antigravityMaxAllowedIdleConnTimeout = 210 * time.Second`).
   - A 30-second safety margin below GFE's strict 240.0s idle cutoff eliminates timer skew and network race conditions where clients attempt to reuse connections concurrently severed by Google.
   - Defaults to a gentle 30s timeout and 2 conns/host (matches Go's default and native binary). Bounded at `max-idle-conns-per-host <= 100` to prevent unbounded socket expansion.

4. **Two-Phase Lock-Free Resource Eviction (`TransportCache`)**:
   - Refactored `evictLocked`, `CloseKey`, `CloseMatching`, and `Purge` in `helps.TransportCache` into two phases:
     - Phase 1 (inside mutex): Pure in-memory unlinking and slice collection (nanosecond-level).
     - Phase 2 (outside mutex): Asynchronously/iteratively close idle connections via `CloseIdleConnections()`, eliminating lock contention and I/O syscalls while holding cache locks.
   - Added double-checked locking in `Get` to safely discard redundant builds during concurrent cache misses.

5. **Proactive Quota & Error Eviction**:
   - Hooked `closeAntigravityAuthIdleTransports(auth)` into `Execute` (Unary & Claude), `ExecuteStream` (SSE Stream), and `CountTokens` on 429 quota exhaustion (`FullQuotaExhausted`) and short cooldowns (`ShortCooldownSwitchAuth`).
   - Sockets belonging to exhausted or cooling credentials are immediately released rather than lingering in the proxy.

6. **Hot-Reload Support**:
   - Track `antigravity.connection-pool` diffs in `internal/watcher/diff/config_diff.go`.
   - Server reloads trigger `executor.ResetAntigravityTransports()`, which purges the cache and closes old idle connections gracefully without disrupting in-flight requests.

## Verification
- `go build -ldflags="-s -w" -o /dev/null ./cmd/server` passed.
- `go test -count=1 ./internal/config/... ./internal/watcher/diff/... ./internal/runtime/executor/... ./internal/runtime/executor/helps/...` passed cleanly.
- `go test -race -count=1 ./internal/runtime/executor/helps ./internal/runtime/executor` passed with 0 data races.
- Wire verification (`TestAntigravityShortModeNeverAdvertisesConnectionCloseAndDisconnects` and `TestAntigravityDefaultConfigDisablesPoolingAndClosesConnections`) confirmed zero `Connection: close` header leakage.
- End-to-end hot reload test (`TestUpdateClientsContext_AntigravityConnectionPoolPurgesTransports`) verified cache pre-population and post-reload zero-drain.