### PR TITLE
fix(plugin-store): reduce release checks and honor shared GitHub rate-limit cooldowns

### DIFF
--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -58,8 +58,7 @@ type Handler struct {
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
-	pluginReleaseCacheMu    sync.Mutex
-	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	pluginReleases          pluginReleaseCache
 }
 
 type configReloadSnapshot struct {

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -58,6 +58,7 @@ type Handler struct {
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
+	pluginStoreRateLimiter  *pluginstore.GitHubRateLimiter
 	pluginReleases          pluginReleaseCache
 }
 

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -22,20 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
-
-const (
-	// pluginReleaseCacheTTL bounds how long a resolved latest release version is
-	// reused before the GitHub API is queried again.
-	pluginReleaseCacheTTL = 10 * time.Minute
-	// pluginReleaseFailureCacheTTL throttles retries after a failed lookup so a
-	// rate-limited or unreachable API is not hammered on every listing.
-	pluginReleaseFailureCacheTTL = 30 * time.Second
-)
-
-type pluginReleaseCacheEntry struct {
-	version   string
-	expiresAt time.Time
-}
 
 type pluginStoreListResponse struct {
 	PluginsEnabled bool                   `json:"plugins_enabled"`
@@ -186,6 +170,8 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		storeVersion := plugin.Version
 		if latestVersions[index] != "" {
 			storeVersion = latestVersions[index]
+		} else if cachedVersion := h.pluginReleases.cached(client, plugin); cachedVersion != "" {
+			storeVersion = cachedVersion
 		}
 		entries = append(entries, pluginStoreListEntry{
 			StoreID:             htmlsanitize.String(item.source.ID + "/" + plugin.ID),
@@ -542,13 +528,13 @@ func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, stor
 		registryURL = pluginstore.DefaultRegistryURL
 	}
 	if httpClient != nil {
-		return pluginstore.Client{HTTPClient: httpClient, RegistryURL: registryURL, Auth: storeAuth}
+		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
 	}
 	client := &http.Client{}
 	if strings.TrimSpace(proxyURL) != "" {
 		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}, client)
 	}
-	return pluginstore.Client{HTTPClient: client, RegistryURL: registryURL, Auth: storeAuth}
+	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
 }
 
 func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
@@ -676,64 +662,6 @@ func sanitizePluginStorePlatforms(platforms []pluginstore.Platform) []pluginStor
 
 func pluginAuthConfigured(source pluginstore.Source, plugin pluginstore.Plugin, storeAuth []pluginstore.AuthConfig) bool {
 	return pluginstore.PluginAuthConfigured(source, plugin, storeAuth)
-}
-
-// latestPluginVersions resolves the latest release version of each registry
-// plugin concurrently, returning results positionally aligned with plugins.
-// Unresolved entries are left empty so callers can fall back gracefully.
-func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
-	versions := make([]string, len(plugins))
-	var wg sync.WaitGroup
-	for index := range plugins {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			versions[index] = h.latestPluginVersion(ctx, client, plugins[index])
-		}(index)
-	}
-	wg.Wait()
-	return versions
-}
-
-// latestPluginVersion returns the plugin's latest release version, caching
-// lookups per repository so repeated listings do not exhaust the GitHub API
-// rate limit. Failed lookups are cached for a shorter interval and reported
-// as an empty version.
-func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
-	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
-		return ""
-	}
-	repository := strings.TrimSpace(plugin.Repository)
-	if repository == "" {
-		return ""
-	}
-	now := time.Now()
-	h.pluginReleaseCacheMu.Lock()
-	entry, found := h.pluginReleaseCache[repository]
-	h.pluginReleaseCacheMu.Unlock()
-	if found && now.Before(entry.expiresAt) {
-		return entry.version
-	}
-
-	version := ""
-	ttl := pluginReleaseFailureCacheTTL
-	release, errRelease := client.FetchLatestRelease(ctx, plugin)
-	if errRelease != nil {
-		log.WithError(errRelease).WithField("plugin_id", plugin.ID).Warn("pluginstore: failed to fetch latest release")
-	} else if latestVersion, errVersion := pluginstore.ReleaseVersion(release); errVersion != nil {
-		log.WithError(errVersion).WithField("plugin_id", plugin.ID).Warn("pluginstore: invalid latest release tag")
-	} else {
-		version = latestVersion
-		ttl = pluginReleaseCacheTTL
-	}
-
-	h.pluginReleaseCacheMu.Lock()
-	if h.pluginReleaseCache == nil {
-		h.pluginReleaseCache = make(map[string]pluginReleaseCacheEntry)
-	}
-	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: now.Add(ttl)}
-	h.pluginReleaseCacheMu.Unlock()
-	return version
 }
 
 func pluginLocalStatuses(pluginsEnabled bool, pluginsDir string, configs map[string]config.PluginInstanceConfig, host *pluginhost.Host) (map[string]pluginLocalStatus, error) {

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -40,6 +42,7 @@ type pluginStoreSourceErr struct {
 	SourceName string `json:"source_name"`
 	SourceURL  string `json:"source_url"`
 	Message    string `json:"message"`
+	cause      error
 }
 
 type pluginStoreListEntry struct {
@@ -274,6 +277,9 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errInstall != nil {
+		if writePluginStoreRateLimit(c, errInstall) {
+			return
+		}
 		if errors.Is(errInstall, pluginstore.ErrLoadedPluginLocked) {
 			c.JSON(http.StatusConflict, gin.H{
 				"error":            "plugin_update_requires_restart",
@@ -390,9 +396,29 @@ func installPluginStoreGitHubRelease(ctx context.Context, client pluginstore.Cli
 		if errInstall == nil {
 			return result, nil
 		}
+		var rateLimit *pluginstore.RateLimitError
+		if errors.As(errInstall, &rateLimit) || ctx.Err() != nil {
+			return pluginstore.InstallResult{}, errInstall
+		}
 		errs = append(errs, fmt.Errorf("%s: %w", tag, errInstall))
 	}
 	return pluginstore.InstallResult{}, fmt.Errorf("install release by tag: %w", errors.Join(errs...))
+}
+
+func writePluginStoreRateLimit(c *gin.Context, err error) bool {
+	var rateLimit *pluginstore.RateLimitError
+	if !errors.As(err, &rateLimit) {
+		return false
+	}
+	retryAfter := rateLimit.RetryAfterSeconds(time.Now())
+	c.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+	c.JSON(http.StatusTooManyRequests, gin.H{
+		"error":       "plugin_store_rate_limited",
+		"message":     rateLimit.Error(),
+		"retry_after": retryAfter,
+		"retry_at":    rateLimit.RetryAt.UTC().Format(time.RFC3339),
+	})
+	return true
 }
 
 func pluginStoreManifestForInstall(source pluginstore.Source, plugin pluginstore.Plugin, result pluginstore.InstallResult) (pluginstore.Manifest, error) {
@@ -521,20 +547,22 @@ func (h *Handler) pluginStoreSources(sourceConfigs []string) ([]pluginstore.Sour
 func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, storeAuth []pluginstore.AuthConfig) pluginstore.Client {
 	registryURL = strings.TrimSpace(registryURL)
 	var httpClient pluginstore.HTTPDoer
+	var limiter *pluginstore.GitHubRateLimiter
 	if h != nil {
 		httpClient = h.pluginStoreHTTPClient
+		limiter = h.pluginStoreRateLimiter
 	}
 	if registryURL == "" {
 		registryURL = pluginstore.DefaultRegistryURL
 	}
 	if httpClient != nil {
-		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
+		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RateLimiter: limiter, RegistryURL: registryURL, Auth: storeAuth}
 	}
 	client := &http.Client{}
 	if strings.TrimSpace(proxyURL) != "" {
 		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}, client)
 	}
-	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
+	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RateLimiter: limiter, RegistryURL: registryURL, Auth: storeAuth}
 }
 
 func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
@@ -549,6 +577,7 @@ func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, stor
 				SourceName: source.Name,
 				SourceURL:  source.URL,
 				Message:    errRegistry.Error(),
+				cause:      errRegistry,
 			})
 			continue
 		}
@@ -569,6 +598,9 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 			client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
 			registry, errRegistry := client.FetchRegistry(ctx)
 			if errRegistry != nil {
+				if writePluginStoreRateLimit(c, errRegistry) {
+					return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
+				}
 				c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": errRegistry.Error()})
 				return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 			}
@@ -592,6 +624,9 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 	}
 	if len(matches) == 0 {
 		if len(plugins) == 0 && len(sourceErrors) > 0 {
+			if writePluginStoreRateLimit(c, sourceErrors[0].cause) {
+				return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
+			}
 			c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": sourceErrors[0].Message})
 			return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 		}

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -153,16 +153,23 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		return
 	}
 
-	latestInput := make([]pluginstore.Plugin, 0, len(plugins))
-	for _, item := range plugins {
-		latestInput = append(latestInput, item.plugin)
-	}
-	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
-	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 	pluginSourceCounts := make(map[string]int, len(plugins))
 	for _, item := range plugins {
 		pluginSourceCounts[item.plugin.ID]++
 	}
+	// Browsing the catalog must not spend API quota on uninstalled plugins or
+	// on sources that cannot update the installed plugin. Keep positional
+	// placeholders so release versions still align with the catalog entries.
+	latestInput := make([]pluginstore.Plugin, len(plugins))
+	for index, item := range plugins {
+		status := statuses[item.plugin.ID]
+		_, _, sourceAllowsUpdate := pluginStoreInstallSourceStatus(status, sources, item.source.ID, pluginSourceCounts[item.plugin.ID])
+		if status.Installed && sourceAllowsUpdate {
+			latestInput[index] = item.plugin
+		}
+	}
+	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
+	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 
 	entries := make([]pluginStoreListEntry, 0, len(plugins))
 	for index, item := range plugins {

--- a/internal/api/handlers/management/plugin_store_release.go
+++ b/internal/api/handlers/management/plugin_store_release.go
@@ -1,0 +1,162 @@
+package management
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	pluginReleaseCacheTTL        = time.Hour
+	pluginReleaseFailureCacheTTL = 30 * time.Second
+	pluginReleaseConcurrency     = 2
+)
+
+type pluginReleaseCacheEntry struct {
+	version     string
+	nextCheckAt time.Time
+}
+
+type pluginReleaseLookup struct {
+	done     chan struct{}
+	version  string
+	canceled bool
+}
+
+// pluginReleaseCache shares both in-flight lookups and the concurrency budget
+// across all catalog requests handled by this management server.
+type pluginReleaseCache struct {
+	mu       sync.Mutex
+	entries  map[string]pluginReleaseCacheEntry
+	inflight map[string]*pluginReleaseLookup
+	slots    chan struct{}
+	nowFunc  func() time.Time
+}
+
+func (cache *pluginReleaseCache) now() time.Time {
+	if cache.nowFunc != nil {
+		return cache.nowFunc()
+	}
+	return time.Now()
+}
+
+func pluginReleaseKey(client pluginstore.Client, plugin pluginstore.Plugin) string {
+	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease || plugin.Repository == "" {
+		return ""
+	}
+	key, errKey := client.LatestReleaseCacheKey(plugin)
+	if errKey != nil {
+		return ""
+	}
+	return key
+}
+
+// cached returns the last successful result without causing network activity.
+func (cache *pluginReleaseCache) cached(client pluginstore.Client, plugin pluginstore.Plugin) string {
+	key := pluginReleaseKey(client, plugin)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return cache.entries[key].version
+}
+
+// latestPluginVersions preserves catalog order, including skipped placeholders.
+func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
+	versions := make([]string, len(plugins))
+	var wg sync.WaitGroup
+	for index, plugin := range plugins {
+		if pluginReleaseKey(client, plugin) == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			versions[index] = h.latestPluginVersion(ctx, client, plugins[index])
+		}(index)
+	}
+	wg.Wait()
+	return versions
+}
+
+func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
+	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
+		return ""
+	}
+	client, key, errPrepare := client.PrepareLatestRelease(plugin)
+	if errPrepare != nil {
+		return ""
+	}
+	cache := &h.pluginReleases
+	var entry pluginReleaseCacheEntry
+	var lookup *pluginReleaseLookup
+	for {
+		cache.mu.Lock()
+		entry = cache.entries[key]
+		if cache.now().Before(entry.nextCheckAt) || ctx.Err() != nil {
+			cache.mu.Unlock()
+			return entry.version
+		}
+		if pending := cache.inflight[key]; pending != nil {
+			cache.mu.Unlock()
+			select {
+			case <-pending.done:
+				if pending.canceled && ctx.Err() == nil {
+					// A live waiter takes ownership after a canceled leader. All
+					// other waiters coalesce behind the replacement lookup.
+					continue
+				}
+				return pending.version
+			case <-ctx.Done():
+				return entry.version
+			}
+		}
+		if cache.entries == nil {
+			cache.entries = make(map[string]pluginReleaseCacheEntry)
+		}
+		if cache.inflight == nil {
+			cache.inflight = make(map[string]*pluginReleaseLookup)
+			cache.slots = make(chan struct{}, pluginReleaseConcurrency)
+		}
+		lookup = &pluginReleaseLookup{done: make(chan struct{})}
+		cache.inflight[key] = lookup
+		cache.mu.Unlock()
+		break
+	}
+
+	// Every listing uses the same slots. Canceled waiters do not consume a slot
+	// or install a negative cache entry.
+	select {
+	case cache.slots <- struct{}{}:
+		if ctx.Err() == nil {
+			release, errRelease := client.FetchLatestRelease(ctx, plugin)
+			version := ""
+			if errRelease == nil {
+				version, errRelease = pluginstore.ReleaseVersion(release)
+			}
+			if ctx.Err() == nil {
+				ttl := pluginReleaseFailureCacheTTL
+				if errRelease != nil {
+					log.WithError(errRelease).WithField("plugin_id", plugin.ID).Warn("pluginstore: failed to fetch latest release")
+				} else {
+					entry.version = version
+					ttl = pluginReleaseCacheTTL
+				}
+				// Start the TTL when the lookup finishes, not when it was queued.
+				entry.nextCheckAt = cache.now().Add(ttl)
+			}
+		}
+		<-cache.slots
+	case <-ctx.Done():
+	}
+
+	cache.mu.Lock()
+	cache.entries[key] = entry
+	lookup.version = entry.version
+	lookup.canceled = ctx.Err() != nil
+	delete(cache.inflight, key)
+	close(lookup.done)
+	cache.mu.Unlock()
+	return entry.version
+}

--- a/internal/api/handlers/management/plugin_store_release.go
+++ b/internal/api/handlers/management/plugin_store_release.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -145,6 +146,10 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 				}
 				// Start the TTL when the lookup finishes, not when it was queued.
 				entry.nextCheckAt = cache.now().Add(ttl)
+				var rateLimit *pluginstore.RateLimitError
+				if errors.As(errRelease, &rateLimit) {
+					entry.nextCheckAt = rateLimit.RetryAt
+				}
 			}
 		}
 		<-cache.slots

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -325,6 +326,128 @@ func TestPluginReleaseCacheSeparatesCredentialsAndEgress(t *testing.T) {
 		if strings.Contains(key, "token-") {
 			t.Fatalf("cache key contains credential: %q", key)
 		}
+	}
+}
+
+func TestPluginReleaseChecksStopQueuedRequestsDuringCooldown(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}, 10), make(chan struct{})
+	var calls atomic.Int32
+	reset := time.Now().Add(time.Hour).Truncate(time.Second)
+	h := &Handler{pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{}}
+	h.pluginStoreHTTPClient = pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		headers := make(http.Header)
+		headers.Set("X-RateLimit-Remaining", "0")
+		headers.Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+		return &http.Response{StatusCode: 403, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})
+	client := h.newPluginStoreClient("", "", nil)
+	plugins := make([]pluginstore.Plugin, 10)
+	h.pluginReleases.entries = make(map[string]pluginReleaseCacheEntry)
+	for index := range plugins {
+		plugins[index] = pluginstore.Plugin{ID: fmt.Sprintf("plugin-%d", index), Repository: fmt.Sprintf("https://github.com/owner/plugin-%d", index)}
+		h.pluginReleases.entries[pluginReleaseKey(client, plugins[index])] = pluginReleaseCacheEntry{version: "1.0.0"}
+	}
+	result := make(chan []string, 1)
+	go func() { result <- h.latestPluginVersions(context.Background(), client, plugins) }()
+	for range pluginReleaseConcurrency {
+		<-started
+	}
+	close(release)
+	for _, version := range <-result {
+		if version != "1.0.0" {
+			t.Fatalf("cooldown discarded previous version: %q", version)
+		}
+	}
+	if calls.Load() != pluginReleaseConcurrency {
+		t.Fatalf("requests=%d, want only the %d already in flight", calls.Load(), pluginReleaseConcurrency)
+	}
+	for _, entry := range h.pluginReleases.entries {
+		if !entry.nextCheckAt.Equal(reset) {
+			t.Fatalf("next check=%s, want GitHub reset %s", entry.nextCheckAt, reset)
+		}
+	}
+}
+
+func TestPluginStoreListingCooldownAlsoBlocksInstallation(t *testing.T) {
+	t.Parallel()
+	var apiCalls atomic.Int32
+	h := &Handler{
+		cfg:                    &config.Config{Plugins: config.PluginsConfig{Dir: writeManagementPluginFile(t, "sample-provider")}},
+		pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{},
+		pluginStoreHTTPClient: pluginReleaseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "api.github.com" {
+				return fakePluginStoreHTTPClient{pluginstore.DefaultRegistryURL: registryJSON(t)}.Do(req)
+			}
+			apiCalls.Add(1)
+			headers := make(http.Header)
+			headers.Set("Retry-After", "3600")
+			return &http.Response{StatusCode: 429, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}),
+	}
+	body := listPluginStoreForTest(t, h)
+	if len(body.Plugins) != 1 || body.Plugins[0].Version != "0.1.0" {
+		t.Fatalf("listing failed to fall back during cooldown: %#v", body)
+	}
+	for _, query := range []string{"", "?version=0.2.0"} {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+		c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install"+query, nil)
+		h.InstallPluginFromStore(c)
+		if rec.Code != http.StatusTooManyRequests || !strings.Contains(rec.Body.String(), "plugin_store_rate_limited") || !strings.Contains(rec.Body.String(), "retry_at") {
+			t.Fatalf("install status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		retryAfter, errRetry := strconv.Atoi(rec.Header().Get("Retry-After"))
+		if errRetry != nil || retryAfter <= 0 {
+			t.Fatalf("Retry-After=%q", rec.Header().Get("Retry-After"))
+		}
+	}
+	if apiCalls.Load() != 1 {
+		t.Fatalf("cooldown installation made more requests: %d", apiCalls.Load())
+	}
+}
+
+func TestPluginStoreInstallationPropagatesRegistryRateLimit(t *testing.T) {
+	t.Parallel()
+	h := &Handler{
+		cfg:                    &config.Config{Plugins: config.PluginsConfig{Dir: t.TempDir()}},
+		pluginStoreRegistryURL: "https://api.github.com/repos/owner/store/contents/registry.json",
+		pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{},
+		pluginStoreHTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+			headers := make(http.Header)
+			headers.Set("Retry-After", "3600")
+			return &http.Response{StatusCode: 429, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}),
+	}
+	for _, query := range []string{"", "?source=official"} {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+		c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install"+query, nil)
+		h.InstallPluginFromStore(c)
+		if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") == "" {
+			t.Fatalf("install status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestPluginStoreTagInstallationStopsOnRateLimitError(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, &pluginstore.RateLimitError{StatusCode: 429, RetryAt: time.Now().Add(time.Hour)}
+	})}
+	_, errInstall := installPluginStoreGitHubRelease(context.Background(), client, pluginstore.Plugin{
+		ID: "sample-provider", Name: "Sample", Description: "Test plugin", Author: "owner", Repository: "https://github.com/owner/repo",
+	}, "1.0.0", pluginstore.InstallOptions{PluginsDir: t.TempDir(), GOOS: "linux", GOARCH: "amd64"})
+	var rateLimit *pluginstore.RateLimitError
+	if !errors.As(errInstall, &rateLimit) || calls != 1 {
+		t.Fatalf("error=%v calls=%d, want immediate rate-limit failure without alternate tag", errInstall, calls)
 	}
 }
 

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -1,0 +1,97 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+)
+
+func listPluginStoreForTest(t *testing.T, h *Handler) pluginStoreListResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	h.ListPluginStore(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var body pluginStoreListResponse
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	return body
+}
+
+func TestListPluginStoreSkipsUninstalledReleases(t *testing.T) {
+	t.Parallel()
+
+	registry := pluginstore.Registry{SchemaVersion: pluginstore.SchemaVersion}
+	for index := range 100 {
+		version := ""
+		if index%2 == 0 {
+			version = "1.0.0"
+		}
+		registry.Plugins = append(registry.Plugins, pluginstore.Plugin{
+			ID: fmt.Sprintf("plugin-%d", index), Name: "Plugin", Description: "Test plugin", Author: "test",
+			Version: version, Repository: fmt.Sprintf("https://github.com/test/plugin-%d", index),
+		})
+	}
+	data, errMarshal := json.Marshal(registry)
+	if errMarshal != nil {
+		t.Fatal(errMarshal)
+	}
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
+		pluginstore.DefaultRegistryURL: data,
+	}}
+	h := &Handler{
+		cfg: &config.Config{Plugins: config.PluginsConfig{
+			Dir: t.TempDir(),
+			// Configuration alone does not mean the plugin is installed.
+			Configs: map[string]config.PluginInstanceConfig{"plugin-0": pluginConfigFromYAML(t, "enabled: true\n")},
+		}},
+		pluginStoreHTTPClient: httpClient,
+	}
+	for range 2 {
+		body := listPluginStoreForTest(t, h)
+		if len(body.Plugins) != 100 {
+			t.Fatalf("plugins = %d, want 100", len(body.Plugins))
+		}
+		for index, entry := range body.Plugins {
+			if entry.Version != registry.Plugins[index].Version || entry.Installed || entry.UpdateAvailable {
+				t.Fatalf("unexpected catalog entry: %#v", entry)
+			}
+		}
+	}
+	httpClient.mu.Lock()
+	defer httpClient.mu.Unlock()
+	if len(httpClient.counts) != 1 || httpClient.counts[pluginstore.DefaultRegistryURL] != 2 {
+		t.Fatalf("requests = %v, want registry requests only", httpClient.counts)
+	}
+}
+
+func TestListPluginStoreSkipsInstalledDirectRelease(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
+		pluginstore.DefaultRegistryURL: directRegistryJSON("https://downloads.example/plugin.zip", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+	}}
+	h := &Handler{
+		cfg:                   &config.Config{Plugins: config.PluginsConfig{Dir: writeManagementPluginFile(t, "sample-provider")}},
+		pluginStoreHTTPClient: httpClient,
+	}
+	body := listPluginStoreForTest(t, h)
+	if len(body.Plugins) != 1 || !body.Plugins[0].Installed || body.Plugins[0].Version != "0.4.0" {
+		t.Fatalf("unexpected direct catalog entry: %#v", body.Plugins)
+	}
+	httpClient.mu.Lock()
+	defer httpClient.mu.Unlock()
+	if len(httpClient.counts) != 1 {
+		t.Fatalf("requests = %v, want registry request only", httpClient.counts)
+	}
+}

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -1,11 +1,18 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -93,5 +100,243 @@ func TestListPluginStoreSkipsInstalledDirectRelease(t *testing.T) {
 	defer httpClient.mu.Unlock()
 	if len(httpClient.counts) != 1 {
 		t.Fatalf("requests = %v, want registry request only", httpClient.counts)
+	}
+}
+
+type pluginReleaseDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f pluginReleaseDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func pluginReleaseResponse(tag string) *http.Response {
+	return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"` + tag + `"}`))}
+}
+
+func TestPluginReleaseCacheRetainsSuccessAndUsesCompletionTime(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	h := &Handler{pluginReleases: pluginReleaseCache{nowFunc: func() time.Time { return now }}}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	calls := 0
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		now = now.Add(time.Minute)
+		switch calls {
+		case 1:
+			return pluginReleaseResponse("v1.0.0"), nil
+		case 2:
+			return nil, errors.New("offline")
+		case 3:
+			return pluginReleaseResponse("invalid-tag"), nil
+		default:
+			return pluginReleaseResponse("v2.0.0"), nil
+		}
+	})}
+	check := func(want string, wantCalls int) {
+		t.Helper()
+		if got := h.latestPluginVersion(context.Background(), client, plugin); got != want || calls != wantCalls {
+			t.Fatalf("version=%q calls=%d, want %q/%d", got, calls, want, wantCalls)
+		}
+	}
+	check("1.0.0", 1)
+	now = now.Add(pluginReleaseCacheTTL - time.Second)
+	check("1.0.0", 1)
+	now = now.Add(time.Second)
+	check("1.0.0", 2)
+	check("1.0.0", 2)
+	now = now.Add(pluginReleaseFailureCacheTTL)
+	check("1.0.0", 3)
+	now = now.Add(pluginReleaseFailureCacheTTL)
+	check("2.0.0", 4)
+}
+
+// Done reports that a caller reached a cancelable wait, without relying on sleeps.
+type pluginReleaseWaitContext struct {
+	context.Context
+	waiting chan struct{}
+	once    sync.Once
+}
+
+func (ctx *pluginReleaseWaitContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.waiting) })
+	return ctx.Context.Done()
+}
+
+func TestPluginReleaseCacheCoalescesConcurrentLookups(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	results := make(chan string, 21)
+	go func() { results <- h.latestPluginVersion(context.Background(), client, plugin) }()
+	<-started
+	for range 20 {
+		ctx := &pluginReleaseWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+		go func() { results <- h.latestPluginVersion(ctx, client, plugin) }()
+		<-ctx.waiting
+	}
+	close(release)
+	for range 21 {
+		if got := <-results; got != "1.0.0" {
+			t.Fatalf("version = %q", got)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheCanceledLeaderHandsOffToFollower(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(req *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	leaderResult := make(chan string, 1)
+	go func() { leaderResult <- h.latestPluginVersion(ctx, client, plugin) }()
+	<-started
+	waitCtx := &pluginReleaseWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+	followerResult := make(chan string, 1)
+	go func() { followerResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-leaderResult; got != "" {
+		t.Fatalf("canceled leader version = %q", got)
+	}
+	if got := <-followerResult; got != "1.0.0" || calls.Load() != 2 {
+		t.Fatalf("handoff version=%q calls=%d, want 1.0.0 and canceled + successful request", got, calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheCanceledFollowerDoesNotCancelLeader(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}), make(chan struct{})
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		close(started)
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	leaderResult := make(chan string, 1)
+	go func() { leaderResult <- h.latestPluginVersion(context.Background(), client, plugin) }()
+	<-started
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	waitCtx := &pluginReleaseWaitContext{Context: ctx, waiting: make(chan struct{})}
+	followerResult := make(chan string, 1)
+	go func() { followerResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-followerResult; got != "" {
+		t.Fatalf("canceled follower version = %q", got)
+	}
+	close(release)
+	if got := <-leaderResult; got != "1.0.0" {
+		t.Fatalf("leader version = %q", got)
+	}
+}
+
+func TestPluginReleaseCacheSharesConcurrencyAndCancelsQueuedLookup(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}, 10), make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	results := make(chan string, pluginReleaseConcurrency)
+	for index := range pluginReleaseConcurrency {
+		go func() {
+			results <- h.latestPluginVersion(context.Background(), client, pluginstore.Plugin{Repository: fmt.Sprintf("https://github.com/test/plugin-%d", index)})
+		}()
+	}
+	for range pluginReleaseConcurrency {
+		<-started
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	waitCtx := &pluginReleaseWaitContext{Context: ctx, waiting: make(chan struct{})}
+	queuedResult := make(chan string, 1)
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/queued"}
+	go func() { queuedResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-queuedResult; got != "" || calls.Load() != pluginReleaseConcurrency {
+		t.Fatalf("queued version=%q calls=%d", got, calls.Load())
+	}
+	close(release)
+	for range pluginReleaseConcurrency {
+		<-results
+	}
+	if got := h.latestPluginVersion(context.Background(), client, plugin); got != "1.0.0" || calls.Load() != pluginReleaseConcurrency+1 {
+		t.Fatalf("canceled lookup was negatively cached: version=%q calls=%d", got, calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheSeparatesCredentialsAndEgress(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	for _, token := range []string{"", "token-a", "token-b", "token-a"} {
+		client.ResolvedAuth = nil
+		if token != "" {
+			client.ResolvedAuth = []pluginstore.ResolvedAuthConfig{{Match: "https://api.github.com/", Type: pluginstore.AuthTypeGitHubToken, Token: pluginstore.Secret(token)}}
+			client.ResolvedAuthExpiresAt = time.Now().Add(time.Hour)
+		}
+		if got := h.latestPluginVersion(context.Background(), client, plugin); got != "1.0.0" {
+			t.Fatalf("version = %q", got)
+		}
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("calls = %d, want 3", calls.Load())
+	}
+	client.NetworkScope = "other-proxy"
+	h.latestPluginVersion(context.Background(), client, plugin)
+	if calls.Load() != 4 {
+		t.Fatalf("calls after proxy change = %d, want 4", calls.Load())
+	}
+	for key := range h.pluginReleases.entries {
+		if strings.Contains(key, "token-") {
+			t.Fatalf("cache key contains credential: %q", key)
+		}
+	}
+}
+
+func TestListPluginStoreUsesCachedUninstalledVersionWithoutRefresh(t *testing.T) {
+	t.Parallel()
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{pluginstore.DefaultRegistryURL: registryJSON(t)}}
+	h := &Handler{cfg: &config.Config{Plugins: config.PluginsConfig{Dir: t.TempDir()}}, pluginStoreHTTPClient: httpClient}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/author-name/cliproxy-sample-provider-plugin"}
+	key := pluginReleaseKey(h.newPluginStoreClient("", "", nil), plugin)
+	h.pluginReleases.entries = map[string]pluginReleaseCacheEntry{key: {version: "2.0.0"}}
+	body := listPluginStoreForTest(t, h)
+	if body.Plugins[0].Version != "2.0.0" || len(httpClient.counts) != 1 {
+		t.Fatalf("plugins=%#v requests=%v", body.Plugins, httpClient.counts)
 	}
 }

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -301,6 +301,7 @@ func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 		pluginStoreRegistryURL: "https://registry.example/registry.json",
 		pluginStoreHTTPClient:  httpClient,
 	}
+	h.cfg.Plugins.Dir = writeManagementPluginFile(t, "sample-provider")
 
 	listOnce := func() pluginStoreListResponse {
 		rec := httptest.NewRecorder()
@@ -457,10 +458,10 @@ func TestListPluginStoreMatchesInstalledStatusToManifestSource(t *testing.T) {
 			},
 		},
 		configFilePath: writeTestConfigFile(t),
-		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+		pluginStoreHTTPClient: &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
 			pluginstore.DefaultRegistryURL: registryJSON(t),
 			communityURL:                   thirdPartySampleRegistryJSON(t),
-		},
+		}},
 	}
 
 	rec := httptest.NewRecorder()
@@ -505,6 +506,13 @@ func TestListPluginStoreMatchesInstalledStatusToManifestSource(t *testing.T) {
 	community := entries[communitySourceID]
 	if community.InstalledSourceID != pluginstore.DefaultSourceID || community.InstallSourceStatus != "different" || community.UpdateAvailable {
 		t.Fatalf("community entry = %#v, want different source without update", community)
+	}
+	httpClient := h.pluginStoreHTTPClient.(*countingPluginStoreHTTPClient)
+	if calls := httpClient.count("https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/latest"); calls != 1 {
+		t.Fatalf("installed source release calls = %d, want 1", calls)
+	}
+	if calls := httpClient.count("https://api.github.com/repos/community/cliproxy-sample-provider-plugin/releases/latest"); calls != 0 {
+		t.Fatalf("different source release calls = %d, want 0", calls)
 	}
 }
 

--- a/internal/homeplugins/network_scope_test.go
+++ b/internal/homeplugins/network_scope_test.go
@@ -1,0 +1,69 @@
+package homeplugins
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	internalpluginstore "github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
+)
+
+type networkScopeDoer func(*http.Request) (*http.Response, error)
+
+func (f networkScopeDoer) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestPluginStoreClientsShareProxyCooldown(t *testing.T) {
+	var proxyCalls atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyCalls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	const tokenEnv = "HOME_PLUGIN_NETWORK_SCOPE_TEST_TOKEN"
+	t.Setenv(tokenEnv, t.Name())
+	auth := []sdkpluginstore.ResolvedAuthConfig{{
+		Match: "https://api.github.com/", Type: sdkpluginstore.AuthTypeGitHubToken,
+		Token: sdkpluginstore.Secret(t.Name()),
+	}}
+	expiresAt := time.Now().Add(time.Hour)
+	plugin := sdkpluginstore.Plugin{Repository: "https://github.com/test/home-network-scope"}
+	// Seed the same process-wide cooldown used by management and Home clients.
+	seed := sdkpluginstore.NewClientWithResolvedAuthExpiry(networkScopeDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{"Retry-After": {"3600"}}, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	}), "", auth, expiresAt).WithNetworkScope(proxy.URL)
+	_, errRelease := seed.FetchLatestRelease(context.Background(), plugin)
+	var rateLimit *internalpluginstore.RateLimitError
+	if !errors.As(errRelease, &rateLimit) {
+		t.Fatalf("seed cooldown: %v", errRelease)
+	}
+
+	cfg := &config.Config{}
+	cfg.ProxyURL = " " + proxy.URL + " "
+	cfg.Plugins.StoreAuth = []sdkpluginstore.AuthConfig{{
+		Match: "https://api.github.com/", Type: sdkpluginstore.AuthTypeGitHubToken, TokenEnv: tokenEnv,
+	}}
+	for name, client := range map[string]sdkpluginstore.Client{
+		"configured auth": newPluginStoreClient(cfg),
+		"resolved auth":   newResolvedPluginStoreClient(cfg, auth, expiresAt),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, errRelease := client.FetchLatestRelease(context.Background(), plugin)
+			var rateLimit *internalpluginstore.RateLimitError
+			if !errors.As(errRelease, &rateLimit) {
+				t.Fatalf("Home client did not inherit the proxy cooldown: %v", errRelease)
+			}
+		})
+	}
+	if proxyCalls.Load() != 0 {
+		t.Fatalf("cooldown made %d proxy requests, want 0", proxyCalls.Load())
+	}
+}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -803,21 +803,27 @@ func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
 var newPluginStoreClient = func(cfg *config.Config) sdkpluginstore.Client {
 	client := &http.Client{}
 	var storeAuth []sdkpluginstore.AuthConfig
-	if cfg != nil && strings.TrimSpace(cfg.ProxyURL) != "" {
-		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(cfg.ProxyURL)}, client)
-	}
+	var proxyURL string
 	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 		storeAuth = cfg.Plugins.StoreAuth
 	}
-	return sdkpluginstore.NewClientWithAuth(client, "", storeAuth)
+	if proxyURL != "" {
+		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: proxyURL}, client)
+	}
+	return sdkpluginstore.NewClientWithAuth(client, "", storeAuth).WithNetworkScope(proxyURL)
 }
 
 var newResolvedPluginStoreClient = func(cfg *config.Config, auth []sdkpluginstore.ResolvedAuthConfig, expiresAt time.Time) sdkpluginstore.Client {
 	client := &http.Client{}
-	if cfg != nil && strings.TrimSpace(cfg.ProxyURL) != "" {
-		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(cfg.ProxyURL)}, client)
+	var proxyURL string
+	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
-	return sdkpluginstore.NewClientWithResolvedAuthExpiry(client, "", auth, expiresAt)
+	if proxyURL != "" {
+		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: proxyURL}, client)
+	}
+	return sdkpluginstore.NewClientWithResolvedAuthExpiry(client, "", auth, expiresAt).WithNetworkScope(proxyURL)
 }
 
 func pluginConfigEnabled(item config.PluginInstanceConfig) bool {

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -25,6 +25,7 @@ type Client struct {
 	HTTPClient HTTPDoer
 	// NetworkScope distinguishes request state for different proxy/egress configurations.
 	NetworkScope          string
+	RateLimiter           *GitHubRateLimiter
 	RegistryURL           string
 	UserAgent             string
 	Auth                  []AuthConfig
@@ -147,10 +148,18 @@ func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
 
 func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
+	limiter := c.githubRateLimiter()
 	for redirects := 0; ; redirects++ {
+		if errContext := ctx.Err(); errContext != nil {
+			return nil, errContext
+		}
 		headers, authenticated, errAuth := c.authHeaders(currentURL, kind)
 		if errAuth != nil {
 			return nil, errAuth
+		}
+		rateKey := githubRateLimitKey(currentURL, c.NetworkScope, headers, authenticated)
+		if errLimit := limiter.check(rateKey); errLimit != nil {
+			return nil, errLimit
 		}
 		if headers.Get("Accept") == "" {
 			headers.Set("Accept", accept)
@@ -171,6 +180,7 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 			return nil, errDo
 		}
 		if pluginStoreRedirectStatus(resp.StatusCode) {
+			_ = limiter.observe(rateKey, resp.StatusCode, resp.Header, nil)
 			nextURL, errRedirect := pluginStoreRedirectURL(resp, currentURL)
 			if errClose := resp.Body.Close(); errClose != nil {
 				log.WithError(errClose).Debug("failed to close plugin store redirect body")
@@ -184,7 +194,7 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 			currentURL = nextURL
 			continue
 		}
-		return readPluginStoreResponse(resp, maxSize, authenticated)
+		return readPluginStoreResponse(resp, maxSize, authenticated, limiter, rateKey)
 	}
 }
 
@@ -258,19 +268,30 @@ func pluginStoreRedirectURL(resp *http.Response, requestURL string) (string, err
 	return next.String(), nil
 }
 
-func readPluginStoreResponse(resp *http.Response, maxSize int64, authenticated bool) ([]byte, error) {
+func readPluginStoreResponse(resp *http.Response, maxSize int64, authenticated bool, limiter *GitHubRateLimiter, rateKey string) ([]byte, error) {
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
 			log.WithError(errClose).Debug("failed to close plugin store response body")
 		}
 	}()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		if authenticated {
+		// Apply header-based limits before reading a potentially slow body.
+		if errLimit := limiter.observe(rateKey, resp.StatusCode, resp.Header, nil); errLimit != nil {
+			return nil, errLimit
+		}
+		if authenticated && (rateKey == "" || resp.StatusCode != http.StatusForbidden) {
 			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if errLimit := limiter.observe(rateKey, resp.StatusCode, resp.Header, body); errLimit != nil {
+			return nil, errLimit
+		}
+		if authenticated {
+			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		}
 		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+	_ = limiter.observe(rateKey, resp.StatusCode, resp.Header, nil)
 	reader := io.Reader(resp.Body)
 	if maxSize > 0 {
 		reader = io.LimitReader(resp.Body, maxSize+1)

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -22,12 +22,15 @@ const maxPluginStoreRedirects = 10
 type HTTPDoer = httpfetch.Doer
 
 type Client struct {
-	HTTPClient            HTTPDoer
+	HTTPClient HTTPDoer
+	// NetworkScope distinguishes request state for different proxy/egress configurations.
+	NetworkScope          string
 	RegistryURL           string
 	UserAgent             string
 	Auth                  []AuthConfig
 	ResolvedAuth          []ResolvedAuthConfig
 	ResolvedAuthExpiresAt time.Time
+	preparedAuth          *preparedPluginStoreAuth
 }
 
 type Release struct {
@@ -145,19 +148,15 @@ func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
 func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
 	for redirects := 0; ; redirects++ {
-		if errURL := validatePluginStoreRequestURL(c.Auth, currentURL, kind); errURL != nil {
-			return nil, errURL
-		}
-		if errExpiry := validateResolvedAuthExpiry(c.ResolvedAuth, c.ResolvedAuthExpiresAt, time.Now().UTC(), currentURL, kind); errExpiry != nil {
-			return nil, errExpiry
-		}
-		headers := http.Header{
-			"Accept":     []string{accept},
-			"User-Agent": []string{c.userAgent()},
-		}
-		authenticated, errAuth := applyPluginStoreAuthForClient(headers, c.ResolvedAuth, c.Auth, currentURL, kind)
+		headers, authenticated, errAuth := c.authHeaders(currentURL, kind)
 		if errAuth != nil {
 			return nil, errAuth
+		}
+		if headers.Get("Accept") == "" {
+			headers.Set("Accept", accept)
+		}
+		if headers.Get("User-Agent") == "" {
+			headers.Set("User-Agent", c.userAgent())
 		}
 		resp, errDo := pluginStoreGetNoRedirect(ctx, c.httpClient(), currentURL, headers)
 		if authenticated {

--- a/internal/pluginstore/github_rate_limit.go
+++ b/internal/pluginstore/github_rate_limit.go
@@ -1,0 +1,190 @@
+package pluginstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimitError reports a GitHub API cooldown without exposing response bodies
+// or credentials. RetryAt is also populated for requests blocked locally.
+type RateLimitError struct {
+	StatusCode int
+	RetryAt    time.Time
+}
+
+func (err *RateLimitError) Error() string {
+	return fmt.Sprintf("GitHub API rate limited; retry after %s", err.RetryAt.UTC().Format(time.RFC3339))
+}
+
+// RetryAfterSeconds rounds up so clients never retry before the reset time.
+func (err *RateLimitError) RetryAfterSeconds(now time.Time) int64 {
+	delay := err.RetryAt.Sub(now)
+	if delay <= 0 {
+		return 0
+	}
+	seconds := int64(delay / time.Second)
+	if delay%time.Second != 0 {
+		seconds++
+	}
+	return seconds
+}
+
+type githubCooldown struct {
+	retryAt  time.Time
+	status   int
+	failures uint8
+}
+
+// GitHubRateLimiter shares cooldowns across repositories, release metadata and
+// API asset downloads. Its zero value is ready for use. Clients without an
+// explicit limiter share the process-wide default.
+type GitHubRateLimiter struct {
+	mu          sync.Mutex
+	entries     map[string]githubCooldown
+	nextPruneAt time.Time
+	nowFunc     func() time.Time
+}
+
+var defaultGitHubRateLimiter GitHubRateLimiter
+
+func (c Client) githubRateLimiter() *GitHubRateLimiter {
+	if c.RateLimiter != nil {
+		return c.RateLimiter
+	}
+	return &defaultGitHubRateLimiter
+}
+
+func (limiter *GitHubRateLimiter) now() time.Time {
+	if limiter.nowFunc != nil {
+		return limiter.nowFunc()
+	}
+	return time.Now()
+}
+
+func githubRateLimitKey(requestURL, networkScope string, headers http.Header, authenticated bool) string {
+	parsed, errParse := url.Parse(requestURL)
+	if errParse != nil || !strings.EqualFold(parsed.Scheme, "https") || !strings.EqualFold(parsed.Hostname(), "api.github.com") || (parsed.Port() != "" && parsed.Port() != "443") {
+		return ""
+	}
+	return "api.github.com/" + requestIdentity(networkScope, headers, authenticated)
+}
+
+func (limiter *GitHubRateLimiter) check(key string) error {
+	if key == "" {
+		return nil
+	}
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	now := limiter.now()
+	limiter.pruneLocked(now)
+	entry := limiter.entries[key]
+	if now.Before(entry.retryAt) {
+		return &RateLimitError{StatusCode: entry.status, RetryAt: entry.retryAt}
+	}
+	return nil
+}
+
+// pruneLocked drops inactive identities after a grace period so credential and
+// proxy rotation cannot leave cooldown state behind indefinitely. Retaining
+// recently expired entries preserves secondary-limit backoff across retries.
+func (limiter *GitHubRateLimiter) pruneLocked(now time.Time) {
+	if now.Before(limiter.nextPruneAt) {
+		return
+	}
+	for key, entry := range limiter.entries {
+		if !now.Before(entry.retryAt.Add(time.Hour)) {
+			delete(limiter.entries, key)
+		}
+	}
+	limiter.nextPruneAt = now.Add(time.Hour)
+}
+
+// observe records even successful responses that consume the final request.
+// A late success must not clear a cooldown established by another request.
+func (limiter *GitHubRateLimiter) observe(key string, status int, headers http.Header, body []byte) error {
+	if key == "" {
+		return nil
+	}
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	now := limiter.now()
+	limiter.pruneLocked(now)
+	entry := limiter.entries[key]
+	remainingZero := strings.TrimSpace(headers.Get("X-RateLimit-Remaining")) == "0"
+	retryAt := githubRetryAfter(headers.Get("Retry-After"), now)
+	rateLimited := status == http.StatusTooManyRequests || (status == http.StatusForbidden &&
+		(remainingZero || !retryAt.IsZero() || githubRateLimitMessage(body)))
+	if !rateLimited && !remainingZero {
+		if status >= http.StatusOK && status < http.StatusMultipleChoices && !now.Before(entry.retryAt) {
+			delete(limiter.entries, key)
+		}
+		return nil
+	}
+	if remainingZero {
+		if reset, errReset := strconv.ParseInt(strings.TrimSpace(headers.Get("X-RateLimit-Reset")), 10, 64); errReset == nil && reset > 0 {
+			if resetAt := time.Unix(reset, 0); resetAt.After(retryAt) {
+				retryAt = resetAt
+			}
+		}
+	}
+	if !retryAt.After(now) {
+		if !rateLimited {
+			return nil
+		}
+		// Headerless secondary limits start at one minute and back off up to an
+		// hour. Only an actual upstream rejection increments this counter.
+		delay := time.Minute * time.Duration(1<<entry.failures)
+		if delay > time.Hour {
+			delay = time.Hour
+		}
+		retryAt = now.Add(delay)
+		if entry.failures < 6 {
+			entry.failures++
+		}
+	}
+	if retryAt.After(entry.retryAt) {
+		entry.retryAt = retryAt
+	}
+	entry.status = status
+	if !rateLimited {
+		entry.status = http.StatusTooManyRequests
+	}
+	if limiter.entries == nil {
+		limiter.entries = make(map[string]githubCooldown)
+	}
+	limiter.entries[key] = entry
+	if rateLimited {
+		return &RateLimitError{StatusCode: status, RetryAt: entry.retryAt}
+	}
+	return nil
+}
+
+func githubRetryAfter(value string, now time.Time) time.Time {
+	value = strings.TrimSpace(value)
+	if seconds, errSeconds := strconv.ParseInt(value, 10, 64); errSeconds == nil && seconds >= 0 && seconds <= int64((1<<63-1)/time.Second) {
+		return now.Add(time.Duration(seconds) * time.Second)
+	}
+	if retryAt, errDate := http.ParseTime(value); errDate == nil {
+		return retryAt
+	}
+	return time.Time{}
+}
+
+func githubRateLimitMessage(body []byte) bool {
+	var message struct {
+		Message string `json:"message"`
+	}
+	if errDecode := json.Unmarshal(body, &message); errDecode != nil {
+		return false
+	}
+	text := strings.ToLower(message.Message)
+	return strings.Contains(text, "secondary rate limit") ||
+		strings.Contains(text, "api rate limit exceeded") ||
+		strings.Contains(text, "abuse detection")
+}

--- a/internal/pluginstore/github_rate_limit_test.go
+++ b/internal/pluginstore/github_rate_limit_test.go
@@ -1,0 +1,341 @@
+package pluginstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func githubTestHeaders(values map[string]string) http.Header {
+	headers := make(http.Header)
+	for name, value := range values {
+		headers.Set(name, value)
+	}
+	return headers
+}
+
+func TestGitHubRateLimitHeaders(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	reset := strconv.FormatInt(now.Add(time.Hour).Unix(), 10)
+	tests := []struct {
+		name    string
+		status  int
+		headers map[string]string
+		body    string
+		wait    time.Duration
+	}{
+		{name: "primary forbidden", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: time.Hour},
+		{name: "retry seconds", status: 429, headers: map[string]string{"Retry-After": "120"}, wait: 2 * time.Minute},
+		{name: "retry date", status: 429, headers: map[string]string{"Retry-After": now.Add(3 * time.Minute).Format(http.TimeFormat)}, wait: 3 * time.Minute},
+		{name: "reset wins", status: 403, headers: map[string]string{"Retry-After": "120", "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: time.Hour},
+		{name: "retry wins", status: 429, headers: map[string]string{"Retry-After": "7200", "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: 2 * time.Hour},
+		{name: "secondary message", status: 403, body: `{"message":"You have exceeded a secondary rate limit."}`, wait: time.Minute},
+		{name: "abuse message", status: 403, body: `{"message":"You have triggered an abuse detection mechanism."}`, wait: time.Minute},
+		{name: "retry forbidden", status: 403, headers: map[string]string{"Retry-After": "60"}, wait: time.Minute},
+		{name: "headerless too many requests", status: 429, wait: time.Minute},
+		{name: "invalid retry", status: 429, headers: map[string]string{"Retry-After": "invalid"}, wait: time.Minute},
+		{name: "overflow retry", status: 429, headers: map[string]string{"Retry-After": "9223372036854775807"}, wait: time.Minute},
+		{name: "negative retry", status: 429, headers: map[string]string{"Retry-After": "-10"}, wait: time.Minute},
+		{name: "past reset", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1"}, wait: time.Minute},
+		{name: "invalid reset", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "invalid"}, wait: time.Minute},
+		{name: "permission denied", status: 403, body: `{"message":"Resource not accessible by integration"}`},
+		{name: "invalid body", status: 403, body: "forbidden"},
+		{name: "not found", status: 404},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+			errLimit := limiter.observe("quota", tt.status, githubTestHeaders(tt.headers), []byte(tt.body))
+			if tt.wait == 0 {
+				if errLimit != nil || limiter.check("quota") != nil {
+					t.Fatalf("non-rate-limit response started cooldown: %v", errLimit)
+				}
+				return
+			}
+			var rateLimit *RateLimitError
+			if !errors.As(errLimit, &rateLimit) || rateLimit.StatusCode != tt.status || !rateLimit.RetryAt.Equal(now.Add(tt.wait)) {
+				t.Fatalf("error=%v, want status=%d retry=%s", errLimit, tt.status, now.Add(tt.wait))
+			}
+			if errCheck := limiter.check("quota"); !errors.As(errCheck, &rateLimit) {
+				t.Fatalf("check=%v, want cooldown", errCheck)
+			}
+		})
+	}
+}
+
+func TestGitHubRateLimitKeyCanonicalHost(t *testing.T) {
+	t.Parallel()
+	want := githubRateLimitKey("https://api.github.com/repos/owner/repo", "", nil, false)
+	for _, requestURL := range []string{"https://api.github.com:443/repos/other/repo", "https://API.GITHUB.COM/releases"} {
+		if got := githubRateLimitKey(requestURL, "", nil, false); got != want || got == "" {
+			t.Fatalf("key for %s = %q, want %q", requestURL, got, want)
+		}
+	}
+	for _, requestURL := range []string{"https://api.github.com:444/repos/owner/repo", "http://api.github.com/", "https://api.github.com.example/", "https://raw.githubusercontent.com/"} {
+		if got := githubRateLimitKey(requestURL, "", nil, false); got != "" {
+			t.Fatalf("unrelated URL %s has GitHub quota key %q", requestURL, got)
+		}
+	}
+}
+
+func TestGitHubRateLimitPrunesInactiveIdentities(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	_ = limiter.observe("old-token", 429, nil, nil)
+	_ = limiter.observe("active-token", 429, githubTestHeaders(map[string]string{"Retry-After": "7200"}), nil)
+	now = now.Add(time.Hour + time.Minute)
+	_ = limiter.check("new-token")
+	if _, exists := limiter.entries["old-token"]; exists {
+		t.Fatal("inactive credential cooldown was not pruned")
+	}
+	if errCheck := limiter.check("active-token"); errCheck == nil {
+		t.Fatal("active cooldown was pruned")
+	}
+}
+
+func TestGitHubRateLimitBackoffAndRecovery(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	for _, delay := range []time.Duration{time.Minute, 2 * time.Minute, 4 * time.Minute, 8 * time.Minute, 16 * time.Minute, 32 * time.Minute, time.Hour, time.Hour} {
+		errLimit := limiter.observe("quota", 429, nil, nil)
+		var rateLimit *RateLimitError
+		if !errors.As(errLimit, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(delay)) {
+			t.Fatalf("backoff=%v, want %s", errLimit, delay)
+		}
+		for range 5 {
+			if limiter.check("quota") == nil {
+				t.Fatal("local check lost cooldown")
+			}
+		}
+		now = now.Add(delay)
+		if errCheck := limiter.check("quota"); errCheck != nil {
+			t.Fatalf("expired cooldown: %v", errCheck)
+		}
+	}
+	_ = limiter.observe("quota", 200, nil, nil)
+	var rateLimit *RateLimitError
+	if errLimit := limiter.observe("quota", 429, nil, nil); !errors.As(errLimit, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("success did not reset backoff: %v", errLimit)
+	}
+}
+
+func TestGitHubRateLimitSuccessfulExhaustionAndLateResponses(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	headers := githubTestHeaders(map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": strconv.FormatInt(now.Add(time.Hour).Unix(), 10)})
+	if errObserve := limiter.observe("quota", 200, headers, nil); errObserve != nil {
+		t.Fatalf("final successful request failed: %v", errObserve)
+	}
+	_ = limiter.observe("quota", 200, nil, nil)
+	_ = limiter.observe("quota", 429, githubTestHeaders(map[string]string{"Retry-After": "60"}), nil)
+	var rateLimit *RateLimitError
+	if errCheck := limiter.check("quota"); !errors.As(errCheck, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("late response shortened cooldown: %v", errCheck)
+	}
+}
+
+func TestGitHubCooldownSharedAcrossClientsRepositoriesAndAssets(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	calls := 0
+	doer := pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "60"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	})
+	first := Client{HTTPClient: doer, RateLimiter: limiter}
+	second := Client{HTTPClient: doer, RateLimiter: limiter}
+	ctx := context.Background()
+	_, errFirst := first.FetchLatestRelease(ctx, Plugin{Repository: "https://github.com/owner/first"})
+	_, errSecond := second.FetchReleaseByTag(ctx, Plugin{Repository: "https://github.com/other/second"}, "v1.0.0")
+	_, errAsset := second.DownloadAsset(ctx, ReleaseAsset{APIURL: "https://api.github.com:443/repos/other/second/releases/assets/1"})
+	for _, errRequest := range []error{errFirst, errSecond, errAsset} {
+		var rateLimit *RateLimitError
+		if !errors.As(errRequest, &rateLimit) {
+			t.Fatalf("request error=%v, want rate limit", errRequest)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
+	}
+	if _, errRaw := second.get(ctx, DefaultRegistryURL, "application/json", RequestKindRegistry, 0); errRaw != nil {
+		t.Fatalf("API cooldown blocked raw registry: %v", errRaw)
+	}
+	now = now.Add(time.Minute)
+	if _, errRecovered := second.FetchLatestRelease(ctx, Plugin{Repository: "https://github.com/other/second"}); errRecovered != nil || calls != 3 {
+		t.Fatalf("recovery error=%v calls=%d", errRecovered, calls)
+	}
+}
+
+func TestGitHubCooldownSeparatesCredentialsAndNetworkScope(t *testing.T) {
+	t.Parallel()
+	limiter := &GitHubRateLimiter{}
+	calls := 0
+	client := Client{RateLimiter: limiter, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})}
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	for _, token := range []string{"", "token-a", "token-b", "token-a", ""} {
+		client.ResolvedAuth = nil
+		if token != "" {
+			client.ResolvedAuth = []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret(token)}}
+		}
+		_, _ = client.FetchLatestRelease(context.Background(), plugin)
+	}
+	if calls != 3 {
+		t.Fatalf("credential scopes made %d calls, want 3", calls)
+	}
+	client.NetworkScope = "other-egress"
+	_, _ = client.FetchLatestRelease(context.Background(), plugin)
+	if calls != 4 {
+		t.Fatalf("egress scopes made %d calls, want 4", calls)
+	}
+}
+
+func TestGitHubRateLimitAuthenticatedBodyIsNotExposed(t *testing.T) {
+	t.Parallel()
+	client := Client{
+		RateLimiter:  &GitHubRateLimiter{},
+		ResolvedAuth: []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret("secret-token")}},
+		HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 403, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"message":"secondary rate limit: secret-token"}`))}, nil
+		}),
+	}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	var rateLimit *RateLimitError
+	if !errors.As(errRelease, &rateLimit) || strings.Contains(errRelease.Error(), "secret-token") {
+		t.Fatalf("unsafe or unclassified error: %v", errRelease)
+	}
+}
+
+func TestGitHubDefaultCooldownBlocksConcurrentNewClients(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := Client{NetworkScope: t.Name(), HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})}
+	key := githubRateLimitKey("https://api.github.com/", client.NetworkScope, nil, false)
+	t.Cleanup(func() {
+		defaultGitHubRateLimiter.mu.Lock()
+		delete(defaultGitHubRateLimiter.entries, key)
+		defaultGitHubRateLimiter.mu.Unlock()
+	})
+	_, _ = client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/first"})
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			copyClient := Client{NetworkScope: client.NetworkScope, HTTPClient: client.HTTPClient}
+			_, errRelease := copyClient.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/other/second"})
+			var rateLimit *RateLimitError
+			if !errors.As(errRelease, &rateLimit) {
+				t.Errorf("request error = %v", errRelease)
+			}
+		})
+	}
+	wg.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("calls=%d, want 1", calls.Load())
+	}
+}
+
+type githubHeaderOnlyBody struct {
+	reads  int
+	closed bool
+}
+
+func (body *githubHeaderOnlyBody) Read([]byte) (int, error) {
+	body.reads++
+	return 0, errors.New("body must not be read")
+}
+
+func (body *githubHeaderOnlyBody) Close() error {
+	body.closed = true
+	return nil
+}
+
+func TestGitHubHeaderCooldownClosesBodyWithoutReading(t *testing.T) {
+	t.Parallel()
+	body := &githubHeaderOnlyBody{}
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "60"}), Body: body}, nil
+	})}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	var rateLimit *RateLimitError
+	if !errors.As(errRelease, &rateLimit) || body.reads != 0 || !body.closed {
+		t.Fatalf("error=%v reads=%d closed=%v", errRelease, body.reads, body.closed)
+	}
+}
+
+func TestGitHubSuccessfulFinalRequestReturnsRelease(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: 200,
+			Header:     githubTestHeaders(map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)}),
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`)),
+		}, nil
+	})}
+	release, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	if errRelease != nil || release.TagName != "v1.0.0" {
+		t.Fatalf("release=%#v error=%v", release, errRelease)
+	}
+	_, errNext := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/other"})
+	var rateLimit *RateLimitError
+	if !errors.As(errNext, &rateLimit) || calls != 1 {
+		t.Fatalf("next error=%v calls=%d", errNext, calls)
+	}
+}
+
+func TestNonGitHubRateLimitDoesNotCoolGitHub(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if req.URL.Host != "api.github.com" {
+			return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	})}
+	_, errRegistry := client.FetchRegistry(context.Background())
+	var rateLimit *RateLimitError
+	if errRegistry == nil || errors.As(errRegistry, &rateLimit) {
+		t.Fatalf("non-API error=%v, want ordinary HTTP error", errRegistry)
+	}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	if errRelease != nil || calls != 2 {
+		t.Fatalf("release error=%v calls=%d", errRelease, calls)
+	}
+}
+
+func TestRateLimitRetryAfterRoundsUp(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(100, 0)
+	for _, tt := range []struct {
+		delay time.Duration
+		want  int64
+	}{{-time.Second, 0}, {0, 0}, {time.Nanosecond, 1}, {time.Second, 1}, {time.Second + time.Nanosecond, 2}} {
+		errLimit := &RateLimitError{RetryAt: now.Add(tt.delay)}
+		if got := errLimit.RetryAfterSeconds(now); got != tt.want {
+			t.Fatalf("RetryAfterSeconds(%s)=%d, want %d", tt.delay, got, tt.want)
+		}
+	}
+}

--- a/internal/pluginstore/request_identity.go
+++ b/internal/pluginstore/request_identity.go
@@ -1,0 +1,65 @@
+package pluginstore
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type preparedPluginStoreAuth struct {
+	requestURL    string
+	kind          string
+	headers       http.Header
+	authenticated bool
+}
+
+// LatestReleaseCacheKey identifies a repository under the effective credentials
+// and network scope, without retaining credential material in the key.
+func (c Client) LatestReleaseCacheKey(plugin Plugin) (string, error) {
+	_, key, errPrepare := c.PrepareLatestRelease(plugin)
+	return key, errPrepare
+}
+
+// PrepareLatestRelease binds the cache identity and initial release request to
+// the same credential snapshot, even when environment values change in a queue.
+func (c Client) PrepareLatestRelease(plugin Plugin) (Client, string, error) {
+	owner, repo, errRepository := GitHubRepositoryParts(plugin.Repository)
+	if errRepository != nil {
+		return Client{}, "", errRepository
+	}
+	requestURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", url.PathEscape(owner), url.PathEscape(repo))
+	headers, authenticated, errHeaders := c.authHeaders(requestURL, RequestKindMetadata)
+	if errHeaders != nil {
+		return Client{}, "", errHeaders
+	}
+	c.preparedAuth = &preparedPluginStoreAuth{requestURL: requestURL, kind: RequestKindMetadata, headers: headers, authenticated: authenticated}
+	return c, strings.ToLower(requestURL) + "/" + requestIdentity(c.NetworkScope, headers, authenticated), nil
+}
+
+func (c Client) authHeaders(requestURL, kind string) (http.Header, bool, error) {
+	if errURL := validatePluginStoreRequestURL(c.Auth, requestURL, kind); errURL != nil {
+		return nil, false, errURL
+	}
+	if errExpiry := validateResolvedAuthExpiry(c.ResolvedAuth, c.ResolvedAuthExpiresAt, time.Now().UTC(), requestURL, kind); errExpiry != nil {
+		return nil, false, errExpiry
+	}
+	if prepared := c.preparedAuth; prepared != nil && prepared.requestURL == requestURL && prepared.kind == kind {
+		return prepared.headers.Clone(), prepared.authenticated, nil
+	}
+	headers := make(http.Header)
+	authenticated, errAuth := applyPluginStoreAuthForClient(headers, c.ResolvedAuth, c.Auth, requestURL, kind)
+	return headers, authenticated, errAuth
+}
+
+func requestIdentity(networkScope string, headers http.Header, authenticated bool) string {
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "%s\x00%t\x00", networkScope, authenticated)
+	if authenticated {
+		// Header.Write sorts header names, making equivalent auth rules share a key.
+		_ = headers.Write(hash)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}

--- a/internal/pluginstore/request_identity_test.go
+++ b/internal/pluginstore/request_identity_test.go
@@ -1,0 +1,82 @@
+package pluginstore
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLatestReleaseCacheKeyNormalizesRepository(t *testing.T) {
+	t.Parallel()
+	client := Client{}
+	key, errKey := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/Owner/Repo/"})
+	if errKey != nil {
+		t.Fatal(errKey)
+	}
+	other, errOther := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/owner/repo"})
+	if errOther != nil || key != other {
+		t.Fatalf("equivalent repository keys differ: %q / %q (%v)", key, other, errOther)
+	}
+}
+
+func TestLatestReleaseCacheKeyTracksEnvironmentCredentials(t *testing.T) {
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	client := Client{Auth: []AuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, TokenEnv: "PLUGIN_STORE_CACHE_TEST_TOKEN"}}}
+	t.Setenv("PLUGIN_STORE_CACHE_TEST_TOKEN", "secret-token-one")
+	first, errFirst := client.LatestReleaseCacheKey(plugin)
+	if errFirst != nil {
+		t.Fatal(errFirst)
+	}
+	t.Setenv("PLUGIN_STORE_CACHE_TEST_TOKEN", "secret-token-two")
+	second, errSecond := client.LatestReleaseCacheKey(plugin)
+	if errSecond != nil || first == second {
+		t.Fatalf("credential rotation did not change key: %v", errSecond)
+	}
+	if strings.Contains(first+second, "secret-token") {
+		t.Fatal("cache keys retain raw credentials")
+	}
+}
+
+type pluginIdentityDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f pluginIdentityDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestPrepareLatestReleaseSnapshotsEnvironmentCredentials(t *testing.T) {
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	client := Client{
+		Auth: []AuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, TokenEnv: "PLUGIN_STORE_SNAPSHOT_TEST_TOKEN"}},
+		HTTPClient: pluginIdentityDoerFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer original-token" {
+				t.Errorf("request did not use the credential snapshot")
+			}
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+		}),
+	}
+	t.Setenv("PLUGIN_STORE_SNAPSHOT_TEST_TOKEN", "original-token")
+	prepared, originalKey, errPrepare := client.PrepareLatestRelease(plugin)
+	if errPrepare != nil {
+		t.Fatal(errPrepare)
+	}
+	t.Setenv("PLUGIN_STORE_SNAPSHOT_TEST_TOKEN", "rotated-token")
+	rotatedKey, errKey := client.LatestReleaseCacheKey(plugin)
+	if errKey != nil || originalKey == rotatedKey {
+		t.Fatalf("rotation did not change the unprepared identity: %v", errKey)
+	}
+	if _, errRelease := prepared.FetchLatestRelease(context.Background(), plugin); errRelease != nil {
+		t.Fatal(errRelease)
+	}
+}
+
+func TestLatestReleaseCacheKeyRejectsExpiredCredentials(t *testing.T) {
+	t.Parallel()
+	client := Client{
+		ResolvedAuth:          []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret("secret")}},
+		ResolvedAuthExpiresAt: time.Unix(1, 0),
+	}
+	if _, errKey := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/owner/repo"}); errKey == nil {
+		t.Fatal("expired credentials must not access a cached private release")
+	}
+}

--- a/sdk/pluginstore/network_scope_test.go
+++ b/sdk/pluginstore/network_scope_test.go
@@ -1,0 +1,70 @@
+package pluginstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	internalpluginstore "github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+)
+
+type networkScopeDoer func(*http.Request) (*http.Response, error)
+
+func (f networkScopeDoer) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestClientWithNetworkScope(t *testing.T) {
+	for name, client := range map[string]Client{
+		"plain":           NewClient(nil, ""),
+		"auth":            NewClientWithAuth(nil, "", nil),
+		"resolved":        NewClientWithResolvedAuth(nil, "", nil),
+		"resolved expiry": NewClientWithResolvedAuthExpiry(nil, "", nil, time.Time{}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			scoped := client.WithNetworkScope("  http://proxy.example:8080  ")
+			if scoped.inner.NetworkScope != "http://proxy.example:8080" || client.inner.NetworkScope != "" {
+				t.Fatal("WithNetworkScope must normalize the scope without modifying the original client")
+			}
+			if scoped.WithNetworkScope("").inner.NetworkScope != "" {
+				t.Fatal("empty scope must restore the direct-network identity")
+			}
+		})
+	}
+}
+
+func TestClientNetworkScopeIsolatesAndSharesCooldowns(t *testing.T) {
+	t.Parallel()
+	limiter := &internalpluginstore.GitHubRateLimiter{}
+	plugin := Plugin{Repository: "https://github.com/test/network-scope"}
+	calls := 0
+	client := NewClient(networkScopeDoer(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{"Retry-After": {"3600"}}, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	}), "")
+	client.inner.RateLimiter = limiter
+	proxyA := client.WithNetworkScope("http://proxy-a.example")
+	_, errRelease := proxyA.FetchLatestRelease(context.Background(), plugin)
+	var rateLimit *internalpluginstore.RateLimitError
+	if !errors.As(errRelease, &rateLimit) || calls != 1 {
+		t.Fatalf("first lookup: calls=%d error=%v", calls, errRelease)
+	}
+	for _, scope := range []string{"http://proxy-b.example", ""} {
+		if _, errRelease = client.WithNetworkScope(scope).FetchLatestRelease(context.Background(), plugin); errRelease != nil {
+			t.Fatalf("independent scope %q was blocked: %v", scope, errRelease)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("requests=%d, want 3", calls)
+	}
+	plugin.Repository = "https://github.com/test/another-repository"
+	_, errRelease = client.WithNetworkScope(" http://proxy-a.example ").FetchLatestRelease(context.Background(), plugin)
+	if !errors.As(errRelease, &rateLimit) || calls != 3 {
+		t.Fatalf("same scope must share cooldown across clients and repositories: calls=%d error=%v", calls, errRelease)
+	}
+}

--- a/sdk/pluginstore/pluginstore.go
+++ b/sdk/pluginstore/pluginstore.go
@@ -91,6 +91,15 @@ func NewClientWithResolvedAuthExpiry(httpClient HTTPDoer, registryURL string, au
 	}}
 }
 
+// WithNetworkScope returns a copy with the given proxy/egress identity for shared
+// GitHub API cooldowns. Use the same scope for clients with the same egress and
+// credentials; an empty scope denotes direct connections. This does not configure
+// the HTTP transport, which must use the corresponding proxy/egress separately.
+func (c Client) WithNetworkScope(networkScope string) Client {
+	c.inner.NetworkScope = strings.TrimSpace(networkScope)
+	return c
+}
+
 func (c *Client) ClearAuth() {
 	if c == nil {
 		return


### PR DESCRIPTION
## Summary

Fixes #5608.

Reduce unnecessary GitHub API requests when browsing the plugin store, coalesce release checks across concurrent listings, and honor GitHub rate-limit cooldowns across plugin-store clients. Also propagate proxy/egress identity through the SDK and Home plugin-sync paths so one exit IP's cooldown does not incorrectly block another exit IP.

## Problem

Previously, listing the plugin store queried the latest GitHub release for every catalog entry, including uninstalled plugins and sources that could not update an installed plugin. A sufficiently large catalog could exhaust GitHub's unauthenticated limit of 60 requests per hour per IP just by being opened.

The existing per-repository cache did not coalesce in-flight requests or bound concurrency across listings. Failed lookups used a fixed retry interval instead of GitHub's cooldown information, allowing subsequent listings or installations to keep hitting an already rate-limited API.

## Changes

### 1. Only check releases that can update installed plugins

- Query latest releases only for installed plugins whose catalog source is allowed to update them.
- Skip uninstalled plugins, direct-download plugins, and unrelated or unverifiable update sources.
- Preserve catalog ordering and positional version results.
- Use the registry version when no successful release lookup is available. Previously cached successful versions can still be displayed without issuing another request, including for uninstalled plugins.

### 2. Share and throttle release lookups

- Coalesce concurrent lookups for the same repository, effective credentials, and network scope.
- Limit active release checks to **two per management handler**, shared across catalog requests.
- Cache successful lookups for **one hour**; retry ordinary failures after **30 seconds**. Start these intervals when the lookup finishes, not when it enters the queue.
- Retain the last successful version when a refresh fails rather than replacing it with an empty result.
- Handle cancellation without poisoning the failure cache: a canceled follower does not cancel the leader, and a live follower can take over after a canceled leader.
- Bind the cache identity and initial release request to the same credential snapshot, including when environment-provided credentials change while a request is queued.

### 3. Honor shared GitHub API cooldowns

- Share cooldowns across clients, repositories, release metadata, and API-hosted asset downloads for the same effective credentials and network scope.
- Recognize HTTP 429 and rate-limit-related HTTP 403 responses using `Retry-After`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and recognized GitHub rate-limit messages.
- Use exponential backoff from **one minute up to one hour** when a rate-limit rejection has no usable retry time.
- Record successful responses that consume the final request, while still returning their data. Late successful responses do not clear an active cooldown.
- Reject new requests locally during a cooldown, including queued release checks. Ordinary non-rate-limit 403 responses and non-GitHub hosts do not establish a GitHub cooldown.
- Apply header-based cooldowns before reading an error body, and avoid exposing authenticated response bodies or credentials in rate-limit errors.
- Prune inactive cooldown identities after a grace period.
- Return HTTP **429** with `Retry-After` and `plugin_store_rate_limited`, `retry_after`, and `retry_at` fields when installation encounters a rate limit, including during registry resolution.
- Stop alternate release-tag installation attempts immediately on rate-limit errors or request cancellation.

### 4. Preserve proxy/egress isolation in SDK and Home clients

- Add the backward-compatible `Client.WithNetworkScope()` SDK method; existing constructor signatures remain unchanged.
- Pass the normalized proxy URL as the network scope in both Home client creation paths: configured authentication and temporary resolved authentication.
- Keep cooldowns shared for the same credentials and exit configuration, but isolated between distinct proxy scopes and the direct-connection scope.
- `WithNetworkScope()` identifies the egress; it does **not** configure the HTTP transport. SDK embedders using custom proxies should set a matching scope explicitly.

## User-visible behavior

- Browsing an uninstalled catalog no longer triggers per-plugin GitHub release checks; fetching the configured registries is still required.
- Installed plugins retain update checks, restricted to the applicable source and subject to caching and concurrency limits.
- Release-check failures or cooldowns do not discard previously known versions.
- Installation receives actionable retry timing instead of repeatedly attempting requests during a known cooldown.
- Switching Home's configured proxy uses the corresponding cooldown identity rather than inheriting another exit configuration's state.

## Validation

Completed locally:

- [x] `gofmt -w .`
- [x] `go test ./...`
- [x] `go test -race ./sdk/pluginstore ./internal/homeplugins ./internal/pluginstore ./internal/api/handlers/management`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] `git diff --check`

Regression coverage includes catalog filtering, source matching, successful-version retention, completion-based cache intervals, concurrent lookup coalescing, cancellation handoff, shared concurrency limits, credential snapshots and expiry, GitHub cooldown parsing/backoff/recovery, queued-request suppression, installation retry responses, and SDK/Home network-scope isolation and sharing.

The Home network-scope regression test was also run against the pre-fix Home implementation using a Go overlay: both client paths failed by issuing proxy requests instead of observing the existing scoped cooldown. The same test passes with this fix.

Tests use mocked responses or a local test proxy; they do not intentionally exhaust a live GitHub API quota.
