### PR TITLE
fix(auth): cool explicit model_not_found failures

### DIFF
--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1434,6 +1434,8 @@ func resultErrorFromError(err error) *Error {
 		resultErr.HTTPStatus = statusCodeFromError(err)
 	}
 	switch {
+	case isExplicitModelNotFoundError(err, ""):
+		resultErr.Code = "model_not_found"
 	case isRequestScopedError(err) || isRequestInvalidError(err):
 		// Prefer true request-scoped faults (including Claude OAuth cancellation)
 		// over the broader connection-lifecycle classification.
@@ -1660,6 +1662,9 @@ func isInvalidGrantResultError(err *Error) bool {
 func isModelSupportResultError(err *Error) bool {
 	if err == nil {
 		return false
+	}
+	if isExplicitModelNotFoundError(err, "") {
+		return true
 	}
 	status := statusCodeFromResult(err)
 	if status != http.StatusBadRequest && status != http.StatusUnprocessableEntity {
@@ -1976,6 +1981,9 @@ func isRequestInvalidError(err error) bool {
 	}
 	if isRequestScopedError(err) {
 		return true
+	}
+	if isExplicitModelNotFoundError(err, "") {
+		return false
 	}
 	if isCloudflareChallengeError(err) {
 		return false

--- a/sdk/cliproxy/auth/model_not_found_cooldown_test.go
+++ b/sdk/cliproxy/auth/model_not_found_cooldown_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type modelNotFoundStatusError struct {
+	status int
+	body   string
+}
+
+func (e modelNotFoundStatusError) Error() string   { return e.body }
+func (e modelNotFoundStatusError) StatusCode() int { return e.status }
+
+func TestModelNotFoundResultCoolsCredentialModel(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			upstreamErr := modelNotFoundStatusError{
+				status: status,
+				body:   `{"error":{"type":"invalid_request_error","code":"model_not_found","message":"The model gpt-5.5 does not exist or you do not have access to it."}}`,
+			}
+			resultErr := resultErrorFromError(upstreamErr)
+			if resultErr == nil {
+				t.Fatal("resultErrorFromError() returned nil")
+			}
+			if resultErr.Code != "model_not_found" {
+				t.Fatalf("error code = %q, want model_not_found", resultErr.Code)
+			}
+			if shouldSkipCredentialCooldown(resultErr) {
+				t.Fatal("model_not_found was treated as request-scoped")
+			}
+
+			m := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "model-not-found-" + http.StatusText(status), Provider: "codex"}
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			m.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    "gpt-5.5",
+				Success:  false,
+				Error:    resultErr,
+			})
+
+			updated, ok := m.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatal("expected auth to remain registered")
+			}
+			state := updated.ModelStates["gpt-5.5"]
+			if state == nil || !state.Unavailable {
+				t.Fatalf("expected model cooldown state, got %#v", state)
+			}
+			remaining := time.Until(state.NextRetryAfter)
+			if remaining < 11*time.Hour || remaining > 12*time.Hour {
+				t.Fatalf("model cooldown = %v, want about 12h", remaining)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the `model_not_found` code before generic request-fault classification;
- keep explicit model-not-found responses eligible for the existing per-credential/per-model cooldown;
- prevent `invalid_request_error + model_not_found` from being treated as request-scoped;
- add regression coverage for both 400 and 404 representations of the streamed error.

## Problem

Codex can return a terminal stream error with `type=invalid_request_error` and `code=model_not_found`. The generic request-fault classifier currently wins, causing `shouldSkipCredentialCooldown` to skip model cooling and preserve session affinity. A credential that cannot execute the requested model can therefore remain selected repeatedly.

The model-not-found identifier is more specific than the generic error type and should use the existing model-support cooldown path.

This does not change generic 404 handling and is complementary to #5514.

## Verification

- `go test ./sdk/cliproxy/auth -count=1`
- `go build -o /tmp/cli-proxy-api-upstream-pr-check ./cmd/server`
- `git diff --check origin/main...HEAD`

Fixes #5635