### PR TITLE
fix(codex): preserve GLM Flash tool images on ZAI Responses

### DIFF
--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -73,6 +73,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return resp, errReplay
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
+	body = helps.NormalizeZAIToolOutputImages(baseModel, baseURL, body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	var identityState codexIdentityConfuseState

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -79,6 +79,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return nil, errReplay
 	}
 	reporter.SetTranslatedReasoningEffort(body, to.String())
+	body = helps.NormalizeZAIToolOutputImages(baseModel, baseURL, body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	var identityState codexIdentityConfuseState

--- a/internal/runtime/executor/codex_executor_zai_tool_image_test.go
+++ b/internal/runtime/executor/codex_executor_zai_tool_image_test.go
@@ -1,0 +1,117 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type zaiToolImageRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f zaiToolImageRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestCodexExecutorZAIToolImagesAreRelocatedForResponsesPaths(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			payload := zaiToolImageExecutorPayload()
+			var captured []byte
+			transport := zaiToolImageRoundTripper(func(req *http.Request) (*http.Response, error) {
+				var err error
+				captured, err = io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(`data: {"type":"response.completed","response":{"id":"resp_test","status":"completed","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}` + "\n\n"))}, nil
+			})
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			executor := NewCodexExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://api.z.ai/api/v1/", "api_key": "test"}}
+			req := cliproxyexecutor.Request{Model: "glm-5.3-flash", Payload: payload}
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response"), OriginalRequest: payload, Stream: stream}
+			if stream {
+				result, err := executor.ExecuteStream(ctx, auth, req, opts)
+				if err != nil {
+					t.Fatalf("ExecuteStream() error = %v", err)
+				}
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error = %v", chunk.Err)
+					}
+				}
+			} else if _, err := executor.Execute(ctx, auth, req, opts); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			assertZAIToolImageCapture(t, captured)
+		})
+	}
+}
+
+func zaiToolImageExecutorPayload() []byte {
+	parts := make([]string, 0, 15)
+	parts = append(parts, `{"type":"input_text","text":"retain this tool text"}`)
+	for index := range 14 {
+		parts = append(parts, `{"type":"input_image","image_url":`+strconv.Quote(zaiTestImageURL(index))+`,"detail":"original"}`)
+	}
+	return []byte(`{"model":"glm-5.3-flash","input":[{"type":"function_call_output","call_id":"call_images","output":[` + strings.Join(parts, ",") + `]}]}`)
+}
+
+func zaiTestImageURL(index int) string {
+	return "data:image/png;base64," + strings.Repeat(string(rune('A'+index)), 2*1024*1024)
+}
+
+func assertZAIToolImageCapture(t *testing.T, body []byte) {
+	t.Helper()
+	input := gjson.GetBytes(body, "input")
+	if got := len(input.Array()); got != 2 {
+		t.Fatalf("upstream input items = %d, want tool output plus visual message", got)
+	}
+	if got := input.Get("0.type").String(); got != "function_call_output" {
+		t.Fatalf("input.0.type = %q, body starts %s", got, body[:min(len(body), 512)])
+	}
+	if got := input.Get("0.call_id").String(); got != "call_images" {
+		t.Fatalf("call_id = %q", got)
+	}
+	if got := input.Get("0.output.0.text").String(); got != "retain this tool text" {
+		t.Fatalf("tool text = %q", got)
+	}
+	if got := input.Get("0.output.1.text").String(); got != "Tool-produced image appears in the following visual context." {
+		t.Fatalf("tool image reference = %q", got)
+	}
+	if got := input.Get("1.type").String(); got != "message" || input.Get("1.role").String() != "user" {
+		t.Fatalf("relocated message is not immediately after tool output: %s", body[:min(len(body), 1024)])
+	}
+	if got := input.Get("1.content.0.text").String(); got != "Tool-produced image follows as visual context; treat it as tool output." {
+		t.Fatalf("visual marker = %q", got)
+	}
+	if got := input.Get("1.content.#").Int(); got != 15 {
+		t.Fatalf("visual content parts = %d, want marker plus 14 images", got)
+	}
+	for index := 1; index <= 14; index++ {
+		imageURL := zaiTestImageURL(index - 1)
+		if got := input.Get("1.content." + strconv.Itoa(index) + ".image_url").String(); got != imageURL {
+			t.Fatalf("relocated content %d image bytes changed", index)
+		}
+		if got := bytes.Count(body, []byte(imageURL)); got != 1 {
+			t.Fatalf("image %d appears %d times, want 1", index, got)
+		}
+		if got := input.Get("1.content." + strconv.Itoa(index) + ".type").String(); got != "input_image" {
+			t.Fatalf("relocated content %d type = %q", index, got)
+		}
+		if got := input.Get("1.content." + strconv.Itoa(index) + ".detail").String(); got != "original" {
+			t.Fatalf("relocated content %d detail = %q", index, got)
+		}
+	}
+	if got := bytes.Count(body, []byte("data:image/png;base64,")); got != 14 {
+		t.Fatalf("image payload occurrences = %d, want 14", got)
+	}
+}

--- a/internal/runtime/executor/helps/zai_tool_images.go
+++ b/internal/runtime/executor/helps/zai_tool_images.go
@@ -1,0 +1,115 @@
+package helps
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	zaiToolImageMarker    = "Tool-produced image follows as visual context; treat it as tool output."
+	zaiToolImageReference = "Tool-produced image appears in the following visual context."
+)
+
+// NormalizeZAIToolOutputImages makes image-bearing tool output visible to ZAI GLM Flash.
+func NormalizeZAIToolOutputImages(model, baseURL string, body []byte) []byte {
+	if !strings.EqualFold(strings.TrimSpace(model), "glm-5.3-flash") || !strings.EqualFold(strings.TrimSuffix(strings.TrimSpace(baseURL), "/"), "https://api.z.ai/api/v1") {
+		return body
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+	items := input.Array()
+	updated := make([]json.RawMessage, 0, len(items))
+	changed := false
+	for _, item := range items {
+		if item.Get("type").String() != "function_call_output" {
+			updated = append(updated, json.RawMessage(item.Raw))
+			continue
+		}
+		images, output, moved := moveZAIToolOutputImages(item.Get("output"))
+		if !moved {
+			updated = append(updated, json.RawMessage(item.Raw))
+			continue
+		}
+		toolItem, err := sjson.SetRawBytes([]byte(item.Raw), "output", output)
+		if err != nil {
+			return body
+		}
+		updated = append(updated, json.RawMessage(toolItem))
+		changed = true
+		promotion, err := zaiToolImageMessage(images)
+		if err != nil {
+			return body
+		}
+		updated = append(updated, json.RawMessage(promotion))
+	}
+	if !changed {
+		return body
+	}
+	encoded, err := json.Marshal(updated)
+	if err != nil {
+		return body
+	}
+	out, err := sjson.SetRawBytes(body, "input", encoded)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func moveZAIToolOutputImages(output gjson.Result) ([]json.RawMessage, []byte, bool) {
+	wasString := output.Type == gjson.String
+	if wasString {
+		if !gjson.Valid(output.String()) {
+			return nil, nil, false
+		}
+		output = gjson.Parse(output.String())
+	}
+	if !output.IsArray() {
+		return nil, nil, false
+	}
+	images := make([]json.RawMessage, 0)
+	remaining := make([]json.RawMessage, 0, len(output.Array())+1)
+	output.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() != "input_image" || part.Get("image_url").Type != gjson.String || strings.TrimSpace(part.Get("image_url").String()) == "" {
+			remaining = append(remaining, json.RawMessage(part.Raw))
+			return true
+		}
+		images = append(images, json.RawMessage(part.Raw))
+		return true
+	})
+	if len(images) == 0 {
+		return nil, nil, false
+	}
+	reference, err := json.Marshal(map[string]string{"type": "input_text", "text": zaiToolImageReference})
+	if err != nil {
+		return nil, nil, false
+	}
+	remaining = append(remaining, reference)
+	encoded, err := json.Marshal(remaining)
+	if err != nil {
+		return nil, nil, false
+	}
+	if wasString {
+		encoded, err = json.Marshal(string(encoded))
+		if err != nil {
+			return nil, nil, false
+		}
+	}
+	return images, encoded, true
+}
+
+func zaiToolImageMessage(images []json.RawMessage) ([]byte, error) {
+	content := make([]json.RawMessage, 0, len(images)+1)
+	marker, err := json.Marshal(map[string]string{"type": "input_text", "text": zaiToolImageMarker})
+	if err != nil {
+		return nil, err
+	}
+	content = append(content, marker)
+	content = append(content, images...)
+	return json.Marshal(map[string]any{"type": "message", "role": "user", "content": content})
+}

--- a/internal/runtime/executor/helps/zai_tool_images_test.go
+++ b/internal/runtime/executor/helps/zai_tool_images_test.go
@@ -1,0 +1,77 @@
+package helps
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const zaiTestURL = "https://api.z.ai/api/v1/"
+
+func TestNormalizeZAIToolOutputImagesMovesMixedOutputAndPreservesUnknownParts(t *testing.T) {
+	body := []byte(`{"input":[{"type":"function_call_output","call_id":"call_1","output":[{"type":"input_text","text":"keep"},{"type":"input_image","image_url":"data:image/png;base64,ONE","detail":"original"},{"type":"unknown","value":{"keep":true}},{"type":"input_image","image_url":12}]}]}`)
+	out := NormalizeZAIToolOutputImages("glm-5.3-flash", zaiTestURL, body)
+	input := gjson.GetBytes(out, "input")
+	if got := len(input.Array()); got != 2 {
+		t.Fatalf("input items = %d, want 2: %s", got, out)
+	}
+	if got := input.Get("0.call_id").String(); got != "call_1" {
+		t.Fatalf("call_id = %q", got)
+	}
+	if got := input.Get("0.output.0.text").String(); got != "keep" {
+		t.Fatalf("tool text = %q", got)
+	}
+	if got := input.Get("0.output.1.value.keep").Bool(); !got {
+		t.Fatalf("unknown part changed: %s", input.Get("0.output.1").Raw)
+	}
+	if got := input.Get("0.output.2.image_url").Int(); got != 12 {
+		t.Fatalf("unsupported image part changed: %d", got)
+	}
+	if got := input.Get("0.output.3.text").String(); got != zaiToolImageReference {
+		t.Fatalf("tool reference = %q", got)
+	}
+	if got := input.Get("1.content.0.text").String(); got != zaiToolImageMarker {
+		t.Fatalf("marker = %q", got)
+	}
+	if got := input.Get("1.content.1.image_url").String(); got != "data:image/png;base64,ONE" {
+		t.Fatalf("relocated image = %q", got)
+	}
+	if got := input.Get("1.content.1.detail").String(); got != "original" {
+		t.Fatalf("detail = %q", got)
+	}
+	if got := bytes.Count(out, []byte("data:image/png;base64,ONE")); got != 1 {
+		t.Fatalf("image appears %d times: %s", got, out)
+	}
+}
+
+func TestNormalizeZAIToolOutputImagesPreservesStringOutputAndIsIdempotent(t *testing.T) {
+	body := []byte(`{"input":[{"type":"function_call_output","call_id":"one","output":"[{\"type\":\"input_text\",\"text\":\"keep\"},{\"type\":\"input_image\",\"image_url\":\"data:image/png;base64,TWO\",\"detail\":\"high\"}]"}]}`)
+	out := NormalizeZAIToolOutputImages("glm-5.3-flash", zaiTestURL, body)
+	if got := gjson.GetBytes(out, "input.0.output").Type; got != gjson.String {
+		t.Fatalf("output type = %v, want string", got)
+	}
+	stringOutput := gjson.Parse(gjson.GetBytes(out, "input.0.output").String())
+	if got := stringOutput.Get("0.text").String(); got != "keep" {
+		t.Fatalf("string text = %q", got)
+	}
+	if got := stringOutput.Get("1.text").String(); got != zaiToolImageReference {
+		t.Fatalf("string reference = %q", got)
+	}
+	if again := NormalizeZAIToolOutputImages("glm-5.3-flash", zaiTestURL, out); !bytes.Equal(again, out) {
+		t.Fatalf("normalization not idempotent: %s", again)
+	}
+}
+
+func TestNormalizeZAIToolOutputImagesLeavesOtherScopesAndDirectImages(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,DIRECT"}]},{"type":"function_call_output","output":[{"type":"input_image","image_url":"data:image/png;base64,TOOL"}]}]}`)
+	for _, scope := range [][2]string{{"glm-5.3", zaiTestURL}, {"glm-5.3-flash", "https://example.com/v1"}} {
+		if got := NormalizeZAIToolOutputImages(scope[0], scope[1], body); !bytes.Equal(got, body) {
+			t.Fatalf("scope %q %q changed body: %s", scope[0], scope[1], got)
+		}
+	}
+	out := NormalizeZAIToolOutputImages("glm-5.3-flash", zaiTestURL, body)
+	if got := gjson.GetBytes(out, "input.0.content.0.image_url").String(); got != "data:image/png;base64,DIRECT" {
+		t.Fatalf("direct image changed: %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

With `codex-api-key` pointing at `https://api.z.ai/api/v1` and model `glm-5.3-flash`, images returned by a tool can remain opaque inside Responses `function_call_output.output`, even though the same images work as user visual input. This affects the native `/responses` route; the Responses-to-Chat-Completions conversion covered by #4699 and #5453 is a different path.

## Change

For that exact model and endpoint, move supported tool `input_image` parts into an immediately following visual message explicitly marked as tool output. Leave a short reference in the tool result and preserve its call ID, text, unknown parts, and array/string representation. Keep image URLs, encoded bytes, and detail unchanged. Each image is transmitted once and applying the adapter again is a no-op.

Both streaming and non-streaming Responses requests use the adapter. Direct user images and other models/endpoints are unchanged.

The earlier duplicate-image incident occurred in a private compatibility patch, not upstream CLIProxyAPI. This PR adds the missing upstream compatibility behavior using single-copy relocation from the outset. It contains no private marker migration, fixed request-size cap, context-error remapping, configuration changes, or translator edits.

## Validation

- `go test -p 2 ./internal/runtime/executor/... ./sdk/api/handlers/openai/... -count=1` passed.
- `go build -o /tmp/cli-proxy-api-zai-tool-images ./cmd/server` passed.
- `git diff --check` and formatting passed.
- With only the two adapter hooks removed, the new executor regression fails for both streaming and non-streaming requests. Restoring the hooks makes both pass.
- The final strengthened executor test captures 14 distinct synthetic image URLs containing 2 MiB each, checks every complete image URL occurs exactly once in the adjacent visual message, and checks image detail, tool text, and call ID. Its focused rerun passed after adding the per-image assertions.

Prior live validation of the same relocation approach against the ZAI Responses route successfully read synthetic tool images, including 14 images in a 29,803,115-byte request with 11,741 reported input tokens and `response.completed`. Those measurements came from the separately deployed adapter, not this exact PR build. The committed regression tests use a mock transport and no credentials or real user images.

## AI assistance

Prepared with Codex; validation results above are from commands actually run locally.
