### PR TITLE
fix(auth): bound quota cooldowns so restored quota is not latched out

### DIFF
--- a/sdk/cliproxy/auth/claude_ratelimit_cooldown_test.go
+++ b/sdk/cliproxy/auth/claude_ratelimit_cooldown_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestAuthManager_ConcurrentSuccessDoesNotClearActiveCredentialCooldown(t *testing.T) {
 	now := time.Now()
-	sevenDayReset := now.Add(7 * 24 * time.Hour)
 
 	manager := NewManager(nil, nil, nil)
 
@@ -63,7 +62,11 @@ func TestAuthManager_ConcurrentSuccessDoesNotClearActiveCredentialCooldown(t *te
 	if !ok || updatedAuth == nil {
 		t.Fatal("auth not found")
 	}
-	if !updatedAuth.Quota.Exceeded || !updatedAuth.Quota.NextRecoverAt.After(now.Add(6*24*time.Hour)) {
+	// The 7d provider deadline is clamped to maxQuotaCooldownCeiling so that quota
+	// restored ahead of the reported reset is rediscovered instead of staying latched
+	// out for a week. The concurrent success must still neither clear the cooldown nor
+	// shorten it below that ceiling.
+	if !updatedAuth.Quota.Exceeded || updatedAuth.Quota.NextRecoverAt.Before(now.Add(maxQuotaCooldownCeiling-time.Minute)) {
 		t.Fatalf("auth quota was cleared or shortened by concurrent success: quota=%+v", updatedAuth.Quota)
 	}
 
@@ -71,10 +74,10 @@ func TestAuthManager_ConcurrentSuccessDoesNotClearActiveCredentialCooldown(t *te
 	for _, m := range []string{"claude-3-5-sonnet-20241022", "claude-3-opus-20240229", "claude-3-7-sonnet-20250219"} {
 		blocked, reason, next := isAuthBlockedForModel(updatedAuth, m, time.Now())
 		if !blocked {
-			t.Fatalf("model %q was unblocked despite active 7d credential cooldown", m)
+			t.Fatalf("model %q was unblocked despite active credential cooldown", m)
 		}
-		if reason != blockReasonCooldown || next.Before(sevenDayReset.Add(-time.Minute)) {
-			t.Fatalf("model %q block reason=%v next=%v, want cooldown ~7d", m, reason, next)
+		if reason != blockReasonCooldown || next.Before(now.Add(maxQuotaCooldownCeiling-time.Minute)) {
+			t.Fatalf("model %q block reason=%v next=%v, want cooldown ~maxQuotaCooldownCeiling", m, reason, next)
 		}
 	}
 }
@@ -131,7 +134,7 @@ func TestAuthManager_UpdatePreservesActiveCredentialCooldown(t *testing.T) {
 	if !ok || persistedAuth == nil {
 		t.Fatal("auth not found after update")
 	}
-	if !persistedAuth.Quota.Exceeded || persistedAuth.Quota.Reason != "credential_quota" || !persistedAuth.Quota.NextRecoverAt.After(now.Add(6*24*time.Hour)) {
+	if !persistedAuth.Quota.Exceeded || persistedAuth.Quota.Reason != "credential_quota" || persistedAuth.Quota.NextRecoverAt.Before(now.Add(maxQuotaCooldownCeiling-time.Minute)) {
 		t.Fatalf("credential cooldown was lost after Update: quota=%+v", persistedAuth.Quota)
 	}
 
@@ -297,7 +300,7 @@ func TestAuthManager_CooldownPersistenceAcrossRestore(t *testing.T) {
 	if !ok || restoredAuth == nil {
 		t.Fatal("restored auth not found")
 	}
-	if !restoredAuth.Quota.Exceeded || restoredAuth.Quota.NextRecoverAt.Before(time.Now().Add(6*24*time.Hour)) {
+	if !restoredAuth.Quota.Exceeded || restoredAuth.Quota.NextRecoverAt.Before(time.Now().Add(maxQuotaCooldownCeiling-time.Minute)) {
 		t.Fatalf("restored auth quota was not preserved: quota=%+v", restoredAuth.Quota)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -361,11 +361,27 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	if quota.Exceeded && quota.NextRecoverAt.IsZero() {
 		quota.NextRecoverAt = record.NextRetryAfter
 	}
+	// A store written before the ceiling existed can hold a multi-day quota deadline.
+	// The selector blocks such a credential, so no 429 path can ever run to re-clamp it;
+	// without migrating on restore the credential stays latched for its original
+	// duration even after this fix is deployed. The migrated deadline is persisted by
+	// the RestoreCooldownStates caller.
+	restoredRetryAfter := record.NextRetryAfter
+	if quota.Exceeded {
+		quotaNext := quota.NextRecoverAt
+		quota.NextRecoverAt = clampQuotaCooldown(quotaNext, now)
+		// Only clamp the retry deadline when it is the quota cooldown itself. A longer
+		// value carries a non-quota cooldown (e.g. a 12h 404) that the ceiling must not
+		// shorten, matching the live failure paths.
+		if !quotaNext.IsZero() && !restoredRetryAfter.After(quotaNext) {
+			restoredRetryAfter = clampQuotaCooldown(restoredRetryAfter, now)
+		}
+	}
 
 	if model == "" {
 		auth.Unavailable = true
 		auth.Status = StatusError
-		auth.NextRetryAfter = record.NextRetryAfter
+		auth.NextRetryAfter = restoredRetryAfter
 		applyCooldownFields(&auth.Quota, quota)
 		auth.Quota = mergeQuotaObservation(auth.Quota, quota)
 		auth.Generation++
@@ -382,7 +398,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 		Unavailable:    true,
 		Status:         StatusError,
 		StatusMessage:  reason,
-		NextRetryAfter: record.NextRetryAfter,
+		NextRetryAfter: restoredRetryAfter,
 		Quota:          quota,
 		LastError:      cloneError(record.LastError),
 		UpdatedAt:      updatedAt,
@@ -897,6 +913,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 										if otherState.Quota.Exceeded && otherState.Quota.NextRecoverAt.After(otherQuotaNext) {
 											otherQuotaNext = otherState.Quota.NextRecoverAt
 										}
+										// Clamp after the maximum: a sibling's stored multi-day quota
+										// deadline would otherwise be promoted to credential_quota and
+										// park every model for the original duration.
+										otherQuotaNext = clampQuotaCooldown(otherQuotaNext, now)
 										otherRetryAfter := otherQuotaNext
 										// Propagation only extends a sibling's still-live
 										// per-model deadline; it never shortens one.
@@ -919,6 +939,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								if auth.Quota.NextRecoverAt.After(authNext) {
 									authNext = auth.Quota.NextRecoverAt
 								}
+								// Same reasoning as the sibling clamp above: this deadline becomes the
+								// credential-wide credential_quota that isAuthBlockedForModel enforces.
+								authNext = clampQuotaCooldown(authNext, now)
 								auth.Quota.NextRecoverAt = authNext
 								auth.NextRetryAfter = authNext
 							}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -551,6 +551,28 @@ func modelsForRegisteredAuth(authID string) []string {
 	return models
 }
 
+// clampQuotaCooldown bounds a computed quota cooldown deadline to
+// maxQuotaCooldownCeiling past now.
+//
+// The clamp is applied to the final deadline rather than to the provider-supplied
+// retry-after, because both quota paths take the maximum of the new deadline and the
+// credential's existing NextRecoverAt in order to preserve an active cooldown across
+// subsequent failures. Clamping only the incoming value would let a previously stored
+// long deadline win and re-extend the cooldown unbounded.
+//
+// A zero deadline means "no cooldown" (cooling disabled) and is returned untouched, and
+// a deadline already inside the ceiling is left exactly as the provider reported it.
+func clampQuotaCooldown(next, now time.Time) time.Time {
+	if next.IsZero() {
+		return next
+	}
+	ceiling := now.Add(maxQuotaCooldownCeiling)
+	if next.After(ceiling) {
+		return ceiling
+	}
+	return next
+}
+
 func (m *Manager) persistCooldownStates(ctx context.Context) {
 	if m == nil {
 		return
@@ -857,6 +879,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
 									next = state.Quota.NextRecoverAt
 								}
+								next = clampQuotaCooldown(next, now)
 							}
 							state.NextRetryAfter = next
 							applyCooldownFields(&state.Quota, QuotaState{
@@ -2083,6 +2106,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 				if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
 					next = auth.Quota.NextRecoverAt
 				}
+				next = clampQuotaCooldown(next, now)
 			}
 			auth.Quota.NextRecoverAt = next
 			auth.NextRetryAfter = next

--- a/sdk/cliproxy/auth/conductor_cooldown_ceiling_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_ceiling_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -145,5 +146,139 @@ func TestApplyAuthFailureState_NonQuotaDeadlineIsNotClamped(t *testing.T) {
 
 	if !auth.NextRetryAfter.After(now.Add(maxQuotaCooldownCeiling)) {
 		t.Fatalf("NextRetryAfter = %v, want a 404 deadline well beyond the quota ceiling", auth.NextRetryAfter)
+	}
+}
+
+// A cooldown store written before the ceiling existed can hold a multi-day quota
+// deadline. The selector blocks such a credential, so no 429 path can run to re-clamp
+// it; unless the deadline is migrated on restore the credential stays latched for its
+// original duration even after this fix ships.
+func TestRestoreCooldownStates_ClampsPreFixMultiDayQuotaRecord(t *testing.T) {
+	now := time.Now()
+	sevenDaysOut := now.Add(7 * 24 * time.Hour)
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-prefix-record", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.SetCooldownStateStore(&mockCooldownStateStore{records: []CooldownStateRecord{
+		{
+			Provider:       "codex",
+			AuthID:         "auth-prefix-record",
+			NextRetryAfter: sevenDaysOut,
+			Reason:         "quota exhausted",
+			Quota: QuotaState{
+				Exceeded:      true,
+				Reason:        "credential_quota",
+				NextRecoverAt: sevenDaysOut,
+			},
+			UpdatedAt: now,
+		},
+	}})
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	restored, ok := manager.GetByID("auth-prefix-record")
+	if !ok || restored == nil {
+		t.Fatal("restored auth not found")
+	}
+	ceiling := now.Add(maxQuotaCooldownCeiling)
+	if restored.Quota.NextRecoverAt.After(ceiling.Add(time.Minute)) {
+		t.Fatalf("restored Quota.NextRecoverAt = %v, want clamped to ~%v", restored.Quota.NextRecoverAt, ceiling)
+	}
+	if restored.NextRetryAfter.After(ceiling.Add(time.Minute)) {
+		t.Fatalf("restored NextRetryAfter = %v, want clamped to ~%v", restored.NextRetryAfter, ceiling)
+	}
+	// The credential must still be cooling; migrating the deadline must not clear it.
+	if !restored.Quota.Exceeded {
+		t.Fatal("restored Quota.Exceeded = false, want the cooldown preserved")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(restored, "", now); !blocked {
+		t.Fatal("restored credential is not blocked, want it still cooling until the ceiling")
+	}
+}
+
+// A restored record whose retry deadline is longer than its quota deadline carries a
+// non-quota cooldown (e.g. a 12h 404). The ceiling must not shorten that.
+func TestRestoreCooldownStates_LeavesLongerNonQuotaDeadlineIntact(t *testing.T) {
+	now := time.Now()
+	quotaNext := now.Add(20 * time.Minute)
+	notFoundNext := now.Add(12 * time.Hour)
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: "auth-mixed-record", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("Register() returned error: %v", errRegister)
+	}
+	manager.SetCooldownStateStore(&mockCooldownStateStore{records: []CooldownStateRecord{
+		{
+			Provider:       "codex",
+			AuthID:         "auth-mixed-record",
+			NextRetryAfter: notFoundNext,
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: quotaNext},
+			UpdatedAt:      now,
+		},
+	}})
+
+	if errRestore := manager.RestoreCooldownStates(context.Background()); errRestore != nil {
+		t.Fatalf("RestoreCooldownStates() returned error: %v", errRestore)
+	}
+
+	restored, ok := manager.GetByID("auth-mixed-record")
+	if !ok || restored == nil {
+		t.Fatal("restored auth not found")
+	}
+	if !restored.NextRetryAfter.Equal(notFoundNext) {
+		t.Fatalf("restored NextRetryAfter = %v, want the non-quota deadline %v untouched", restored.NextRetryAfter, notFoundNext)
+	}
+	if !restored.Quota.NextRecoverAt.Equal(quotaNext) {
+		t.Fatalf("restored Quota.NextRecoverAt = %v, want %v untouched (already inside the ceiling)", restored.Quota.NextRecoverAt, quotaNext)
+	}
+}
+
+// A credential-scoped 429 promotes a deadline to every model on the credential. If the
+// stored aggregate deadline were carried through the maximum unclamped, it would become
+// credential_quota and park the whole credential for the original multi-day duration.
+func TestMarkResult_CredentialScopePropagationIsClamped(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "model-a", "model-b")
+
+	// Simulate a credential that already carries a pre-fix multi-day quota deadline.
+	now := time.Now()
+	stale := auth.Clone()
+	stale.Quota.Exceeded = true
+	stale.Quota.Reason = "quota"
+	stale.Quota.NextRecoverAt = now.Add(7 * 24 * time.Hour)
+	if _, errUpdate := m.Update(WithSkipPersist(context.Background()), stale); errUpdate != nil {
+		t.Fatalf("Update() returned error: %v", errUpdate)
+	}
+
+	short := 5 * time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: auth.Provider, Model: "model-a",
+		Success: false, RetryAfter: &short, CredentialScope: true,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "credential 429"},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("auth not found")
+	}
+	ceiling := now.Add(maxQuotaCooldownCeiling).Add(time.Minute)
+	if updated.Quota.NextRecoverAt.After(ceiling) {
+		t.Fatalf("credential-wide Quota.NextRecoverAt = %v, want clamped to ~%v", updated.Quota.NextRecoverAt, ceiling)
+	}
+	for _, model := range []string{"model-a", "model-b"} {
+		state := existingModelState(updated, canonicalModelKey(model))
+		if state == nil {
+			continue
+		}
+		if state.Quota.NextRecoverAt.After(ceiling) {
+			t.Fatalf("model %q Quota.NextRecoverAt = %v, want clamped to ~%v", model, state.Quota.NextRecoverAt, ceiling)
+		}
 	}
 }

--- a/sdk/cliproxy/auth/conductor_cooldown_ceiling_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_ceiling_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// A provider-reported reset deadline is a prediction made at the moment of failure, so
+// it must never park a credential indefinitely: quota can be restored ahead of it by a
+// window rollover or an operator-initiated reset. These tests pin the ceiling behaviour
+// and, just as importantly, the cases where the clamp must NOT interfere.
+
+func TestClampQuotaCooldown(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	ceiling := now.Add(maxQuotaCooldownCeiling)
+
+	tests := []struct {
+		name string
+		next time.Time
+		want time.Time
+	}{
+		{name: "zero stays zero", next: time.Time{}, want: time.Time{}},
+		{name: "exactly at ceiling is untouched", next: ceiling, want: ceiling},
+		{name: "one nanosecond under ceiling is untouched", next: ceiling.Add(-time.Nanosecond), want: ceiling.Add(-time.Nanosecond)},
+		{name: "one nanosecond over ceiling is clamped", next: ceiling.Add(time.Nanosecond), want: ceiling},
+		{name: "seven day reset is clamped", next: now.Add(7 * 24 * time.Hour), want: ceiling},
+		{name: "absurd far future does not overflow", next: time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC), want: ceiling},
+		// A deadline already in the past is expired. Clamping must never push it
+		// forward, which would resurrect a cooldown that had already elapsed.
+		{name: "past deadline is not extended", next: now.Add(-time.Hour), want: now.Add(-time.Hour)},
+		{name: "far past deadline is not extended", next: now.Add(-30 * 24 * time.Hour), want: now.Add(-30 * 24 * time.Hour)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clampQuotaCooldown(tc.next, now); !got.Equal(tc.want) {
+				t.Fatalf("clampQuotaCooldown(%v) = %v, want %v", tc.next, got, tc.want)
+			}
+		})
+	}
+}
+
+// The floor and the ceiling must not invert, otherwise a cooldown could be clamped
+// below the minimum it was just raised to.
+func TestQuotaCooldownBoundsAreOrdered(t *testing.T) {
+	if minQuotaCooldownFloor >= maxQuotaCooldownCeiling {
+		t.Fatalf("minQuotaCooldownFloor (%v) must be below maxQuotaCooldownCeiling (%v)", minQuotaCooldownFloor, maxQuotaCooldownCeiling)
+	}
+	if quotaBackoffMax > maxQuotaCooldownCeiling {
+		t.Fatalf("quotaBackoffMax (%v) exceeds maxQuotaCooldownCeiling (%v), so backoff would always clamp", quotaBackoffMax, maxQuotaCooldownCeiling)
+	}
+}
+
+func TestApplyAuthFailureState_ClampsLongProviderReset(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	sevenDays := 7 * 24 * time.Hour
+	auth := &Auth{ID: "codex-ceiling", Provider: "codex"}
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}, &sevenDays, now, false)
+
+	want := now.Add(maxQuotaCooldownCeiling)
+	if !auth.Quota.NextRecoverAt.Equal(want) {
+		t.Fatalf("Quota.NextRecoverAt = %v, want clamped %v", auth.Quota.NextRecoverAt, want)
+	}
+	if !auth.NextRetryAfter.Equal(want) {
+		t.Fatalf("NextRetryAfter = %v, want clamped %v", auth.NextRetryAfter, want)
+	}
+	if !auth.Quota.Exceeded {
+		t.Fatal("Quota.Exceeded = false, want the credential to remain in cooldown")
+	}
+}
+
+// Regression guard for the reason the clamp is applied to the final deadline rather
+// than to the incoming retry-after: both quota paths raise the new deadline to the
+// stored NextRecoverAt to keep a cooldown monotonic. If only the incoming value were
+// clamped, a previously stored multi-day deadline would win and re-extend forever.
+func TestApplyAuthFailureState_ClampsPreservedLongDeadlineOnReArm(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	short := 5 * time.Minute
+	auth := &Auth{ID: "codex-rearm", Provider: "codex"}
+	auth.Quota.Exceeded = true
+	auth.Quota.Reason = "quota"
+	auth.Quota.NextRecoverAt = now.Add(7 * 24 * time.Hour)
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}, &short, now, false)
+
+	want := now.Add(maxQuotaCooldownCeiling)
+	if !auth.Quota.NextRecoverAt.Equal(want) {
+		t.Fatalf("re-armed Quota.NextRecoverAt = %v, want clamped %v", auth.Quota.NextRecoverAt, want)
+	}
+}
+
+// A deadline already inside the ceiling must be honoured exactly, so the clamp cannot
+// silently lengthen short provider cooldowns.
+func TestApplyAuthFailureState_ShortResetIsUnchanged(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	short := 5 * time.Minute
+	auth := &Auth{ID: "codex-short", Provider: "codex"}
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}, &short, now, false)
+
+	if want := now.Add(short); !auth.Quota.NextRecoverAt.Equal(want) {
+		t.Fatalf("Quota.NextRecoverAt = %v, want untouched %v", auth.Quota.NextRecoverAt, want)
+	}
+}
+
+// The existing floor must keep applying underneath the ceiling.
+func TestApplyAuthFailureState_SubSecondResetStillRaisedToFloor(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	tiny := time.Nanosecond
+	auth := &Auth{ID: "codex-floor", Provider: "codex"}
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}, &tiny, now, false)
+
+	if want := now.Add(minQuotaCooldownFloor); !auth.Quota.NextRecoverAt.Equal(want) {
+		t.Fatalf("Quota.NextRecoverAt = %v, want floor %v", auth.Quota.NextRecoverAt, want)
+	}
+}
+
+// With cooling disabled the deadlines stay zero; the clamp must not manufacture a
+// cooldown out of "no cooldown".
+func TestApplyAuthFailureState_DisableCoolingKeepsZeroDeadline(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	sevenDays := 7 * 24 * time.Hour
+	auth := &Auth{ID: "codex-nocool", Provider: "codex"}
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}, &sevenDays, now, true)
+
+	if !auth.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("Quota.NextRecoverAt = %v, want zero when cooling is disabled", auth.Quota.NextRecoverAt)
+	}
+	if !auth.NextRetryAfter.IsZero() {
+		t.Fatalf("NextRetryAfter = %v, want zero when cooling is disabled", auth.NextRetryAfter)
+	}
+}
+
+// Non-quota failures are deliberately outside the ceiling: a 404 keeps its 12h
+// deadline, so the clamp must not leak into other status codes.
+func TestApplyAuthFailureState_NonQuotaDeadlineIsNotClamped(t *testing.T) {
+	now := time.Date(2026, 9, 8, 3, 0, 0, 0, time.UTC)
+	auth := &Auth{ID: "codex-404", Provider: "codex"}
+
+	applyAuthFailureState(auth, &Error{HTTPStatus: http.StatusNotFound, Message: "not found"}, nil, now, false)
+
+	if !auth.NextRetryAfter.After(now.Add(maxQuotaCooldownCeiling)) {
+		t.Fatalf("NextRetryAfter = %v, want a 404 deadline well beyond the quota ceiling", auth.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -34,7 +34,16 @@ const (
 	quotaBackoffBase          = time.Second
 	quotaBackoffMax           = 30 * time.Minute
 	minQuotaCooldownFloor     = 10 * time.Second
-	transientErrorCooldown    = time.Minute
+	// maxQuotaCooldownCeiling bounds how long a single quota cooldown may keep a
+	// credential parked. Providers report a reset deadline (e.g. Codex
+	// usage_limit_reached carries resets_at) that can sit days out, and that value is
+	// only a prediction made at the moment of failure: a weekly window can roll over
+	// early, and OpenAI lets users spend a "reset" to restore quota on demand. Without
+	// a ceiling the deadline is a one-way latch, so restored quota stays unreachable
+	// until it expires. Capping it lets the next request probe upstream for real; a
+	// still-exhausted credential simply re-arms on the next 429.
+	maxQuotaCooldownCeiling = time.Hour
+	transientErrorCooldown  = time.Minute
 )
 
 // StartAutoRefresh launches a background loop that evaluates auth freshness

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -503,18 +503,23 @@ func TestManager_RestoreCooldownStates(t *testing.T) {
 
 func TestManager_RestoreCooldownStatesCanonicalizesThinkingSuffixes(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	laterRetry := now.Add(2 * time.Hour)
+	// Both deadlines stay inside maxQuotaCooldownCeiling: this test is about
+	// canonicalizing thinking suffixes to a single model key and letting the later
+	// record win, not about the quota ceiling, so it must not depend on deadlines the
+	// restore path now clamps.
+	earlierRetry := now.Add(30 * time.Minute)
+	laterRetry := now.Add(45 * time.Minute)
 	store := &recordingCooldownStateStore{
 		load: []CooldownStateRecord{
 			{
 				Provider:       "gemini",
 				AuthID:         "auth-thinking",
 				Model:          "gemini-3.1-pro-preview(high)",
-				NextRetryAfter: now.Add(time.Hour),
+				NextRetryAfter: earlierRetry,
 				Quota: QuotaState{
 					Exceeded:      true,
 					Reason:        "quota",
-					NextRecoverAt: now.Add(time.Hour),
+					NextRecoverAt: earlierRetry,
 				},
 				UpdatedAt: now,
 			},


### PR DESCRIPTION
Fixes #5611, which describes the bug and how it was found in full.

## Problem

A provider's quota reset deadline is treated as ground truth for as long as it claims, with nothing ever re-checking it.

Codex returns `resets_at` in its `usage_limit_reached` body. For a weekly plan limit that lands about 7 days out. `parseCodexRetryAfter` turns it into a cooldown, it becomes `Quota.NextRecoverAt`, and `isAuthBlockedForModel` (`selector.go:834`) refuses the credential until it elapses.

There is no re-probe anywhere in `sdk/cliproxy/auth` — no half-open, no revalidation, no periodic recheck. The cooldown is a one-way latch with exactly three exits: the deadline passes, the credential is disabled, or the process restarts.

That matters because `resets_at` is a *prediction made at the instant of failure*, and it can become wrong in the user's favour:

- a weekly window can roll over earlier than the deadline reported when it was exhausted
- **OpenAI ships a "Full reset" that users can spend to restore quota on demand**

In both cases the proxy keeps serving 429s against quota the account actually has, for up to a week.

## How this was found

A deployment had both Codex credentials returning 429 for every request:

```
{"error":{"code":"model_cooldown",
  "last_upstream_error":"usage_limit_reached: The usage limit has been reached",
  "message":"All credentials for model <model> are cooling down via provider codex",
  "reset_seconds":14723,"reset_time":"4h5m22s"}}
```

The proxy log showed both credentials latched, one for ~4h and one for ~144h:

```
[11:09:27] 429 | upstream execution failed: provider=codex model=<model>
           auth_file=codex-<redacted>-prolite.json
           err={"error":{"type":"usage_limit_reached","message":"The usage limit has been reached",
                "plan_type":"prolite","resets_at":<epoch>}}

[11:09:27] auth unavailable: 2 of 2 candidate(s) for model "<model>" (provider=codex) are in cooldown:
           [auth_file=codex-<redacted>-prolite.json, reason=quota,            remaining=4h5m47s],
           [auth_file=codex-<redacted>-pro.json,     reason=credential_quota, remaining=144h0m12s]
```

**But OpenAI's own usage settings for the `-pro` account showed `Weekly limit — 100% left, resets in 7d 0h`.** The weekly window had rolled over; the proxy was refusing against quota that was fully available.

Two things were ruled out before touching the code:

1. **It was not the OAuth token.** That credential's access token was refreshed, the watcher reloaded the file, and the cooldown survived unchanged:

```
[11:10:03] auth file changed (WRITE): codex-<redacted>-pro.json, processing incrementally
[11:12:18] auth unavailable: ... auth_file=codex-<redacted>-pro.json,
           reason=credential_quota, remaining=143h57m22s
```

This is `conductor_lifecycle.go:211` deliberately copying `existing.Quota` onto the reloaded credential. Preserving a cooldown across a refresh is correct on its own; the problem is that nothing else can clear it either.

2. **The quota really was available.** Restarting the container — which drops the in-memory cooldown table — restored service immediately. Both models returned `200` on the first request, and failover behaved correctly, with the genuinely-still-limited credential 429ing and the recovered one serving:

```
[11:21:47] 429  codex-<redacted>-prolite.json   <- real 5h-window limit, correctly cooled
[11:21:49] 200                                  <- failed over to the recovered credential
```

Worth noting that the restart only worked because that deployment has no cooldown store configured. With `SetCooldownStateStore` in use, `RestoreCooldownStates` reinstates the deadline (as `TestAuthManager_CooldownPersistenceAcrossRestore` asserts), so the operator has no workaround at all.

## Fix

Add `maxQuotaCooldownCeiling` (1h) alongside the existing `minQuotaCooldownFloor`, and clamp the computed deadline in both quota paths (`MarkResult` per-model, and `applyAuthFailureState` credential-wide).

A still-exhausted credential re-arms on its next 429, costing at most one upstream request per credential per hour. A recovered one is picked up within the ceiling instead of never.

The clamp is applied to the **final** deadline rather than to the incoming retry-after, because both paths raise the new deadline to the stored `NextRecoverAt` to keep cooldowns monotonic (#5501). Clamping only the incoming value would let a previously stored multi-day deadline win and re-extend the cooldown unbounded — there is a regression test for exactly this.

Non-quota cooldowns (401 / 404 / transient) are untouched; the ceiling applies only to the 429 quota branch.

## Note on the changed tests

Three tests in `claude_ratelimit_cooldown_test.go` asserted that a 7-day deadline stays 7 days. They now assert it is clamped, while still verifying their original intent — that a concurrent success, an `Update`, or a restore neither clears nor shortens an active cooldown.

I want to flag this explicitly for review, since it changes behaviour those tests were added to protect. The argument for doing so is that the unbounded latch is wrong for *any* provider, not just Codex: no provider's reset prediction can account for quota being restored early, so honouring one for days without ever re-checking will strand a credential on any of them. If you would rather keep the long deadlines for Claude and scope the ceiling to Codex only, or add a half-open probe that preserves `NextRecoverAt` and lets a single request through instead, I am glad to rework it either way.

## Testing

- `gofmt -w .` clean
- `go build ./cmd/server` OK
- `go test ./...` — 92 packages, 0 failures
- New `conductor_cooldown_ceiling_test.go` covers ceiling boundaries (exactly at / 1ns over / 1ns under), zero deadlines, absurd far-future values, past deadlines that must never be extended, the floor still applying beneath the ceiling, `disableCooling` keeping zero deadlines, non-quota deadlines staying unclamped, and the re-arm path above
- The new tests were mutation-checked: with the clamp neutered to a no-op they fail, so they are not passing vacuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)

