### PR TITLE
fix(claude): preserve thinking binding beta for OAuth requests

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -62,6 +62,40 @@ func TestApplyClaudeHeaders_ConfirmedClientKeepsOAuthCredentialBetas(t *testing.
 	}
 }
 
+func TestApplyClaudeHeaders_ThinkingBindingControlsPreservedForOAuth(t *testing.T) {
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", claudeThinkingBindingBeta)
+
+	body := []byte(`{"model":"claude-fable-5-1","thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"drop_block"}}}`)
+
+	for _, stream := range []bool{false, true} {
+		req := newClaudeHeaderTestRequest(t, nil)
+		if err := applyClaudeHeaders(
+			req,
+			claudeOAuthAuthForBetaPolicy(),
+			claudeRaceProbeOAuthKey,
+			stream,
+			nil,
+			body,
+			nil,
+			incoming,
+			false,
+		); err != nil {
+			t.Fatalf("applyClaudeHeaders(stream=%v) error = %v", stream, err)
+		}
+
+		got := req.Header.Get("Anthropic-Beta")
+		if !strings.Contains(got, claudeThinkingBindingBeta) {
+			t.Fatalf(
+				"stream=%v: Anthropic-Beta = %q, want %s",
+				stream,
+				got,
+				claudeThinkingBindingBeta,
+			)
+		}
+	}
+}
+
 func TestApplyClaudeHeaders_ConfirmedAPIKeyClientKeepsPurePassthrough(t *testing.T) {
 	incoming := http.Header{}
 	incoming.Set("Anthropic-Beta", claudeCodeBeta+","+claudeEffortBeta)

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -46,6 +46,7 @@ const (
 	claudeServerSideFallbackBeta     = "server-side-fallback-2026-06-01"
 	claudeFallbackCreditBeta         = "fallback-credit-2026-06-01"
 	claudeStructuredOutputsBeta      = "structured-outputs-2025-12-15"
+	claudeThinkingBindingBeta        = "thinking-binding-controls-2026-08-01"
 	claudeThinkingDisplayUpdatesBeta = "thinking-display-updates-2026-08-18"
 	claudeExtendedCacheTTLBeta       = "extended-cache-ttl-2025-04-11"
 	claudeCacheDiagnosisBeta         = "cache-diagnosis-2026-04-07"
@@ -74,6 +75,7 @@ var claudeCodeTrailingBetas = []string{
 	claudeServerSideFallbackBeta,
 	claudeFallbackCreditBeta,
 	claudeStructuredOutputsBeta,
+	claudeThinkingBindingBeta,
 }
 
 // claudeCodeCLIBetas assembles the Anthropic-Beta baseline the way Claude Code


### PR DESCRIPTION
## Summary

Preserve `thinking-binding-controls-2026-08-01` when reconstructing the `Anthropic-Beta` header for Claude OAuth requests.

Clients such as OpenCode can send:

```json
{
  "thinking": {
    "type": "adaptive",
    "block_binding": {
      "prefix_mismatch_behavior": "drop_block"
    }
  }
}
```

along with:

```text
Anthropic-Beta: thinking-binding-controls-2026-08-01
```

CLIProxyAPI currently recognizes the incoming beta, but drops it when rebuilding the Claude Code beta header for the upstream Anthropic request.

This causes Anthropic to reject the otherwise valid `thinking.block_binding` field with:

```text
thinking.adaptive.block_binding: Extra inputs are not permitted
```

## Changes

* Add `thinking-binding-controls-2026-08-01` to the set of supported caller-requested Claude betas.
* Preserve it in the reconstructed upstream `Anthropic-Beta` header when explicitly requested by the client.
* Add a regression test covering both streaming and non-streaming Claude OAuth requests using adaptive thinking with `block_binding`.

This keeps the existing beta allowlisting/reconstruction behavior rather than broadly forwarding arbitrary caller-supplied betas.
