### PR TITLE
feat(codex): support native history/notes backend endpoints

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -416,7 +416,10 @@ nonstream-keepalive-interval: 0
 #           - "context_window_exceeded"
 #         action: "stop-and-cooldown"
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
-#     alpha-search: false # optional: allow this key to serve /v1/alpha/search via base-url + /alpha/search
+#     alpha-search: false # optional: allow this key to serve Codex alpha/search and alpha/history|notes via base-url
+#       # History/notes also need a Codex client that uses the official backend auth
+#       # path (is_openai + current_auth_uses_codex_backend). Token-budget flags on a
+#       # generic custom provider are not enough in Codex 0.153.4.
 #     headers:
 #       X-Custom-Header: "custom-value"
 #       # Values starting with "$" dynamically copy the header value from downstream client requests.

--- a/internal/api/server_codex_history_notes.go
+++ b/internal/api/server_codex_history_notes.go
@@ -1,0 +1,286 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	codexHistoryNotesOfficialBase = "https://chatgpt.com/backend-api/codex/"
+)
+
+var allowedCodexHistoryNotesPaths = map[string]struct{}{
+	"alpha/history/v2/list_windows":       {},
+	"alpha/history/v2/list_items":         {},
+	"alpha/history/v2/read_item":          {},
+	"alpha/history/v2/search_contents":    {},
+	"alpha/notes/v2/list_files_by_prefix": {},
+	"alpha/notes/v2/read_file":            {},
+	"alpha/notes/v2/search_contents":      {},
+	"alpha/notes/v2/append_to_file":       {},
+	"alpha/notes/v2/write_file":           {},
+}
+
+func parseCodexHistoryNotesPath(path string) (string, bool) {
+	path = strings.TrimSpace(strings.SplitN(path, "?", 2)[0])
+	switch {
+	case strings.HasPrefix(path, "/backend-api/codex/"):
+		path = strings.TrimPrefix(path, "/backend-api/codex/")
+	case strings.HasPrefix(path, "/v1/"):
+		path = strings.TrimPrefix(path, "/v1/")
+	default:
+		return "", false
+	}
+	if _, ok := allowedCodexHistoryNotesPaths[path]; !ok {
+		return "", false
+	}
+	return path, true
+}
+
+func codexHistoryNotesSessionID(body []byte, headerSessionID string) string {
+	var payload struct {
+		Context struct {
+			SessionID string `json:"session_id"`
+		} `json:"context"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		if sessionID := strings.TrimSpace(payload.Context.SessionID); sessionID != "" {
+			return sessionID
+		}
+	}
+	return strings.TrimSpace(headerSessionID)
+}
+
+// codexAlphaHistoryNotes forwards Codex history/notes backend operations.
+// The payload is already in Codex format and must not pass through a protocol translator.
+func (s *Server) codexAlphaHistoryNotes(c *gin.Context) {
+	relativePath, ok := parseCodexHistoryNotesPath(c.Request.URL.Path)
+	if !ok {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	if s == nil || s.handlers == nil || s.handlers.AuthManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth manager unavailable"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, 16<<20))
+	if err != nil {
+		c.JSON(clienterror.HTTPStatusFromErrorOr(err, http.StatusBadRequest), gin.H{"error": "Failed to read history/notes request"})
+		return
+	}
+
+	var routing struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &routing)
+	sessionID := codexHistoryNotesSessionID(body, c.GetHeader("Session_id"))
+
+	selectionHeaders := c.Request.Header.Clone()
+	if sessionID != "" {
+		selectionHeaders.Set("X-Session-ID", sessionID)
+	}
+	ctx := context.WithValue(c.Request.Context(), "gin", c)
+	ctx = handlers.EnrichContextWithSessionHierarchy(ctx, selectionHeaders, body, nil)
+	selectionModel, errRoute := s.codexAlphaSearchSelectionModel(ctx, c, body, strings.TrimSpace(routing.Model))
+	if errRoute != nil {
+		log.WithError(errRoute).Warn("codex history/notes: model router returned an unsupported target")
+		c.JSON(clienterror.HTTPStatusFromErrorOr(errRoute, http.StatusServiceUnavailable), gin.H{"error": errRoute.Error()})
+		return
+	}
+	// Reuse the Alpha Search credential policy: official Codex OAuth, plus
+	// API keys that opted into Codex backend extras via alpha-search: true.
+	selectionOpts := coreexecutor.Options{Headers: selectionHeaders, OriginalRequest: body}
+	var selection *auth.HomeDispatchSelection
+	var selected *auth.Auth
+	if s.handlers.AuthManager.HomeEnabled() {
+		selection, err = s.handlers.AuthManager.SelectHomeAuthWithCredentialPolicy(ctx, "codex", selectionModel, auth.CredentialPolicyCodexAlphaSearchV1, selectionOpts)
+		if selection != nil {
+			selected = selection.CloneAuth()
+		}
+	} else {
+		selected, err = s.handlers.AuthManager.SelectAuthWithCredentialPolicy(ctx, "codex", selectionModel, auth.CredentialPolicyCodexAlphaSearchV1, selectionOpts)
+	}
+	if err != nil {
+		status := clienterror.HTTPStatusFromErrorOr(err, http.StatusServiceUnavailable)
+		for _, value := range auth.SafeResponseHeaders(err).Values("Retry-After") {
+			c.Writer.Header().Add("Retry-After", value)
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	if selected == nil {
+		if selection != nil {
+			selection.End("missing_auth")
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth unavailable"})
+		return
+	}
+	if selection != nil && selection.CanonicalSessionID != "" {
+		meta := logging.GetClientRequestMetadata(ctx)
+		meta.SessionID = selection.CanonicalSessionID
+		if selection.ParentSessionID != "" {
+			meta.ParentSessionID = selection.ParentSessionID
+		} else {
+			meta.ParentSessionID = ""
+		}
+		if meta.SessionID == meta.ParentSessionID {
+			meta.ParentSessionID = ""
+		}
+		ctx = logging.WithClientRequestMetadata(ctx, meta)
+	}
+	if selection != nil {
+		attemptCtx, release, errBind := homeSelectionAttemptContext(ctx, selection)
+		if errBind != nil {
+			selection.End("attempt_bind_failed")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": errBind.Error()})
+			return
+		}
+		ctx = attemptCtx
+		defer release()
+	}
+	logging.SetGinCPATraceID(c, selected.EnsureIndex())
+
+	baseHeaders := make(http.Header)
+	baseHeaders.Set("Content-Type", "application/json")
+	baseHeaders.Set("Accept", "application/json")
+	baseHeaders.Set("Originator", "codex_cli_rs")
+	for _, name := range []string{
+		"Version",
+		"User-Agent",
+		"Session_id",
+		"X-Client-Request-Id",
+		"x-openai-encrypted-tool-arguments",
+		"x-openai-tool-output-truncation-policy",
+	} {
+		if value := strings.TrimSpace(c.GetHeader(name)); value != "" {
+			baseHeaders.Set(name, value)
+		}
+	}
+	if sessionID != "" {
+		baseHeaders.Set("Session_id", sessionID)
+		baseHeaders.Set("X-Session-ID", sessionID)
+	}
+
+	errMissingBaseURL := errors.New("Codex history/notes API key base URL unavailable")
+	routeModel := strings.TrimSpace(selectionModel)
+	if routeModel == "" {
+		routeModel = strings.TrimSpace(routing.Model)
+	}
+	performRequest := func(current *auth.Auth) (*http.Response, error) {
+		headers := baseHeaders.Clone()
+		if accountID, ok := current.Metadata["account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+			headers.Set("Chatgpt-Account-Id", accountID)
+		}
+		upstreamURL := codexHistoryNotesOfficialBase + relativePath
+		requestBody := body
+		if current.AuthKind() == auth.AuthKindAPIKey {
+			baseURL := ""
+			if current.Attributes != nil {
+				baseURL = strings.TrimSpace(current.Attributes["base_url"])
+			}
+			if baseURL == "" {
+				return nil, errMissingBaseURL
+			}
+			upstreamURL = strings.TrimRight(baseURL, "/") + "/" + relativePath
+			if upstreamModel := s.handlers.AuthManager.ResolveExecutionModel(current, routeModel); upstreamModel != "" {
+				requestBody = rewriteCodexAlphaSearchModel(requestBody, upstreamModel)
+			}
+		}
+		req, errRequest := s.handlers.AuthManager.NewHttpRequest(ctx, current, http.MethodPost, upstreamURL, requestBody, headers)
+		if errRequest != nil {
+			return nil, errRequest
+		}
+		authType, authValue := current.AccountInfo()
+		helps.RecordAPIRequest(ctx, s.cfg, helps.UpstreamRequestLog{
+			URL:       upstreamURL,
+			Method:    http.MethodPost,
+			Headers:   req.Header.Clone(),
+			Body:      requestBody,
+			Provider:  "codex",
+			AuthID:    current.ID,
+			AuthLabel: current.Label,
+			AuthType:  authType,
+			AuthValue: authValue,
+		})
+		return s.handlers.AuthManager.HttpRequest(ctx, current, req)
+	}
+
+	if errCtx := ctx.Err(); errCtx != nil {
+		if selection != nil {
+			selection.End("attempt_canceled")
+		}
+		c.JSON(clienterror.HTTPStatusFromErrorOr(errCtx, http.StatusRequestTimeout), gin.H{"error": errCtx.Error()})
+		return
+	}
+	resp, err := performRequest(selected)
+	if err != nil {
+		if errors.Is(err, errMissingBaseURL) {
+			if selection != nil {
+				selection.End("missing_base_url")
+			}
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+			return
+		}
+		if selection != nil {
+			selection.End("request_failed")
+		}
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
+		c.JSON(clienterror.HTTPStatusFromErrorOr(err, http.StatusBadGateway), gin.H{"error": err.Error()})
+		return
+	}
+	closeResponseBody := func() error {
+		errClose := resp.Body.Close()
+		if errClose != nil {
+			log.Errorf("codex history/notes: close response body error: %v", errClose)
+		}
+		return errClose
+	}
+	if selection != nil {
+		if errBind := selection.Bind(closeResponseBody); errBind != nil {
+			if resp.StatusCode == http.StatusUnauthorized {
+				s.handlers.AuthManager.ReportHomeUnauthorized(ctx, selected, "codex", selectionModel)
+			}
+			selection.End("response_bind_failed")
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": errBind.Error()})
+			return
+		}
+		defer selection.End("response_closed")
+	} else {
+		defer func() { _ = closeResponseBody() }()
+	}
+	helps.RecordAPIResponseMetadata(ctx, s.cfg, resp.StatusCode, resp.Header.Clone())
+	upstreamBody, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		helps.AppendAPIResponseChunk(ctx, s.cfg, upstreamBody)
+		if selection != nil && resp.StatusCode == http.StatusUnauthorized {
+			s.handlers.AuthManager.ReportHomeUnauthorized(ctx, selected, "codex", selectionModel, upstreamBody)
+		}
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
+		c.JSON(clienterror.HTTPStatusFromErrorOr(err, http.StatusBadGateway), gin.H{"error": "Failed to read Codex history/notes response"})
+		return
+	}
+	helps.AppendAPIResponseChunk(ctx, s.cfg, upstreamBody)
+	if selection != nil && resp.StatusCode == http.StatusUnauthorized {
+		s.handlers.AuthManager.ReportHomeUnauthorized(ctx, selected, "codex", selectionModel, upstreamBody)
+		log.WithField("status", resp.StatusCode).Warnf("codex history/notes upstream request failed: %s", logging.SafeDiagnosticForLog(string(upstreamBody)))
+	}
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		c.Header("Content-Type", contentType)
+	}
+	c.Status(resp.StatusCode)
+	_, _ = c.Writer.Write(upstreamBody)
+}

--- a/internal/api/server_codex_history_notes_test.go
+++ b/internal/api/server_codex_history_notes_test.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestCodexHistoryNotesForwardsOAuthRequest(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token", "account_id": "account-123"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	cases := []struct {
+		path        string
+		body        string
+		upstreamURL string
+	}{
+		{
+			path:        "/v1/alpha/notes/v2/list_files_by_prefix",
+			body:        `{"prefix":"","context":{"session_id":"11111111-1111-4111-8111-111111111111","current_agent_name":"/root"}}`,
+			upstreamURL: "https://chatgpt.com/backend-api/codex/alpha/notes/v2/list_files_by_prefix",
+		},
+		{
+			path:        "/v1/alpha/history/v2/list_windows",
+			body:        `{"limit":1,"context":{"session_id":"11111111-1111-4111-8111-111111111111","current_agent_name":"/root"}}`,
+			upstreamURL: "https://chatgpt.com/backend-api/codex/alpha/history/v2/list_windows",
+		},
+		{
+			path:        "/backend-api/codex/alpha/notes/v2/list_files_by_prefix",
+			body:        `{"prefix":"","context":{"session_id":"22222222-2222-4222-8222-222222222222","current_agent_name":"/root"}}`,
+			upstreamURL: "https://chatgpt.com/backend-api/codex/alpha/notes/v2/list_files_by_prefix",
+		},
+		{
+			path:        "/backend-api/codex/alpha/history/v2/list_windows",
+			body:        `{"limit":1,"context":{"session_id":"22222222-2222-4222-8222-222222222222","current_agent_name":"/root"}}`,
+			upstreamURL: "https://chatgpt.com/backend-api/codex/alpha/history/v2/list_windows",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			executor.request = nil
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer test-key")
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			if executor.request == nil {
+				t.Fatal("Codex executor did not receive a request")
+			}
+			if got := executor.request.URL.String(); got != tc.upstreamURL {
+				t.Fatalf("upstream URL = %q, want %q", got, tc.upstreamURL)
+			}
+			if got := string(executor.body); got != tc.body {
+				t.Fatalf("upstream body = %q, want %q", got, tc.body)
+			}
+			if got := executor.request.Header.Get("Authorization"); got != "Bearer codex-token" {
+				t.Fatalf("Authorization = %q", got)
+			}
+			if got := executor.request.Header.Get("Chatgpt-Account-Id"); got != "account-123" {
+				t.Fatalf("Chatgpt-Account-Id = %q", got)
+			}
+		})
+	}
+}
+
+func TestCodexHistoryNotesPreservesEncryptedHeadersAndSessionContext(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	body := `{"query":"secret","context":{"session_id":"33333333-3333-4333-8333-333333333333","current_agent_name":"/root"}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/notes/v2/search_contents", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-openai-encrypted-tool-arguments", "true")
+	req.Header.Set("x-openai-tool-output-truncation-policy", `{"max_bytes":4096}`)
+	req.Header.Set("Version", "0.153.4")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.request == nil {
+		t.Fatal("Codex executor did not receive a request")
+	}
+	if got := executor.request.Header.Get("x-openai-encrypted-tool-arguments"); got != "true" {
+		t.Fatalf("encrypted arguments header = %q", got)
+	}
+	if got := executor.request.Header.Get("x-openai-tool-output-truncation-policy"); got != `{"max_bytes":4096}` {
+		t.Fatalf("truncation policy header = %q", got)
+	}
+	if got := executor.request.Header.Get("Version"); got != "0.153.4" {
+		t.Fatalf("Version = %q", got)
+	}
+	if got := executor.request.Header.Get("Session_id"); got != "33333333-3333-4333-8333-333333333333" {
+		t.Fatalf("Session_id = %q", got)
+	}
+	if got := executor.request.Header.Get("X-Session-ID"); got != "33333333-3333-4333-8333-333333333333" {
+		t.Fatalf("X-Session-ID = %q", got)
+	}
+}
+
+func TestCodexHistoryNotesOptInAPIKeyUsesConfiguredEndpoint(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-alpha-api-key",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Attributes: map[string]string{
+			auth.AttributeAPIKey:           "codex-alpha-key",
+			auth.AttributeCodexAlphaSearch: "true",
+			"base_url":                     "https://codex.example.com/v1/",
+		},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex API key: %v", err)
+	}
+
+	body := `{"prefix":"","context":{"session_id":"44444444-4444-4444-8444-444444444444","current_agent_name":"/root"}}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/notes/v2/list_files_by_prefix", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.request == nil {
+		t.Fatal("Codex executor did not receive a request")
+	}
+	if got, want := executor.request.URL.String(), "https://codex.example.com/v1/alpha/notes/v2/list_files_by_prefix"; got != want {
+		t.Fatalf("upstream URL = %q, want %q", got, want)
+	}
+	if got := executor.request.Header.Get("Authorization"); got != "Bearer codex-alpha-key" {
+		t.Fatalf("Authorization = %q, want API key bearer", got)
+	}
+	if got := string(executor.body); got != body {
+		t.Fatalf("upstream body = %q, want %q", got, body)
+	}
+}
+
+func TestCodexHistoryNotesRejectsOrdinaryAPIKey(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-plain-api-key",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Attributes: map[string]string{
+			auth.AttributeAPIKey: "plain-key",
+			"base_url":           "https://codex.example.com/v1",
+		},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex API key: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/history/v2/list_windows", strings.NewReader(`{"limit":1}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+	if executor.request != nil {
+		t.Fatal("ordinary API key sent an upstream request")
+	}
+}
+
+func TestCodexHistoryNotesRejectsUnknownAction(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/notes/v2/not_a_real_op", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
+	if executor.request != nil {
+		t.Fatal("unknown action sent an upstream request")
+	}
+}
+
+func TestParseCodexHistoryNotesPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{path: "/v1/alpha/notes/v2/list_files_by_prefix", want: "alpha/notes/v2/list_files_by_prefix", ok: true},
+		{path: "/backend-api/codex/alpha/history/v2/list_windows", want: "alpha/history/v2/list_windows", ok: true},
+		{path: "/v1/alpha/notes/v2/not_a_real_op", ok: false},
+		{path: "/v1/alpha/search", ok: false},
+	}
+	for _, tc := range cases {
+		got, ok := parseCodexHistoryNotesPath(tc.path)
+		if ok != tc.ok || got != tc.want {
+			t.Fatalf("parseCodexHistoryNotesPath(%q) = (%q, %v), want (%q, %v)", tc.path, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestCodexHistoryNotesSessionIDFromContext(t *testing.T) {
+	body := []byte(`{"prefix":"","context":{"session_id":"55555555-5555-4555-8555-555555555555","current_agent_name":"/root"}}`)
+	if got := codexHistoryNotesSessionID(body, ""); got != "55555555-5555-4555-8555-555555555555" {
+		t.Fatalf("session id = %q", got)
+	}
+	if got := codexHistoryNotesSessionID([]byte(`{}`), "header-session"); got != "header-session" {
+		t.Fatalf("header fallback = %q", got)
+	}
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -78,6 +78,8 @@ func (s *Server) setupRoutes() {
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		v1.POST("/alpha/search", s.codexAlphaSearch)
+		v1.POST("/alpha/history/v2/:action", s.codexAlphaHistoryNotes)
+		v1.POST("/alpha/notes/v2/:action", s.codexAlphaHistoryNotes)
 		v1.POST("/live", s.codexLiveHandler.Handle)
 		v1.GET("/live/:call_id", s.codexLiveHandler.HandleSideband)
 	}
@@ -115,6 +117,8 @@ func (s *Server) setupRoutes() {
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
 		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		codexDirect.POST("/alpha/search", s.codexAlphaSearch)
+		codexDirect.POST("/alpha/history/v2/:action", s.codexAlphaHistoryNotes)
+		codexDirect.POST("/alpha/notes/v2/:action", s.codexAlphaHistoryNotes)
 	}
 
 	// Gemini compatible API routes


### PR DESCRIPTION
## Summary
- Codex 0.153.4 issues `POST /alpha/history/v2/*` and `/alpha/notes/v2/*` in addition to `/responses`. Current `dev` only registers `/alpha/search`, so the four issue probes (and the rest of the official action set) return 404 before any credential or upstream hop.
- Register the nine official Codex 0.153.4 actions on both `/v1` and `/backend-api/codex`. Forward the body as-is (no translator), reuse `CredentialPolicyCodexAlphaSearchV1`, and pass through `x-openai-encrypted-tool-arguments`, `x-openai-tool-output-truncation-policy`, and `context.session_id`.
- Ordinary API keys still 503 unless they opt in with `alpha-search: true`. This does not change Codex's own `is_openai()` / `current_auth_uses_codex_backend()` client gate; that is tracked in openai/codex#43194.

Fixes #5547

## Test plan
- [x] `go test -count=1 -run 'TestCodexAlphaSearch|TestCodexHistoryNotes|TestParseCodexHistoryNotesPath' ./internal/api/`
- [x] `gofmt` on the touched Go files
- [x] `go build -o test-output ./cmd/server`

Made with [Cursor](https://cursor.com)