### PR TITLE
feat(management): add auth file model probes

### DIFF
--- a/internal/api/handlers/management/auth_file_model_probe.go
+++ b/internal/api/handlers/management/auth_file_model_probe.go
@@ -1,0 +1,184 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// TestAuthFileModel executes a small generation request using only the selected credential.
+// POST /v0/management/auth-files/test-model requires the normal management authentication.
+func (h *Handler) TestAuthFileModel(c *gin.Context) {
+	var body struct {
+		AuthIndex string `json:"auth_index"`
+		Model     string `json:"model"`
+	}
+	if errBind := c.ShouldBindJSON(&body); errBind != nil || strings.TrimSpace(body.AuthIndex) == "" || strings.TrimSpace(body.Model) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index and model are required"})
+		return
+	}
+	body.Model = strings.TrimSpace(body.Model)
+	auth := h.authByIndex(body.AuthIndex)
+	if auth == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth not found"})
+		return
+	}
+	if auth.Disabled || auth.Status == coreauth.StatusDisabled {
+		c.JSON(http.StatusConflict, gin.H{"error": "auth is disabled"})
+		return
+	}
+	var model *registry.ModelInfo
+	for _, candidate := range registry.GetGlobalRegistry().GetModelsForClient(auth.ID) {
+		if candidate != nil && candidate.ID == body.Model {
+			model = candidate
+			break
+		}
+	}
+	if model == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model is not registered for this auth"})
+		return
+	}
+	kind := authFileModelTestKind(model)
+	if kind == "unsupported" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "this model does not support text or image tests"})
+		return
+	}
+	payload := map[string]any{
+		"model": body.Model, "stream": false, "max_tokens": 64,
+		"messages": []map[string]string{{"role": "user", "content": "Reply with OK."}},
+	}
+	format := translator.FormatOpenAI
+	path := "/v1/chat/completions"
+	if kind == "image" {
+		format = translator.FromString(registry.OpenAIImageModelType)
+		path = "/v1/images/generations"
+		payload = map[string]any{"model": body.Model, "prompt": "A small blue circle on a plain white background.", "n": 1, "response_format": "b64_json"}
+	}
+	if kind == "image" && (auth.Provider == "gemini" || auth.Provider == "gemini-cli" || auth.Provider == "antigravity" || auth.Provider == "vertex") {
+		format = translator.FormatOpenAI
+		path = "/v1/chat/completions"
+		payload = map[string]any{
+			"model": body.Model, "stream": false,
+			"messages":   []map[string]string{{"role": "user", "content": "Generate an image of a small blue circle on a plain white background."}},
+			"modalities": []string{"text", "image"},
+		}
+	}
+	raw, errMarshal := json.Marshal(payload)
+	if errMarshal != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to prepare model test"})
+		return
+	}
+	opts := coreexecutor.Options{
+		SourceFormat: format, OriginalRequest: raw,
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+		Metadata: map[string]any{
+			coreexecutor.PinnedAuthMetadataKey:     auth.ID,
+			coreexecutor.RequestedModelMetadataKey: body.Model,
+			coreexecutor.RequestPathMetadataKey:    path,
+		},
+	}
+	if kind == "image" {
+		opts.Metadata[coreexecutor.DisallowFreeAuthMetadataKey] = true
+	}
+	started := time.Now()
+	response, errExecute := h.authManager.Execute(c.Request.Context(), []string{auth.Provider}, coreexecutor.Request{Model: body.Model, Payload: raw}, opts)
+	result := gin.H{"success": false, "model": body.Model, "kind": kind, "latency_ms": time.Since(started).Milliseconds()}
+	if errExecute != nil {
+		// Keep upstream failures inside a successful management response: an upstream 401 must not log out the operator.
+		status := clienterror.HTTPStatusFromErrorOr(errExecute, http.StatusBadGateway)
+		message := http.StatusText(status)
+		if message == "" {
+			message = "Model request failed"
+		}
+		result["error"] = gin.H{"code": "upstream_error", "status_code": status, "message": message}
+		c.JSON(http.StatusOK, result)
+		return
+	}
+	text, images := authFileModelTestOutput(response.Payload, kind)
+	if text == "" && images == 0 {
+		result["error"] = gin.H{"code": "empty_output", "message": "Upstream returned no generated output"}
+	} else {
+		result["success"] = true
+		if text != "" {
+			result["message"] = text
+		}
+		if images > 0 {
+			result["image_count"] = images
+		}
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// authFileModelTestKind follows the image endpoints' supported model families.
+func authFileModelTestKind(model *registry.ModelInfo) string {
+	if model.Type == registry.OpenAIImageModelType {
+		return "image"
+	}
+	for _, name := range []string{model.ID, model.Name, model.Version} {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if i := strings.LastIndex(name, "/"); i >= 0 {
+			name = name[i+1:]
+		}
+		switch name {
+		case "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-image-2.0":
+			return "image"
+		}
+		if strings.Contains(name, "video") || strings.Contains(name, "embedding") || strings.Contains(name, "whisper") || strings.Contains(name, "tts") {
+			return "unsupported"
+		}
+	}
+	for _, modality := range model.SupportedOutputModalities {
+		if strings.EqualFold(modality, "IMAGE") {
+			return "image"
+		}
+		if strings.EqualFold(modality, "VIDEO") || strings.EqualFold(modality, "AUDIO") {
+			return "unsupported"
+		}
+	}
+	return "text"
+}
+
+func authFileModelTestOutput(payload []byte, kind string) (string, int) {
+	if !gjson.ValidBytes(payload) || gjson.GetBytes(payload, "error").Exists() {
+		return "", 0
+	}
+	if kind == "image" {
+		count := 0
+		for _, item := range gjson.GetBytes(payload, "data").Array() {
+			if strings.TrimSpace(item.Get("b64_json").String()) != "" || strings.TrimSpace(item.Get("url").String()) != "" {
+				count++
+			}
+		}
+		for _, item := range gjson.GetBytes(payload, "choices.0.message.images").Array() {
+			if strings.TrimSpace(item.Get("image_url.url").String()) != "" {
+				count++
+			}
+		}
+		return "", count
+	}
+	content := gjson.GetBytes(payload, "choices.0.message.content")
+	text := ""
+	if content.Type == gjson.String {
+		text = content.String()
+	} else if content.IsArray() {
+		for _, part := range content.Array() {
+			if part.Get("type").String() == "text" {
+				text += part.Get("text").String()
+			}
+		}
+	}
+	text = strings.TrimSpace(text)
+	if runes := []rune(text); len(runes) > 512 {
+		text = string(runes[:512]) + "…"
+	}
+	return text, 0
+}

--- a/internal/api/handlers/management/auth_file_model_probe_test.go
+++ b/internal/api/handlers/management/auth_file_model_probe_test.go
@@ -1,0 +1,169 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+type modelProbeExecutor struct {
+	coreauth.ProviderExecutor
+	execute func(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error)
+}
+
+func (e *modelProbeExecutor) Identifier() string { return "codex" }
+func (e *modelProbeExecutor) Execute(ctx context.Context, a *coreauth.Auth, r coreexecutor.Request, o coreexecutor.Options) (coreexecutor.Response, error) {
+	return e.execute(ctx, a, r, o)
+}
+
+func TestAuthFileModelProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name, model, payload, format, path string
+		success                            bool
+	}{
+		{"text", "gpt-5.5", `{"choices":[{"message":{"content":"OK"}}]}`, "openai", "/v1/chat/completions", true},
+		{"image15", "gpt-image-1.5", `{"data":[{"b64_json":"aW1hZ2U="}]}`, "openai-image", "/v1/images/generations", true},
+		{"image2", "gpt-image-2", `{"data":[{"url":"https://example.invalid/test.png"}]}`, "openai-image", "/v1/images/generations", true},
+		{"empty image", "gpt-image-2", `{"data":[]}`, "openai-image", "/v1/images/generations", false},
+		{"empty text", "gpt-5.5", `{"choices":[]}`, "openai", "/v1/chat/completions", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := coreauth.NewManager(nil, nil, nil)
+			reg := registry.GetGlobalRegistry()
+			for _, id := range []string{"probe-other", "probe-selected"} {
+				a := &coreauth.Auth{ID: id, FileName: id + ".json", Provider: "codex", Status: coreauth.StatusActive}
+				if _, err := manager.Register(context.Background(), a); err != nil {
+					t.Fatal(err)
+				}
+				reg.RegisterClient(id, "codex", []*registry.ModelInfo{{ID: tc.model, Type: "openai"}})
+				t.Cleanup(func() { reg.UnregisterClient(id) })
+			}
+			calls := 0
+			manager.RegisterExecutor(&modelProbeExecutor{execute: func(ctx context.Context, a *coreauth.Auth, r coreexecutor.Request, o coreexecutor.Options) (coreexecutor.Response, error) {
+				calls++
+				if a.ID != "probe-selected" {
+					t.Fatalf("wrong credential: %s", a.ID)
+				}
+				if o.SourceFormat.String() != tc.format || o.Metadata[coreexecutor.RequestPathMetadataKey] != tc.path {
+					t.Fatalf("wrong protocol: %+v", o)
+				}
+				if r.Model != tc.model || gjson.GetBytes(r.Payload, "model").String() != tc.model {
+					t.Fatalf("wrong model: %s", r.Payload)
+				}
+				if tc.format == "openai-image" && gjson.GetBytes(r.Payload, "n").Int() != 1 {
+					t.Fatal("must generate one image")
+				}
+				if ctx.Err() != nil {
+					t.Fatal(ctx.Err())
+				}
+				return coreexecutor.Response{Payload: []byte(tc.payload)}, nil
+			}})
+			a, _ := manager.GetByID("probe-selected")
+			h := &Handler{authManager: manager}
+			router := gin.New()
+			router.POST("/test", h.TestAuthFileModel)
+			body, _ := json.Marshal(map[string]string{"auth_index": a.EnsureIndex(), "model": tc.model})
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequest("POST", "/test", strings.NewReader(string(body))))
+			if rec.Code != 200 || gjson.GetBytes(rec.Body.Bytes(), "success").Bool() != tc.success || calls != 1 {
+				t.Fatalf("status=%d calls=%d body=%s", rec.Code, calls, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "aW1hZ2U=") {
+				t.Fatal("image data should not be returned by a probe")
+			}
+		})
+	}
+}
+
+func TestAuthFileModelProbeValidation(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	a := &coreauth.Auth{ID: "probe-validation", Provider: "codex", Status: coreauth.StatusActive}
+	_, _ = manager.Register(context.Background(), a)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(a.ID, "codex", []*registry.ModelInfo{{ID: "allowed"}})
+	defer reg.UnregisterClient(a.ID)
+	h := &Handler{authManager: manager}
+	router := gin.New()
+	router.POST("/test", h.TestAuthFileModel)
+	for _, tc := range []struct {
+		body   string
+		status int
+	}{
+		{`{}`, 400}, {`{"auth_index":"unknown","model":"allowed"}`, 404},
+		{`{"auth_index":"` + a.EnsureIndex() + `","model":"unregistered"}`, 400},
+	} {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(tc.body)))
+		if rec.Code != tc.status {
+			t.Fatalf("got %d want %d: %s", rec.Code, tc.status, rec.Body.String())
+		}
+	}
+}
+
+func TestAuthFileModelProbeUpstreamFailureAndCancellation(t *testing.T) {
+	for _, cancelled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "upstream 401", true: "cancellation"}[cancelled], func(t *testing.T) {
+			manager := coreauth.NewManager(nil, nil, nil)
+			a := &coreauth.Auth{ID: "probe-failure", Provider: "codex", Status: coreauth.StatusActive}
+			_, _ = manager.Register(context.Background(), a)
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(a.ID, "codex", []*registry.ModelInfo{{ID: "probe-text"}})
+			defer reg.UnregisterClient(a.ID)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls := 0
+			manager.RegisterExecutor(&modelProbeExecutor{execute: func(callCtx context.Context, _ *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
+				calls++
+				if cancelled {
+					cancel()
+					<-callCtx.Done()
+					return coreexecutor.Response{}, callCtx.Err()
+				}
+				return coreexecutor.Response{}, &coreauth.Error{HTTPStatus: 401, Message: "secret-upstream-token"}
+			}})
+			h := &Handler{authManager: manager}
+			router := gin.New()
+			router.POST("/test", h.TestAuthFileModel)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/test", strings.NewReader(`{"auth_index":"`+a.EnsureIndex()+`","model":"probe-text"}`)).WithContext(ctx)
+			router.ServeHTTP(rec, req)
+			status := int(gjson.GetBytes(rec.Body.Bytes(), "error.status_code").Int())
+			want := 401
+			if cancelled {
+				want = 499
+			}
+			if rec.Code != 200 || status != want || calls != 1 || strings.Contains(rec.Body.String(), "secret-upstream-token") {
+				t.Fatalf("%d %s calls=%d", rec.Code, rec.Body.String(), calls)
+			}
+		})
+	}
+}
+
+func TestAuthFileModelTestKind(t *testing.T) {
+	for _, tc := range []struct {
+		info registry.ModelInfo
+		want string
+	}{
+		{registry.ModelInfo{ID: "team/image-alias", Version: "gpt-image-2"}, "image"},
+		{registry.ModelInfo{ID: "configured-image", Type: registry.OpenAIImageModelType}, "image"},
+		{registry.ModelInfo{ID: "gemini-image", Type: "gemini", SupportedOutputModalities: []string{"TEXT", "IMAGE"}}, "image"},
+		{registry.ModelInfo{ID: "grok-imagine-video"}, "unsupported"},
+	} {
+		if got := authFileModelTestKind(&tc.info); got != tc.want {
+			t.Errorf("%s = %s want %s", tc.info.ID, got, tc.want)
+		}
+	}
+	text, count := authFileModelTestOutput([]byte(`{"choices":[{"message":{"content":"image description","images":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AA=="}}]}}]}`), "image")
+	if text != "" || count != 1 {
+		t.Fatalf("image output: %q %d", text, count)
+	}
+}

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -196,7 +196,8 @@ func (h *Handler) GetAuthFileModels(c *gin.Context) {
 	result := make([]gin.H, 0, len(models))
 	for _, m := range models {
 		entry := gin.H{
-			"id": m.ID,
+			"id":        m.ID,
+			"test_kind": authFileModelTestKind(m),
 		}
 		if m.DisplayName != "" {
 			entry["display_name"] = m.DisplayName

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -165,6 +165,7 @@ func (s *Server) registerManagementRoutes() {
 
 		mgmt.GET("/auth-files", s.mgmt.ListAuthFiles)
 		mgmt.GET("/auth-files/models", s.mgmt.GetAuthFileModels)
+		mgmt.POST("/auth-files/test-model", s.mgmt.TestAuthFileModel)
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)
 		mgmt.GET("/auth-files/download", s.mgmt.DownloadAuthFile)
 		mgmt.POST("/auth-files", s.mgmt.UploadAuthFile)


### PR DESCRIPTION
Fixes router-for-me/Cli-Proxy-API-Management-Center#426.

## Summary

Add a management API probe for testing a registered model through one selected auth file.

## Changes

- Add `POST /v0/management/auth-files/test-model` with auth index and model validation.
- Pin execution to the selected credential and reject disabled, unknown, unregistered, and unsupported models.
- Select the appropriate OpenAI text or image request shape, including multimodal image generation providers.
- Return success, model kind, latency, and compact output metadata while redacting generated image data and upstream error details.
- Include `test_kind` in the existing auth-file model listing so clients can expose capability-aware controls.
- Add regression coverage for credential pinning, protocol selection, validation, empty output, failures, cancellation, and image-data redaction.

## Validation

- `gofmt` clean for changed Go files
- `go test ./internal/api/handlers/management`
- `go build -o /tmp/cliproxy-api-test ./cmd/server`
- `go test ./...` (one pre-existing timing-sensitive `internal/home` test failed once; rerunning `TestEnsureClientsWaitsForPreviousTargetClose` passed)
