### PR TITLE
feat(session): enhance harness hierarchy recognition, deduplicate selector, and normalize usage to UUIDv8

### DIFF
--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -73,6 +74,8 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	} else if parentSessionID == "" && sessionID == strings.TrimSpace(clientRequestMetadata.SessionID) {
 		parentSessionID = strings.TrimSpace(clientRequestMetadata.ParentSessionID)
 	}
+	sessionID = coresession.NormalizeToCanonicalUUID(sessionID)
+	parentSessionID = coresession.NormalizeToCanonicalUUID(parentSessionID)
 	if sessionID == "" || sessionID == parentSessionID {
 		parentSessionID = ""
 	}

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -610,8 +611,40 @@ func TestUsageQueuePluginPayloadIncludesExplicitSessionHierarchy(t *testing.T) {
 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "request_id", "ctx-session-req-1")
-		requireStringField(t, payload, "session_id", "slot:pi-worker-1")
-		requireStringField(t, payload, "parent_session_id", "slot:pi-main-root")
+		wantSession := coresession.NormalizeToCanonicalUUID("slot:pi-worker-1")
+		wantParent := coresession.NormalizeToCanonicalUUID("slot:pi-main-root")
+		requireStringField(t, payload, "session_id", wantSession)
+		requireStringField(t, payload, "parent_session_id", wantParent)
+		if len(wantSession) != 36 || wantSession[14] != '8' {
+			t.Fatalf("expected 36-char UUIDv8 for session_id, got %q", wantSession)
+		}
+		if len(wantParent) != 36 || wantParent[14] != '8' {
+			t.Fatalf("expected 36-char UUIDv8 for parent_session_id, got %q", wantParent)
+		}
+	})
+}
+
+func TestUsageQueuePluginPayloadNormalizesPrefixedNativeUUID(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "ctx-native-uuid-1")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:        "codex",
+			Model:           "gpt-5.6-sol",
+			APIKey:          "test-key",
+			SessionID:       "codex:01a07e72-c84d-7fd3-8207-d217b41cc649",
+			ParentSessionID: "codex:01a07e71-a1b2-7c3d-98e1-f23456789abc",
+			RequestedAt:     time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+			Latency:         1000 * time.Millisecond,
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "session_id", "01a07e72-c84d-7fd3-8207-d217b41cc649")
+		requireStringField(t, payload, "parent_session_id", "01a07e71-a1b2-7c3d-98e1-f23456789abc")
 	})
 }
 
@@ -635,7 +668,8 @@ func TestUsageQueuePluginPayloadPreventsSelfReferentialLoop(t *testing.T) {
 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "request_id", "ctx-loop-req-1")
-		requireStringField(t, payload, "session_id", "loop-sess-1")
+		wantSession := coresession.NormalizeToCanonicalUUID("loop-sess-1")
+		requireStringField(t, payload, "session_id", wantSession)
 		if _, exists := payload["parent_session_id"]; exists {
 			t.Fatalf("expected parent_session_id to be omitted on self-referential loop, got %s", payload["parent_session_id"])
 		}
@@ -667,7 +701,8 @@ func TestUsageQueuePluginPayloadSameOriginFallback(t *testing.T) {
 		})
 
 		payload := popSinglePayload(t)
-		requireStringField(t, payload, "session_id", "new-custom-root")
+		wantSession := coresession.NormalizeToCanonicalUUID("new-custom-root")
+		requireStringField(t, payload, "session_id", wantSession)
 		if _, exists := payload["parent_session_id"]; exists {
 			t.Fatalf("expected parent_session_id to be omitted when record is independent root, got %s", payload["parent_session_id"])
 		}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -137,6 +137,9 @@ func isHierarchyParent(primary, parent string) bool {
 	if idx1 > 0 && idx2 > 0 && primary[:idx1] == parent[:idx2] {
 		return true
 	}
+	if idx1 == -1 && idx2 == -1 {
+		return true
+	}
 	return false
 }
 

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -283,4 +283,20 @@ func TestEnrichContextWithSessionHierarchyFromBody(t *testing.T) {
 	if metaCleared.SessionID != "" || metaCleared.ParentSessionID != "" {
 		t.Fatalf("cleared context = (%q, %q), want (empty, empty)", metaCleared.SessionID, metaCleared.ParentSessionID)
 	}
+
+	// 7. Roo Code task delegation from body
+	rooBody := []byte(`{"taskId":"task-child-99","parentTaskId":"task-parent-99"}`)
+	ctx7 := EnrichContextWithSessionHierarchy(context.Background(), nil, rooBody, nil)
+	meta7 := logging.GetClientRequestMetadata(ctx7)
+	if meta7.SessionID != "task:task-child-99" || meta7.ParentSessionID != "task:task-parent-99" {
+		t.Fatalf("Roo Code task session = (%q, %q), want (task:task-child-99, task:task-parent-99)", meta7.SessionID, meta7.ParentSessionID)
+	}
+
+	// 8. OpenCode parent_id in payload
+	opencodeBody := []byte(`{"session_id":"opencode-sess-1","parent_id":"opencode-root-1"}`)
+	ctx8 := EnrichContextWithSessionHierarchy(context.Background(), nil, opencodeBody, nil)
+	meta8 := logging.GetClientRequestMetadata(ctx8)
+	if meta8.SessionID != "session:opencode-sess-1" || meta8.ParentSessionID != "session:opencode-root-1" {
+		t.Fatalf("OpenCode parent_id session = (%q, %q), want (session:opencode-sess-1, session:opencode-root-1)", meta8.SessionID, meta8.ParentSessionID)
+	}
 }

--- a/sdk/cliproxy/auth/home_session_alias.go
+++ b/sdk/cliproxy/auth/home_session_alias.go
@@ -246,6 +246,9 @@ func isHierarchyParent(primary, fallback string) bool {
 	if idx1 > 0 && idx2 > 0 && primary[:idx1] == fallback[:idx2] {
 		return true
 	}
+	if idx1 == -1 && idx2 == -1 {
+		return true
+	}
 	return false
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 )
@@ -1387,27 +1386,6 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 }
 
-func isBodyForkCandidate(root, reqRoot gjson.Result, hasNestedReq bool) bool {
-	if !root.Exists() {
-		return false
-	}
-	for _, k := range []string{
-		"forked_from_thread_id", "forked_from_id",
-		"metadata.forked_from_thread_id", "metadata.forked_from_id",
-		"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-	} {
-		if val := normalizedSessionCandidate(root.Get(k).String()); val != "" {
-			return true
-		}
-		if hasNestedReq {
-			if val := normalizedSessionCandidate(reqRoot.Get(k).String()); val != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // normalizedSessionCandidate validates an explicit client-provided session signal.
 // It keeps opaque printable IDs intact while rejecting values that are unsafe or
 // implausibly large for routing keys and logs.
@@ -1423,26 +1401,6 @@ func isSubagentSession(primaryID, fallbackID string) bool {
 		return false
 	}
 	return isHierarchyParent(primaryID, fallbackID)
-}
-
-func sessionHeaderValue(headers http.Header, name string) string {
-	if headers == nil {
-		return ""
-	}
-	if value := normalizedSessionCandidate(headers.Get(name)); value != "" {
-		return value
-	}
-	for key, values := range headers {
-		if !strings.EqualFold(key, name) {
-			continue
-		}
-		for _, raw := range values {
-			if value := normalizedSessionCandidate(raw); value != "" {
-				return value
-			}
-		}
-	}
-	return ""
 }
 
 // CanonicalSessionID resolves the single authoritative session identity from request options and metadata.
@@ -1481,506 +1439,48 @@ func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]a
 	return primary
 }
 
+func extractConversationAlias(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	root := gjson.ParseBytes(payload)
+	conversation := root.Get("conversation")
+	if !conversation.Exists() {
+		req := root.Get("request")
+		if req.Exists() && !root.Get("contents").Exists() {
+			conversation = req.Get("conversation")
+		}
+	}
+	if sid := normalizedSessionCandidate(conversation.Get("id").String()); sid != "" {
+		return "conv:" + sid
+	} else if conversation.Type == gjson.String {
+		if sid := normalizedSessionCandidate(conversation.String()); sid != "" {
+			return "conv:" + sid
+		}
+	}
+	return ""
+}
+
 // extractExplicitSessionIDs returns only client- or execution-provided identities.
 // LCP fallback must run after this function so explicit harness sessions remain authoritative.
 func extractExplicitSessionIDs(headers http.Header, payload []byte, metadata map[string]any) (string, string) {
-	var primary, fallback string
-
-	// Extract parent candidate from payload once if payload is non-empty
-	var root gjson.Result
-	var reqRoot gjson.Result
-	var hasNestedReq bool
-	var parentIDCandidate string
-	if len(payload) > 0 {
-		root = util.ParseGJSONBytesNoCopy(payload)
-		reqRoot = root
-		req := root.Get("request")
-		hasNestedReq = req.Exists() && !root.Get("contents").Exists()
-		if hasNestedReq {
-			reqRoot = req
+	info, ok := cliproxysession.ExtractSessionInfo(headers, payload, metadata)
+	if !ok || info.ClientType == "lcp" {
+		return "", ""
+	}
+	if metadata != nil {
+		if info.IsFork {
+			metadata[cliproxyexecutor.IsForkMetadataKey] = true
 		}
-		for _, parentPath := range []string{
-			"parent_session_id", "parentSessionId",
-			"parent_thread_id", "parentThreadId",
-			"forked_from_thread_id", "forked_from_id",
-			"parent_conversation_id", "parentConversationId",
-			"metadata.parent_session_id", "metadata.parent_thread_id",
-			"metadata.forked_from_thread_id", "metadata.forked_from_id",
-			"extra_body.parent_session_id", "extra_body.parent_thread_id",
-			"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-		} {
-			if psid := normalizedSessionCandidate(root.Get(parentPath).String()); psid != "" {
-				parentIDCandidate = psid
-				break
-			}
-			if hasNestedReq {
-				if psid := normalizedSessionCandidate(reqRoot.Get(parentPath).String()); psid != "" {
-					parentIDCandidate = psid
-					break
-				}
-			}
-		}
-		if parentIDCandidate == "" {
-			parentIDCandidate = cliproxysession.ClaudeMetadataParentSessionID(payload)
+		if info.ParentSessionID != "" {
+			metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = info.ParentSessionID
 		}
 	}
-
-	// 1. Anthropic / Claude Code
-	if sid := sessionHeaderValue(headers, "X-Claude-Code-Session-Id"); sid != "" {
-		agentID := sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		if agentID == "" && root.Exists() {
-			agentID = normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-			}
-			if agentID == "" && hasNestedReq {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-				if agentID == "" {
-					agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-				}
-			}
-		}
-		if agentID == "" {
-			_, _, agentID = cliproxysession.ClaudeMetadataIdentities(payload)
-		}
-		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
-		if agentID != "" && agentID != "main" {
-			primary = "claude:" + sid + ":agent:" + agentID
-			fallback = "claude:" + sid
-			if parentAgentID != "" && parentAgentID != "main" && parentAgentID != agentID {
-				fallback = "claude:" + sid + ":agent:" + parentAgentID
-			} else if parentIDCandidate != "" && parentIDCandidate != sid {
-				fallback = "claude:" + parentIDCandidate
-			}
-			return primary, fallback
-		}
-		primary = "claude:" + sid
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			fallback = "claude:" + parentIDCandidate
-		}
-		return primary, fallback
+	fallback := info.ParentSessionID
+	if fallback == "" && strings.HasPrefix(info.SessionID, "pck:") && len(payload) > 0 {
+		fallback = extractConversationAlias(payload)
 	}
-	if sid, parentSID, agentID := cliproxysession.ClaudeMetadataIdentities(payload); sid != "" {
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		}
-		if agentID == "" && root.Exists() {
-			agentID = normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-			}
-			if agentID == "" && hasNestedReq {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-				if agentID == "" {
-					agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-				}
-			}
-		}
-		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
-		if agentID != "" && agentID != "main" {
-			primary = "claude:" + sid + ":agent:" + agentID
-			fallback = "claude:" + sid
-			if parentAgentID != "" && parentAgentID != "main" && parentAgentID != agentID {
-				fallback = "claude:" + sid + ":agent:" + parentAgentID
-			} else if parentSID != "" && parentSID != sid {
-				fallback = "claude:" + parentSID
-			} else if parentIDCandidate != "" && parentIDCandidate != sid {
-				fallback = "claude:" + parentIDCandidate
-			}
-			return primary, fallback
-		}
-		primary = "claude:" + sid
-		if parentSID != "" && parentSID != sid {
-			fallback = "claude:" + parentSID
-		} else if parentIDCandidate != "" && parentIDCandidate != sid {
-			fallback = "claude:" + parentIDCandidate
-		}
-		return primary, fallback
-	}
-
-	// 2. OpenAI / Codex CLI
-	sid := sessionHeaderValue(headers, "Session-Id")
-	if sid == "" {
-		sid = sessionHeaderValue(headers, "Session_id")
-	}
-	tid := sessionHeaderValue(headers, "Thread-Id")
-	if tid == "" {
-		tid = sessionHeaderValue(headers, "Thread_id")
-	}
-
-	var codexTurnMeta string
-	for k, v := range headers {
-		if strings.EqualFold(k, "X-Codex-Turn-Metadata") && len(v) > 0 {
-			codexTurnMeta = strings.TrimSpace(v[0])
-			break
-		}
-	}
-	var codexTurnMetaJSON gjson.Result
-	if codexTurnMeta != "" {
-		codexTurnMetaJSON = gjson.Parse(codexTurnMeta)
-	}
-
-	if sid == "" && codexTurnMetaJSON.Exists() {
-		sid = normalizedSessionCandidate(codexTurnMetaJSON.Get("session_id").String())
-	}
-	if tid == "" && codexTurnMetaJSON.Exists() {
-		tid = normalizedSessionCandidate(codexTurnMetaJSON.Get("thread_id").String())
-	}
-	if tid == "" && sid != "" && root.Exists() {
-		for _, path := range []string{"thread_id", "threadId", "metadata.thread_id"} {
-			if tid = normalizedSessionCandidate(root.Get(path).String()); tid != "" {
-				break
-			}
-			if hasNestedReq {
-				if tid = normalizedSessionCandidate(reqRoot.Get(path).String()); tid != "" {
-					break
-				}
-			}
-		}
-	}
-
-	if sid != "" || tid != "" {
-		parentThreadID := sessionHeaderValue(headers, "x-codex-parent-thread-id")
-		if parentThreadID == "" {
-			parentThreadID = sessionHeaderValue(headers, "X-Codex-Parent-Thread-Id")
-		}
-		if parentThreadID == "" && codexTurnMetaJSON.Exists() {
-			parentThreadID = normalizedSessionCandidate(codexTurnMetaJSON.Get("parent_thread_id").String())
-		}
-
-		forkedFrom := ""
-		if codexTurnMetaJSON.Exists() {
-			forkedFrom = normalizedSessionCandidate(codexTurnMetaJSON.Get("forked_from_thread_id").String())
-			if forkedFrom == "" {
-				forkedFrom = normalizedSessionCandidate(codexTurnMetaJSON.Get("forked_from_id").String())
-			}
-		}
-		if forkedFrom == "" && root.Exists() {
-			for _, forkPath := range []string{
-				"forked_from_thread_id", "forked_from_id",
-				"metadata.forked_from_thread_id", "metadata.forked_from_id",
-				"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-			} {
-				if forkedFrom = normalizedSessionCandidate(root.Get(forkPath).String()); forkedFrom != "" {
-					break
-				}
-				if hasNestedReq {
-					if forkedFrom = normalizedSessionCandidate(reqRoot.Get(forkPath).String()); forkedFrom != "" {
-						break
-					}
-				}
-			}
-		}
-
-		cleanAgentName := ""
-		if codexTurnMetaJSON.Exists() {
-			rawName := codexTurnMetaJSON.Get("agent_name").String()
-			rawName = strings.TrimPrefix(rawName, "/root/")
-			rawName = strings.TrimPrefix(rawName, "/")
-			rawName = strings.TrimSpace(rawName)
-			rawName = normalizedSessionCandidate(rawName)
-			if rawName != "" && rawName != "root" && rawName != "main" {
-				cleanAgentName = rawName
-			}
-		}
-
-		subVal := sessionHeaderValue(headers, "X-Openai-Subagent")
-		subagentSignal := subVal != "" && !strings.EqualFold(subVal, "false") && subVal != "0"
-		if codexTurnMetaJSON.Exists() && codexTurnMetaJSON.Get("subagent_kind").String() == "thread_spawn" {
-			subagentSignal = true
-		}
-
-		// 1. Fork detection
-		if forkedFrom != "" {
-			forkSessionID := tid
-			if forkSessionID == "" {
-				forkSessionID = sid
-			}
-			if forkSessionID == forkedFrom && sid != "" && sid != forkedFrom {
-				forkSessionID = sid
-			}
-			primary = "codex:" + forkSessionID
-			fallback = "codex:" + forkedFrom
-			if metadata != nil {
-				metadata[cliproxyexecutor.IsForkMetadataKey] = true
-				metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-			}
-			return primary, fallback
-		}
-
-		// 2. Multi-Agent / Subagent detection
-		if subagentSignal || (tid != "" && sid != "" && tid != sid) || (parentThreadID != "" && parentThreadID != tid && parentThreadID != sid) {
-			childSessionID := tid
-			if childSessionID == "" {
-				childSessionID = sid
-			}
-			parentSID := parentThreadID
-			if parentSID == "" {
-				parentSID = sid
-			}
-			if cleanAgentName != "" && sid != "" {
-				primary = "codex:" + sid + ":agent:" + cleanAgentName
-				if parentSID != "" {
-					fallback = "codex:" + parentSID
-				} else if parentIDCandidate != "" && parentIDCandidate != sid {
-					fallback = "codex:" + parentIDCandidate
-				}
-			} else {
-				primary = "codex:" + childSessionID
-				if parentSID != "" && parentSID != childSessionID {
-					fallback = "codex:" + parentSID
-				} else if parentIDCandidate != "" && parentIDCandidate != childSessionID {
-					fallback = "codex:" + parentIDCandidate
-				}
-			}
-			if metadata != nil && fallback != "" {
-				metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-			}
-			return primary, fallback
-		}
-
-		// 3. Normal session
-		sessionID := sid
-		if sessionID == "" {
-			sessionID = tid
-		}
-		primary = "codex:" + sessionID
-		if parentThreadID != "" && parentThreadID != sessionID {
-			fallback = "codex:" + parentThreadID
-		} else if parentIDCandidate != "" && parentIDCandidate != sessionID {
-			fallback = "codex:" + parentIDCandidate
-		}
-		if metadata != nil && fallback != "" {
-			metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-		}
-		return primary, fallback
-	}
-
-	// 3. Antigravity CLI (agy) / Google Cloud Code
-	if sid := sessionHeaderValue(headers, "X-Http-Session-Id"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "agy:" + sid, "agy:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "agy:" + sid, "agy:" + parentIDCandidate
-		}
-		return "agy:" + sid, ""
-	}
-
-	// 4. OpenCode / Pi Slot / Generic Headers
-	if sid := sessionHeaderValue(headers, "X-Session-ID"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "header:" + sid, "header:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "header:" + sid, "header:" + parentIDCandidate
-		}
-		return "header:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Session-Affinity"); sid != "" {
-		parentAffinity := sessionHeaderValue(headers, "X-Parent-Session-Affinity")
-		if parentAffinity == "" {
-			parentAffinity = sessionHeaderValue(headers, "X-Parent-Session-ID")
-		}
-		if parentAffinity != "" && parentAffinity != sid {
-			return "affinity:" + sid, "affinity:" + parentAffinity
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "affinity:" + sid, "affinity:" + parentIDCandidate
-		}
-		return "affinity:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Slot-Session-Id"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "slot:" + sid, "slot:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "slot:" + sid, "slot:" + parentIDCandidate
-		}
-		return "slot:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "conv:" + sid, "conv:" + parentIDCandidate
-		}
-		return "conv:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-ID"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "conv:" + sid, "conv:" + parentIDCandidate
-		}
-		return "conv:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-Id"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "thread:" + sid, "thread:" + parentIDCandidate
-		}
-		return "thread:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-ID"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "thread:" + sid, "thread:" + parentIDCandidate
-		}
-		return "thread:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Client-Request-Id"); sid != "" {
-		return "clientreq:" + sid, ""
-	}
-
-	// 5. Body payload inspection
-	if len(payload) > 0 && root.Exists() {
-		reqRoot := root
-		req := root.Get("request")
-		hasNestedReq := req.Exists() && !root.Get("contents").Exists()
-		if hasNestedReq {
-			reqRoot = req
-		}
-
-		// Google Gemini Context Caching
-		for _, cachePath := range []string{"cachedContent", "cached_content"} {
-			cacheID := normalizedSessionCandidate(root.Get(cachePath).String())
-			if cacheID == "" && hasNestedReq {
-				cacheID = normalizedSessionCandidate(reqRoot.Get(cachePath).String())
-			}
-			if cacheID != "" {
-				if parentIDCandidate != "" && parentIDCandidate != cacheID {
-					return "geminicache:" + cacheID, "geminicache:" + parentIDCandidate
-				}
-				return "geminicache:" + cacheID, ""
-			}
-		}
-
-		// OpenAI Assistants / Threads
-		for _, threadPath := range []string{"thread_id", "threadId", "metadata.thread_id"} {
-			tid := normalizedSessionCandidate(root.Get(threadPath).String())
-			if tid == "" && hasNestedReq {
-				tid = normalizedSessionCandidate(reqRoot.Get(threadPath).String())
-			}
-			if tid != "" {
-				if parentIDCandidate != "" && parentIDCandidate != tid {
-					if isBodyForkCandidate(root, reqRoot, hasNestedReq) && metadata != nil {
-						metadata[cliproxyexecutor.IsForkMetadataKey] = true
-						metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = "thread:" + parentIDCandidate
-					}
-					return "thread:" + tid, "thread:" + parentIDCandidate
-				}
-				return "thread:" + tid, ""
-			}
-		}
-
-		// Session ID paths
-		agentID := normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-		if agentID == "" {
-			agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-		}
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		}
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "x-agent-id")
-		}
-		if agentID == "" && hasNestedReq {
-			agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-			}
-		}
-		for _, path := range []string{"session_id", "sessionId", "sessionID", "metadata.session_id", "extra_body.session_id"} {
-			sid := normalizedSessionCandidate(root.Get(path).String())
-			if sid == "" && hasNestedReq {
-				sid = normalizedSessionCandidate(reqRoot.Get(path).String())
-			}
-			if sid != "" {
-				if agentID != "" && agentID != "main" {
-					primary = "session:" + sid + ":agent:" + agentID
-					fallback = "session:" + sid
-					if parentIDCandidate != "" && parentIDCandidate != sid {
-						fallback = "session:" + parentIDCandidate
-					}
-					return primary, fallback
-				}
-				if parentIDCandidate != "" && parentIDCandidate != sid {
-					fallback = "session:" + parentIDCandidate
-					if isBodyForkCandidate(root, reqRoot, hasNestedReq) && metadata != nil {
-						metadata[cliproxyexecutor.IsForkMetadataKey] = true
-						metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-					}
-					return "session:" + sid, fallback
-				}
-				return "session:" + sid, ""
-			}
-		}
-
-		conversationID := ""
-		conversation := root.Get("conversation")
-		if !conversation.Exists() && hasNestedReq {
-			conversation = reqRoot.Get("conversation")
-		}
-		if sid := normalizedSessionCandidate(conversation.Get("id").String()); sid != "" {
-			conversationID = "conv:" + sid
-		} else if conversation.Type == gjson.String {
-			if sid := normalizedSessionCandidate(conversation.String()); sid != "" {
-				conversationID = "conv:" + sid
-			}
-		}
-		pck := normalizedSessionCandidate(root.Get("prompt_cache_key").String())
-		if pck == "" {
-			pck = normalizedSessionCandidate(root.Get("promptCacheKey").String())
-		}
-		if pck == "" && hasNestedReq {
-			pck = normalizedSessionCandidate(reqRoot.Get("prompt_cache_key").String())
-			if pck == "" {
-				pck = normalizedSessionCandidate(reqRoot.Get("promptCacheKey").String())
-			}
-		}
-		if pck != "" {
-			return "pck:" + pck, conversationID
-		}
-		if conversationID != "" {
-			if parentIDCandidate != "" && ("conv:"+parentIDCandidate) != conversationID {
-				return conversationID, "conv:" + parentIDCandidate
-			}
-			return conversationID, ""
-		}
-		userID := normalizedSessionCandidate(root.Get("metadata.user_id").String())
-		if userID == "" && hasNestedReq {
-			userID = normalizedSessionCandidate(reqRoot.Get("metadata.user_id").String())
-		}
-		if userID != "" {
-			return "user:" + userID, ""
-		}
-		for _, convPath := range []string{"conversation_id", "conversationId", "chat_id", "chatId", "metadata.conversation_id", "extra_body.conversation_id"} {
-			cid := normalizedSessionCandidate(root.Get(convPath).String())
-			if cid == "" && hasNestedReq {
-				cid = normalizedSessionCandidate(reqRoot.Get(convPath).String())
-			}
-			if cid != "" {
-				if parentIDCandidate != "" && ("conv:"+parentIDCandidate) != ("conv:"+cid) {
-					return "conv:" + cid, "conv:" + parentIDCandidate
-				}
-				return "conv:" + cid, ""
-			}
-		}
-	}
-
-	if executionID, ok := metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string); ok {
-		if executionID = normalizedSessionCandidate(executionID); executionID != "" {
-			return "execution:" + executionID, ""
-		}
-	}
-	return "", ""
+	return info.SessionID, fallback
 }
 
 // extractSessionIDs returns (primaryID, fallbackID) for session affinity.

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -2635,3 +2635,68 @@ func TestSessionAffinitySelector_DerivedIDBoundConsistencyOnResult(t *testing.T)
 		t.Fatalf("affinity failed: got auth %s, want %s", secondPicked.ID, pickedAuth.ID)
 	}
 }
+
+func TestExtractExplicitSessionIDs_EnhancedHarnesses(t *testing.T) {
+	t.Parallel()
+
+	// 1. Roo Code / Cline task headers
+	rooHeaders := http.Header{}
+	rooHeaders.Set("X-Task-ID", "task-abc-1")
+	rooHeaders.Set("X-Parent-Task-ID", "task-root-1")
+	meta := map[string]any{}
+	primary, fallback := extractExplicitSessionIDs(rooHeaders, nil, meta)
+	if primary != "task:task-abc-1" || fallback != "task:task-root-1" {
+		t.Fatalf("Roo Code extractExplicitSessionIDs() = (%q, %q), want (task:task-abc-1, task:task-root-1)", primary, fallback)
+	}
+	if meta[cliproxyexecutor.ParentSessionIDMetadataKey] != "task:task-root-1" {
+		t.Fatalf("ParentSessionIDMetadataKey = %v, want task:task-root-1", meta[cliproxyexecutor.ParentSessionIDMetadataKey])
+	}
+
+	// 2. OpenClaw forkSource sets IsForkMetadataKey
+	clawPayload := []byte(`{"sessionId":"claw-c-1","forkSource":{"sessionId":"claw-p-1"}}`)
+	metaClaw := map[string]any{}
+	primary, fallback = extractExplicitSessionIDs(nil, clawPayload, metaClaw)
+	if primary != "session:claw-c-1" || fallback != "session:claw-p-1" {
+		t.Fatalf("OpenClaw extractExplicitSessionIDs() = (%q, %q), want (session:claw-c-1, session:claw-p-1)", primary, fallback)
+	}
+	if isFork, ok := metaClaw[cliproxyexecutor.IsForkMetadataKey].(bool); !ok || !isFork {
+		t.Fatalf("OpenClaw IsForkMetadataKey = %v, want true", metaClaw[cliproxyexecutor.IsForkMetadataKey])
+	}
+
+	// 3. Roo Code subagent task inherits parent credential via affinity selector
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-1"}, {ID: "auth-2"}}
+
+	parentOpts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Task-ID": []string{"task-parent-100"}},
+	}
+	parentAuth, err := selector.Pick(context.Background(), "openai", "gpt-5.4", parentOpts, auths)
+	if err != nil || parentAuth == nil {
+		t.Fatalf("parent Pick() failed: %v", err)
+	}
+	selector.OnResult(Result{
+		AuthID:   parentAuth.ID,
+		Provider: "openai",
+		Model:    "gpt-5.4",
+		Success:  true,
+		Options:  parentOpts,
+	})
+
+	// Subagent task request specifying parent task
+	subagentOpts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Task-ID":        []string{"task-child-101"},
+			"X-Parent-Task-ID": []string{"task-parent-100"},
+		},
+	}
+	// Reverse candidate order to prove affinity, not order
+	reverseAuths := []*Auth{{ID: "auth-2"}, {ID: "auth-1"}}
+	subagentAuth, err := selector.Pick(context.Background(), "openai", "gpt-5.4", subagentOpts, reverseAuths)
+	if err != nil || subagentAuth == nil {
+		t.Fatalf("subagent Pick() failed: %v", err)
+	}
+	if subagentAuth.ID != parentAuth.ID {
+		t.Fatalf("subagent did not inherit parent task credential: got %s, want %s", subagentAuth.ID, parentAuth.ID)
+	}
+}

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -40,6 +40,66 @@ type canonicalPart struct {
 	Value string `json:"value"`
 }
 
+var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+var knownSessionPrefixes = []string{
+	"lcp:v1:", "lcp:",
+	"codex:", "claude:", "header:", "session:",
+	"affinity:", "slot:", "task:", "conv:",
+	"thread:", "clientreq:", "geminicache:",
+	"pck:", "user:", "execution:", "agy:", "derived:",
+}
+
+// NormalizeToCanonicalUUID deterministically normalizes any session identifier to a
+// canonical 36-character lowercase UUID (RFC 4122 / RFC 9562 compliant):
+//  1. If rawID (or rawID without known protocol prefix) is already a standard UUID (e.g. Codex UUIDv7,
+//     Claude UUIDv4, Header UUID), it strips the prefix and returns the lowercase UUID.
+//  2. If rawID has a known protocol prefix but the remainder is not a UUID (e.g. custom task strings),
+//     the known prefix is stripped and the remaining identifier is deterministically projected.
+//  3. If rawID is not a standard UUID (e.g. LCP 64-hex hash, subagent hierarchy, or custom string),
+//     it deterministically projects it to an RFC 9562 UUIDv8 using SHA-256 with domain separation.
+//  4. Idempotent: NormalizeToCanonicalUUID(NormalizeToCanonicalUUID(x)) == NormalizeToCanonicalUUID(x).
+func NormalizeToCanonicalUUID(rawID string) string {
+	clean := strings.TrimSpace(rawID)
+	if clean == "" {
+		return ""
+	}
+
+	// 1. Direct UUID match (already clean UUID)
+	if canonicalUUIDPattern.MatchString(clean) {
+		return strings.ToLower(clean)
+	}
+
+	// 2. Strip known protocol prefix and check if remainder is a UUID
+	for _, p := range knownSessionPrefixes {
+		if strings.HasPrefix(clean, p) {
+			clean = strings.TrimPrefix(clean, p)
+			break
+		}
+	}
+	clean = strings.TrimSpace(clean)
+	if canonicalUUIDPattern.MatchString(clean) {
+		return strings.ToLower(clean)
+	}
+
+	// 3. Check if any generic prefix "prefix:<uuid>" exists
+	if idx := strings.Index(clean, ":"); idx > 0 {
+		candidate := strings.TrimSpace(clean[idx+1:])
+		if canonicalUUIDPattern.MatchString(candidate) {
+			return strings.ToLower(candidate)
+		}
+	}
+
+	// 4. Deterministic projection to RFC 9562 UUIDv8 for LCP hashes and arbitrary non-UUID strings
+	sum := sha256.Sum256([]byte("cpa:canonical-uuid:v1\x00" + clean))
+	u := [16]byte(sum[:16])
+	u[6] = (u[6] & 0x0f) | 0x80 // RFC 9562 Version 8
+	u[8] = (u[8] & 0x3f) | 0x80 // RFC 4122 / RFC 9562 Variant
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
+}
+
 // NormalizeExplicitID validates an explicit client-provided session identifier.
 // It preserves opaque printable values while rejecting oversized or control-bearing IDs.
 func NormalizeExplicitID(raw string) string {
@@ -75,11 +135,32 @@ func ClaudeMetadataIdentities(payload []byte) (sessionID, parentSessionID, agent
 		parsed := gjson.Parse(userID)
 		sessionID = NormalizeExplicitID(parsed.Get("session_id").String())
 		parentSessionID = NormalizeExplicitID(parsed.Get("parent_session_id").String())
+		if parentSessionID == "" {
+			parentSessionID = NormalizeExplicitID(parsed.Get("parent_agent_id").String())
+		}
+		if parentSessionID == "" {
+			parentSessionID = NormalizeExplicitID(parsed.Get("parent_id").String())
+		}
 		agentID = NormalizeExplicitID(parsed.Get("agent_id").String())
+		if agentID == "" {
+			agentID = NormalizeExplicitID(parsed.Get("subagent_id").String())
+		}
 		return sessionID, parentSessionID, agentID
 	}
 	if matches := legacyClaudeSessionPattern.FindStringSubmatch(userID); len(matches) >= 2 {
-		return NormalizeExplicitID(matches[1]), "", ""
+		sid := NormalizeExplicitID(matches[1])
+		pAgent := NormalizeExplicitID(root.Get("metadata.parent_agent_id").String())
+		if pAgent == "" {
+			pAgent = NormalizeExplicitID(root.Get("metadata.parent_session_id").String())
+		}
+		if pAgent == "" {
+			pAgent = NormalizeExplicitID(root.Get("metadata.parent_id").String())
+		}
+		ag := NormalizeExplicitID(root.Get("metadata.agent_id").String())
+		if ag == "" {
+			ag = NormalizeExplicitID(root.Get("metadata.subagent_id").String())
+		}
+		return sid, pAgent, ag
 	}
 	return "", "", ""
 }
@@ -240,17 +321,30 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"Session_id",
 		"x-codex-parent-thread-id",
 		"X-Codex-Parent-Thread-Id",
+		"X-Codex-Turn-Metadata",
+		"X-Openai-Subagent",
 		"X-Http-Session-Id",
 		"X-Session-ID",
 		"X-Session-Affinity",
 		"X-Parent-Session-ID",
 		"X-Parent-Session-Id",
 		"X-Parent-Session-Affinity",
+		"X-Parent-ID",
+		"X-Parent-Id",
 		"X-Slot-Session-Id",
+		"X-Parent-Slot-Session-Id",
+		"X-Task-ID",
+		"X-Task-Id",
+		"X-Parent-Task-ID",
+		"X-Parent-Task-Id",
 		"X-Conversation-Id",
 		"X-Conversation-ID",
+		"X-Parent-Conversation-Id",
+		"X-Parent-Conversation-ID",
 		"X-Thread-Id",
 		"X-Thread-ID",
+		"X-Parent-Thread-Id",
+		"X-Parent-Thread-ID",
 		"Thread-Id",
 		"X-Client-Request-Id",
 	} {
@@ -274,6 +368,13 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"session_id",
 		"sessionId",
 		"sessionID",
+		"child_session_id",
+		"childSessionId",
+		"task_id",
+		"taskId",
+		"taskID",
+		"action_id",
+		"actionId",
 		"cachedContent",
 		"cached_content",
 		"thread_id",
@@ -288,12 +389,33 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"parentSessionId",
 		"parent_thread_id",
 		"parentThreadId",
+		"parent_id",
+		"parentId",
+		"parentID",
+		"parent_task_id",
+		"parentTaskId",
+		"parent_action_id",
+		"parentActionId",
+		"parent_session",
+		"parentSession",
+		"parent_subagent_id",
+		"forkSource.sessionId",
+		"previousSessionId",
 		"forked_from_thread_id",
 		"forked_from_id",
 		"metadata.session_id",
+		"metadata.sessionId",
+		"metadata.task_id",
+		"metadata.taskId",
 		"metadata.thread_id",
 		"metadata.conversation_id",
+		"metadata.parent_id",
+		"metadata.parent_task_id",
+		"metadata.parent_agent_id",
 		"extra_body.session_id",
+		"extra_body.task_id",
+		"extra_body.parent_id",
+		"extra_body.parent_task_id",
 	} {
 		if NormalizeExplicitID(root.Get(path).String()) != "" {
 			return true

--- a/sdk/cliproxy/session/identity_test.go
+++ b/sdk/cliproxy/session/identity_test.go
@@ -478,3 +478,99 @@ func TestEnrich_MetadataOnlyCanonicalAndParentSessionPreserved(t *testing.T) {
 		t.Fatalf("self-loop parent was not eliminated in metadata-only mode")
 	}
 }
+
+func TestNormalizeToCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	// 1. Empty and whitespace
+	if got := NormalizeToCanonicalUUID(""); got != "" {
+		t.Fatalf("NormalizeToCanonicalUUID(\"\") = %q, want empty", got)
+	}
+	if got := NormalizeToCanonicalUUID("   "); got != "" {
+		t.Fatalf("NormalizeToCanonicalUUID(\"   \") = %q, want empty", got)
+	}
+
+	// 2. Native UUIDs (v4 and v7, various casings)
+	rawUUIDv4 := "b2839f64-668d-4dc3-a42a-64da829d1e33"
+	if got := NormalizeToCanonicalUUID(rawUUIDv4); got != rawUUIDv4 {
+		t.Fatalf("NormalizeToCanonicalUUID(rawUUIDv4) = %q, want %q", got, rawUUIDv4)
+	}
+	upperUUID := "B2839F64-668D-4DC3-A42A-64DA829D1E33"
+	if got := NormalizeToCanonicalUUID(upperUUID); got != rawUUIDv4 {
+		t.Fatalf("NormalizeToCanonicalUUID(upperUUID) = %q, want %q", got, rawUUIDv4)
+	}
+	rawUUIDv7 := "01a07e72-c84d-7fd3-8207-d217b41cc649"
+	if got := NormalizeToCanonicalUUID(rawUUIDv7); got != rawUUIDv7 {
+		t.Fatalf("NormalizeToCanonicalUUID(rawUUIDv7) = %q, want %q", got, rawUUIDv7)
+	}
+
+	// 3. Known prefixes with UUIDs
+	prefixedCases := map[string]string{
+		"codex:01a07e72-c84d-7fd3-8207-d217b41cc649":         "01a07e72-c84d-7fd3-8207-d217b41cc649",
+		"claude:b2839f64-668d-4dc3-a42a-64da829d1e33":        "b2839f64-668d-4dc3-a42a-64da829d1e33",
+		"header:7a8b9c0d-1111-2222-3333-444455556666":        "7a8b9c0d-1111-2222-3333-444455556666",
+		"session:b2839f64-668d-4dc3-a42a-64da829d1e33":       "b2839f64-668d-4dc3-a42a-64da829d1e33",
+		"thread:01a07e72-c84d-7fd3-8207-d217b41cc649":        "01a07e72-c84d-7fd3-8207-d217b41cc649",
+		"custom-prefix:01a07e72-c84d-7fd3-8207-d217b41cc649": "01a07e72-c84d-7fd3-8207-d217b41cc649",
+	}
+	for input, want := range prefixedCases {
+		got := NormalizeToCanonicalUUID(input)
+		if got != want {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, want %q", input, got, want)
+		}
+	}
+
+	// 4. LCP 64-hex and non-UUID inputs projected to RFC 9562 UUIDv8
+	nonUUIDCases := []string{
+		"lcp:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"lcp:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"claude:b2839f64-668d-4dc3-a42a-64da829d1e33:agent:worker-reviewer",
+		"task:task-abc-1",
+		"slot:pi-slot-789",
+		"ses_f8189891effeCLIq0MasUgMQsC",
+		"my-custom-test-task",
+	}
+
+	for _, input := range nonUUIDCases {
+		got := NormalizeToCanonicalUUID(input)
+		if len(got) != 36 {
+			t.Errorf("NormalizeToCanonicalUUID(%q) length = %d, want 36", input, len(got))
+		}
+		if !canonicalUUIDPattern.MatchString(got) {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, does not match UUID pattern", input, got)
+		}
+		// Verify RFC 9562 Version 8 (13th char is '8', index 14)
+		if got[14] != '8' {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, version char is %c, want '8'", input, got, got[14])
+		}
+		// Verify RFC 4122 Variant (17th char is '8', '9', 'a', or 'b', index 19)
+		variantChar := got[19]
+		if variantChar != '8' && variantChar != '9' && variantChar != 'a' && variantChar != 'b' {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, variant char is %c, want 8/9/a/b", input, got, variantChar)
+		}
+		// Verify Idempotency
+		if reGot := NormalizeToCanonicalUUID(got); reGot != got {
+			t.Errorf("NormalizeToCanonicalUUID is not idempotent: first=%q, second=%q", got, reGot)
+		}
+	}
+
+	// 5. Uniqueness and determinism
+	id1 := NormalizeToCanonicalUUID("lcp:v1:hash-A")
+	id1Again := NormalizeToCanonicalUUID("lcp:v1:hash-A")
+	id2 := NormalizeToCanonicalUUID("lcp:v1:hash-B")
+	if id1 != id1Again {
+		t.Fatalf("NormalizeToCanonicalUUID is non-deterministic: %q != %q", id1, id1Again)
+	}
+	if id1 == id2 {
+		t.Fatalf("NormalizeToCanonicalUUID collided for different inputs: %q == %q", id1, id2)
+	}
+
+	// 6. Same content with or without "lcp:v1:" prefix produces identical UUID
+	lcpPrefixed := "lcp:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	lcpBare := "c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	if NormalizeToCanonicalUUID(lcpPrefixed) != NormalizeToCanonicalUUID(lcpBare) {
+		t.Fatalf("lcp prefixed (%q) and bare (%q) produced different UUIDs",
+			NormalizeToCanonicalUUID(lcpPrefixed), NormalizeToCanonicalUUID(lcpBare))
+	}
+}

--- a/sdk/cliproxy/session/info.go
+++ b/sdk/cliproxy/session/info.go
@@ -67,14 +67,44 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			reqRoot = req
 		}
 		for _, p := range []string{
-			"parent_session_id", "parentSessionId",
-			"parent_thread_id", "parentThreadId",
+			// Standard session / thread parent keys
+			"parent_session_id", "parentSessionId", "parentSessionID",
+			"parent_thread_id", "parentThreadId", "parentThreadID",
 			"forked_from_thread_id", "forked_from_id",
-			"parent_conversation_id", "parentConversationId",
-			"metadata.parent_session_id", "metadata.parent_thread_id",
+			"parent_conversation_id", "parentConversationId", "parentConversationID",
+			// OpenCode / generic parent ID keys
+			"parent_id", "parentId", "parentID",
+			// Roo Code / Cline task delegation keys
+			"parent_task_id", "parentTaskId", "parentTaskID",
+			// OpenHands action tree keys
+			"parent_action_id", "parentActionId", "parentActionID",
+			// Pi session keys
+			"parent_session", "parentSession",
+			// Hermes subagent keys
+			"parent_subagent_id", "parentSubagentId",
+			// OpenClaw fork sources
+			"forkSource.sessionId", "fork_source.session_id",
+			"previousSessionId", "previous_session_id",
+			// Metadata nested keys
+			"metadata.parent_session_id", "metadata.parentSessionId", "metadata.parentSessionID",
+			"metadata.parent_thread_id", "metadata.parentThreadId",
 			"metadata.forked_from_thread_id", "metadata.forked_from_id",
-			"extra_body.parent_session_id", "extra_body.parent_thread_id",
+			"metadata.parent_id", "metadata.parentId", "metadata.parentID",
+			"metadata.parent_task_id", "metadata.parentTaskId", "metadata.parentTaskID",
+			"metadata.parent_action_id", "metadata.parentActionId",
+			"metadata.parent_subagent_id", "metadata.parentSubagentId",
+			"metadata.parent_session", "metadata.parentSession",
+			"metadata.parent_agent_id", "metadata.parentAgentId",
+			"metadata.forkSource.sessionId", "metadata.previousSessionId",
+			// Extra body nested keys
+			"extra_body.parent_session_id", "extra_body.parentSessionId", "extra_body.parentSessionID",
+			"extra_body.parent_thread_id", "extra_body.parentThreadId",
 			"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
+			"extra_body.parent_id", "extra_body.parentId", "extra_body.parentID",
+			"extra_body.parent_task_id", "extra_body.parentTaskId",
+			"extra_body.parent_action_id", "extra_body.parentActionId",
+			"extra_body.parent_subagent_id", "extra_body.parentSubagentId",
+			"extra_body.parent_session", "extra_body.parentSession",
 		} {
 			if val := normalizedSessionCandidate(root.Get(p).String()); val != "" {
 				parentCandidate = val
@@ -112,6 +142,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			_, _, agentID = ClaudeMetadataIdentities(payload)
 		}
 		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
+		if parentAgentID == "" && root.Exists() {
+			parentAgentID = normalizedSessionCandidate(root.Get("metadata.parent_agent_id").String())
+			if parentAgentID == "" {
+				parentAgentID = normalizedSessionCandidate(root.Get("metadata.parentAgentId").String())
+			}
+			if parentAgentID == "" && hasNestedReq {
+				parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parent_agent_id").String())
+				if parentAgentID == "" {
+					parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parentAgentId").String())
+				}
+			}
+		}
 		if agentID != "" && agentID != "main" {
 			info.AgentName = agentID
 			info.ParentSessionID = "claude:" + sid
@@ -152,6 +194,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 				}
 			}
 			parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
+			if parentAgentID == "" && root.Exists() {
+				parentAgentID = normalizedSessionCandidate(root.Get("metadata.parent_agent_id").String())
+				if parentAgentID == "" {
+					parentAgentID = normalizedSessionCandidate(root.Get("metadata.parentAgentId").String())
+				}
+				if parentAgentID == "" && hasNestedReq {
+					parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parent_agent_id").String())
+					if parentAgentID == "" {
+						parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parentAgentId").String())
+					}
+				}
+			}
 			if agentID != "" && agentID != "main" {
 				info.SessionID = "claude:" + sid + ":agent:" + agentID
 				info.ParentSessionID = "claude:" + sid
@@ -352,6 +406,12 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
 		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "agy:" + parentSID
 			info.AgentName = "subagent"
@@ -364,13 +424,19 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		return finalizeSessionInfo(info)
 	}
 
-	// 5. OpenCode / Pi Slot / Generic Headers
+	// 5. OpenCode / Pi Slot / Task / Generic Headers
 	if sid := sessionHeaderValue(headers, "X-Session-ID"); sid != "" {
 		info.ClientType = "generic"
 		info.SessionID = "header:" + sid
 		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
 		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "header:" + parentSID
@@ -390,6 +456,12 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		if parentAffinity == "" {
 			parentAffinity = sessionHeaderValue(headers, "X-Parent-Session-ID")
 		}
+		if parentAffinity == "" {
+			parentAffinity = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentAffinity == "" {
+			parentAffinity = sessionHeaderValue(headers, "X-Parent-Id")
+		}
 		if parentAffinity != "" && parentAffinity != sid {
 			info.ParentSessionID = "affinity:" + parentAffinity
 			info.AgentName = "subagent"
@@ -404,9 +476,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Slot-Session-Id"); sid != "" {
 		info.ClientType = "pi"
 		info.SessionID = "slot:" + sid
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
+		parentSID := sessionHeaderValue(headers, "X-Parent-Slot-Session-Id")
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Session-ID")
+		}
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
 		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "slot:" + parentSID
@@ -419,21 +500,54 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		}
 		return finalizeSessionInfo(info)
 	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
-		info.ClientType = "conv"
-		info.SessionID = "conv:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
-			info.ParentSessionID = "conv:" + parentCandidate
+	taskID := sessionHeaderValue(headers, "X-Task-ID")
+	if taskID == "" {
+		taskID = sessionHeaderValue(headers, "X-Task-Id")
+	}
+	if taskID == "" {
+		taskID = sessionHeaderValue(headers, "X-Task_ID")
+	}
+	if taskID != "" {
+		info.ClientType = "task"
+		info.SessionID = "task:" + taskID
+		parentTaskID := sessionHeaderValue(headers, "X-Parent-Task-ID")
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Task-Id")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Session-ID")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
+		if parentTaskID != "" && parentTaskID != taskID {
+			info.ParentSessionID = "task:" + parentTaskID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != taskID {
+			info.ParentSessionID = "task:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
 			info.AgentName = "main"
 		}
 		return finalizeSessionInfo(info)
 	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-ID"); sid != "" {
+	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
 		info.ClientType = "conv"
 		info.SessionID = "conv:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
+		parentCID := sessionHeaderValue(headers, "X-Parent-Conversation-Id")
+		if parentCID == "" {
+			parentCID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentCID != "" && parentCID != sid {
+			info.ParentSessionID = "conv:" + parentCID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
 			info.ParentSessionID = "conv:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
@@ -444,18 +558,14 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Thread-Id"); sid != "" {
 		info.ClientType = "openai-thread"
 		info.SessionID = "thread:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
-			info.ParentSessionID = "thread:" + parentCandidate
-			info.AgentName = "subagent"
-		} else {
-			info.AgentName = "main"
+		parentTID := sessionHeaderValue(headers, "X-Parent-Thread-Id")
+		if parentTID == "" {
+			parentTID = sessionHeaderValue(headers, "X-Parent-ID")
 		}
-		return finalizeSessionInfo(info)
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-ID"); sid != "" {
-		info.ClientType = "openai-thread"
-		info.SessionID = "thread:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
+		if parentTID != "" && parentTID != sid {
+			info.ParentSessionID = "thread:" + parentTID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
 			info.ParentSessionID = "thread:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
@@ -466,7 +576,22 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Client-Request-Id"); sid != "" {
 		info.ClientType = "generic"
 		info.SessionID = "clientreq:" + sid
-		info.AgentName = "main"
+		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
+		if parentSID != "" && parentSID != sid {
+			info.ParentSessionID = "clientreq:" + parentSID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
+			info.ParentSessionID = "clientreq:" + parentCandidate
+			info.AgentName = "subagent"
+		} else {
+			info.AgentName = "main"
+		}
 		return finalizeSessionInfo(info)
 	}
 
@@ -535,7 +660,13 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			}
 		}
 
-		for _, path := range []string{"session_id", "sessionId", "sessionID", "metadata.session_id", "extra_body.session_id"} {
+		for _, path := range []string{
+			"session_id", "sessionId", "sessionID",
+			"child_session_id", "childSessionId",
+			"metadata.session_id", "metadata.sessionId", "metadata.sessionID",
+			"metadata.child_session_id",
+			"extra_body.session_id", "extra_body.sessionId", "extra_body.sessionID",
+		} {
 			sid := normalizedSessionCandidate(root.Get(path).String())
 			if sid == "" && hasNestedReq {
 				sid = normalizedSessionCandidate(reqRoot.Get(path).String())
@@ -564,6 +695,38 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 					} else {
 						info.AgentName = "main"
 					}
+				}
+				return finalizeSessionInfo(info)
+			}
+		}
+
+		// Task / Action in payload (Roo Code, Cline, OpenHands)
+		for _, path := range []string{
+			"task_id", "taskId", "taskID",
+			"action_id", "actionId", "actionID",
+			"metadata.task_id", "metadata.taskId", "metadata.taskID",
+			"metadata.action_id", "metadata.actionId", "metadata.actionID",
+			"extra_body.task_id", "extra_body.taskId", "extra_body.taskID",
+		} {
+			tid := normalizedSessionCandidate(root.Get(path).String())
+			if tid == "" && hasNestedReq {
+				tid = normalizedSessionCandidate(reqRoot.Get(path).String())
+			}
+			if tid != "" {
+				info.ClientType = "task"
+				info.SessionID = "task:" + tid
+				if parentCandidate != "" && parentCandidate != tid {
+					info.ParentSessionID = "task:" + parentCandidate
+					if isBodyForkCandidate(root, reqRoot, hasNestedReq) {
+						info.IsFork = true
+						info.IsSubagent = false
+						info.AgentName = "main"
+					} else {
+						info.AgentName = "subagent"
+						info.IsSubagent = true
+					}
+				} else {
+					info.AgentName = "main"
 				}
 				return finalizeSessionInfo(info)
 			}
@@ -686,8 +849,12 @@ func isBodyForkCandidate(root, reqRoot gjson.Result, hasNestedReq bool) bool {
 	}
 	for _, k := range []string{
 		"forked_from_thread_id", "forked_from_id",
+		"forkSource.sessionId", "fork_source.session_id",
+		"previousSessionId", "previous_session_id",
 		"metadata.forked_from_thread_id", "metadata.forked_from_id",
+		"metadata.forkSource.sessionId", "metadata.previousSessionId",
 		"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
+		"extra_body.forkSource.sessionId", "extra_body.previousSessionId",
 	} {
 		if val := normalizedSessionCandidate(root.Get(k).String()); val != "" {
 			return true

--- a/sdk/cliproxy/session/info_test.go
+++ b/sdk/cliproxy/session/info_test.go
@@ -647,3 +647,118 @@ func TestBoundSessionIdentitySafetyAndUniqueness(t *testing.T) {
 		t.Fatalf("bounded lengths = (%d, %d), want <= 256", len(boundedA), len(boundedB))
 	}
 }
+
+func TestExtractSessionInfoEnhancedHarnesses(t *testing.T) {
+	t.Parallel()
+
+	// 1. Roo Code / Cline task headers
+	rooHeaders := http.Header{}
+	rooHeaders.Set("X-Task-ID", "task-child-001")
+	rooHeaders.Set("X-Parent-Task-ID", "task-parent-001")
+	info, ok := ExtractSessionInfo(rooHeaders, nil, nil)
+	if !ok || info.SessionID != "task:task-child-001" || info.ParentSessionID != "task:task-parent-001" || info.ClientType != "task" || info.AgentName != "subagent" {
+		t.Fatalf("Roo Code headers extraction failed: %+v", info)
+	}
+
+	// 2. Roo Code / Cline payload
+	rooPayload := []byte(`{"taskId":"task-child-002","parentTaskId":"task-parent-002"}`)
+	info, ok = ExtractSessionInfo(nil, rooPayload, nil)
+	if !ok || info.SessionID != "task:task-child-002" || info.ParentSessionID != "task:task-parent-002" || info.ClientType != "task" || info.AgentName != "subagent" {
+		t.Fatalf("Roo Code payload extraction failed: %+v", info)
+	}
+
+	// 3. OpenCode parent_id / parentID in payload
+	opencodePayload := []byte(`{"session_id":"opencode-child-100","parent_id":"opencode-parent-100"}`)
+	info, ok = ExtractSessionInfo(nil, opencodePayload, nil)
+	if !ok || info.SessionID != "session:opencode-child-100" || info.ParentSessionID != "session:opencode-parent-100" || info.AgentName != "subagent" {
+		t.Fatalf("OpenCode parent_id extraction failed: %+v", info)
+	}
+
+	opencodePayload2 := []byte(`{"sessionID":"opencode-child-200","parentID":"opencode-parent-200"}`)
+	info, ok = ExtractSessionInfo(nil, opencodePayload2, nil)
+	if !ok || info.SessionID != "session:opencode-child-200" || info.ParentSessionID != "session:opencode-parent-200" {
+		t.Fatalf("OpenCode parentID extraction failed: %+v", info)
+	}
+
+	// 4. OpenClaw forkSource.sessionId & previousSessionId
+	openclawPayload1 := []byte(`{"sessionId":"claw-child-1","forkSource":{"sessionId":"claw-parent-1"}}`)
+	info, ok = ExtractSessionInfo(nil, openclawPayload1, nil)
+	if !ok || info.SessionID != "session:claw-child-1" || info.ParentSessionID != "session:claw-parent-1" || !info.IsFork {
+		t.Fatalf("OpenClaw forkSource extraction failed: %+v", info)
+	}
+
+	openclawPayload2 := []byte(`{"sessionId":"claw-child-2","previousSessionId":"claw-parent-2"}`)
+	info, ok = ExtractSessionInfo(nil, openclawPayload2, nil)
+	if !ok || info.SessionID != "session:claw-child-2" || info.ParentSessionID != "session:claw-parent-2" || !info.IsFork {
+		t.Fatalf("OpenClaw previousSessionId extraction failed: %+v", info)
+	}
+
+	// 5. Hermes Agent child_session_id & parent_subagent_id
+	hermesPayload := []byte(`{"child_session_id":"hermes-child-1","parent_subagent_id":"hermes-parent-1"}`)
+	info, ok = ExtractSessionInfo(nil, hermesPayload, nil)
+	if !ok || info.SessionID != "session:hermes-child-1" || info.ParentSessionID != "session:hermes-parent-1" {
+		t.Fatalf("Hermes Agent extraction failed: %+v", info)
+	}
+
+	// 6. OpenHands action_id & parent_action_id
+	openhandsPayload := []byte(`{"action_id":"openhands-action-1","parent_action_id":"openhands-parent-action"}`)
+	info, ok = ExtractSessionInfo(nil, openhandsPayload, nil)
+	if !ok || info.SessionID != "task:openhands-action-1" || info.ParentSessionID != "task:openhands-parent-action" || info.ClientType != "task" {
+		t.Fatalf("OpenHands action extraction failed: %+v", info)
+	}
+
+	// 7. Pi Coding Agent slot parent & parent_session payload
+	piSlotHeaders := http.Header{}
+	piSlotHeaders.Set("X-Slot-Session-Id", "slot-child-001")
+	piSlotHeaders.Set("X-Parent-Slot-Session-Id", "slot-parent-001")
+	info, ok = ExtractSessionInfo(piSlotHeaders, nil, nil)
+	if !ok || info.SessionID != "slot:slot-child-001" || info.ParentSessionID != "slot:slot-parent-001" || info.ClientType != "pi" || info.AgentName != "subagent" {
+		t.Fatalf("Pi slot parent extraction failed: %+v", info)
+	}
+
+	piPayload := []byte(`{"prompt_cache_key":"pi-pck-001","parent_session":"pi-parent-001"}`)
+	info, ok = ExtractSessionInfo(nil, piPayload, nil)
+	if !ok || info.SessionID != "pck:pi-pck-001" || info.ParentSessionID != "pck:pi-parent-001" {
+		t.Fatalf("Pi parent_session extraction failed: %+v", info)
+	}
+
+	// 8. Claude Code Body metadata.parent_agent_id
+	claudeBody := []byte(`{
+		"metadata": {
+			"user_id": "user_123_acc__session_01a06a06-e830-7da9-a866-98470a94389c",
+			"agent_id": "worker-reviewer",
+			"parent_agent_id": "orchestrator-main"
+		}
+	}`)
+	info, ok = ExtractSessionInfo(nil, claudeBody, nil)
+	if !ok || info.SessionID != "claude:01a06a06-e830-7da9-a866-98470a94389c:agent:worker-reviewer" ||
+		info.ParentSessionID != "claude:01a06a06-e830-7da9-a866-98470a94389c:agent:orchestrator-main" ||
+		info.AgentName != "worker-reviewer" {
+		t.Fatalf("Claude metadata parent_agent_id extraction failed: %+v", info)
+	}
+
+	// 9. Generic universal parent headers
+	genericHeaders := http.Header{}
+	genericHeaders.Set("X-Session-ID", "gen-child-001")
+	genericHeaders.Set("X-Parent-ID", "gen-parent-001")
+	info, ok = ExtractSessionInfo(genericHeaders, nil, nil)
+	if !ok || info.SessionID != "header:gen-child-001" || info.ParentSessionID != "header:gen-parent-001" {
+		t.Fatalf("Generic X-Parent-ID header extraction failed: %+v", info)
+	}
+
+	convHeaders := http.Header{}
+	convHeaders.Set("X-Conversation-Id", "conv-child-001")
+	convHeaders.Set("X-Parent-Conversation-Id", "conv-parent-001")
+	info, ok = ExtractSessionInfo(convHeaders, nil, nil)
+	if !ok || info.SessionID != "conv:conv-child-001" || info.ParentSessionID != "conv:conv-parent-001" {
+		t.Fatalf("Conversation X-Parent-Conversation-Id extraction failed: %+v", info)
+	}
+
+	threadHeaders := http.Header{}
+	threadHeaders.Set("X-Thread-Id", "thread-child-001")
+	threadHeaders.Set("X-Parent-Thread-Id", "thread-parent-001")
+	info, ok = ExtractSessionInfo(threadHeaders, nil, nil)
+	if !ok || info.SessionID != "thread:thread-child-001" || info.ParentSessionID != "thread:thread-parent-001" {
+		t.Fatalf("Thread X-Parent-Thread-Id extraction failed: %+v", info)
+	}
+}


### PR DESCRIPTION
## Summary
This PR enhances session and parent session hierarchy extraction across major agent harnesses, deduplicates over 500 lines of extraction logic in `sdk/cliproxy/auth/selector.go` by delegating to `cliproxysession.ExtractSessionInfo`, and normalizes reported session hierarchies to canonical 36-character RFC 9562 UUIDv8 strings at the usage reporting boundary (`internal/redisqueue`).

## Changes
1. **Harness Hierarchy Extraction**:
   - Expanded recognition in `sdk/cliproxy/session/info.go` for Roo Code / Cline (`task_id`, `parent_task_id`, `X-Task-ID`, `X-Parent-Task-ID`), OpenCode (`parent_id`, `X-Session-Affinity`), OpenClaw (`forkSource.sessionId`, `previousSessionId`), Hermes (`parent_subagent_id`), OpenHands (`parent_action_id`), Pi (`parent_session`), and nested `metadata.*` / `extra_body.*` keys.
   - Bound extracted session identities with UTF-8 character safety (<= 256 bytes).

2. **Deduplication in Selector**:
   - Replaced duplicate extraction routines in `sdk/cliproxy/auth/selector.go` with delegation to `cliproxysession.ExtractSessionInfo`, preserving precedence across Claude, Codex, Antigravity, generic headers, body payloads, and LCP fallbacks.

3. **Hierarchy Parent Rule Relaxation**:
   - Relaxed `isHierarchyParent` in `internal/runtime/executor/helps/usage_helpers.go` and `sdk/cliproxy/auth/home_session_alias.go` for raw identifiers (e.g. prefixless UUIDs).

4. **Canonical UUIDv8 Normalization at Usage Reporting Boundary**:
   - Implemented `NormalizeToCanonicalUUID` in `sdk/cliproxy/session/identity.go`:
     - Strips 17+ known protocol prefixes (e.g., `codex:`, `claude:`, `task:`, `lcp:v1:`).
     - Directly preserves native 36-character UUIDs (v4/v7/etc.) in lowercase.
     - Deterministically maps non-standard strings and 64-hex LCP hashes to RFC 9562 UUIDv8 using SHA-256 with domain separation salt (`cpa:canonical-uuid:v1\x00`), with correct version (`0x80`) and variant (`0x80` Variant 1) bitmasks.
     - Fully respects no-copy invariants via Go 1.20+ slice-to-array conversions (`[16]byte(sum[:16])`).
   - Integrated into `internal/redisqueue/plugin.go` `HandleUsage`, with strict post-normalization self-loop elimination (`if sessionID == "" || sessionID == parentSessionID { parentSessionID = "" }`).

## Review & Verification
- Independently reviewed by two models (Gemini 3.8 Flash & Qwen 3.8 27B), returning `Merge verdict: OK with notes` (0 P0, 0 P1).
- Passed `go test -race -count=1` across all affected packages (`sdk/cliproxy/session/...`, `internal/redisqueue/...`, `sdk/cliproxy/auth/...`).
- Passed `internal/util/nocopy_invariant_test.go` (`TestInPlaceByteWritesAreReviewed`).
- Live-verified on persistent local CPA against 10 distinct harness scenarios with real Redis usage queue records in SQLite Keeper DB.