### PR TITLE
fix(pluginstore): limit release checks and honor GitHub cooldowns

### DIFF
--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -153,15 +153,24 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		return
 	}
 
-	latestInput := make([]pluginstore.Plugin, 0, len(plugins))
-	for _, item := range plugins {
-		latestInput = append(latestInput, item.plugin)
-	}
-	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
-	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 	pluginSourceCounts := make(map[string]int, len(plugins))
 	for _, item := range plugins {
 		pluginSourceCounts[item.plugin.ID]++
+	}
+	latestInput := make([]pluginstore.Plugin, 0, len(plugins))
+	latestIndices := make([]int, 0, len(plugins))
+	for index, item := range plugins {
+		status := statuses[item.plugin.ID]
+		_, _, sourceAllowsUpdate := pluginStoreInstallSourceStatus(status, sources, item.source.ID, pluginSourceCounts[item.plugin.ID])
+		if (status.Installed || status.Registered) && sourceAllowsUpdate && pluginstore.PluginInstallType(item.plugin) == pluginstore.InstallTypeGitHubRelease {
+			latestInput = append(latestInput, item.plugin)
+			latestIndices = append(latestIndices, index)
+		}
+	}
+	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
+	latestVersions := make([]string, len(plugins))
+	for index, version := range h.latestPluginVersions(c.Request.Context(), client, latestInput) {
+		latestVersions[latestIndices[index]] = version
 	}
 
 	entries := make([]pluginStoreListEntry, 0, len(plugins))
@@ -690,8 +699,8 @@ func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.C
 
 // latestPluginVersion returns the plugin's latest release version, caching
 // lookups per repository so repeated listings do not exhaust the GitHub API
-// rate limit. Failed lookups are cached for a shorter interval and reported
-// as an empty version.
+// rate limit. Rate-limited lookups retain the previous version until retry is
+// allowed; other failures use a short cache interval and an empty version.
 func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
 	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
 		return ""
@@ -720,11 +729,17 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 		ttl = pluginReleaseCacheTTL
 	}
 
+	expiresAt := time.Now().Add(ttl)
+	var rateLimit *pluginstore.RateLimitError
+	if errors.As(errRelease, &rateLimit) {
+		version = entry.version
+		expiresAt = rateLimit.RetryAt
+	}
 	h.pluginReleaseCacheMu.Lock()
 	if h.pluginReleaseCache == nil {
 		h.pluginReleaseCache = make(map[string]pluginReleaseCacheEntry)
 	}
-	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: now.Add(ttl)}
+	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: expiresAt}
 	h.pluginReleaseCacheMu.Unlock()
 	return version
 }

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -731,11 +731,11 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 
 	expiresAt := time.Now().Add(ttl)
 	var rateLimit *pluginstore.RateLimitError
+	h.pluginReleaseCacheMu.Lock()
 	if errors.As(errRelease, &rateLimit) {
-		version = entry.version
+		version = h.pluginReleaseCache[repository].version
 		expiresAt = rateLimit.RetryAt
 	}
-	h.pluginReleaseCacheMu.Lock()
 	if h.pluginReleaseCache == nil {
 		h.pluginReleaseCache = make(map[string]pluginReleaseCacheEntry)
 	}

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -35,6 +35,7 @@ const (
 type pluginReleaseCacheEntry struct {
 	version   string
 	expiresAt time.Time
+	retryAt   time.Time
 }
 
 type pluginStoreListResponse struct {
@@ -732,14 +733,24 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 	expiresAt := time.Now().Add(ttl)
 	var rateLimit *pluginstore.RateLimitError
 	h.pluginReleaseCacheMu.Lock()
+	current := h.pluginReleaseCache[repository]
+	retryAt := current.retryAt
 	if errors.As(errRelease, &rateLimit) {
-		version = h.pluginReleaseCache[repository].version
+		version = current.version
 		expiresAt = rateLimit.RetryAt
+		if rateLimit.RetryAt.After(retryAt) {
+			retryAt = rateLimit.RetryAt
+		}
+	} else if version == "" && time.Now().Before(retryAt) {
+		version = current.version
+	}
+	if retryAt.After(expiresAt) {
+		expiresAt = retryAt
 	}
 	if h.pluginReleaseCache == nil {
 		h.pluginReleaseCache = make(map[string]pluginReleaseCacheEntry)
 	}
-	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: expiresAt}
+	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: expiresAt, retryAt: retryAt}
 	h.pluginReleaseCacheMu.Unlock()
 	return version
 }

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -501,6 +501,60 @@ func TestLatestPluginVersionRateLimitPreservesConcurrentRefresh(t *testing.T) {
 	}
 }
 
+func TestLatestPluginVersionPreservesConcurrentCooldown(t *testing.T) {
+	t.Parallel()
+	for _, outcome := range []string{"success", "failure", "shorter-limit"} {
+		t.Run(outcome, func(t *testing.T) {
+			repository := "https://github.com/author/sample"
+			plugin := pluginstore.Plugin{ID: "sample", Repository: repository}
+			retryAt := time.Now().Add(time.Hour).Truncate(time.Second)
+			h := &Handler{pluginReleaseCache: map[string]pluginReleaseCacheEntry{
+				repository: {version: "0.1.0", expiresAt: time.Now().Add(-time.Second)},
+			}}
+			started := make(chan struct{})
+			finish := make(chan struct{})
+			result := make(chan string, 1)
+			laterClient := pluginstore.Client{HTTPClient: pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+				close(started)
+				<-finish
+				switch outcome {
+				case "failure":
+					return nil, fmt.Errorf("simulated network failure")
+				case "shorter-limit":
+					headers := make(http.Header)
+					headers.Set("Retry-After", "120")
+					return &http.Response{StatusCode: http.StatusTooManyRequests, Header: headers, Body: io.NopCloser(strings.NewReader(""))}, nil
+				default:
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"tag_name":"v0.2.0"}`))}, nil
+				}
+			})}
+			go func() {
+				result <- h.latestPluginVersion(context.Background(), laterClient, plugin)
+			}()
+			<-started
+			limitedClient := pluginstore.Client{HTTPClient: pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+				headers := make(http.Header)
+				headers.Set("Retry-After", retryAt.Format(http.TimeFormat))
+				return &http.Response{StatusCode: http.StatusForbidden, Header: headers, Body: io.NopCloser(strings.NewReader(""))}, nil
+			})}
+			h.latestPluginVersion(context.Background(), limitedClient, plugin)
+			close(finish)
+			version := <-result
+			wantVersion := "0.1.0"
+			if outcome == "success" {
+				wantVersion = "0.2.0"
+			}
+			entry := h.pluginReleaseCache[repository]
+			if version != wantVersion || entry.version != wantVersion || !entry.expiresAt.Equal(retryAt) || !entry.retryAt.Equal(retryAt) {
+				t.Fatalf("version = %q, cache = %+v; want %s until %v", version, entry, wantVersion, retryAt)
+			}
+			if cached := h.latestPluginVersion(context.Background(), laterClient, plugin); cached != wantVersion {
+				t.Fatalf("cached version = %q, want %q", cached, wantVersion)
+			}
+		})
+	}
+}
+
 func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -461,6 +461,46 @@ func TestLatestPluginVersionCacheStartsAfterRequest(t *testing.T) {
 	}
 }
 
+func TestLatestPluginVersionRateLimitPreservesConcurrentRefresh(t *testing.T) {
+	t.Parallel()
+	repository := "https://github.com/author/sample"
+	plugin := pluginstore.Plugin{ID: "sample", Repository: repository}
+	retryAt := time.Now().Add(time.Hour).Truncate(time.Second)
+	h := &Handler{pluginReleaseCache: map[string]pluginReleaseCacheEntry{
+		repository: {version: "0.1.0", expiresAt: time.Now().Add(-time.Second)},
+	}}
+	started := make(chan struct{})
+	releaseLimited := make(chan struct{})
+	limitedResult := make(chan string, 1)
+	limitedClient := pluginstore.Client{HTTPClient: pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		close(started)
+		<-releaseLimited
+		headers := make(http.Header)
+		headers.Set("Retry-After", retryAt.Format(http.TimeFormat))
+		return &http.Response{StatusCode: http.StatusForbidden, Header: headers, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}
+	go func() {
+		limitedResult <- h.latestPluginVersion(context.Background(), limitedClient, plugin)
+	}()
+	<-started
+	successClient := pluginstore.Client{HTTPClient: pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"tag_name":"v0.2.0"}`))}, nil
+	})}
+	successVersion := h.latestPluginVersion(context.Background(), successClient, plugin)
+	close(releaseLimited)
+	limitedVersion := <-limitedResult
+	if successVersion != "0.2.0" || limitedVersion != "0.2.0" {
+		t.Fatalf("versions: success = %q, limited = %q; want 0.2.0", successVersion, limitedVersion)
+	}
+	entry := h.pluginReleaseCache[repository]
+	if entry.version != "0.2.0" || !entry.expiresAt.Equal(retryAt) {
+		t.Fatalf("cache = %+v, want version 0.2.0 until %v", entry, retryAt)
+	}
+	if version := h.latestPluginVersion(context.Background(), limitedClient, plugin); version != "0.2.0" {
+		t.Fatalf("cached version = %q, want 0.2.0", version)
+	}
+}
+
 func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -3,9 +3,11 @@ package management
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"html"
 	"io"
 	"net/http"
@@ -16,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -280,6 +283,184 @@ func TestListPluginStoreEscapesRegistryStrings(t *testing.T) {
 	}
 }
 
+func TestListPluginStoreOnlyChecksInstalledSources(t *testing.T) {
+	t.Parallel()
+	for _, installedCount := range []int{0, 2} {
+		t.Run(fmt.Sprintf("installed-%d", installedCount), func(t *testing.T) {
+			pluginsDir := t.TempDir()
+			archDir := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH)
+			if errMkdir := os.MkdirAll(archDir, 0o755); errMkdir != nil {
+				t.Fatal(errMkdir)
+			}
+			communityURL := "https://community.example/registry.json"
+			configs := map[string]config.PluginInstanceConfig{}
+			var plugins []map[string]any
+			responses := fakePluginStoreHTTPClient{}
+			for index := 0; index < 57; index++ {
+				id := fmt.Sprintf("sample-%d", index)
+				repository := fmt.Sprintf("https://github.com/author/plugin-%d", index)
+				plugins = append(plugins, map[string]any{"id": id, "name": id, "description": "Test plugin", "author": "author", "version": "0.1.0", "repository": repository})
+				responses[fmt.Sprintf("https://api.github.com/repos/author/plugin-%d/releases/latest", index)] = []byte(fmt.Sprintf(`{"tag_name":"v0.2.%d"}`, index))
+				if index == 3 || index == 41 {
+					configs[id] = pluginConfigWithStoreSource(t, pluginstore.DefaultSourceID, pluginstore.DefaultRegistryURL)
+					if installedCount > 0 {
+						path := filepath.Join(archDir, id+"-v0.0.1"+managementPluginExtension(runtime.GOOS))
+						if errWrite := os.WriteFile(path, []byte("x"), 0o644); errWrite != nil {
+							t.Fatal(errWrite)
+						}
+					}
+				}
+			}
+			registry, errMarshal := json.Marshal(map[string]any{"schema_version": 1, "plugins": plugins})
+			if errMarshal != nil {
+				t.Fatal(errMarshal)
+			}
+			responses[pluginstore.DefaultRegistryURL] = registry
+			responses[communityURL] = []byte(`{"schema_version":1,"plugins":[{"id":"sample-3","name":"Other source","description":"Test plugin","author":"community","version":"0.9.0","repository":"https://github.com/community/other"}]}`)
+			httpClient := &countingPluginStoreHTTPClient{responses: responses}
+			h := &Handler{cfg: &config.Config{Plugins: config.PluginsConfig{Enabled: true, Dir: pluginsDir, StoreSources: []string{communityURL}, Configs: configs}}, pluginStoreHTTPClient: httpClient}
+			for call := 0; call < 2; call++ {
+				body := listPluginStoreForTest(t, h)
+				if len(body.Plugins) != 58 {
+					t.Fatalf("got %d plugins, want 58", len(body.Plugins))
+				}
+				for _, entry := range body.Plugins {
+					wantVersion := "0.1.0"
+					if entry.SourceID != pluginstore.DefaultSourceID {
+						wantVersion = "0.9.0"
+					} else if installedCount > 0 && (entry.ID == "sample-3" || entry.ID == "sample-41") {
+						wantVersion = "0.2." + strings.TrimPrefix(entry.ID, "sample-")
+					}
+					if entry.Version != wantVersion {
+						t.Fatalf("%s: version %s, want %s", entry.StoreID, entry.Version, wantVersion)
+					}
+				}
+			}
+			for index := 0; index < 57; index++ {
+				want := 0
+				if installedCount > 0 && (index == 3 || index == 41) {
+					want = 1
+				}
+				if got := httpClient.count(fmt.Sprintf("https://api.github.com/repos/author/plugin-%d/releases/latest", index)); got != want {
+					t.Fatalf("plugin-%d calls = %d, want %d", index, got, want)
+				}
+			}
+			if got := httpClient.count("https://api.github.com/repos/community/other/releases/latest"); got != 0 {
+				t.Fatalf("other source queried %d times", got)
+			}
+		})
+	}
+}
+
+func listPluginStoreForTest(t *testing.T, h *Handler) pluginStoreListResponse {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	h.ListPluginStore(ctx)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var body pluginStoreListResponse
+	if errDecode := json.Unmarshal(recorder.Body.Bytes(), &body); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	return body
+}
+
+type pluginStoreHTTPDoerFunc func(*http.Request) (*http.Response, error)
+
+func (do pluginStoreHTTPDoerFunc) Do(request *http.Request) (*http.Response, error) {
+	return do(request)
+}
+
+func TestListPluginStoreRateLimitCache(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		status  int
+		limited bool
+	}{
+		{http.StatusForbidden, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusForbidden, false},
+	} {
+		for _, previousVersion := range []string{"", "0.2.0"} {
+			t.Run(fmt.Sprintf("%d/limited-%t/previous-%s", test.status, test.limited, previousVersion), func(t *testing.T) {
+				repository := "https://github.com/author-name/cliproxy-sample-provider-plugin"
+				retryAt := time.Now().Add(time.Hour).Truncate(time.Second)
+				calls := 0
+				h := &Handler{cfg: &config.Config{Plugins: config.PluginsConfig{Enabled: true, Dir: writeManagementPluginFile(t, "sample-provider")}}}
+				h.pluginReleaseCache = map[string]pluginReleaseCacheEntry{repository: {version: previousVersion, expiresAt: time.Now().Add(-time.Hour)}}
+				h.pluginStoreHTTPClient = pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+					if request.URL.String() == pluginstore.DefaultRegistryURL {
+						return fakePluginStoreHTTPClient{pluginstore.DefaultRegistryURL: registryJSON(t)}.Do(request)
+					}
+					calls++
+					headers := make(http.Header)
+					headers.Set("X-RateLimit-Reset", fmt.Sprint(retryAt.Unix()))
+					if test.limited {
+						headers.Set("X-RateLimit-Remaining", "0")
+					}
+					return &http.Response{StatusCode: test.status, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+				})
+				for call := 0; call < 2; call++ {
+					body := listPluginStoreForTest(t, h)
+					wantVersion := "0.1.0"
+					if previousVersion != "" && test.limited {
+						wantVersion = previousVersion
+					}
+					if len(body.Plugins) != 1 || body.Plugins[0].Version != wantVersion || !body.Plugins[0].Installed {
+						t.Fatalf("unexpected entries: %+v", body.Plugins)
+					}
+				}
+				if calls != 1 {
+					t.Fatalf("calls = %d, want 1", calls)
+				}
+				entry := h.pluginReleaseCache[repository]
+				if test.limited {
+					if !entry.expiresAt.Equal(retryAt) {
+						t.Fatalf("expiry = %v, want %v", entry.expiresAt, retryAt)
+					}
+				} else if entry.expiresAt.After(time.Now().Add(time.Minute)) {
+					t.Fatal("ordinary error received long cooldown")
+				}
+				entry.expiresAt = time.Now().Add(-time.Second)
+				h.pluginReleaseCache[repository] = entry
+				listPluginStoreForTest(t, h)
+				if calls != 2 {
+					t.Fatalf("calls after expiry = %d, want 2", calls)
+				}
+			})
+		}
+	}
+}
+
+func TestLatestPluginVersionCacheStartsAfterRequest(t *testing.T) {
+	t.Parallel()
+	for _, success := range []bool{false, true} {
+		t.Run(fmt.Sprintf("success-%t", success), func(t *testing.T) {
+			var completedAt time.Time
+			client := pluginstore.Client{HTTPClient: pluginStoreHTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+				completedAt = time.Now()
+				if !success {
+					return nil, fmt.Errorf("simulated network failure")
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"tag_name":"v0.2.0"}`))}, nil
+			})}
+			h := &Handler{}
+			plugin := pluginstore.Plugin{ID: "sample", Repository: "https://github.com/author/sample"}
+			h.latestPluginVersion(context.Background(), client, plugin)
+			ttl := pluginReleaseFailureCacheTTL
+			if success {
+				ttl = pluginReleaseCacheTTL
+			}
+			if expiry := h.pluginReleaseCache[plugin.Repository].expiresAt; expiry.Before(completedAt.Add(ttl)) {
+				t.Fatalf("expiry %v precedes completion plus TTL %v", expiry, completedAt.Add(ttl))
+			}
+		})
+	}
+}
+
 func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 	t.Parallel()
 
@@ -294,7 +475,7 @@ func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 		cfg: &config.Config{
 			Plugins: config.PluginsConfig{
 				Enabled: true,
-				Dir:     t.TempDir(),
+				Dir:     writeManagementPluginFile(t, "sample-provider"),
 			},
 		},
 		configFilePath:         writeTestConfigFile(t),

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -52,9 +52,6 @@ func (err *RateLimitError) Error() string {
 }
 
 func pluginStoreRateLimitError(status int, headers http.Header, now time.Time) *RateLimitError {
-	if status != http.StatusTooManyRequests && (status != http.StatusForbidden || strings.TrimSpace(headers.Get("X-RateLimit-Remaining")) != "0") {
-		return nil
-	}
 	var retryAt time.Time
 	if reset, errParse := strconv.ParseInt(strings.TrimSpace(headers.Get("X-RateLimit-Reset")), 10, 64); errParse == nil && reset > 0 {
 		retryAt = time.Unix(reset, 0).UTC()
@@ -65,6 +62,9 @@ func pluginStoreRateLimitError(status int, headers http.Header, now time.Time) *
 		retryAfterTime = now.Add(time.Duration(seconds) * time.Second)
 	} else if date, errDate := http.ParseTime(retryAfter); errDate == nil {
 		retryAfterTime = date
+	}
+	if status != http.StatusTooManyRequests && (status != http.StatusForbidden || (strings.TrimSpace(headers.Get("X-RateLimit-Remaining")) != "0" && retryAfterTime.IsZero())) {
+		return nil
 	}
 	if retryAfterTime.After(retryAt) {
 		retryAt = retryAfterTime

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,6 +40,39 @@ type ReleaseAsset struct {
 	APIURL             string `json:"url"`
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type RateLimitError struct {
+	StatusCode int
+	RetryAt    time.Time
+}
+
+func (err *RateLimitError) Error() string {
+	return fmt.Sprintf("unexpected status %d; retry at %s", err.StatusCode, err.RetryAt.UTC().Format(time.RFC3339))
+}
+
+func pluginStoreRateLimitError(status int, headers http.Header, now time.Time) *RateLimitError {
+	if status != http.StatusTooManyRequests && (status != http.StatusForbidden || strings.TrimSpace(headers.Get("X-RateLimit-Remaining")) != "0") {
+		return nil
+	}
+	var retryAt time.Time
+	if reset, errParse := strconv.ParseInt(strings.TrimSpace(headers.Get("X-RateLimit-Reset")), 10, 64); errParse == nil && reset > 0 {
+		retryAt = time.Unix(reset, 0).UTC()
+	}
+	retryAfter := strings.TrimSpace(headers.Get("Retry-After"))
+	var retryAfterTime time.Time
+	if seconds, errParse := strconv.ParseUint(retryAfter, 10, 63); errParse == nil && seconds <= uint64((1<<63-1)/int64(time.Second)) {
+		retryAfterTime = now.Add(time.Duration(seconds) * time.Second)
+	} else if date, errDate := http.ParseTime(retryAfter); errDate == nil {
+		retryAfterTime = date
+	}
+	if retryAfterTime.After(retryAt) {
+		retryAt = retryAfterTime
+	}
+	if !retryAt.After(now) {
+		retryAt = now.Add(time.Minute)
+	}
+	return &RateLimitError{StatusCode: status, RetryAt: retryAt}
 }
 
 func (c Client) FetchRegistry(ctx context.Context) (Registry, error) {
@@ -266,6 +300,9 @@ func readPluginStoreResponse(resp *http.Response, maxSize int64, authenticated b
 		}
 	}()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		if errRateLimit := pluginStoreRateLimitError(resp.StatusCode, resp.Header, time.Now()); errRateLimit != nil {
+			return nil, errRateLimit
+		}
 		if authenticated {
 			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 		}

--- a/internal/pluginstore/github_test.go
+++ b/internal/pluginstore/github_test.go
@@ -33,8 +33,14 @@ func TestPluginStoreRateLimitError(t *testing.T) {
 		{"past", 429, "", strconv.FormatInt(now.Add(-time.Hour).Unix(), 10), "0", time.Minute},
 		{"overflow", 429, "", "", "9223372036854775807", time.Minute},
 		{"negative", 429, "", "-1", "-30", time.Minute},
-		{"permission", 403, "1", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "120", 0},
-		{"permission missing remaining", 403, "", "", "120", 0},
+		{"secondary nonzero remaining", 403, "1", "", "120", 2 * time.Minute},
+		{"secondary missing remaining", 403, "", "", "120", 2 * time.Minute},
+		{"secondary date", 403, "1", "", now.Add(3 * time.Minute).Format(http.TimeFormat), 3 * time.Minute},
+		{"secondary reset later", 403, "1", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "120", time.Hour},
+		{"secondary zero", 403, "", "", "0", time.Minute},
+		{"permission", 403, "1", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "", 0},
+		{"permission missing remaining", 403, "", "", "", 0},
+		{"permission invalid retry", 403, "1", "", "bad", 0},
 		{"server error", 500, "0", "", "120", 0},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/pluginstore/github_test.go
+++ b/internal/pluginstore/github_test.go
@@ -3,9 +3,70 @@ package pluginstore
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestPluginStoreRateLimitError(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name       string
+		status     int
+		remaining  string
+		reset      string
+		retryAfter string
+		wait       time.Duration
+	}{
+		{"reset", 403, "0", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "", time.Hour},
+		{"seconds", 429, "", "", "120", 2 * time.Minute},
+		{"date", 429, "", "", now.Add(3 * time.Minute).Format(http.TimeFormat), 3 * time.Minute},
+		{"reset later", 403, "0", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "120", time.Hour},
+		{"retry later", 429, "", strconv.FormatInt(now.Add(time.Minute).Unix(), 10), "120", 2 * time.Minute},
+		{"missing", 429, "", "", "", time.Minute},
+		{"invalid", 403, "0", "bad", "bad", time.Minute},
+		{"past", 429, "", strconv.FormatInt(now.Add(-time.Hour).Unix(), 10), "0", time.Minute},
+		{"overflow", 429, "", "", "9223372036854775807", time.Minute},
+		{"negative", 429, "", "-1", "-30", time.Minute},
+		{"permission", 403, "1", strconv.FormatInt(now.Add(time.Hour).Unix(), 10), "120", 0},
+		{"permission missing remaining", 403, "", "", "120", 0},
+		{"server error", 500, "0", "", "120", 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			headers := make(http.Header)
+			headers.Set("X-RateLimit-Remaining", test.remaining)
+			headers.Set("X-RateLimit-Reset", test.reset)
+			headers.Set("Retry-After", test.retryAfter)
+			err := pluginStoreRateLimitError(test.status, headers, now)
+			if test.wait == 0 {
+				if err != nil {
+					t.Fatalf("unexpected rate limit: %v", err)
+				}
+				return
+			}
+			if err == nil || !err.RetryAt.Equal(now.Add(test.wait)) || err.StatusCode != test.status {
+				t.Fatalf("rate limit = %v, want retry at %v", err, now.Add(test.wait))
+			}
+		})
+	}
+}
+
+func TestReadPluginStoreResponseRateLimit(t *testing.T) {
+	t.Parallel()
+	for _, authenticated := range []bool{false, true} {
+		response := &http.Response{StatusCode: 429, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("private upstream details"))}
+		_, err := readPluginStoreResponse(response, 0, authenticated)
+		var rateLimit *RateLimitError
+		if !errors.As(err, &rateLimit) || strings.Contains(err.Error(), "private") {
+			t.Fatalf("expected sanitized rate limit, got %v", err)
+		}
+	}
+}
 
 func TestSelectReleaseAssets(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- only check latest GitHub releases for actually installed or registered plugins whose installation source matches the store entry, while keeping all store entries visible
- cache rate-limited release lookups until the retry time specified by GitHub and retain the last successful version; keep the existing short cache for ordinary failures
- add regression tests for installed-only queries, source matching, rate-limit headers, cached versions, and cache expiration

This reduces cold-cache release lookups from 58 to 2 when only two of the 58 store entries are installed, and prevents repeated refreshes from querying a rate-limited repository before its cooldown expires.

Fixes #5608

## Validation

- `go test ./...`
- `go test -race ./internal/pluginstore ./internal/api/handlers/management`
- `go build -o /tmp/cpa-pr-5608-build.uSxBge/cli-proxy-api ./cmd/server`
- `git diff --check`

This PR intentionally contains only the backend fix and its regression tests; the local implementation plan is not included. No frontend, API routes, production configuration, or running services are changed by this patch.
