### PR TITLE
fix(wsrelay): wait for buffer space instead of evicting a queued frame

### DIFF
--- a/internal/wsrelay/session.go
+++ b/internal/wsrelay/session.go
@@ -89,22 +89,25 @@ func (pr *pendingRequest) deliverTerminal(sessClosed <-chan struct{}, msg Messag
 	if pr.closed {
 		return false
 	}
-	pr.terminal = true
 
+	var ctxDone <-chan struct{}
+	if pr.reqCtx != nil {
+		ctxDone = pr.reqCtx.Done()
+	}
+
+	// Wait for buffer space like deliver does instead of evicting a queued
+	// frame: dropping response data to make room for the terminal message
+	// reports a successful stream while part of the response is missing.
 	select {
+	case <-pr.done:
+		return false
+	case <-sessClosed:
+		return false
+	case <-ctxDone:
+		return false
 	case pr.ch <- msg:
+		pr.terminal = true
 		return true
-	default:
-		select {
-		case <-pr.ch:
-		default:
-		}
-		select {
-		case pr.ch <- msg:
-			return true
-		default:
-			return false
-		}
 	}
 }
 

--- a/internal/wsrelay/session_test.go
+++ b/internal/wsrelay/session_test.go
@@ -247,23 +247,84 @@ func TestSession_Dispatch_TerminalDeliveredWhenBufferFullAndSessionClosing(t *te
 		})
 	}
 
-	// Dispatch terminal message
-	s.dispatch(Message{
-		ID:   reqID,
-		Type: MessageTypeStreamEnd,
-	})
+	enteredDispatch := make(chan struct{})
+	go func() {
+		close(enteredDispatch)
+		// Dispatch terminal message against a saturated buffer
+		s.dispatch(Message{
+			ID:   reqID,
+			Type: MessageTypeStreamEnd,
+		})
+	}()
 
-	var msgs []Message
-	for msg := range req.ch {
-		msgs = append(msgs, msg)
+	<-enteredDispatch
+	// Small yield to ensure the goroutine is in deliverTerminal's select
+	time.Sleep(10 * time.Millisecond)
+
+	msgs := make([]Message, 0, pendingChannelBuffer+1)
+drain:
+	for {
+		select {
+		case msg, ok := <-req.ch:
+			if !ok {
+				break drain
+			}
+			msgs = append(msgs, msg)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out after %d frames waiting for the terminal message", len(msgs))
+		}
 	}
 
-	if len(msgs) == 0 {
-		t.Fatalf("expected messages, got 0")
+	if len(msgs) != pendingChannelBuffer+1 {
+		t.Fatalf("frame loss: expected %d frames, got %d", pendingChannelBuffer+1, len(msgs))
+	}
+	for i := 0; i < pendingChannelBuffer; i++ {
+		if msgs[i].Type != MessageTypeStreamChunk {
+			t.Fatalf("expected frame %d to be MessageTypeStreamChunk, got %s", i, msgs[i].Type)
+		}
+		if seq, ok := msgs[i].Payload["seq"].(int); !ok || seq != i {
+			t.Fatalf("frame %d out of order: payload %v", i, msgs[i].Payload)
+		}
 	}
 	lastMsg := msgs[len(msgs)-1]
 	if lastMsg.Type != MessageTypeStreamEnd {
 		t.Fatalf("expected last message to be MessageTypeStreamEnd, got %s", lastMsg.Type)
+	}
+}
+
+func TestSession_Dispatch_TerminalUnblocksOnSessionClose(t *testing.T) {
+	sess := &session{
+		closed: make(chan struct{}),
+	}
+	reqID := "req-terminal-sess-close"
+	req := newPendingRequest(context.Background())
+	sess.pending.Store(reqID, req)
+
+	// Fill channel to buffer capacity
+	for i := 0; i < pendingChannelBuffer; i++ {
+		sess.dispatch(Message{ID: reqID, Type: MessageTypeStreamChunk})
+	}
+
+	enteredDispatch := make(chan struct{})
+	doneDispatch := make(chan struct{})
+	go func() {
+		close(enteredDispatch)
+		sess.dispatch(Message{ID: reqID, Type: MessageTypeStreamEnd})
+		close(doneDispatch)
+	}()
+
+	<-enteredDispatch
+	// Small yield to ensure the goroutine is in deliverTerminal's select
+	time.Sleep(10 * time.Millisecond)
+
+	// Close session to unblock the saturated terminal delivery
+	sess.cleanup(errClosed)
+
+	select {
+	case <-doneDispatch:
+		// Succeeded in unblocking
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("terminal dispatch remained blocked after session cleanup")
 	}
 }
 


### PR DESCRIPTION
## Problem

`deliverTerminal` evicts one queued frame when the pending request channel is full, then enqueues the terminal message in its freed slot:

```go
default:
    select {
    case <-pr.ch:   // oldest queued response frame is discarded
    default:
    }
```

`dispatch` treats that delivery as normal completion and closes the request channel, so the consumer receives `stream_end` and a successful end-of-stream while one response chunk is gone. Ordinary chunk delivery is not affected: `deliver` already waits for buffer space.

Checked on base commit `82f4f370df45f7a5a4be52f8101d4294f656ff02` (`dev`):

- `internal/wsrelay/session.go:82` — `deliverTerminal`, the eviction path.
- `internal/wsrelay/session.go:53` — `deliver`, which blocks on a select with `done` / session-closed / request-context escape hatches.
- `internal/wsrelay/session.go:261` — `dispatch`, which closes the request after terminal delivery.

The eviction path was introduced with the buffered-delivery hardening in `02c02cda` (the fix for #4709); that change covered ordinary chunks but left terminal delivery lossy under buffer pressure.

## Changes

`internal/wsrelay/session.go`

- `deliverTerminal` now waits for buffer space using the same select as `deliver`, so a terminal message never replaces response data. The `done`, session-closed and request-context cases are preserved, so a stalled consumer cannot pin the session read loop — the same escape hatches `deliver` relies on, already covered by `TestSession_SlowConsumer_UnblocksOnContextCancel` and `TestSession_SlowConsumer_UnblocksOnSessionClose`.
- `pr.terminal` is set only once the message is actually queued. Previously it was set even when delivery failed, which suppressed the explicit error frame `cancelWithError` injects for a request that never received its terminal message.

`internal/wsrelay/session_test.go`

- `TestSession_Dispatch_TerminalDeliveredWhenBufferFullAndSessionClosing` now dispatches the terminal message from a goroutine against a saturated buffer and drains with a concurrent consumer, asserting all 64 chunks arrive in sequence order followed by `stream_end`. The previous assertion only checked that some messages arrived and that the last one was `stream_end`, which the eviction path satisfied.
- `TestSession_Dispatch_TerminalUnblocksOnSessionClose` is added so a saturated terminal delivery is proven to unblock on session cleanup rather than hanging.

## Verification

Red state on the unmodified base, with the test change applied:

```
$ go test ./internal/wsrelay -run '^TestSession_Dispatch_Terminal' -count=1
--- FAIL: TestSession_Dispatch_TerminalDeliveredWhenBufferFullAndSessionClosing (0.01s)
    session_test.go:279: frame loss: expected 65 frames, got 64
FAIL
```

This matches the failure reported in #5535.

Green state after the fix:

```
$ go test ./internal/wsrelay -count=1
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/wsrelay	0.528s

$ go test ./internal/wsrelay -count=5 -race
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/wsrelay	1.891s

$ gofmt -l internal/wsrelay/
$ go build -o test-output ./cmd/server
$ go test ./...
```

`go test ./...` passes with no failures. `gofmt` reports nothing for the changed files.

The regression the new assertions catch: a terminal message that is delivered by discarding buffered response data, reported downstream as a successful stream.

## Scope and omissions

- `cancelWithError` uses the same evict-then-enqueue shape when it injects an error frame during cleanup. That path is a failure path where the stream is already being torn down, and #5535 does not cover it, so it is left unchanged rather than folded into this fix.
- Production occurrence frequency is not measured; the reproduction is the in-repo unit test, which needs no credentials, model or client.
