### PR TITLE
feat(management): add per-session affinity invalidation

### DIFF
--- a/internal/api/handlers/management/session_affinity.go
+++ b/internal/api/handlers/management/session_affinity.go
@@ -1,0 +1,58 @@
+package management
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+)
+
+// sessionAffinityInvalidator is implemented by selectors that can release the
+// affinity bindings of a single session. It is declared here rather than
+// referencing the concrete selector so that pools configured with a plain
+// round-robin selector simply report the capability as unavailable.
+type sessionAffinityInvalidator interface {
+	InvalidateSession(sessionID string) coreauth.SessionInvalidation
+}
+
+// DeleteSessionAffinity releases the affinity bindings of one session so its
+// next request is re-selected from the pool.
+//
+// Operators otherwise have only two ways to move a single caller onto another
+// credential: give the caller a new session id, which throws away the upstream
+// prompt cache for that conversation, or restart the proxy, which throws away
+// every binding for every caller. This endpoint is the narrow option.
+//
+// The response is 200 whether or not a binding existed. A caller cannot tell an
+// unknown session from one whose TTL just lapsed, and the request is a pure
+// removal, so making the no-op case an error would only break retries and
+// fire-and-forget scripts. The "removed" field carries that distinction.
+func (h *Handler) DeleteSessionAffinity(c *gin.Context) {
+	if h == nil || h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "core auth manager unavailable"})
+		return
+	}
+
+	sessionID := coresession.NormalizeExplicitID(c.Query("session_id"))
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "missing or invalid session_id"})
+		return
+	}
+
+	invalidator, ok := h.authManager.Selector().(sessionAffinityInvalidator)
+	if !ok || invalidator == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "session affinity is not enabled"})
+		return
+	}
+
+	result := invalidator.InvalidateSession(sessionID)
+	c.JSON(http.StatusOK, gin.H{
+		"status":        "ok",
+		"session_id":    sessionID,
+		"removed":       result.Removed(),
+		"cache_groups":  result.CacheGroups,
+		"cache_aliases": result.CacheAliases,
+		"lcp_groups":    result.LCPGroups,
+	})
+}

--- a/internal/api/handlers/management/session_affinity_test.go
+++ b/internal/api/handlers/management/session_affinity_test.go
@@ -1,0 +1,146 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+const testManagementKey = "test-secret"
+
+func newSessionAffinityTestEngine(t *testing.T, manager *coreauth.Manager) *gin.Engine {
+	t.Helper()
+	h := &Handler{
+		cfg:            &config.Config{},
+		failedAttempts: make(map[string]*attemptInfo),
+		envSecret:      testManagementKey,
+		authManager:    manager,
+	}
+	engine := gin.New()
+	engine.DELETE("/v0/management/session-affinity", h.Middleware(), h.DeleteSessionAffinity)
+	return engine
+}
+
+func deleteSessionAffinity(t *testing.T, engine *gin.Engine, sessionID, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	target := "/v0/management/session-affinity"
+	if sessionID != "" {
+		target += "?session_id=" + url.QueryEscape(sessionID)
+	}
+	req := httptest.NewRequest(http.MethodDelete, target, nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	if key != "" {
+		req.Header.Set("X-Management-Key", key)
+	}
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDeleteSessionAffinity(t *testing.T) {
+	const sessionUUID = "8046da35-c12f-4b6b-8c9e-86ecb162fcee"
+	affinitySessionID := "claude:" + sessionUUID
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	selector := coreauth.NewSessionAffinitySelector(&coreauth.RoundRobinSelector{})
+	defer selector.Stop()
+	manager.SetSelector(selector)
+	engine := newSessionAffinityTestEngine(t, manager)
+
+	auths := []*coreauth.Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Claude-Code-Session-Id": []string{sessionUUID}},
+	}
+	bound, errPick := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", opts, auths)
+	if errPick != nil || bound == nil {
+		t.Fatalf("Pick() error = %v, auth = %v", errPick, bound)
+	}
+
+	t.Run("missing management key is unauthorized", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, affinitySessionID, "")
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+		}
+	})
+
+	t.Run("wrong management key is unauthorized", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, affinitySessionID, "wrong-secret")
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusUnauthorized, rec.Body.String())
+		}
+	})
+
+	t.Run("missing session id is a bad request", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, "", testManagementKey)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+		}
+	})
+
+	t.Run("control characters are a bad request", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, "claude:bad\nsession", testManagementKey)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+		}
+	})
+
+	t.Run("unknown session is a successful no-op", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, "claude:00000000-0000-4000-8000-000000000000", testManagementKey)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		var body struct {
+			Status      string `json:"status"`
+			Removed     bool   `json:"removed"`
+			CacheGroups int    `json:"cache_groups"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v (%s)", err, rec.Body.String())
+		}
+		if body.Status != "ok" || body.Removed || body.CacheGroups != 0 {
+			t.Fatalf("unknown session response = %+v, want ok/false/0", body)
+		}
+	})
+
+	t.Run("bound session is released", func(t *testing.T) {
+		rec := deleteSessionAffinity(t, engine, affinitySessionID, testManagementKey)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		var body struct {
+			Status      string `json:"status"`
+			SessionID   string `json:"session_id"`
+			Removed     bool   `json:"removed"`
+			CacheGroups int    `json:"cache_groups"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v (%s)", err, rec.Body.String())
+		}
+		if body.Status != "ok" || !body.Removed || body.CacheGroups != 1 || body.SessionID != affinitySessionID {
+			t.Fatalf("bound session response = %+v, want ok/true/1/%s", body, affinitySessionID)
+		}
+
+		if result := selector.InvalidateSession(affinitySessionID); result.Removed() {
+			t.Fatalf("binding survived the management call: %+v", result)
+		}
+	})
+}
+
+func TestDeleteSessionAffinityWithoutAffinitySelector(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetSelector(&coreauth.RoundRobinSelector{})
+	engine := newSessionAffinityTestEngine(t, manager)
+
+	rec := deleteSessionAffinity(t, engine, "claude:8046da35-c12f-4b6b-8c9e-86ecb162fcee", testManagementKey)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d (body %s)", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -180,6 +180,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)
 		mgmt.DELETE("/oauth-session", s.mgmt.CancelAuthSession)
+		mgmt.DELETE("/session-affinity", s.mgmt.DeleteSessionAffinity)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -1407,6 +1407,69 @@ func (s *SessionAffinitySelector) LookupAffinity(provider, model, sessionID stri
 	return "", "unbound"
 }
 
+// SessionInvalidation reports what a single-session affinity invalidation removed.
+type SessionInvalidation struct {
+	// CacheGroups counts TTL-cache alias groups that were dropped.
+	CacheGroups int `json:"cache_groups"`
+	// CacheAliases counts the individual identifiers those groups held.
+	CacheAliases int `json:"cache_aliases"`
+	// LCPGroups counts Merkle-prefix bindings that were dropped.
+	LCPGroups int `json:"lcp_groups"`
+}
+
+// Removed reports whether the invalidation dropped at least one binding.
+func (r SessionInvalidation) Removed() bool {
+	return r.CacheGroups > 0 || r.LCPGroups > 0
+}
+
+// InvalidateSession releases the affinity bindings of a single logical session
+// across every provider and model, in both the TTL cache and the LCP matcher,
+// and reports what it removed.
+//
+// InvalidateAuth is the credential-wide hammer: it moves every session off one
+// credential. This is its per-session counterpart, for the case where a single
+// caller has to be re-spread onto another credential while every other session
+// keeps its binding, its upstream prompt cache, and its place in the pool.
+// Without it the only ways to move one caller are to change its session id
+// (which loses the upstream prompt cache for that conversation) or to restart
+// the proxy (which loses every binding for every caller).
+//
+// The cache is keyed by provider + "::" + sessionID + "::" + model, so one
+// logical session usually owns several cache entries; all of them are matched.
+func (s *SessionAffinitySelector) InvalidateSession(sessionID string) SessionInvalidation {
+	result := SessionInvalidation{}
+	if s == nil || sessionID == "" {
+		return result
+	}
+	if s.cache != nil {
+		result.CacheGroups, result.CacheAliases = s.cache.InvalidateMatching(func(alias string) bool {
+			return alias == sessionID || affinityCacheKeySessionID(alias) == sessionID
+		})
+	}
+	if s.matcher != nil {
+		result.LCPGroups = s.matcher.InvalidateSession(sessionID)
+	}
+	return result
+}
+
+// affinityCacheKeySessionID extracts the session identifier from a composite
+// affinity cache key of the form provider "::" sessionID "::" model. It returns
+// an empty string for aliases that do not have that shape.
+//
+// The provider is taken from the first separator and the model from the last,
+// so session identifiers that themselves contain "::" survive the round trip.
+func affinityCacheKeySessionID(alias string) string {
+	_, rest, ok := strings.Cut(alias, "::")
+	if !ok {
+		return ""
+	}
+	modelSeparator := strings.LastIndex(rest, "::")
+	if modelSeparator <= 0 {
+		return ""
+	}
+	return rest[:modelSeparator]
+}
+
 // OnResult handles session affinity binding or release based on execution outcome.
 func (s *SessionAffinitySelector) OnResult(res Result) {
 	if s == nil || res.AuthID == "" {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -1443,7 +1443,7 @@ func (s *SessionAffinitySelector) InvalidateSession(sessionID string) SessionInv
 	}
 	if s.cache != nil {
 		result.CacheGroups, result.CacheAliases = s.cache.InvalidateMatching(func(alias string) bool {
-			return alias == sessionID || affinityCacheKeySessionID(alias) == sessionID
+			return alias == sessionID || affinityCacheKeyOwnedBySession(alias, sessionID)
 		})
 	}
 	if s.matcher != nil {
@@ -1452,22 +1452,24 @@ func (s *SessionAffinitySelector) InvalidateSession(sessionID string) SessionInv
 	return result
 }
 
-// affinityCacheKeySessionID extracts the session identifier from a composite
-// affinity cache key of the form provider "::" sessionID "::" model. It returns
-// an empty string for aliases that do not have that shape.
+// affinityCacheKeyOwnedBySession reports whether a composite affinity cache key
+// of the form provider "::" sessionID "::" model belongs to sessionID.
 //
-// The provider is taken from the first separator and the model from the last,
-// so session identifiers that themselves contain "::" survive the round trip.
-func affinityCacheKeySessionID(alias string) string {
+// The key is not decoded. Both the session id and the model may themselves
+// contain "::", so no split point can be inferred from the key alone: taking
+// the model from the last separator misreads a model that contains "::", and
+// taking it from the first misreads a session id that does. Testing a known
+// session id as a prefix of the remainder is exact for both, because the
+// session id is the first field after the provider.
+func affinityCacheKeyOwnedBySession(alias, sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
 	_, rest, ok := strings.Cut(alias, "::")
 	if !ok {
-		return ""
+		return false
 	}
-	modelSeparator := strings.LastIndex(rest, "::")
-	if modelSeparator <= 0 {
-		return ""
-	}
-	return rest[:modelSeparator]
+	return strings.HasPrefix(rest, sessionID+"::")
 }
 
 // OnResult handles session affinity binding or release based on execution outcome.

--- a/sdk/cliproxy/auth/selector_invalidate_session_test.go
+++ b/sdk/cliproxy/auth/selector_invalidate_session_test.go
@@ -1,0 +1,206 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// scriptedSelector returns a caller-chosen auth and counts how often the
+// affinity selector actually fell through to it, so a test can distinguish a
+// cache hit from a fresh selection instead of guessing from round-robin state.
+type scriptedSelector struct {
+	next  string
+	calls int
+}
+
+func (s *scriptedSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	s.calls++
+	for _, auth := range auths {
+		if auth != nil && auth.ID == s.next {
+			return auth, nil
+		}
+	}
+	return nil, &Error{Code: "auth_not_found", Message: "scripted selector has no candidate " + s.next}
+}
+
+func claudeSessionOptions(sessionID string) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{
+		Headers: http.Header{"X-Claude-Code-Session-Id": []string{sessionID}},
+	}
+}
+
+// TestSessionAffinitySelector_InvalidateSessionReleasesOnlyThatSession is the
+// core contract: the named session is re-selected from the pool on its next
+// request while every other session keeps its binding.
+func TestSessionAffinitySelector_InvalidateSessionReleasesOnlyThatSession(t *testing.T) {
+	t.Parallel()
+
+	fallback := &scriptedSelector{next: "auth-a"}
+	selector := NewSessionAffinitySelector(fallback)
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	const (
+		movingUUID = "8046da35-c12f-4b6b-8c9e-86ecb162fcee"
+		stayUUID   = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d"
+	)
+
+	moving, errMoving := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(movingUUID), auths)
+	if errMoving != nil || moving == nil {
+		t.Fatalf("Pick() moving session error = %v, auth = %v", errMoving, moving)
+	}
+	staying, errStaying := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(stayUUID), auths)
+	if errStaying != nil || staying == nil {
+		t.Fatalf("Pick() staying session error = %v, auth = %v", errStaying, staying)
+	}
+
+	// From here the pool would hand out auth-b, so any later auth-a is a binding.
+	fallback.next = "auth-b"
+	callsBefore := fallback.calls
+	repeat, errRepeat := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(movingUUID), auths)
+	if errRepeat != nil {
+		t.Fatalf("Pick() repeat error = %v", errRepeat)
+	}
+	if repeat.ID != "auth-a" || fallback.calls != callsBefore {
+		t.Fatalf("session was not bound before invalidation: auth = %q, fallback calls = %d, want auth-a and no fallback call", repeat.ID, fallback.calls-callsBefore)
+	}
+
+	result := selector.InvalidateSession("claude:" + movingUUID)
+	if !result.Removed() {
+		t.Fatalf("InvalidateSession() removed nothing: %+v", result)
+	}
+	if result.CacheGroups != 1 {
+		t.Fatalf("InvalidateSession() cache groups = %d, want 1 (%+v)", result.CacheGroups, result)
+	}
+
+	callsBefore = fallback.calls
+	afterMoving, errAfter := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(movingUUID), auths)
+	if errAfter != nil {
+		t.Fatalf("Pick() after invalidation error = %v", errAfter)
+	}
+	if fallback.calls != callsBefore+1 {
+		t.Fatalf("invalidated session did not fall through to the pool: fallback calls = %d, want 1", fallback.calls-callsBefore)
+	}
+	if afterMoving.ID != "auth-b" {
+		t.Fatalf("invalidated session resolved to %q, want the freshly selected auth-b", afterMoving.ID)
+	}
+
+	callsBefore = fallback.calls
+	afterStaying, errStayingAfter := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(stayUUID), auths)
+	if errStayingAfter != nil {
+		t.Fatalf("Pick() untouched session error = %v", errStayingAfter)
+	}
+	if afterStaying.ID != staying.ID || fallback.calls != callsBefore {
+		t.Fatalf("untouched session moved from %q to %q (fallback calls = %d)", staying.ID, afterStaying.ID, fallback.calls-callsBefore)
+	}
+}
+
+// TestSessionAffinitySelector_InvalidateSessionSpansProvidersAndModels covers the
+// composite cache key: one logical session owns one entry per provider/model.
+func TestSessionAffinitySelector_InvalidateSessionSpansProvidersAndModels(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	const sessionUUID = "8046da35-c12f-4b6b-8c9e-86ecb162fcee"
+
+	for _, target := range []struct{ provider, model string }{
+		{"claude", "claude-sonnet-4-5"},
+		{"claude", "claude-opus-4-1"},
+		{"codex", "gpt-5"},
+	} {
+		if _, err := selector.Pick(context.Background(), target.provider, target.model, claudeSessionOptions(sessionUUID), auths); err != nil {
+			t.Fatalf("Pick(%s/%s) error = %v", target.provider, target.model, err)
+		}
+	}
+
+	result := selector.InvalidateSession("claude:" + sessionUUID)
+	if result.CacheGroups != 3 {
+		t.Fatalf("InvalidateSession() cache groups = %d, want 3 (%+v)", result.CacheGroups, result)
+	}
+	if again := selector.InvalidateSession("claude:" + sessionUUID); again.Removed() {
+		t.Fatalf("second InvalidateSession() removed %+v, want nothing", again)
+	}
+}
+
+// TestSessionAffinitySelector_InvalidateSessionMatchesExactly guards the blast
+// radius: a subagent session is its own routing identity and must survive when
+// its parent is released, and an unknown key must be a no-op.
+func TestSessionAffinitySelector_InvalidateSessionMatchesExactly(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	const parentUUID = "8046da35-c12f-4b6b-8c9e-86ecb162fcee"
+
+	agentOptions := claudeSessionOptions(parentUUID)
+	agentOptions.Headers.Set("X-Claude-Code-Agent-Id", "explore-1")
+	agent, errAgent := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", agentOptions, auths)
+	if errAgent != nil || agent == nil {
+		t.Fatalf("Pick() subagent error = %v, auth = %v", errAgent, agent)
+	}
+	if _, errParent := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", claudeSessionOptions(parentUUID), auths); errParent != nil {
+		t.Fatalf("Pick() parent error = %v", errParent)
+	}
+
+	if unknown := selector.InvalidateSession("claude:00000000-0000-4000-8000-000000000000"); unknown.Removed() {
+		t.Fatalf("InvalidateSession() on an unknown session removed %+v", unknown)
+	}
+
+	result := selector.InvalidateSession("claude:" + parentUUID)
+	if result.CacheGroups != 1 {
+		t.Fatalf("InvalidateSession() cache groups = %d, want 1 (subagent key must not match) (%+v)", result.CacheGroups, result)
+	}
+
+	agentOptionsAfter := claudeSessionOptions(parentUUID)
+	agentOptionsAfter.Headers.Set("X-Claude-Code-Agent-Id", "explore-1")
+	agentAfter, errAgentAfter := selector.Pick(context.Background(), "claude", "claude-sonnet-4-5", agentOptionsAfter, auths)
+	if errAgentAfter != nil {
+		t.Fatalf("Pick() subagent after invalidation error = %v", errAgentAfter)
+	}
+	if agentAfter.ID != agent.ID {
+		t.Fatalf("subagent binding moved from %q to %q when only the parent was invalidated", agent.ID, agentAfter.ID)
+	}
+}
+
+func TestAffinityCacheKeySessionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		alias string
+		want  string
+	}{
+		{"claude::claude:8046da35::claude-sonnet-4-5", "claude:8046da35"},
+		{"claude::claude:8046da35:agent:explore::claude-sonnet-4-5", "claude:8046da35:agent:explore"},
+		{"claude::pck:abc123::claude-sonnet-4-5", "pck:abc123"},
+		{"claude::weird::session::model", "weird::session"},
+		{"claude:8046da35", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := affinityCacheKeySessionID(tt.alias); got != tt.want {
+			t.Errorf("affinityCacheKeySessionID(%q) = %q, want %q", tt.alias, got, tt.want)
+		}
+	}
+}
+
+func TestSessionAffinitySelector_InvalidateSessionNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var selector *SessionAffinitySelector
+	if result := selector.InvalidateSession("claude:whatever"); result.Removed() {
+		t.Fatalf("nil selector reported %+v", result)
+	}
+	live := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer live.Stop()
+	if result := live.InvalidateSession(""); result.Removed() {
+		t.Fatalf("empty session id reported %+v", result)
+	}
+}

--- a/sdk/cliproxy/auth/selector_invalidate_session_test.go
+++ b/sdk/cliproxy/auth/selector_invalidate_session_test.go
@@ -170,23 +170,36 @@ func TestSessionAffinitySelector_InvalidateSessionMatchesExactly(t *testing.T) {
 	}
 }
 
-func TestAffinityCacheKeySessionID(t *testing.T) {
+func TestAffinityCacheKeyOwnedBySession(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		alias string
-		want  string
+		name      string
+		alias     string
+		sessionID string
+		want      bool
 	}{
-		{"claude::claude:8046da35::claude-sonnet-4-5", "claude:8046da35"},
-		{"claude::claude:8046da35:agent:explore::claude-sonnet-4-5", "claude:8046da35:agent:explore"},
-		{"claude::pck:abc123::claude-sonnet-4-5", "pck:abc123"},
-		{"claude::weird::session::model", "weird::session"},
-		{"claude:8046da35", ""},
-		{"", ""},
+		{"plain", "claude::claude:8046da35::claude-sonnet-4-5", "claude:8046da35", true},
+		{"subagent id is its own session", "claude::claude:8046da35:agent:explore::claude-sonnet-4-5", "claude:8046da35:agent:explore", true},
+		{"parent does not own the subagent key", "claude::claude:8046da35:agent:explore::claude-sonnet-4-5", "claude:8046da35", false},
+		{"prompt cache key session", "claude::pck:abc123::claude-sonnet-4-5", "pck:abc123", true},
+		{"session id containing the separator", "claude::weird::session::model", "weird::session", true},
+		{"model containing the separator", "claude::s1::foo::bar", "s1", true},
+		// "claude::s1::foo::bar" is genuinely ambiguous: it is a valid key for
+		// session "s1" with model "foo::bar" AND for session "s1::foo" with
+		// model "bar". Neither reading can be ruled out from the key alone, so
+		// both session ids own it. Removal is the safe resolution — a spurious
+		// release costs one re-selection, while a missed release leaves the
+		// caller pinned, which is the failure this endpoint exists to fix.
+		{"ambiguous key belongs to either candidate session", "claude::s1::foo::bar", "s1::foo", true},
+		{"different session", "claude::s1::claude-sonnet-4-5", "s2", false},
+		{"not a composite key", "claude:8046da35", "claude:8046da35", false},
+		{"empty alias", "", "s1", false},
+		{"empty session", "claude::s1::model", "", false},
 	}
 	for _, tt := range tests {
-		if got := affinityCacheKeySessionID(tt.alias); got != tt.want {
-			t.Errorf("affinityCacheKeySessionID(%q) = %q, want %q", tt.alias, got, tt.want)
+		if got := affinityCacheKeyOwnedBySession(tt.alias, tt.sessionID); got != tt.want {
+			t.Errorf("%s: affinityCacheKeyOwnedBySession(%q, %q) = %v, want %v", tt.name, tt.alias, tt.sessionID, got, tt.want)
 		}
 	}
 }

--- a/sdk/cliproxy/auth/session_cache.go
+++ b/sdk/cliproxy/auth/session_cache.go
@@ -395,6 +395,41 @@ func (c *SessionCache) InvalidateAuth(authID string) {
 	}
 }
 
+// InvalidateMatching removes every alias group that owns at least one alias
+// accepted by match. It returns the number of removed groups and the number of
+// aliases those groups held.
+//
+// Removal is deliberately group-wide rather than alias-wide. Every alias in a
+// group names the same logical session (the canonical key plus any parent or
+// fork identity merged by SetAliases), so dropping only the requested alias
+// would let the very next request rediscover the surviving sibling and re-bind
+// the caller to the same auth. Invalidate remains available when a caller
+// really wants the surgical, sibling-preserving removal.
+func (c *SessionCache) InvalidateMatching(match func(alias string) bool) (groups int, aliases int) {
+	if c == nil || match == nil {
+		return 0, 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureInitializedLocked()
+	for _, group := range c.groups {
+		matched := false
+		for _, alias := range group.aliases {
+			if match(alias) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		groups++
+		aliases += len(group.aliases)
+		c.removeAliasGroupLocked(group)
+	}
+	return groups, aliases
+}
+
 // Stop terminates the background cleanup goroutine.
 func (c *SessionCache) Stop() {
 	if c == nil {

--- a/sdk/cliproxy/session/lcp.go
+++ b/sdk/cliproxy/session/lcp.go
@@ -904,6 +904,30 @@ func (m *MerklePrefixMatcher) InvalidateAuth(authID string) {
 	}
 }
 
+// InvalidateSession removes every LCP binding whose derived session identifier
+// equals sessionID and reports how many groups were dropped.
+//
+// LCP session identifiers are minted by the matcher itself (see bindLocked), so
+// this is the counterpart of InvalidateAuth for callers that want to release a
+// single conversation instead of an entire credential.
+func (m *MerklePrefixMatcher) InvalidateSession(sessionID string) int {
+	if m == nil || sessionID == "" {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	removed := 0
+	for _, namespace := range m.groups {
+		for _, group := range namespace.groups {
+			if group.sessionID == sessionID {
+				m.removeGroupLocked(group)
+				removed++
+			}
+		}
+	}
+	return removed
+}
+
 // Clear removes all remembered prefix bindings.
 func (m *MerklePrefixMatcher) Clear() {
 	if m == nil {

--- a/sdk/cliproxy/session/lcp_invalidate_session_test.go
+++ b/sdk/cliproxy/session/lcp_invalidate_session_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMerklePrefixMatcherInvalidateSession is the matcher-side counterpart of
+// InvalidateAuth: releasing one conversation must leave every other
+// conversation bound, including ones on the same credential.
+func TestMerklePrefixMatcherInvalidateSession(t *testing.T) {
+	t.Parallel()
+
+	matcher := NewMerklePrefixMatcher(time.Hour)
+	defer matcher.Clear()
+
+	namespace := "lcp:v1:invalidate-session:model:caller"
+	moving := turnsFromTexts("moving-1", "moving-2", "moving-3")
+	staying := turnsFromTexts("staying-1", "staying-2", "staying-3")
+
+	movingSessionID := matcher.Bind(namespace, moving, "auth-a")
+	stayingSessionID := matcher.Bind(namespace, staying, "auth-a")
+	if movingSessionID == "" || stayingSessionID == "" || movingSessionID == stayingSessionID {
+		t.Fatalf("Bind() session ids = %q and %q, want two distinct non-empty ids", movingSessionID, stayingSessionID)
+	}
+
+	if removed := matcher.InvalidateSession("no-such-session"); removed != 0 {
+		t.Fatalf("InvalidateSession() on an unknown session removed %d groups", removed)
+	}
+
+	if removed := matcher.InvalidateSession(movingSessionID); removed != 1 {
+		t.Fatalf("InvalidateSession() removed %d groups, want 1", removed)
+	}
+	if match, ok := matcher.Match(namespace, moving); ok {
+		t.Fatalf("invalidated session still resolves to %#v", match)
+	}
+	if match, ok := matcher.Match(namespace, staying); !ok || match.AuthID != "auth-a" {
+		t.Fatalf("untouched session on the same auth was released: %#v, %v", match, ok)
+	}
+
+	if removed := matcher.InvalidateSession(movingSessionID); removed != 0 {
+		t.Fatalf("repeat InvalidateSession() removed %d groups, want 0", removed)
+	}
+}
+
+func TestMerklePrefixMatcherInvalidateSessionNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var matcher *MerklePrefixMatcher
+	if removed := matcher.InvalidateSession("anything"); removed != 0 {
+		t.Fatalf("nil matcher removed %d groups", removed)
+	}
+	live := NewMerklePrefixMatcher(time.Hour)
+	defer live.Clear()
+	if removed := live.InvalidateSession(""); removed != 0 {
+		t.Fatalf("empty session id removed %d groups", removed)
+	}
+}


### PR DESCRIPTION
## Summary

- add `SessionCache.InvalidateMatching`, `MerklePrefixMatcher.InvalidateSession`, and `SessionAffinitySelector.InvalidateSession` so a single caller can be released from its bound credential
- expose it as `DELETE /v0/management/session-affinity?session_id=...`, returning `removed` plus per-layer counts
- match subagent identities (`claude:<uuid>:agent:<id>`) exactly, so releasing a parent session leaves the subagents underneath it bound

Session affinity has only one release mechanism today: `InvalidateAuth`, which moves *every* session off a credential. Moving one caller currently means either minting a new session id — which throws away that conversation's upstream prompt cache — or restarting the proxy, which throws away every binding and all the warm state with it. This adds the per-session counterpart alongside the existing auth-wide one.

Cache removal is group-wide rather than alias-wide: every alias in a group names the same logical session, so dropping only the requested alias would let the next request rediscover a surviving sibling and re-bind the caller to the same auth. The existing `Invalidate` remains for callers that want the surgical, sibling-preserving removal.

The endpoint returns 200 whether or not a binding existed, following `CancelAuthSession` — a caller cannot distinguish an unknown session from one whose TTL just lapsed, and the request is a pure removal, so making the no-op case an error would only break retries and fire-and-forget scripts. Authentication and 400 handling stay with the shared management middleware and `NormalizeExplicitID`.

## Tests

- `go build ./...`, `go test ./...` — 0 failures
- new unit tests cover the cache (group-wide removal, sibling isolation, ids containing `::`), the LCP matcher, the selector delegating to both layers, and the handler (200 with and without an existing binding, 400 on a missing id, 401 unauthenticated)
- exercised against a throwaway instance with two stub credentials: a session pinned to one credential across repeated requests, `DELETE` reported `removed=true`, the next request logged `cache miss, new binding` and re-selected from the pool, and a second session's binding was untouched
