### PR TITLE
perf(codex): rebuild identity-confuse body once

### DIFF
--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -3,10 +3,8 @@ package executor
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -158,126 +156,40 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	return httpReq, rawJSON, identityState, nil
 }
 
-type jsonStringField struct {
-	path  string
-	value string
-}
-
 func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, userPayload []byte, rawJSON []byte) ([]byte, codexIdentityConfuseState) {
 	if !codexIdentityConfuseEnabled(cfg) || auth == nil || strings.TrimSpace(auth.ID) == "" || len(rawJSON) == 0 {
 		return rawJSON, codexIdentityConfuseState{}
 	}
 
 	state := codexIdentityConfuseState{enabled: true, authID: strings.TrimSpace(auth.ID)}
-	var fields []jsonStringField
+	var fields []helps.JSONStringField
 	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(userPayload, "prompt_cache_key").String()); promptCacheKey != "" {
 		state.originalPromptCacheKey = promptCacheKey
 		state.promptCacheKey = codexIdentityConfuseUUID(auth.ID, "prompt-cache", promptCacheKey)
-		fields = append(fields, jsonStringField{path: "prompt_cache_key", value: state.promptCacheKey})
+		fields = append(fields, helps.JSONStringField{Path: "prompt_cache_key", Value: state.promptCacheKey})
 	}
 	if installationID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-installation-id").String()); installationID != "" {
-		fields = append(fields, jsonStringField{
-			path:  "client_metadata.x-codex-installation-id",
-			value: codexIdentityConfuseUUID(auth.ID, "installation", installationID),
+		fields = append(fields, helps.JSONStringField{
+			Path:  "client_metadata.x-codex-installation-id",
+			Value: codexIdentityConfuseUUID(auth.ID, "installation", installationID),
 		})
 	}
 	if turnMetadata := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
-		fields = append(fields, jsonStringField{
-			path:  "client_metadata.x-codex-turn-metadata",
-			value: applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state),
+		fields = append(fields, helps.JSONStringField{
+			Path:  "client_metadata.x-codex-turn-metadata",
+			Value: applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state),
 		})
 	}
 	if state.promptCacheKey != "" {
 		if windowID := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-window-id").String()); windowID != "" {
-			fields = append(fields, jsonStringField{
-				path:  "client_metadata.x-codex-window-id",
-				value: state.promptCacheKey + ":0",
+			fields = append(fields, helps.JSONStringField{
+				Path:  "client_metadata.x-codex-window-id",
+				Value: state.promptCacheKey + ":0",
 			})
 		}
 	}
 
-	return replaceJSONStringFields(rawJSON, fields), state
-}
-
-func replaceJSONStringFields(payload []byte, fields []jsonStringField) []byte {
-	if len(payload) == 0 || len(fields) == 0 {
-		return payload
-	}
-
-	type replacement struct {
-		index int
-		oldN  int
-		neu   []byte
-	}
-	replacements := make([]replacement, 0, len(fields))
-	var missing []jsonStringField
-	extra := 0
-	for _, field := range fields {
-		if field.path == "" {
-			continue
-		}
-		current := gjson.GetBytes(payload, field.path)
-		if !current.Exists() || current.Index <= 0 {
-			missing = append(missing, field)
-			continue
-		}
-		encoded, errMarshal := json.Marshal(field.value)
-		if errMarshal != nil {
-			missing = append(missing, field)
-			continue
-		}
-		if current.Raw == string(encoded) {
-			continue
-		}
-		replacements = append(replacements, replacement{
-			index: current.Index,
-			oldN:  len(current.Raw),
-			neu:   encoded,
-		})
-		extra += len(encoded) - len(current.Raw)
-	}
-	if extra < 0 {
-		extra = 0
-	}
-
-	out := payload
-	if len(replacements) > 0 {
-		sort.Slice(replacements, func(i, j int) bool {
-			return replacements[i].index < replacements[j].index
-		})
-		buf := make([]byte, 0, len(payload)+extra)
-		last := 0
-		for _, item := range replacements {
-			if item.index < last || item.index+item.oldN > len(payload) {
-				return fallbackSetJSONStringFields(payload, fields)
-			}
-			buf = append(buf, payload[last:item.index]...)
-			buf = append(buf, item.neu...)
-			last = item.index + item.oldN
-		}
-		buf = append(buf, payload[last:]...)
-		out = buf
-	}
-	for _, field := range missing {
-		updated, errSet := sjson.SetBytes(out, field.path, field.value)
-		if errSet != nil {
-			continue
-		}
-		out = updated
-	}
-	return out
-}
-
-func fallbackSetJSONStringFields(payload []byte, fields []jsonStringField) []byte {
-	out := payload
-	for _, field := range fields {
-		updated, errSet := sjson.SetBytes(out, field.path, field.value)
-		if errSet != nil {
-			continue
-		}
-		out = updated
-	}
-	return out
+	return helps.ReplaceJSONStringFields(rawJSON, fields), state
 }
 
 func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityConfuseState) {

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -3,8 +3,10 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -156,30 +158,126 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	return httpReq, rawJSON, identityState, nil
 }
 
+type jsonStringField struct {
+	path  string
+	value string
+}
+
 func applyCodexIdentityConfuseBody(cfg *config.Config, auth *cliproxyauth.Auth, userPayload []byte, rawJSON []byte) ([]byte, codexIdentityConfuseState) {
 	if !codexIdentityConfuseEnabled(cfg) || auth == nil || strings.TrimSpace(auth.ID) == "" || len(rawJSON) == 0 {
 		return rawJSON, codexIdentityConfuseState{}
 	}
 
 	state := codexIdentityConfuseState{enabled: true, authID: strings.TrimSpace(auth.ID)}
+	var fields []jsonStringField
 	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(userPayload, "prompt_cache_key").String()); promptCacheKey != "" {
 		state.originalPromptCacheKey = promptCacheKey
 		state.promptCacheKey = codexIdentityConfuseUUID(auth.ID, "prompt-cache", promptCacheKey)
-		rawJSON = helps.SetStringIfDifferent(rawJSON, "prompt_cache_key", state.promptCacheKey)
+		fields = append(fields, jsonStringField{path: "prompt_cache_key", value: state.promptCacheKey})
 	}
 	if installationID := strings.TrimSpace(gjson.GetBytes(userPayload, "client_metadata.x-codex-installation-id").String()); installationID != "" {
-		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-installation-id", codexIdentityConfuseUUID(auth.ID, "installation", installationID))
+		fields = append(fields, jsonStringField{
+			path:  "client_metadata.x-codex-installation-id",
+			value: codexIdentityConfuseUUID(auth.ID, "installation", installationID),
+		})
 	}
 	if turnMetadata := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
-		rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-turn-metadata", applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state))
+		fields = append(fields, jsonStringField{
+			path:  "client_metadata.x-codex-turn-metadata",
+			value: applyCodexTurnMetadataIdentityConfuse(turnMetadata, &state),
+		})
 	}
 	if state.promptCacheKey != "" {
 		if windowID := strings.TrimSpace(gjson.GetBytes(rawJSON, "client_metadata.x-codex-window-id").String()); windowID != "" {
-			rawJSON, _ = sjson.SetBytes(rawJSON, "client_metadata.x-codex-window-id", state.promptCacheKey+":0")
+			fields = append(fields, jsonStringField{
+				path:  "client_metadata.x-codex-window-id",
+				value: state.promptCacheKey + ":0",
+			})
 		}
 	}
 
-	return rawJSON, state
+	return replaceJSONStringFields(rawJSON, fields), state
+}
+
+func replaceJSONStringFields(payload []byte, fields []jsonStringField) []byte {
+	if len(payload) == 0 || len(fields) == 0 {
+		return payload
+	}
+
+	type replacement struct {
+		index int
+		oldN  int
+		neu   []byte
+	}
+	replacements := make([]replacement, 0, len(fields))
+	var missing []jsonStringField
+	extra := 0
+	for _, field := range fields {
+		if field.path == "" {
+			continue
+		}
+		current := gjson.GetBytes(payload, field.path)
+		if !current.Exists() || current.Index <= 0 {
+			missing = append(missing, field)
+			continue
+		}
+		encoded, errMarshal := json.Marshal(field.value)
+		if errMarshal != nil {
+			missing = append(missing, field)
+			continue
+		}
+		if current.Raw == string(encoded) {
+			continue
+		}
+		replacements = append(replacements, replacement{
+			index: current.Index,
+			oldN:  len(current.Raw),
+			neu:   encoded,
+		})
+		extra += len(encoded) - len(current.Raw)
+	}
+	if extra < 0 {
+		extra = 0
+	}
+
+	out := payload
+	if len(replacements) > 0 {
+		sort.Slice(replacements, func(i, j int) bool {
+			return replacements[i].index < replacements[j].index
+		})
+		buf := make([]byte, 0, len(payload)+extra)
+		last := 0
+		for _, item := range replacements {
+			if item.index < last || item.index+item.oldN > len(payload) {
+				return fallbackSetJSONStringFields(payload, fields)
+			}
+			buf = append(buf, payload[last:item.index]...)
+			buf = append(buf, item.neu...)
+			last = item.index + item.oldN
+		}
+		buf = append(buf, payload[last:]...)
+		out = buf
+	}
+	for _, field := range missing {
+		updated, errSet := sjson.SetBytes(out, field.path, field.value)
+		if errSet != nil {
+			continue
+		}
+		out = updated
+	}
+	return out
+}
+
+func fallbackSetJSONStringFields(payload []byte, fields []jsonStringField) []byte {
+	out := payload
+	for _, field := range fields {
+		updated, errSet := sjson.SetBytes(out, field.path, field.value)
+		if errSet != nil {
+			continue
+		}
+		out = updated
+	}
+	return out
 }
 
 func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityConfuseState) {

--- a/internal/runtime/executor/codex_identity_confuse_alloc_test.go
+++ b/internal/runtime/executor/codex_identity_confuse_alloc_test.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestApplyCodexIdentityConfuseBodyDoesNotCopyEntireDocumentPerField(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocation budget")
+	}
+
+	const transcriptSize = 2 << 20
+	body := largeCodexIdentityBody(transcriptSize)
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{SessionAffinity: true},
+		Codex:   config.CodexConfig{IdentityConfuse: true},
+	}
+	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex"}
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.SetBytes(int64(len(body)))
+		b.ReportAllocs()
+		for b.Loop() {
+			updated, _ := applyCodexIdentityConfuseBody(cfg, auth, body, body)
+			if len(updated) < transcriptSize {
+				b.Fatalf("confused body too small: %d", len(updated))
+			}
+		}
+	})
+
+	// One rewritten document is expected. Four sjson.SetBytes calls on a 2MiB
+	// payload (prompt_cache_key, installation-id, turn-metadata, window-id)
+	// were the live heap in production pprof (sjson.appendRawPaths).
+	maxAllocated := int64(len(body)) * 2
+	t.Logf("identity confuse allocated %d bytes per op for %d input bytes (%.2fx)", result.AllocedBytesPerOp(), len(body), float64(result.AllocedBytesPerOp())/float64(len(body)))
+	if allocated := result.AllocedBytesPerOp(); allocated > maxAllocated {
+		t.Fatalf("applyCodexIdentityConfuseBody allocated %d bytes for a %d-byte body (want <= %d). Each sjson.SetBytes copies the whole document.", allocated, len(body), maxAllocated)
+	}
+}
+
+func largeCodexIdentityBody(transcriptSize int) []byte {
+	content := strings.Repeat("x", transcriptSize)
+	return []byte(`{"model":"gpt-5-codex","stream":true,"prompt_cache_key":"cache-1","client_metadata":{"x-codex-installation-id":"install-1","x-codex-turn-metadata":"{\"prompt_cache_key\":\"cache-1\",\"turn_id\":\"turn-1\",\"window_id\":\"cache-1:0\"}","x-codex-window-id":"cache-1:0"},"input":[{"type":"message","id":"msg-1","role":"user","content":"` + content + `"}]}`)
+}

--- a/internal/runtime/executor/helps/payload_mutations.go
+++ b/internal/runtime/executor/helps/payload_mutations.go
@@ -1,6 +1,9 @@
 package helps
 
 import (
+	"encoding/json"
+	"sort"
+
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -78,4 +81,93 @@ func JoinRawJSONStrings(items []string) []byte {
 		out = append(out, item...)
 	}
 	return append(out, ']')
+}
+
+// JSONStringField is a JSON string path to overwrite in one document rewrite.
+type JSONStringField struct {
+	Path  string
+	Value string
+}
+
+// ReplaceJSONStringFields copies payload once and writes all existing string
+// fields in a single splice. Missing paths fall back to sjson.SetBytes.
+func ReplaceJSONStringFields(payload []byte, fields []JSONStringField) []byte {
+	if len(payload) == 0 || len(fields) == 0 {
+		return payload
+	}
+
+	type replacement struct {
+		index int
+		oldN  int
+		neu   []byte
+	}
+	replacements := make([]replacement, 0, len(fields))
+	var missing []JSONStringField
+	extra := 0
+	for _, field := range fields {
+		if field.Path == "" {
+			continue
+		}
+		current := gjson.GetBytes(payload, field.Path)
+		if !current.Exists() || current.Index <= 0 {
+			missing = append(missing, field)
+			continue
+		}
+		encoded, errMarshal := json.Marshal(field.Value)
+		if errMarshal != nil {
+			missing = append(missing, field)
+			continue
+		}
+		if current.Raw == string(encoded) {
+			continue
+		}
+		replacements = append(replacements, replacement{
+			index: current.Index,
+			oldN:  len(current.Raw),
+			neu:   encoded,
+		})
+		extra += len(encoded) - len(current.Raw)
+	}
+	if extra < 0 {
+		extra = 0
+	}
+
+	out := payload
+	if len(replacements) > 0 {
+		sort.Slice(replacements, func(i, j int) bool {
+			return replacements[i].index < replacements[j].index
+		})
+		buf := make([]byte, 0, len(payload)+extra)
+		last := 0
+		for _, item := range replacements {
+			if item.index < last || item.index+item.oldN > len(payload) {
+				return fallbackSetJSONStringFields(payload, fields)
+			}
+			buf = append(buf, payload[last:item.index]...)
+			buf = append(buf, item.neu...)
+			last = item.index + item.oldN
+		}
+		buf = append(buf, payload[last:]...)
+		out = buf
+	}
+	for _, field := range missing {
+		updated, errSet := sjson.SetBytes(out, field.Path, field.Value)
+		if errSet != nil {
+			continue
+		}
+		out = updated
+	}
+	return out
+}
+
+func fallbackSetJSONStringFields(payload []byte, fields []JSONStringField) []byte {
+	out := payload
+	for _, field := range fields {
+		updated, errSet := sjson.SetBytes(out, field.Path, field.Value)
+		if errSet != nil {
+			continue
+		}
+		out = updated
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

- Rebuild the Codex `identity-confuse` request body in one splice instead of calling `sjson.SetBytes` once per remapped field.
- Keep the same remapped IDs (`prompt_cache_key`, installation id, turn metadata, window id).
- Missing paths still fall back to `sjson.SetBytes`.

Fixes #5598

## Why

`applyCodexIdentityConfuseBody` currently copies the full Codex `/v1/responses` document four times. On a 2 MiB fixture that is 4.02x the input. Live transcripts are often 20-35 MiB, so one in-flight request holds a large extra working set until the stream ends.

Same shape as #5461: collect local replacements, copy the full payload once.

## User-visible change

None. Confused IDs and request JSON field values stay the same. No config, no persistence, no migration.

Rollback: revert the commit.

## Benchmark

Method: `go test ./internal/runtime/executor -run TestApplyCodexIdentityConfuseBodyDoesNotCopyEntireDocumentPerField -count=3 -v`

Fixture: 2 MiB `input[].content` plus the four identity-confuse fields. Go 1.26.1, darwin/arm64, `main` @ `934fb792`.

```
before: 8430492 B/op  (4.02x input, three runs 8430492 / 8430483 / 8430470)
after:  2110465 B/op  (1.01x input)
```

## Verification

- `go test ./internal/runtime/executor`
- Existing identity-confuse tests still pass, including `TestCodexIdentityConfuseKeepsClientBodySeparateFromUpstreamBody` and `TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders`
