### PR TITLE
fix(logging): silence successful health probes while preserving errors

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -48,8 +48,8 @@ func (s *Server) setupRoutes() {
 
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	}
-	s.engine.GET("/healthz", healthzHandler)
-	s.engine.HEAD("/healthz", healthzHandler)
+	s.engine.GET("/healthz", logging.SkipGinRequestLogging, healthzHandler)
+	s.engine.HEAD("/healthz", logging.SkipGinRequestLogging, healthzHandler)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -48,8 +48,8 @@ func (s *Server) setupRoutes() {
 
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	}
-	s.engine.GET("/healthz", logging.SkipGinRequestLogging, healthzHandler)
-	s.engine.HEAD("/healthz", logging.SkipGinRequestLogging, healthzHandler)
+	s.engine.GET("/healthz", healthzHandler)
+	s.engine.HEAD("/healthz", healthzHandler)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -20,6 +20,7 @@ import (
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v7/internal/api/handlers/management"
 	claudemodels "github.com/router-for-me/CLIProxyAPI/v7/internal/client/claude/models"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
@@ -668,44 +669,61 @@ func TestHealthz(t *testing.T) {
 	})
 }
 
-func TestHealthzSkipsAccessLogging(t *testing.T) {
+func TestHealthzAccessLogging(t *testing.T) {
 	server := newTestServer(t)
+	previousHome := home.Current()
+	home.ClearCurrent()
+	t.Cleanup(func() { home.SetCurrent(previousHome) })
 	logger := log.StandardLogger()
 	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
 	previousLevel := logger.GetLevel()
 	hook := logtest.NewLocal(logger)
 	logger.SetLevel(log.InfoLevel)
-	t.Cleanup(func() {
-		logger.ReplaceHooks(previousHooks)
-		logger.SetLevel(previousLevel)
-	})
-
-	for _, method := range []string{http.MethodGet, http.MethodHead} {
-		t.Run(method, func(t *testing.T) {
-			hook.Reset()
-			recorder := httptest.NewRecorder()
-			server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
-			if recorder.Code != http.StatusOK {
-				t.Fatalf("health probe status = %d, want 200", recorder.Code)
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks); logger.SetLevel(previousLevel) })
+	for _, tc := range []struct {
+		name        string
+		homeEnabled bool
+		status      int
+	}{
+		{"healthy", false, http.StatusOK},
+		{"home_unavailable", true, http.StatusServiceUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server.cfg.Home.Enabled = tc.homeEnabled
+			for _, method := range []string{http.MethodGet, http.MethodHead} {
+				t.Run(method, func(t *testing.T) {
+					hook.Reset()
+					recorder := httptest.NewRecorder()
+					server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
+					if recorder.Code != tc.status {
+						t.Fatalf("status = %d, want %d", recorder.Code, tc.status)
+					}
+					count := 0
+					for _, entry := range hook.AllEntries() {
+						if _, ok := entry.Data["request_id"]; ok && strings.Contains(entry.Message, `"/healthz"`) {
+							count++
+							if tc.homeEnabled && entry.Level != log.ErrorLevel {
+								t.Errorf("failed probe log level = %v, want error", entry.Level)
+							}
+						}
+					}
+					wantCount := 0
+					if tc.homeEnabled {
+						wantCount = 1
+					}
+					if count != wantCount {
+						t.Errorf("probe access logs = %d, want %d", count, wantCount)
+					}
+					hook.Reset()
+					server.engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
+					for _, entry := range hook.AllEntries() {
+						if _, ok := entry.Data["request_id"]; ok && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
+							return
+						}
+					}
+					t.Error("ordinary request did not emit an access log after health probe")
+				})
 			}
-			for _, entry := range hook.AllEntries() {
-				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz"`) {
-					t.Errorf("health probe emitted an access log: %s", entry.Message)
-				}
-			}
-
-			hook.Reset()
-			ordinary := httptest.NewRecorder()
-			server.engine.ServeHTTP(ordinary, httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
-			if ordinary.Code != http.StatusNotFound {
-				t.Fatalf("control status = %d, want 404", ordinary.Code)
-			}
-			for _, entry := range hook.AllEntries() {
-				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
-					return
-				}
-			}
-			t.Error("ordinary request did not emit an access log after health probe")
 		})
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -32,6 +32,8 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"gopkg.in/yaml.v3"
 )
 
@@ -664,6 +666,48 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestHealthzSkipsAccessLogging(t *testing.T) {
+	server := newTestServer(t)
+	logger := log.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	previousLevel := logger.GetLevel()
+	hook := logtest.NewLocal(logger)
+	logger.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		logger.ReplaceHooks(previousHooks)
+		logger.SetLevel(previousLevel)
+	})
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			hook.Reset()
+			recorder := httptest.NewRecorder()
+			server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("health probe status = %d, want 200", recorder.Code)
+			}
+			for _, entry := range hook.AllEntries() {
+				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz"`) {
+					t.Errorf("health probe emitted an access log: %s", entry.Message)
+				}
+			}
+
+			hook.Reset()
+			ordinary := httptest.NewRecorder()
+			server.engine.ServeHTTP(ordinary, httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
+			if ordinary.Code != http.StatusNotFound {
+				t.Fatalf("control status = %d, want 404", ordinary.Code)
+			}
+			for _, entry := range hook.AllEntries() {
+				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
+					return
+				}
+			}
+			t.Error("ordinary request did not emit an access log after health probe")
+		})
+	}
 }
 
 func TestCodexLiveRoutesRequireAuthAndAreRegistered(t *testing.T) {

--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -55,6 +55,12 @@ func GinLogrusLogger() gin.HandlerFunc {
 
 		c.Next()
 
+		// Keep failed health probes visible, including responses from global middleware.
+		if path == "/healthz" && (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) &&
+			c.Writer.Status() >= http.StatusOK && c.Writer.Status() < http.StatusMultipleChoices {
+			return
+		}
+
 		if shouldSkipGinRequestLogging(c) {
 			return
 		}

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestGinLogrusRecoveryRepanicsErrAbortHandler(t *testing.T) {
@@ -146,5 +148,46 @@ func TestGinLogrusLoggerAddsRequestIDForCodexBackend(t *testing.T) {
 	}
 	if requestIDFromGin != requestIDFromContext {
 		t.Fatalf("expected Gin request ID %q to match context request ID %q", requestIDFromGin, requestIDFromContext)
+	}
+}
+
+func TestGinLogrusLoggerHealthProbeStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := log.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	previousLevel := logger.GetLevel()
+	hook := logtest.NewLocal(logger)
+	logger.SetLevel(log.InfoLevel)
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks); logger.SetLevel(previousLevel) })
+	for _, tc := range []struct {
+		name, method, path string
+		status             int
+		wantLog            bool
+	}{
+		{"get_ok", "GET", "/healthz", 200, false},
+		{"head_ok", "HEAD", "/healthz", 200, false},
+		{"success_boundary", "GET", "/healthz", 299, false},
+		{"redirect", "GET", "/healthz", 300, true},
+		{"client_error", "GET", "/healthz", 400, true},
+		{"server_error", "HEAD", "/healthz", 503, true},
+		{"similar_path", "GET", "/healthz-extra", 200, true},
+		{"other_method", "POST", "/healthz", 200, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := gin.New()
+			engine.Use(GinLogrusLogger())
+			// Simulate an early global middleware response before route handlers run.
+			engine.Use(func(c *gin.Context) { c.AbortWithStatus(tc.status) })
+			engine.Handle(tc.method, tc.path, func(c *gin.Context) { t.Error("aborted request reached route handler") })
+			hook.Reset()
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, httptest.NewRequest(tc.method, tc.path, nil))
+			if recorder.Code != tc.status {
+				t.Fatalf("status = %d, want %d", recorder.Code, tc.status)
+			}
+			if got := len(hook.AllEntries()) > 0; got != tc.wantLog {
+				t.Errorf("access log present = %v, want %v", got, tc.wantLog)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #5623.

Suppress Gin access logs only for GET and HEAD `/healthz` requests whose final status is 2xx. Check the final response after downstream middleware runs, so the decision also covers responses produced before the route handler executes.

Failed probes, including 503 responses from the Home heartbeat gate, intentionally retain their access logs for diagnosis. Health-check responses and heartbeat gating are unchanged. Other paths and methods retain their existing logging behavior.

Validation:
- API integration tests cover successful GET/HEAD responses, Home-unavailable 503 responses with Error-level access logs, and subsequent ordinary requests.
- Logger tests cover early middleware responses, 2xx/3xx boundaries, 400/503 errors, similar paths, and other methods. The new early-success cases fail before the update and pass afterward.
- `go test ./internal/api ./internal/logging -count=1` passes.
- `go build -o ../cli-proxy-api-healthz ./cmd/server` passes.
- Validated locally on macOS arm64 with Go 1.26.8; no full-repository or Kubernetes test run.

Thanks for reporting the probe log noise and for reviewing the middleware ordering.
