### PR TITLE
feat(sdk): observe final HTTP attempts without replacing provider transports

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -22,6 +22,7 @@ import (
 	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/httptransport"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
@@ -414,7 +415,8 @@ func antigravityCredentialScope(prefix, secret string) string {
 // negotiates TLS 1.3 without advertising an ALPN protocol and therefore never uses h2.
 // The underlying Transport is always shared so keep-alive connections survive across
 // requests instead of forcing a fresh TCP + TLS handshake every time.
-func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
+func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) (clientOut *http.Client) {
+	defer func() { clientOut = httptransport.Decorate(ctx, clientOut) }()
 	// Native Antigravity reuses one transport across requests. Opt into a
 	// credential-scoped proxy transport only here so other providers keep their
 	// existing lifecycle and different OAuth identities remain isolated.
@@ -426,7 +428,7 @@ func newAntigravityHTTPClient(ctx context.Context, cfg *config.Config, auth *cli
 		// context transport fallback, preserving the previous behavior.
 	}
 
-	client := helps.NewProxyAwareHTTPClient(ctx, cfg, auth, timeout)
+	client := helps.NewProxyAwareHTTPClient(httptransport.WithoutDecorator(ctx), cfg, auth, timeout)
 	// Direct requests share an HTTP/1.1 pool only within the selected credential.
 	if client.Transport == nil {
 		client.Transport = antigravityHTTP11Transport(auth, antigravityBaseTransport, cfg)

--- a/internal/runtime/executor/antigravity_transport_decorator_test.go
+++ b/internal/runtime/executor/antigravity_transport_decorator_test.go
@@ -1,0 +1,34 @@
+package executor
+
+import (
+	"context"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/httptransport"
+	"net/http"
+	"testing"
+)
+
+type auditTestTransport struct{ http.RoundTripper }
+
+func TestAntigravityDecoratorRunsAfterCredentialHTTP11PoolSelection(t *testing.T) {
+	for _, proxy := range []string{"", "http://localhost:12345"} {
+		calls := 0
+		var selected http.RoundTripper
+		ctx := httptransport.WithDecorator(context.Background(), func(next http.RoundTripper) http.RoundTripper {
+			calls++
+			selected = next
+			tr, ok := next.(*http.Transport)
+			if !ok || tr.ForceAttemptHTTP2 {
+				t.Fatal("decorator preceded H1 selection")
+			}
+			return &auditTestTransport{next}
+		})
+		auth := &coreauth.Auth{ID: "decorator-fixture", ProxyURL: proxy}
+		c := newAntigravityHTTPClient(ctx, &config.Config{}, auth, 0)
+		plain := newAntigravityHTTPClient(context.Background(), &config.Config{}, auth, 0)
+		if calls != 1 || c.Transport.(*auditTestTransport).RoundTripper != selected || plain.Transport != selected {
+			t.Fatal("pool replaced or helper decorated twice")
+		}
+	}
+}

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/httptransport"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -25,7 +26,8 @@ import (
 //
 // Returns:
 //   - *http.Client: An HTTP client with configured proxy or transport
-func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
+func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) (clientOut *http.Client) {
+	defer func() { clientOut = httptransport.Decorate(ctx, clientOut) }()
 	httpClient := &http.Client{}
 	if timeout > 0 {
 		httpClient.Timeout = timeout

--- a/internal/runtime/executor/helps/transport_decorator_test.go
+++ b/internal/runtime/executor/helps/transport_decorator_test.go
@@ -1,0 +1,42 @@
+package helps
+
+import (
+	"context"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/httptransport"
+	"net/http"
+	"testing"
+)
+
+type observingTransport struct{ http.RoundTripper }
+
+func TestClientDecoratorsPreserveProtectedAndProxyTransports(t *testing.T) {
+	for _, factory := range []string{"plain", "utls"} {
+		for _, proxy := range []string{"", "http://localhost:12345"} {
+			t.Run(factory+proxy, func(t *testing.T) {
+				calls := 0
+				var selected http.RoundTripper
+				ctx := httptransport.WithDecorator(context.Background(), func(next http.RoundTripper) http.RoundTripper {
+					calls++
+					selected = next
+					return &observingTransport{next}
+				})
+				auth := &coreauth.Auth{ProxyURL: proxy}
+				var c *http.Client
+				if factory == "utls" {
+					c = NewUtlsHTTPClient(ctx, &config.Config{}, auth, 0)
+					rt, ok := selected.(*fallbackRoundTripper)
+					if !ok || rt.anthropic == nil || rt.chrome == nil || rt.fallback == nil {
+						t.Fatal("lost TLS profiles")
+					}
+				} else {
+					c = NewProxyAwareHTTPClient(ctx, &config.Config{}, auth, 0)
+				}
+				if calls != 1 || c.Transport.(*observingTransport).RoundTripper != selected {
+					t.Fatal("decoration replaced transport or ran twice")
+				}
+			})
+		}
+	}
+}

--- a/internal/runtime/executor/helps/utls_client.go
+++ b/internal/runtime/executor/helps/utls_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/httpwire"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/httptransport"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
@@ -366,7 +367,8 @@ func (f *fallbackRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 // fingerprints for protected hosts. It uses Claude Code's Node/OpenSSL profile
 // for Anthropic and a Chrome profile for ChatGPT, with a standard-transport
 // fallback for other hosts.
-func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) *http.Client {
+func NewUtlsHTTPClient(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, timeout time.Duration) (clientOut *http.Client) {
+	defer func() { clientOut = httptransport.Decorate(ctx, clientOut) }()
 	var proxyURL string
 	if auth != nil {
 		proxyURL = strings.TrimSpace(auth.ProxyURL)

--- a/sdk/httptransport/decorator.go
+++ b/sdk/httptransport/decorator.go
@@ -1,0 +1,52 @@
+// Package httptransport exposes an additive, request-scoped observation seam.
+// A decorator wraps the transport already selected by the executor: it must not
+// replace provider fingerprints, proxy routing, pools, or HTTP protocol policy.
+package httptransport
+
+import (
+	"context"
+	"net/http"
+)
+
+type decoratorKey struct{}
+
+// Decorator may wrap next to observe final HTTP requests and response bodies.
+// It is called during client construction; implementations must be concurrency
+// safe, must delegate to next, and must not retain secrets or consume bodies.
+// A decorator does not observe WebSocket messages after an upgrade.
+type Decorator func(next http.RoundTripper) http.RoundTripper
+
+// WithDecorator attaches a decorator to one execution context. It does not
+// enable request logging or modify executor credential/selection policy.
+func WithDecorator(ctx context.Context, decorator Decorator) context.Context {
+	return context.WithValue(ctx, decoratorKey{}, decorator)
+}
+
+// WithoutDecorator suppresses intermediate helper decoration. A specialized
+// executor that further configures its helper's transport must apply Decorate
+// once, after its own protocol/pool policy is complete.
+func WithoutDecorator(ctx context.Context) context.Context { return WithDecorator(ctx, nil) }
+
+// Decorate applies a context decorator AFTER transport selection. With no
+// decorator, the exact original client is returned. Only the client value is
+// copied; the original selected transport/pool and all client policy survive.
+func Decorate(ctx context.Context, client *http.Client) *http.Client {
+	if ctx == nil || client == nil {
+		return client
+	}
+	decorator, _ := ctx.Value(decoratorKey{}).(Decorator)
+	if decorator == nil {
+		return client
+	}
+	next := client.Transport
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	wrapped := decorator(next)
+	if wrapped == nil {
+		return client
+	}
+	clone := *client
+	clone.Transport = wrapped
+	return &clone
+}

--- a/sdk/httptransport/decorator_test.go
+++ b/sdk/httptransport/decorator_test.go
@@ -1,0 +1,38 @@
+package httptransport
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type wrapped struct{ http.RoundTripper }
+
+func TestDecoratorPreservesSelectionAndClientPolicy(t *testing.T) {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ForceAttemptHTTP2 = false
+	tr.MaxIdleConnsPerHost = 37
+	c := &http.Client{Transport: tr, Timeout: time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	if Decorate(context.Background(), c) != c {
+		t.Fatal("absent decorator changed client")
+	}
+	calls := 0
+	ctx := WithDecorator(context.Background(), func(next http.RoundTripper) http.RoundTripper {
+		calls++
+		if next != tr {
+			t.Fatal("selected transport replaced")
+		}
+		return &wrapped{next}
+	})
+	got := Decorate(ctx, c)
+	if got == c || c.Transport != tr || got.Transport.(*wrapped).RoundTripper != tr || got.Timeout != c.Timeout || got.CheckRedirect == nil {
+		t.Fatal("client/transport policy changed")
+	}
+	if Decorate(WithoutDecorator(ctx), c) != c || calls != 1 {
+		t.Fatal("intermediate suppression failed")
+	}
+	if Decorate(WithDecorator(ctx, func(http.RoundTripper) http.RoundTripper { return nil }), c) != c {
+		t.Fatal("nil decorator result changed behavior")
+	}
+}


### PR DESCRIPTION
Closes #5616.

Adds sdk/httptransport.WithDecorator + Decorate. Embedders can wrap the executor-selected RoundTripper after proxy/TLS/pool selection rather than replacing it through the conductor override. Nil decorators preserve exact existing client identity. Client copies preserve timeouts/redirect/jar policy and reuse the original transport/pool. No request logging is enabled; callbacks are context-local and documented as concurrency-safe.

Applied once at the end of plain proxy-aware, uTLS, and Antigravity HTTP client construction. Antigravity suppresses intermediate helper decoration before final HTTP/1.1/credential-pool policy is applied. WebSocket payload observation is explicitly outside this HTTP seam.

Validation (Docker golang:1.26.6; no host builds; no real provider calls):
- go test -race ./sdk/httptransport ./internal/runtime/executor/helps -run "TestDecorator|TestClientDecorators" — PASS
- go test ./internal/runtime/executor -run TestAntigravityDecorator — PASS
- go build -o /out/cli-proxy-api ./cmd/server — PASS
- gofmt and git diff --check — PASS

Tests pin nil behavior, selected transport identity, protected TLS family retention, proxy selection, HTTP/1.1 and credential pool reuse, and exactly-once decorator application.