### PR TITLE
feat(codex): support GPT Image 2.5 Sunburst and Flare

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -116,7 +116,7 @@ func GetXAIModels() []*ModelInfo {
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
 func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo())
+	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo(), codexBuiltinImage25SunburstModelInfo(), codexBuiltinImage25FlareModelInfo())
 }
 
 // WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
@@ -232,6 +232,30 @@ func xaiBuiltinVideo15PreviewModelInfo() *ModelInfo {
 		DisplayName: "Grok Imagine Video 1.5 Preview",
 		Name:        xaiBuiltinVideo15PreviewID,
 		Description: "Compatibility alias for the xAI Grok video generation model.",
+	}
+}
+
+func codexBuiltinImage25SunburstModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:          "gpt-image-2.5-sunburst",
+		Object:      "model",
+		Created:     1788825600, // 2026-09-08
+		OwnedBy:     "openai",
+		Type:        "openai",
+		DisplayName: "GPT Image 2.5 Sunburst",
+		Version:     "gpt-image-2.5-sunburst",
+	}
+}
+
+func codexBuiltinImage25FlareModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:          "gpt-image-2.5-flare",
+		Object:      "model",
+		Created:     1788825600, // 2026-09-08
+		OwnedBy:     "openai",
+		Type:        "openai",
+		DisplayName: "GPT Image 2.5 Flare",
+		Version:     "gpt-image-2.5-flare",
 	}
 }
 

--- a/internal/registry/model_definitions_image25_test.go
+++ b/internal/registry/model_definitions_image25_test.go
@@ -1,0 +1,41 @@
+package registry
+
+import "testing"
+
+func TestCodexImage25Builtins(t *testing.T) {
+	for _, id := range []string{"gpt-image-2.5-sunburst", "gpt-image-2.5-flare"} {
+		t.Run(id, func(t *testing.T) {
+			// Stale remote metadata must not replace the built-in definition or duplicate it.
+			models := WithCodexBuiltins([]*ModelInfo{{ID: id, DisplayName: "stale"}})
+			models = WithCodexBuiltins(models)
+			count := 0
+			for _, model := range models {
+				if model.ID == id {
+					count++
+					if model.DisplayName == "stale" || model.Version != id || model.OwnedBy != "openai" {
+						t.Fatalf("unexpected builtin metadata: %+v", model)
+					}
+				}
+			}
+			if count != 1 {
+				t.Fatalf("got %d entries for %s, want 1", count, id)
+			}
+			for _, tier := range []struct {
+				name   string
+				models []*ModelInfo
+			}{
+				{"team", GetCodexTeamModels()}, {"plus", GetCodexPlusModels()}, {"pro", GetCodexProModels()},
+			} {
+				found := false
+				for _, model := range tier.models {
+					if model.ID == id {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("%s missing from %s catalog", id, tier.name)
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/codex_openai_images_test.go
+++ b/internal/runtime/executor/codex_openai_images_test.go
@@ -315,3 +315,30 @@ func TestCodexExecutorDirectOpenAIImageEditUsesImagesEditEndpointForMultipart(t 
 		t.Fatalf("mask.image_url = %q, want mask-data data URL; body=%s", maskURL, string(gotBody))
 	}
 }
+
+func TestCodexImage25PreservesRequestedToolModel(t *testing.T) {
+	for _, model := range []string{"gpt-image-2.5-sunburst", "gpt-image-2.5-flare"} {
+		for _, action := range []string{"generate", "edit"} {
+			t.Run(model+"/"+action, func(t *testing.T) {
+				payload := []byte(`{"model":"` + model + `","prompt":"blue circle","quality":"low","images":[{"image_url":"data:image/png;base64,AA=="}]}`)
+				prepare := codexPrepareOpenAIImageGenerationJSON
+				if action == "edit" {
+					prepare = codexPrepareOpenAIImageEditJSON
+				}
+				result, err := prepare(payload, "gpt-image-2")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := gjson.GetBytes(result.Body, "tools.0.model").String(); got != model {
+					t.Fatalf("tool model = %q, want %q", got, model)
+				}
+				if got := gjson.GetBytes(result.Body, "tools.0.action").String(); got != action {
+					t.Fatalf("action = %q, want %q", got, action)
+				}
+				if got := gjson.GetBytes(result.Body, "tools.0.quality").String(); got != "low" {
+					t.Fatalf("quality = %q, want low", got)
+				}
+			})
+		}
+	}
+}

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -28,6 +28,8 @@ import (
 const (
 	defaultImagesMainModel      = "gpt-5.4-mini"
 	gptImage15Model             = "gpt-image-1.5"
+	gptImage25SunburstModel     = "gpt-image-2.5-sunburst"
+	gptImage25FlareModel        = "gpt-image-2.5-flare"
 	defaultImagesToolModel      = "gpt-image-2"
 	defaultXAIImagesModel       = "grok-imagine-image"
 	xaiImagesQualityModel       = "grok-imagine-image-quality"
@@ -239,7 +241,8 @@ func isSupportedImagesModel(model string) bool {
 
 func isCodexImagesToolModel(model string) bool {
 	baseModel := imagesModelBase(model)
-	return baseModel == gptImage15Model || baseModel == defaultImagesToolModel
+	return baseModel == gptImage15Model || baseModel == defaultImagesToolModel ||
+		baseModel == gptImage25SunburstModel || baseModel == gptImage25FlareModel
 }
 
 func isOpenAICompatImagesModel(model string) bool {
@@ -258,7 +261,7 @@ func rejectUnsupportedImagesModel(c *gin.Context, model string) bool {
 
 	c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
 		Error: handlers.ErrorDetail{
-			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s, %s, %s, %s, %s, or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, gptImage15Model, defaultImagesToolModel, defaultXAIImagesModel, xaiImagesQualityModel, xaiImages20Model),
+			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s, %s, %s, %s, %s, %s, %s, or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, gptImage15Model, defaultImagesToolModel, gptImage25SunburstModel, gptImage25FlareModel, defaultXAIImagesModel, xaiImagesQualityModel, xaiImages20Model),
 			Type:    "invalid_request_error",
 		},
 	})

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -46,7 +46,7 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 	}
 
 	message := gjson.GetBytes(resp.Body.Bytes(), "error.message").String()
-	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + gptImage15Model + ", " + defaultImagesToolModel + ", " + defaultXAIImagesModel + ", " + xaiImagesQualityModel + ", " + xaiImages20Model + ", or a configured openai-compatibility image model."
+	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + gptImage15Model + ", " + defaultImagesToolModel + ", " + gptImage25SunburstModel + ", " + gptImage25FlareModel + ", " + defaultXAIImagesModel + ", " + xaiImagesQualityModel + ", " + xaiImages20Model + ", or a configured openai-compatibility image model."
 	if message != expectedMessage {
 		t.Fatalf("error message = %q, want %q", message, expectedMessage)
 	}
@@ -56,7 +56,7 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 }
 
 func TestImagesModelValidationAllowsGPTImageAndXAIModels(t *testing.T) {
-	for _, model := range []string{"gpt-image-1.5", "codex/gpt-image-1.5", "gpt-image-2", "codex/gpt-image-2", "grok-imagine-image", "xai/grok-imagine-image", "grok-imagine-image-quality", "xai/grok-imagine-image-quality", "grok-imagine-image-2.0", "xai/grok-imagine-image-2.0"} {
+	for _, model := range []string{"gpt-image-1.5", "codex/gpt-image-1.5", "gpt-image-2", "codex/gpt-image-2", "gpt-image-2.5-sunburst", "codex/gpt-image-2.5-sunburst", "gpt-image-2.5-flare", "codex/gpt-image-2.5-flare", "grok-imagine-image", "xai/grok-imagine-image", "grok-imagine-image-quality", "xai/grok-imagine-image-quality", "grok-imagine-image-2.0", "xai/grok-imagine-image-2.0"} {
 		if !isSupportedImagesModel(model) {
 			t.Fatalf("expected %s to be supported", model)
 		}


### PR DESCRIPTION
Requests for `gpt-image-2.5-sunburst` or `gpt-image-2.5-flare` currently fail local image-model validation even though the Codex OAuth Responses image tool accepts both IDs. Add both as built-in Codex models and allow them on `/v1/images/generations` and `/v1/images/edits`, including prefixed model names. Keep the existing default unchanged.

Tests cover catalog availability and deduplication, endpoint validation, and preservation of the requested tool model for generation and editing.

Validation:
- `go test ./internal/registry ./sdk/api/handlers/openai ./internal/runtime/executor` passed.
- `go build -buildvcs=false -o test-output ./cmd/server` passed; VCS stamping was disabled because of the local worktree environment.
- A temporary server built from this change advertised both IDs through `/v1/models`. Each model returned HTTP 200 and one image from `/v1/images/generations` using copied Codex OAuth credentials, low quality, 1024x1024, and `gpt-image-2-base-model: gpt-6-astra`. The existing service was left running unchanged. Editing is covered by regression tests, not a live image-edit request.

Official model documentation: https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst and https://developers.openai.com/api/docs/models/gpt-image-2.5-flare.
