### PR TITLE
feat(routing): per-model credential weights via model_weights

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -275,6 +275,11 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 						}
 					}
 				}
+				if mv := gjson.GetBytes(data, coreauth.AttributeModelWeights); mv.Exists() && mv.IsObject() {
+					if modelWeights, errModelWeights := coreauth.ParseModelWeights(mv.Raw); errModelWeights == nil && len(modelWeights) > 0 {
+						fileData[coreauth.AttributeModelWeights] = modelWeights
+					}
+				}
 				if nv := gjson.GetBytes(data, "note"); nv.Exists() && nv.Type == gjson.String {
 					if trimmed := strings.TrimSpace(nv.String()); trimmed != "" {
 						fileData["note"] = trimmed
@@ -428,6 +433,9 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	if weight, ok := authWeightValue(auth); ok {
 		entry[coreauth.AttributeWeight] = weight
 	}
+	if modelWeights := authModelWeightsValue(auth); len(modelWeights) > 0 {
+		entry[coreauth.AttributeModelWeights] = modelWeights
+	}
 	if websockets, ok := authWebsocketsValue(auth); ok {
 		entry["websockets"] = websockets
 	}
@@ -502,6 +510,33 @@ func authWeightValue(auth *coreauth.Auth) (int64, bool) {
 	}
 	weight, errWeight := credentialweight.ParseValue(rawWeight)
 	return weight, errWeight == nil
+}
+
+// authModelWeightsValue exposes the per-model weight table (attribute form first, raw
+// metadata second) so the management API mirrors what the selector actually uses.
+func authModelWeightsValue(auth *coreauth.Auth) map[string]int64 {
+	if auth == nil {
+		return nil
+	}
+	if raw := strings.TrimSpace(authAttribute(auth, coreauth.AttributeModelWeights)); raw != "" {
+		modelWeights, errParse := coreauth.ParseModelWeights(raw)
+		if errParse != nil {
+			return nil
+		}
+		return modelWeights
+	}
+	if auth.Metadata == nil {
+		return nil
+	}
+	rawModelWeights, ok := auth.Metadata[coreauth.AttributeModelWeights]
+	if !ok || rawModelWeights == nil {
+		return nil
+	}
+	modelWeights, errParse := coreauth.ParseModelWeights(rawModelWeights)
+	if errParse != nil {
+		return nil
+	}
+	return modelWeights
 }
 
 func authWebsocketsValue(auth *coreauth.Auth) (bool, bool) {

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -310,6 +310,28 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		} else if rootAuthFileField(fieldPath) == coreauth.AttributeWeight {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "weight does not support nested fields"})
 			return
+		} else if fieldPath == coreauth.AttributeModelWeights {
+			if value == nil {
+				delete(targetAuth.Metadata, coreauth.AttributeModelWeights)
+			} else {
+				modelWeights, errModelWeights := coreauth.ParseModelWeights(value)
+				if errModelWeights != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": errModelWeights.Error()})
+					return
+				}
+				if len(modelWeights) == 0 {
+					delete(targetAuth.Metadata, coreauth.AttributeModelWeights)
+				} else {
+					normalized := make(map[string]any, len(modelWeights))
+					for model, weight := range modelWeights {
+						normalized[model] = weight
+					}
+					targetAuth.Metadata[coreauth.AttributeModelWeights] = normalized
+				}
+			}
+		} else if rootAuthFileField(fieldPath) == coreauth.AttributeModelWeights {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "model_weights does not support nested fields; send the whole object"})
+			return
 		} else if fieldPath == "headers" {
 			applyAuthFileHeadersPatch(targetAuth, value)
 		} else if errSet := setAuthFileMetadataValue(targetAuth.Metadata, fieldPath, value); errSet != nil {
@@ -559,6 +581,9 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	if _, ok := touchedRoots[coreauth.AttributeWeight]; ok {
 		syncAuthFileWeightAttribute(auth)
 	}
+	if _, ok := touchedRoots[coreauth.AttributeModelWeights]; ok {
+		syncAuthFileModelWeightsAttribute(auth)
+	}
 	if _, ok := touchedRoots["note"]; ok {
 		syncAuthFileNoteAttribute(auth)
 	}
@@ -619,6 +644,26 @@ func syncAuthFileWeightAttribute(auth *coreauth.Auth) {
 		return
 	}
 	auth.Attributes[coreauth.AttributeWeight] = strconv.FormatInt(weight, 10)
+}
+
+func syncAuthFileModelWeightsAttribute(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	rawModelWeights, ok := auth.Metadata[coreauth.AttributeModelWeights]
+	if !ok || rawModelWeights == nil {
+		delete(auth.Attributes, coreauth.AttributeModelWeights)
+		return
+	}
+	modelWeights, errParse := coreauth.ParseModelWeights(rawModelWeights)
+	if errParse != nil || len(modelWeights) == 0 {
+		delete(auth.Attributes, coreauth.AttributeModelWeights)
+		return
+	}
+	auth.Attributes[coreauth.AttributeModelWeights] = coreauth.EncodeModelWeights(modelWeights)
 }
 
 func authFileIntValue(value any) (int, bool) {

--- a/internal/api/handlers/management/auth_files_model_weights_test.go
+++ b/internal/api/handlers/management/auth_files_model_weights_test.go
@@ -1,0 +1,174 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	fileauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func listAuthFilesForTest(t *testing.T, h *Handler) []map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+	h.ListAuthFiles(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode list: %v", errDecode)
+	}
+	return payload.Files
+}
+
+func TestListAuthFiles_ExposesModelWeightsFromRuntimeAndDisk(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	authDir := t.TempDir()
+	fileName := "claude-a.json"
+	filePath := filepath.Join(authDir, fileName)
+	body := `{"type":"claude","email":"a@example.com","weight":5,"model_weights":{"claude-fable-5-1":1,"claude-opus-5":0}}`
+	if errWrite := os.WriteFile(filePath, []byte(body), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	// Disk listing (no auth manager) reads the raw file.
+	diskFiles := listAuthFilesForTest(t, NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil))
+	if len(diskFiles) != 1 {
+		t.Fatalf("disk files = %d, want 1", len(diskFiles))
+	}
+	diskWeights, _ := diskFiles[0]["model_weights"].(map[string]any)
+	if diskWeights["claude-fable-5-1"] != float64(1) || diskWeights["claude-opus-5"] != float64(0) {
+		t.Fatalf("disk model_weights = %#v", diskFiles[0]["model_weights"])
+	}
+
+	// Runtime listing exposes the attribute form the selector consumes.
+	manager := coreauth.NewManager(nil, nil, nil)
+	registerAuthForLookupTest(t, manager, &coreauth.Auth{
+		ID:       fileName,
+		FileName: fileName,
+		Provider: "claude",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path":                         filePath,
+			coreauth.AttributeWeight:       "5",
+			coreauth.AttributeModelWeights: `{"claude-fable-5-1":1,"claude-opus-5":0}`,
+		},
+	})
+	runtimeFiles := listAuthFilesForTest(t, NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager))
+	if len(runtimeFiles) != 1 {
+		t.Fatalf("runtime files = %d, want 1", len(runtimeFiles))
+	}
+	runtimeWeights, _ := runtimeFiles[0]["model_weights"].(map[string]any)
+	if runtimeWeights["claude-fable-5-1"] != float64(1) || runtimeWeights["claude-opus-5"] != float64(0) {
+		t.Fatalf("runtime model_weights = %#v", runtimeFiles[0]["model_weights"])
+	}
+	if runtimeFiles[0]["weight"] != float64(5) {
+		t.Fatalf("runtime weight = %#v, want 5", runtimeFiles[0]["weight"])
+	}
+
+	// Credentials without a table must not gain the key.
+	plain := coreauth.NewManager(nil, nil, nil)
+	registerAuthForLookupTest(t, plain, &coreauth.Auth{ID: "plain", FileName: "plain.json", Provider: "claude", Status: coreauth.StatusActive, Attributes: map[string]string{coreauth.AttributeWeight: "2"}})
+	plainFiles := listAuthFilesForTest(t, NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, plain))
+	for _, file := range plainFiles {
+		if file["name"] == "plain.json" {
+			if _, ok := file["model_weights"]; ok {
+				t.Fatalf("plain entry should not expose model_weights: %#v", file)
+			}
+		}
+	}
+}
+
+func TestPatchAuthFileFields_ModelWeightsPersistsAndSyncsRuntime(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	authDir := t.TempDir()
+	fileName := "claude-mw.json"
+	filePath := filepath.Join(authDir, fileName)
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:         fileName,
+		FileName:   fileName,
+		Provider:   "claude",
+		Attributes: map[string]string{"path": filePath},
+		Metadata:   map[string]any{"type": "claude"},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	patch := func(field, value string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"name":"` + fileName + `","` + field + `":` + value + `}`
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchAuthFileFields(ctx)
+		return rec
+	}
+	readPersisted := func() map[string]any {
+		t.Helper()
+		raw, errRead := os.ReadFile(filePath)
+		if errRead != nil {
+			t.Fatalf("ReadFile() error = %v", errRead)
+		}
+		var persisted map[string]any
+		if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+			t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+		}
+		return persisted
+	}
+
+	if rec := patch("model_weights", `{"Claude-Fable-5-1":1,"claude-opus-5":0}`); rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated.Attributes[coreauth.AttributeModelWeights] != `{"claude-fable-5-1":1,"claude-opus-5":0}` {
+		t.Fatalf("runtime model_weights attribute = %#v", updated.Attributes)
+	}
+	persisted := readPersisted()
+	persistedWeights, _ := persisted["model_weights"].(map[string]any)
+	if persistedWeights["claude-fable-5-1"] != float64(1) || persistedWeights["claude-opus-5"] != float64(0) {
+		t.Fatalf("persisted model_weights = %#v", persisted["model_weights"])
+	}
+
+	if rec := patch("model_weights", `{"claude-opus-5":1.5}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("fractional status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := patch("model_weights.claude-opus-5", `3`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("nested status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, _ = manager.GetByID(fileName)
+	if updated.Attributes[coreauth.AttributeModelWeights] != `{"claude-fable-5-1":1,"claude-opus-5":0}` {
+		t.Fatalf("rejected patches must not alter runtime table: %#v", updated.Attributes)
+	}
+
+	if rec := patch("model_weights", `null`); rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, _ = manager.GetByID(fileName)
+	if _, exists := updated.Attributes[coreauth.AttributeModelWeights]; exists {
+		t.Fatal("runtime model_weights remains after reset")
+	}
+	if _, exists := readPersisted()["model_weights"]; exists {
+		t.Fatal("persisted model_weights remains after reset")
+	}
+}

--- a/internal/watcher/synthesizer/model_weights_test.go
+++ b/internal/watcher/synthesizer/model_weights_test.go
@@ -1,0 +1,50 @@
+package synthesizer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestSynthesizeAuthFile_MapsModelWeightsAttribute(t *testing.T) {
+	ctx := &SynthesisContext{Config: &config.Config{}, AuthDir: "/auth", Now: time.Now(), IDGenerator: NewStableIDGenerator()}
+	data := []byte(`{"type":"claude","email":"a@example.com","weight":5,"model_weights":{"Claude-Fable-5-1":1,"claude-opus-5":0}}`)
+	auths, err := SynthesizeAuthFile(ctx, "/auth/claude-a.json", data)
+	if err != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("SynthesizeAuthFile() auths = %d, want 1", len(auths))
+	}
+	if got := auths[0].Attributes[coreauth.AttributeWeight]; got != "5" {
+		t.Fatalf("weight attribute = %q, want 5", got)
+	}
+	if got := auths[0].Attributes[coreauth.AttributeModelWeights]; got != `{"claude-fable-5-1":1,"claude-opus-5":0}` {
+		t.Fatalf("model_weights attribute = %q", got)
+	}
+
+	legacy := []byte(`{"type":"claude","email":"b@example.com","model-weights":{"claude-opus-5":2}}`)
+	auths, err = SynthesizeAuthFile(ctx, "/auth/claude-b.json", legacy)
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("SynthesizeAuthFile(legacy key) = %v, %v", auths, err)
+	}
+	if got := auths[0].Attributes[coreauth.AttributeModelWeights]; got != `{"claude-opus-5":2}` {
+		t.Fatalf("legacy model-weights attribute = %q", got)
+	}
+
+	invalid := []byte(`{"type":"claude","email":"c@example.com","model_weights":{"claude-opus-5":1.5}}`)
+	if _, err = SynthesizeAuthFile(ctx, "/auth/claude-c.json", invalid); err == nil {
+		t.Fatal("SynthesizeAuthFile(invalid model_weights) expected error")
+	}
+
+	plain := []byte(`{"type":"claude","email":"d@example.com","weight":2}`)
+	auths, err = SynthesizeAuthFile(ctx, "/auth/claude-d.json", plain)
+	if err != nil || len(auths) != 1 {
+		t.Fatalf("SynthesizeAuthFile(plain) = %v, %v", auths, err)
+	}
+	if _, ok := auths[0].Attributes[coreauth.AttributeModelWeights]; ok {
+		t.Fatalf("plain file should not carry a model_weights attribute, got %q", auths[0].Attributes[coreauth.AttributeModelWeights])
+	}
+}

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -17,6 +17,7 @@ const (
 	AttributeAuthKind         = "auth_kind"
 	AttributeCodexAlphaSearch = "codex_alpha_search"
 	AttributeConfigIndex      = "config_index"
+	AttributeModelWeights     = "model_weights"
 	AttributePath             = "path"
 	AttributeRuntimeOnly      = "runtime_only"
 	AttributeSource           = "source"

--- a/sdk/cliproxy/auth/metadata_keys.go
+++ b/sdk/cliproxy/auth/metadata_keys.go
@@ -16,6 +16,8 @@ func CanonicalCredentialMetadataKey(key string) string {
 		return "fingerprint_profile"
 	case "model-aliases":
 		return "model_aliases"
+	case "model-weights":
+		return "model_weights"
 	case "proxy-url":
 		return "proxy_url"
 	case "request-retry":

--- a/sdk/cliproxy/auth/model_weights.go
+++ b/sdk/cliproxy/auth/model_weights.go
@@ -61,11 +61,27 @@ func ParseModelWeights(value any) (map[string]int64, error) {
 		return nil, nil
 	}
 	out := make(map[string]int64, len(raw))
+	// Two entries can normalize to the same key ("Claude-Opus-5" and
+	// "claude-opus-5", or a model and its thinking-suffix form). Silently
+	// keeping one of them would make the table depend on Go's unspecified map
+	// iteration order: the same file could load a different weight on each
+	// read, and with values 0 and positive the credential would flip between
+	// excluded and active. Reject the table instead — an ambiguous routing
+	// rule must be corrected by its author, not resolved by chance.
+	seen := make(map[string]string, len(raw))
 	for model, rawWeight := range raw {
 		key := modelWeightKey(model)
 		if key == "" {
 			return nil, fmt.Errorf("model_weights contains an empty model key")
 		}
+		if previous, dup := seen[key]; dup {
+			first, second := previous, model
+			if second < first {
+				first, second = second, first
+			}
+			return nil, fmt.Errorf("model_weights has ambiguous entries %q and %q: both resolve to %q", first, second, key)
+		}
+		seen[key] = model
 		weight, errParse := credentialweight.ParseValue(rawWeight)
 		if errParse != nil {
 			return nil, fmt.Errorf("model_weights[%s]: %w", model, errParse)

--- a/sdk/cliproxy/auth/model_weights.go
+++ b/sdk/cliproxy/auth/model_weights.go
@@ -1,0 +1,148 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
+)
+
+// modelWeightKey normalizes a model identifier for per-model weight lookups. The
+// thinking suffix is stripped the same way selector state keys are built, and the
+// result is lower-cased so lookups are case-insensitive like registry model matching.
+func modelWeightKey(model string) string {
+	return strings.ToLower(canonicalModelKey(model))
+}
+
+// ParseModelWeights parses an optional per-model weight override table. Accepted
+// inputs are a JSON object string, a decoded JSON object (map[string]any), or an
+// already-typed map[string]int64. Keys are normalized with modelWeightKey and values
+// follow the same rules as the account-level weight (non-positive normalizes to zero,
+// which excludes the credential for that model only). A nil or empty input yields nil.
+func ParseModelWeights(value any) (map[string]int64, error) {
+	if value == nil {
+		return nil, nil
+	}
+	var raw map[string]any
+	switch typed := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return nil, nil
+		}
+		if errUnmarshal := json.Unmarshal([]byte(trimmed), &raw); errUnmarshal != nil {
+			return nil, fmt.Errorf("model_weights must be a JSON object: %w", errUnmarshal)
+		}
+	case map[string]any:
+		raw = typed
+	case map[string]int64:
+		out := make(map[string]int64, len(typed))
+		for model, weight := range typed {
+			key := modelWeightKey(model)
+			if key == "" {
+				return nil, fmt.Errorf("model_weights contains an empty model key")
+			}
+			normalized, errNormalize := credentialweight.Normalize(weight)
+			if errNormalize != nil {
+				return nil, fmt.Errorf("model_weights[%s]: %w", model, errNormalize)
+			}
+			out[key] = normalized
+		}
+		if len(out) == 0 {
+			return nil, nil
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("model_weights must be a JSON object")
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]int64, len(raw))
+	for model, rawWeight := range raw {
+		key := modelWeightKey(model)
+		if key == "" {
+			return nil, fmt.Errorf("model_weights contains an empty model key")
+		}
+		weight, errParse := credentialweight.ParseValue(rawWeight)
+		if errParse != nil {
+			return nil, fmt.Errorf("model_weights[%s]: %w", model, errParse)
+		}
+		out[key] = weight
+	}
+	return out, nil
+}
+
+// EncodeModelWeights serializes a normalized per-model weight table into the
+// canonical attribute form (a JSON object with sorted keys). Empty input yields "".
+func EncodeModelWeights(weights map[string]int64) string {
+	if len(weights) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(weights))
+	for key := range weights {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var builder strings.Builder
+	builder.WriteByte('{')
+	for index, key := range keys {
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		encodedKey, _ := json.Marshal(key)
+		builder.Write(encodedKey)
+		builder.WriteByte(':')
+		builder.WriteString(fmt.Sprintf("%d", weights[key]))
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}
+
+// authModelWeights returns the per-model weight table for an auth. The attribute form
+// (set by the synthesizer or the management API) takes precedence over raw metadata,
+// mirroring authWeight. Invalid tables are treated as absent so the account-level
+// weight keeps applying; validation happens earlier via ValidateAuthWeight.
+func authModelWeights(auth *Auth) map[string]int64 {
+	if auth == nil {
+		return nil
+	}
+	if raw, ok := auth.Attributes[AttributeModelWeights]; ok {
+		if strings.TrimSpace(raw) == "" {
+			return nil
+		}
+		weights, errParse := ParseModelWeights(raw)
+		if errParse != nil {
+			return nil
+		}
+		return weights
+	}
+	if raw, ok := auth.Metadata[AttributeModelWeights]; ok {
+		weights, errParse := ParseModelWeights(raw)
+		if errParse != nil {
+			return nil
+		}
+		return weights
+	}
+	return nil
+}
+
+// authWeightForModel returns the routing weight of an auth for the requested model.
+// When the auth defines model_weights and the (normalized) model is present, that
+// value wins; otherwise the account-level weight applies exactly as before. An empty
+// model always resolves to the account-level weight.
+func authWeightForModel(auth *Auth, model string) int64 {
+	if auth == nil {
+		return credentialweight.Default
+	}
+	if key := modelWeightKey(model); key != "" {
+		if weights := authModelWeights(auth); len(weights) > 0 {
+			if weight, ok := weights[key]; ok {
+				return weight
+			}
+		}
+	}
+	return authWeight(auth)
+}

--- a/sdk/cliproxy/auth/model_weights_test.go
+++ b/sdk/cliproxy/auth/model_weights_test.go
@@ -1,0 +1,349 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestParseModelWeights_NormalizesKeysAndValues(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseModelWeights(map[string]any{
+		"Claude-Fable-5-1(8192)": float64(7),
+		"claude-opus-5":          "3",
+		"claude-sonnet-5":        float64(0),
+		"claude-haiku-4-5":       float64(-4),
+	})
+	if err != nil {
+		t.Fatalf("ParseModelWeights() error = %v", err)
+	}
+	want := map[string]int64{"claude-fable-5-1": 7, "claude-opus-5": 3, "claude-sonnet-5": 0, "claude-haiku-4-5": 0}
+	if len(got) != len(want) {
+		t.Fatalf("ParseModelWeights() = %#v, want %#v", got, want)
+	}
+	for key, weight := range want {
+		if got[key] != weight {
+			t.Fatalf("ParseModelWeights()[%q] = %d, want %d", key, got[key], weight)
+		}
+	}
+	if encoded := EncodeModelWeights(got); encoded != `{"claude-fable-5-1":7,"claude-haiku-4-5":0,"claude-opus-5":3,"claude-sonnet-5":0}` {
+		t.Fatalf("EncodeModelWeights() = %s", encoded)
+	}
+	roundTrip, errRoundTrip := ParseModelWeights(EncodeModelWeights(got))
+	if errRoundTrip != nil || len(roundTrip) != len(got) {
+		t.Fatalf("round trip = %#v, %v", roundTrip, errRoundTrip)
+	}
+}
+
+func TestParseModelWeights_RejectsInvalidShapes(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []any{
+		"not-json",
+		[]any{"claude-opus-5"},
+		map[string]any{"claude-opus-5": 1.5},
+		map[string]any{"claude-opus-5": float64(1_000_001)},
+		map[string]any{"  ": float64(1)},
+		map[string]any{"claude-opus-5": "abc"},
+	} {
+		if _, err := ParseModelWeights(input); err == nil {
+			t.Fatalf("ParseModelWeights(%#v) expected error", input)
+		}
+	}
+	for _, input := range []any{nil, "", "  ", map[string]any{}} {
+		got, err := ParseModelWeights(input)
+		if err != nil || got != nil {
+			t.Fatalf("ParseModelWeights(%#v) = %#v, %v; want nil, nil", input, got, err)
+		}
+	}
+}
+
+func TestValidateAuthWeight_CoversModelWeights(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateAuthWeight(&Auth{Metadata: map[string]any{AttributeModelWeights: map[string]any{"claude-opus-5": 1.5}}}); err == nil {
+		t.Fatal("ValidateAuthWeight(metadata) expected error for fractional model weight")
+	}
+	if err := ValidateAuthWeight(&Auth{Attributes: map[string]string{AttributeModelWeights: "{bad"}}); err == nil {
+		t.Fatal("ValidateAuthWeight(attributes) expected error for malformed table")
+	}
+	if err := ValidateAuthWeight(&Auth{Metadata: map[string]any{AttributeModelWeights: map[string]any{"claude-opus-5": float64(2)}}}); err != nil {
+		t.Fatalf("ValidateAuthWeight(valid) error = %v", err)
+	}
+}
+
+func TestApplyAuthWeightMetadata_EncodesModelWeightsAttribute(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{}
+	err := ApplyAuthWeightMetadata(auth, map[string]any{
+		AttributeWeight:       float64(4),
+		AttributeModelWeights: map[string]any{"claude-opus-5": float64(9), "Claude-Fable-5-1": float64(0)},
+	})
+	if err != nil {
+		t.Fatalf("ApplyAuthWeightMetadata() error = %v", err)
+	}
+	if auth.Attributes[AttributeWeight] != "4" {
+		t.Fatalf("weight attribute = %q, want 4", auth.Attributes[AttributeWeight])
+	}
+	if auth.Attributes[AttributeModelWeights] != `{"claude-fable-5-1":0,"claude-opus-5":9}` {
+		t.Fatalf("model_weights attribute = %q", auth.Attributes[AttributeModelWeights])
+	}
+
+	// An explicit empty table clears the attribute so a stale override cannot linger.
+	if err := ApplyAuthWeightMetadata(auth, map[string]any{AttributeModelWeights: map[string]any{}}); err != nil {
+		t.Fatalf("ApplyAuthWeightMetadata(empty) error = %v", err)
+	}
+	if _, ok := auth.Attributes[AttributeModelWeights]; ok {
+		t.Fatalf("model_weights attribute should be removed, got %q", auth.Attributes[AttributeModelWeights])
+	}
+}
+
+func TestAuthWeightForModel_OverrideAndFallback(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{Attributes: map[string]string{
+		AttributeWeight:       "5",
+		AttributeModelWeights: `{"claude-fable-5-1":1,"claude-opus-5":0}`,
+	}}
+	if got := authWeightForModel(auth, "claude-fable-5-1"); got != 1 {
+		t.Fatalf("authWeightForModel(fable) = %d, want 1", got)
+	}
+	if got := authWeightForModel(auth, "Claude-Fable-5-1(16384)"); got != 1 {
+		t.Fatalf("authWeightForModel(fable thinking suffix, mixed case) = %d, want 1", got)
+	}
+	if got := authWeightForModel(auth, "claude-opus-5"); got != 0 {
+		t.Fatalf("authWeightForModel(opus) = %d, want 0", got)
+	}
+	if got := authWeightForModel(auth, "claude-sonnet-5"); got != 5 {
+		t.Fatalf("authWeightForModel(unlisted) = %d, want account weight 5", got)
+	}
+	if got := authWeightForModel(auth, ""); got != 5 {
+		t.Fatalf("authWeightForModel(empty model) = %d, want account weight 5", got)
+	}
+	// Metadata form (no synthesizer) is honored too, attribute form wins when both exist.
+	metaAuth := &Auth{Metadata: map[string]any{AttributeWeight: float64(2), AttributeModelWeights: map[string]any{"claude-opus-5": float64(8)}}}
+	if got := authWeightForModel(metaAuth, "claude-opus-5"); got != 8 {
+		t.Fatalf("authWeightForModel(metadata) = %d, want 8", got)
+	}
+	metaAuth.Attributes = map[string]string{AttributeModelWeights: `{"claude-opus-5":3}`}
+	if got := authWeightForModel(metaAuth, "claude-opus-5"); got != 3 {
+		t.Fatalf("authWeightForModel(attribute over metadata) = %d, want 3", got)
+	}
+	// Without a table the behaviour is identical to authWeight.
+	plain := &Auth{Attributes: map[string]string{AttributeWeight: "7"}}
+	if got := authWeightForModel(plain, "claude-opus-5"); got != authWeight(plain) {
+		t.Fatalf("authWeightForModel(no table) = %d, want %d", got, authWeight(plain))
+	}
+}
+
+func pickWeightedCounts(t *testing.T, selector Selector, model string, auths []*Auth, rounds int) map[string]int {
+	t.Helper()
+	counts := make(map[string]int)
+	for index := 0; index < rounds; index++ {
+		picked, errPick := selector.Pick(context.Background(), "claude", model, cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(%s) #%d error = %v", model, index, errPick)
+		}
+		if picked == nil {
+			t.Fatalf("Pick(%s) #%d returned nil", model, index)
+		}
+		counts[picked.ID]++
+	}
+	return counts
+}
+
+func TestWeightedRoundRobinSelectorPick_UsesPerModelWeights(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "a", Provider: "claude", Attributes: map[string]string{AttributeModelWeights: `{"claude-fable-5-1":1,"claude-opus-5":10000}`}}
+	authB := &Auth{ID: "b", Provider: "claude", Attributes: map[string]string{AttributeModelWeights: `{"claude-fable-5-1":10000,"claude-opus-5":1}`}}
+	auths := []*Auth{authA, authB}
+	selector := &WeightedRoundRobinSelector{}
+
+	fable := pickWeightedCounts(t, selector, "claude-fable-5-1", auths, 20)
+	if fable["b"] < 19 {
+		t.Fatalf("fable picks = %#v, want b >= 19", fable)
+	}
+	opus := pickWeightedCounts(t, selector, "claude-opus-5", auths, 20)
+	if opus["a"] < 19 {
+		t.Fatalf("opus picks = %#v, want a >= 19", opus)
+	}
+	// Thinking-suffix variants share the same per-model weight.
+	fableThinking := pickWeightedCounts(t, selector, "claude-fable-5-1(8192)", auths, 20)
+	if fableThinking["b"] < 19 {
+		t.Fatalf("fable(8192) picks = %#v, want b >= 19", fableThinking)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_ModelWeightsFallBackToAccountWeight(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "a", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1", AttributeModelWeights: `{"claude-fable-5-1":3}`}}
+	authC := &Auth{ID: "c", Provider: "claude", Attributes: map[string]string{AttributeWeight: "3"}}
+	auths := []*Auth{authA, authC}
+	selector := &WeightedRoundRobinSelector{}
+
+	// Model listed for A: A=3, C=3 (account weight) -> even split.
+	fable := pickWeightedCounts(t, selector, "claude-fable-5-1", auths, 60)
+	if fable["a"] != 30 || fable["c"] != 30 {
+		t.Fatalf("fable picks = %#v, want 30/30", fable)
+	}
+	// Model not listed for A: A=1 (account), C=3 -> 1:3.
+	sonnet := pickWeightedCounts(t, selector, "claude-sonnet-5", auths, 60)
+	if sonnet["a"] != 15 || sonnet["c"] != 45 {
+		t.Fatalf("sonnet picks = %#v, want 15/45", sonnet)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_ZeroModelWeightExcludesOnlyThatModel(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "a", Provider: "claude", Attributes: map[string]string{AttributeWeight: "5", AttributeModelWeights: `{"claude-fable-5-1":0}`}}
+	authB := &Auth{ID: "b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "5"}}
+	auths := []*Auth{authA, authB}
+	selector := &WeightedRoundRobinSelector{}
+
+	fable := pickWeightedCounts(t, selector, "claude-fable-5-1", auths, 20)
+	if fable["a"] != 0 || fable["b"] != 20 {
+		t.Fatalf("fable picks = %#v, want a excluded", fable)
+	}
+	opus := pickWeightedCounts(t, selector, "claude-opus-5", auths, 20)
+	if opus["a"] != 10 || opus["b"] != 10 {
+		t.Fatalf("opus picks = %#v, want 10/10", opus)
+	}
+
+	// All candidates zero for the model -> auth_unavailable, other models unaffected.
+	authB.Attributes[AttributeModelWeights] = `{"claude-fable-5-1":0}`
+	if _, errPick := selector.Pick(context.Background(), "claude", "claude-fable-5-1", cliproxyexecutor.Options{}, auths); errPick == nil {
+		t.Fatal("Pick(fable) expected error when every credential is zero for the model")
+	}
+	if _, errPick := selector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, auths); errPick != nil {
+		t.Fatalf("Pick(opus) error = %v", errPick)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_NoModelWeightsMatchesLegacyBehaviour(t *testing.T) {
+	t.Parallel()
+
+	build := func() []*Auth {
+		return []*Auth{
+			{ID: "a", Provider: "claude", Attributes: map[string]string{AttributeWeight: "3"}},
+			{ID: "b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1"}},
+			{ID: "c", Provider: "claude"},
+		}
+	}
+	withEmptyTable := build()
+	withEmptyTable[0].Attributes[AttributeModelWeights] = ""
+	withEmptyTable[1].Metadata = map[string]any{AttributeModelWeights: map[string]any{}}
+
+	plainSeq := make([]string, 0, 10)
+	emptySeq := make([]string, 0, 10)
+	plainSelector := &WeightedRoundRobinSelector{}
+	emptySelector := &WeightedRoundRobinSelector{}
+	for index := 0; index < 10; index++ {
+		plain, errPlain := plainSelector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, build())
+		empty, errEmpty := emptySelector.Pick(context.Background(), "claude", "claude-opus-5", cliproxyexecutor.Options{}, withEmptyTable)
+		if errPlain != nil || errEmpty != nil {
+			t.Fatalf("Pick() errors = %v / %v", errPlain, errEmpty)
+		}
+		plainSeq = append(plainSeq, plain.ID)
+		emptySeq = append(emptySeq, empty.ID)
+	}
+	if fmt.Sprint(plainSeq) != fmt.Sprint(emptySeq) {
+		t.Fatalf("sequence with empty model_weights = %v, want identical to plain %v", emptySeq, plainSeq)
+	}
+	if fmt.Sprint(plainSeq) != "[a b a c a a b a c a]" {
+		t.Fatalf("legacy sequence = %v", plainSeq)
+	}
+}
+
+func TestSessionAffinitySelector_ZeroModelWeightBlocksNewBindingForThatModelOnly(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&WeightedRoundRobinSelector{})
+	defer selector.Stop()
+	authA := &Auth{ID: "auth-a", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1000000", AttributeModelWeights: `{"claude-fable-5-1":0}`}}
+	authB := &Auth{ID: "auth-b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	pick := func(model string, index int) *Auth {
+		t.Helper()
+		opts := cliproxyexecutor.Options{OriginalRequest: []byte(fmt.Sprintf(`{"session_id":"mw-session-%s-%d"}`, model, index))}
+		picked, errPick := selector.Pick(context.Background(), "claude", model, opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(%s #%d) error = %v", model, index, errPick)
+		}
+		return picked
+	}
+	for index := 0; index < 10; index++ {
+		if got := pick("claude-fable-5-1", index); got.ID != authB.ID {
+			t.Fatalf("fable new session #%d bound to %q, want %q (A is zero for fable)", index, got.ID, authB.ID)
+		}
+	}
+	opusCounts := make(map[string]int)
+	for index := 0; index < 10; index++ {
+		opusCounts[pick("claude-opus-5", index).ID]++
+	}
+	if opusCounts[authA.ID] != 10 {
+		t.Fatalf("opus new sessions = %#v, want all on auth-a", opusCounts)
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinUsesPerModelWeights(t *testing.T) {
+	t.Parallel()
+
+	reg := registry.GetGlobalRegistry()
+	for _, authID := range []string{"mw-a", "mw-b", "mw-c"} {
+		reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: "claude-fable-5-1"}, {ID: "claude-opus-5"}})
+	}
+	t.Cleanup(func() {
+		for _, authID := range []string{"mw-a", "mw-b", "mw-c"} {
+			reg.UnregisterClient(authID)
+		}
+	})
+	authA := &Auth{ID: "mw-a", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1", AttributeModelWeights: `{"claude-fable-5-1":1,"claude-opus-5":10000}`}}
+	authB := &Auth{ID: "mw-b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1", AttributeModelWeights: `{"claude-fable-5-1":10000,"claude-opus-5":1}`}}
+	authC := &Auth{ID: "mw-c", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1", AttributeModelWeights: `{"claude-fable-5-1":0}`}}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, authA, authB, authC)
+
+	count := func(model string, rounds int) map[string]int {
+		t.Helper()
+		counts := make(map[string]int)
+		for index := 0; index < rounds; index++ {
+			got, errPick := scheduler.pickSingle(context.Background(), "claude", model, cliproxyexecutor.Options{}, nil)
+			if errPick != nil {
+				t.Fatalf("pickSingle(%s) #%d error = %v", model, index, errPick)
+			}
+			counts[got.ID]++
+		}
+		return counts
+	}
+	fable := count("claude-fable-5-1", 20)
+	if fable["mw-b"] < 19 || fable["mw-c"] != 0 {
+		t.Fatalf("scheduler fable picks = %#v, want b >= 19 and c excluded", fable)
+	}
+	opus := count("claude-opus-5", 20)
+	if opus["mw-a"] < 19 {
+		t.Fatalf("scheduler opus picks = %#v, want a >= 19", opus)
+	}
+	// c has no opus entry, so its account weight (1) applies: over one full smooth-WRR
+	// cycle (10000+1+1 picks) it must surface exactly once, proving it was not excluded.
+	opusCycle := count("claude-opus-5", 10002)
+	if opusCycle["mw-c"] != 1 || opusCycle["mw-b"] != 1 || opusCycle["mw-a"] != 10000 {
+		t.Fatalf("scheduler opus full cycle = %#v, want a:10000 b:1 c:1", opusCycle)
+	}
+
+	// Hot update: flip A's fable weight and the shard must follow without a rebuild.
+	authA.Attributes[AttributeModelWeights] = `{"claude-fable-5-1":10000,"claude-opus-5":10000}`
+	scheduler.upsertAuth(authA)
+	authB.Attributes[AttributeModelWeights] = `{"claude-fable-5-1":1,"claude-opus-5":1}`
+	scheduler.upsertAuth(authB)
+	fableAfter := count("claude-fable-5-1", 20)
+	if fableAfter["mw-a"] < 19 {
+		t.Fatalf("scheduler fable picks after update = %#v, want a >= 19", fableAfter)
+	}
+}

--- a/sdk/cliproxy/auth/model_weights_test.go
+++ b/sdk/cliproxy/auth/model_weights_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"strings"
 	"context"
 	"fmt"
 	"testing"
@@ -8,6 +9,29 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
+
+func TestParseModelWeights_RejectsAmbiguousKeys(t *testing.T) {
+	t.Parallel()
+
+	// Both entries normalize to the same key. Keeping either one would make the
+	// loaded table depend on map iteration order, so the same file could route
+	// differently on each read — with 0 and a positive weight the credential
+	// would flip between excluded and active.
+	cases := []map[string]any{
+		{"Claude-Opus-5": 0, "claude-opus-5": 10000},        // case
+		{" claude-opus-5 ": 0, "claude-opus-5": 10000},      // surrounding space
+		{"gpt-5.6-sol(high)": 0, "gpt-5.6-sol": 10000},      // thinking suffix
+	}
+	for _, raw := range cases {
+		got, err := ParseModelWeights(raw)
+		if err == nil {
+			t.Fatalf("ParseModelWeights(%v) = %#v, want error", raw, got)
+		}
+		if !strings.Contains(err.Error(), "ambiguous") {
+			t.Fatalf("ParseModelWeights(%v) error = %v, want it to name the ambiguity", raw, err)
+		}
+	}
+}
 
 func TestParseModelWeights_NormalizesKeysAndValues(t *testing.T) {
 	t.Parallel()

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -79,9 +79,12 @@ type modelScheduler struct {
 }
 
 // scheduledAuth stores the runtime scheduling state for a single auth inside a model shard.
+// weight is the routing weight resolved for this shard's model: the auth's model_weights
+// override when it names the model, the account-level meta.weight otherwise.
 type scheduledAuth struct {
 	meta        *scheduledAuthMeta
 	auth        *Auth
+	weight      int64
 	state       scheduledState
 	nextRetryAt time.Time
 }
@@ -600,7 +603,7 @@ func scheduledAuthPredicate(eligibility authSelectionEligibility, tried map[stri
 		if entry == nil || entry.auth == nil || !eligibility.allows(entry.auth) {
 			return false
 		}
-		if requirePositiveWeight && (entry.meta == nil || entry.meta.weight <= 0) {
+		if requirePositiveWeight && (entry.meta == nil || entry.weight <= 0) {
 			return false
 		}
 		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
@@ -1038,6 +1041,7 @@ func (m *modelScheduler) upsertEntryLocked(meta *scheduledAuthMeta, now time.Tim
 
 	entry.meta = meta
 	entry.auth = meta.auth
+	entry.weight = authWeightForModel(meta.auth, m.modelKey)
 	entry.nextRetryAt = time.Time{}
 	blocked, reason, next := isAuthBlockedForModel(meta.auth, m.modelKey, now)
 	switch {
@@ -1503,13 +1507,13 @@ func scheduledWeightVector(entries []*scheduledAuth) map[string]int64 {
 func scheduledWeightVectorMatching(entries []*scheduledAuth, predicate func(*scheduledAuth) bool) map[string]int64 {
 	weights := make(map[string]int64, len(entries))
 	for _, entry := range entries {
-		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.weight <= 0 {
 			continue
 		}
 		if predicate != nil && !predicate(entry) {
 			continue
 		}
-		weights[entry.auth.ID] = entry.meta.weight
+		weights[entry.auth.ID] = entry.weight
 	}
 	return weights
 }
@@ -1519,14 +1523,14 @@ func pickSmoothWeightedScheduled(entries []*scheduledAuth, current map[string]in
 	var pickedCurrent int64
 	var totalWeight int64
 	for _, entry := range entries {
-		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.weight <= 0 {
 			continue
 		}
 		if predicate != nil && !predicate(entry) {
 			continue
 		}
-		current[entry.auth.ID] = saturatingAddInt64(current[entry.auth.ID], entry.meta.weight)
-		totalWeight = saturatingAddInt64(totalWeight, entry.meta.weight)
+		current[entry.auth.ID] = saturatingAddInt64(current[entry.auth.ID], entry.weight)
+		totalWeight = saturatingAddInt64(totalWeight, entry.weight)
 		if picked == nil || current[entry.auth.ID] > pickedCurrent {
 			picked = entry
 			pickedCurrent = current[entry.auth.ID]

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -660,10 +660,13 @@ func (s *RoundRobinSelector) ensureRotationKey(key string, limit int) {
 	}
 }
 
-func positiveWeightAuths(auths []*Auth) []*Auth {
+// positiveWeightAuths keeps the credentials whose routing weight for model is positive.
+// A credential whose model_weights table pins this model to zero is excluded for this
+// model only; credentials without a table use their account-level weight.
+func positiveWeightAuths(auths []*Auth, model string) []*Auth {
 	weightedCandidates := make([]*Auth, 0, len(auths))
 	for _, auth := range auths {
-		if authWeight(auth) > 0 {
+		if authWeightForModel(auth, model) > 0 {
 			weightedCandidates = append(weightedCandidates, auth)
 		}
 	}
@@ -673,12 +676,12 @@ func positiveWeightAuths(auths []*Auth) []*Auth {
 // Pick selects the next available auth using smooth weighted round-robin.
 func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
-	available, errAvailable := getSelectorAvailableAuths(ctx, positiveWeightAuths(auths), provider, model, time.Now())
+	stateModel := weightedSelectorStateModel(ctx, model)
+	available, errAvailable := getSelectorAvailableAuths(ctx, positiveWeightAuths(auths, stateModel), provider, model, time.Now())
 	if errAvailable != nil {
 		return nil, errAvailable
 	}
 	available = preferCodexWebsocketAuths(ctx, provider, available)
-	stateModel := weightedSelectorStateModel(ctx, model)
 	key := provider + ":" + canonicalModelKey(stateModel)
 
 	s.mu.Lock()
@@ -698,9 +701,9 @@ func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model s
 		state = &smoothWeightedState{}
 		s.states[key] = state
 	}
-	weights := authWeightVector(available)
+	weights := authWeightVector(available, stateModel)
 	state.prepare(weights)
-	picked := pickSmoothWeightedAuth(available, state.current)
+	picked := pickSmoothWeightedAuth(available, state.current, weights)
 	if picked == nil {
 		return nil, &Error{Code: "auth_unavailable", Message: "no auth available with positive weight"}
 	}
@@ -763,26 +766,33 @@ func weightsConfigChanged(left, right map[string]int64) bool {
 	return false
 }
 
-func authWeightVector(auths []*Auth) map[string]int64 {
+// authWeightVector resolves each credential's routing weight for model (per-model
+// override first, account-level weight otherwise) and drops non-positive entries.
+func authWeightVector(auths []*Auth, model string) map[string]int64 {
 	weights := make(map[string]int64, len(auths))
 	for _, auth := range auths {
 		if auth == nil {
 			continue
 		}
-		if weight := authWeight(auth); weight > 0 {
+		if weight := authWeightForModel(auth, model); weight > 0 {
 			weights[auth.ID] = weight
 		}
 	}
 	return weights
 }
 
-func pickSmoothWeightedAuth(auths []*Auth, current map[string]int64) *Auth {
+// pickSmoothWeightedAuth runs one smooth weighted round-robin step over auths using the
+// resolved weight vector; credentials absent from weights are skipped.
+func pickSmoothWeightedAuth(auths []*Auth, current map[string]int64, weights map[string]int64) *Auth {
 	var picked *Auth
 	var pickedCurrent int64
 	var totalWeight int64
 	for _, auth := range auths {
-		weight := authWeight(auth)
-		if auth == nil || weight <= 0 {
+		if auth == nil {
+			continue
+		}
+		weight := weights[auth.ID]
+		if weight <= 0 {
 			continue
 		}
 		current[auth.ID] = saturatingAddInt64(current[auth.ID], weight)
@@ -1012,7 +1022,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	now := time.Now()
 	availabilityCandidates := auths
 	if _, weighted := s.fallback.(*WeightedRoundRobinSelector); weighted {
-		availabilityCandidates = positiveWeightAuths(auths)
+		availabilityCandidates = positiveWeightAuths(auths, model)
 	}
 	if primaryID == "" {
 		fallbackAuths, errAvailable := getSelectorAvailableAuths(ctx, availabilityCandidates, provider, model, now)
@@ -1130,7 +1140,7 @@ func (s *SessionAffinitySelector) pickLCP(ctx context.Context, provider, model s
 
 	availabilityCandidates := auths
 	if _, weighted := s.fallback.(*WeightedRoundRobinSelector); weighted {
-		availabilityCandidates = positiveWeightAuths(auths)
+		availabilityCandidates = positiveWeightAuths(auths, model)
 	}
 	available, errAvailable := getSelectorAvailableAuthsAcrossPriorities(ctx, availabilityCandidates, provider, model, time.Now())
 	if errAvailable != nil {

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -209,7 +209,7 @@ func TestPickSmoothWeightedAuth_SaturatesCorruptState(t *testing.T) {
 	t.Parallel()
 
 	current := map[string]int64{"a": math.MaxInt64, "b": math.MinInt64}
-	picked := pickSmoothWeightedAuth([]*Auth{{ID: "a"}, {ID: "b"}}, current)
+	picked := pickSmoothWeightedAuth([]*Auth{{ID: "a"}, {ID: "b"}}, current, map[string]int64{"a": 1, "b": 1})
 	if picked == nil {
 		t.Fatal("pickSmoothWeightedAuth() returned nil")
 	}

--- a/sdk/cliproxy/auth/weight.go
+++ b/sdk/cliproxy/auth/weight.go
@@ -22,10 +22,21 @@ func ValidateAuthWeight(auth *Auth) error {
 			return fmt.Errorf("invalid metadata weight: %w", errParse)
 		}
 	}
+	if rawModelWeights, ok := auth.Attributes[AttributeModelWeights]; ok {
+		if _, errParse := ParseModelWeights(rawModelWeights); errParse != nil {
+			return fmt.Errorf("invalid attributes model_weights: %w", errParse)
+		}
+	}
+	if rawModelWeights, ok := auth.Metadata[AttributeModelWeights]; ok && rawModelWeights != nil {
+		if _, errParse := ParseModelWeights(rawModelWeights); errParse != nil {
+			return fmt.Errorf("invalid metadata model_weights: %w", errParse)
+		}
+	}
 	return nil
 }
 
-// ApplyAuthWeightMetadata validates the auth and applies a source metadata weight.
+// ApplyAuthWeightMetadata validates the auth and applies the source metadata weight
+// and optional per-model weight table (model_weights) as routing attributes.
 func ApplyAuthWeightMetadata(auth *Auth, metadata map[string]any) error {
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
 		return errWeight
@@ -33,17 +44,29 @@ func ApplyAuthWeightMetadata(auth *Auth, metadata map[string]any) error {
 	if auth == nil || metadata == nil {
 		return nil
 	}
-	rawWeight, ok := metadata[AttributeWeight]
-	if !ok {
-		return nil
+	if rawWeight, ok := metadata[AttributeWeight]; ok {
+		weight, errParse := credentialweight.ParseValue(rawWeight)
+		if errParse != nil {
+			return fmt.Errorf("invalid metadata weight: %w", errParse)
+		}
+		if auth.Attributes == nil {
+			auth.Attributes = make(map[string]string)
+		}
+		auth.Attributes[AttributeWeight] = strconv.FormatInt(weight, 10)
 	}
-	weight, errParse := credentialweight.ParseValue(rawWeight)
-	if errParse != nil {
-		return fmt.Errorf("invalid metadata weight: %w", errParse)
+	if rawModelWeights, ok := metadata[AttributeModelWeights]; ok && rawModelWeights != nil {
+		modelWeights, errParse := ParseModelWeights(rawModelWeights)
+		if errParse != nil {
+			return fmt.Errorf("invalid metadata model_weights: %w", errParse)
+		}
+		if auth.Attributes == nil {
+			auth.Attributes = make(map[string]string)
+		}
+		if encoded := EncodeModelWeights(modelWeights); encoded != "" {
+			auth.Attributes[AttributeModelWeights] = encoded
+		} else {
+			delete(auth.Attributes, AttributeModelWeights)
+		}
 	}
-	if auth.Attributes == nil {
-		auth.Attributes = make(map[string]string)
-	}
-	auth.Attributes[AttributeWeight] = strconv.FormatInt(weight, 10)
 	return nil
 }


### PR DESCRIPTION
## Summary

- add an optional `model_weights` map to a credential's auth file: `{"model_weights": {"claude-opus-5": 0, "claude-fable-5-1": 10000}}`
- `authWeightForModel(auth, model)` resolves the table for the requested model and falls back to the existing account-wide `weight` when the model is absent, so files without the field behave exactly as before
- a value of `0` removes that credential from the pool **for that model only**, leaving it eligible for every other model
- expose the field through the management API: `GET /v0/management/auth-files` reports it, `PATCH /v0/management/auth-files/fields` accepts an object or `null` to clear
- picked up by the existing auth-file watcher, so operators can retune weights without a restart

Today `weight` is per credential, so an operator who wants one account to absorb most of the traffic for one model has no way to say so without changing that account's share for every other model. That is the common case when different models on the same account have separate quota windows: a credential can be nearly exhausted on one model family while still having plenty of room on another, and the single knob forces a choice between starving the healthy family or over-driving the exhausted one.

Keys are matched on the lowercase canonical model id (the thinking-suffix form is normalised first, so `claude-opus-5[1m]`-style variants resolve to their base entry). An unparsable `model_weights` value causes that auth file to be skipped with a warning rather than being silently treated as unweighted — a malformed routing table should be loud, not quietly ignored.

## Tests

- `go build ./...`, `go test ./...` — 0 failures
- new unit tests cover resolution and fallback, `0` excluding one model while others stay eligible, case and thinking-suffix normalisation, malformed values, and the management read/patch/clear round trip
- exercised against a throwaway instance with two stub credentials: with `model_weights` steering one model to the second credential, 20/20 requests for that model landed there while 20/20 requests for another model still landed on the first, and editing the file at runtime flipped the routing without a restart
