### PR TITLE
feat: expose provider-specific model capabilities

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -76,6 +76,7 @@ func (s *Server) setupRoutes() {
 		v1.POST("/messages/count_tokens", claudeCodeHandlers.ClaudeCountTokens)
 		v1.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
+		v1.POST("/responses/input_tokens", openaiResponsesHandlers.InputTokens)
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		v1.POST("/alpha/search", s.codexAlphaSearch)
 		v1.POST("/live", s.codexLiveHandler.Handle)
@@ -113,6 +114,7 @@ func (s *Server) setupRoutes() {
 	{
 		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
+		codexDirect.POST("/responses/input_tokens", openaiResponsesHandlers.InputTokens)
 		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		codexDirect.POST("/alpha/search", s.codexAlphaSearch)
 	}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -584,6 +584,11 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 			return
 		}
 
+		if c.Query("capabilities") == "true" {
+			openaiHandler.OpenAIModels(c)
+			return
+		}
+
 		if s != nil && s.cfg != nil && s.cfg.Home.Enabled {
 			s.handleHomeModels(c)
 			return

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -51,6 +51,7 @@ type codexSearchCaptureExecutor struct {
 	refreshCalls int
 	httpCalls    int
 	countCalls   int
+	countPayload []byte
 	beforeReturn func()
 }
 
@@ -76,7 +77,10 @@ func (e *codexSearchCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*
 
 func (e *codexSearchCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
 	e.countCalls++
-	return coreexecutor.Response{Payload: []byte(`{"object":"response.input_tokens","input_tokens":7}`)}, nil
+	if len(e.countPayload) > 0 {
+		return coreexecutor.Response{Payload: e.countPayload}, nil
+	}
+	return coreexecutor.Response{Payload: []byte(`{"response":{"usage":{"input_tokens":7,"output_tokens":0,"total_tokens":7}}}`)}, nil
 }
 
 func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.Auth) error {
@@ -661,6 +665,34 @@ func TestResponsesInputTokensRoute(t *testing.T) {
 	}
 	if got := strings.TrimSpace(rr.Body.String()); got != `{"object":"response.input_tokens","input_tokens":7}` {
 		t.Fatalf("body = %s", got)
+	}
+}
+
+func TestResponsesInputTokensRouteEstimatesPluginZeroCount(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{countPayload: []byte(`{"total_tokens":0}`)}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{ID: "input-token-estimate-auth", Provider: "codex", Status: auth.StatusActive}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: "gpt-5.4"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", strings.NewReader(`{"model":"gpt-5.4","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var body struct {
+		InputTokens int64 `json:"input_tokens"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.InputTokens == 0 {
+		t.Fatalf("input_tokens = 0, want a local estimate; body=%s", rr.Body.String())
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -48,6 +48,7 @@ type codexSearchCaptureExecutor struct {
 	statuses     []int
 	refreshCalls int
 	httpCalls    int
+	countCalls   int
 	beforeReturn func()
 }
 
@@ -72,7 +73,8 @@ func (e *codexSearchCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*
 }
 
 func (e *codexSearchCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, nil
+	e.countCalls++
+	return coreexecutor.Response{Payload: []byte(`{"object":"response.input_tokens","input_tokens":7}`)}, nil
 }
 
 func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.Auth) error {
@@ -630,6 +632,34 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	return NewServer(cfg, authManager, accessManager, configPath, opts...)
+}
+
+func TestResponsesInputTokensRoute(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{ID: "input-token-auth", Provider: "codex", Status: auth.StatusActive}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: "gpt-5.4"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", strings.NewReader(`{"model":"gpt-5.4","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.countCalls != 1 {
+		t.Fatalf("count calls = %d, want 1", executor.countCalls)
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != `{"object":"response.input_tokens","input_tokens":7}` {
+		t.Fatalf("body = %s", got)
+	}
 }
 
 func TestHealthz(t *testing.T) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	claudeHandlers "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
+	openaiHandlers "github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -2255,6 +2257,39 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 		if !found {
 			t.Fatalf("expected hidden model %s in codex catalog", slug)
 		}
+	}
+}
+
+func TestModelsCapabilitiesUsesLocalProviderRegistryWhenHomeEnabled(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "test-home-capability-catalog"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{
+		ID:                  "factory/home-capability-test",
+		ContextLength:       1050000,
+		MaxCompletionTokens: 128000,
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	server := newTestServer(t)
+	server.cfg.Home.Enabled = true
+
+	rr := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rr)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v1/models?capabilities=true", nil)
+	server.unifiedModelsHandler(&openaiHandlers.OpenAIAPIHandler{}, &claudeHandlers.ClaudeCodeAPIHandler{})(ctx)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", rr.Code, rr.Body.String())
+	}
+	var response struct {
+		Object        string `json:"object"`
+		SchemaVersion int    `json:"schema_version"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Object != "model_capability_list" || response.SchemaVersion != 1 {
+		t.Fatalf("response = %#v body=%s", response, rr.Body.String())
 	}
 }
 

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -134,6 +134,7 @@ func pluginModelInfoToRegistryModelInfo(model pluginapi.ModelInfo) *registry.Mod
 		ContextLength:              int(model.ContextLength),
 		MaxCompletionTokens:        int(model.MaxCompletionTokens),
 		SupportedParameters:        cloneStringSlice(model.SupportedParameters),
+		UnsupportedParameters:      cloneStringSlice(model.UnsupportedParameters),
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   pluginThinkingSupportToRegistryThinkingSupport(model.Thinking),
@@ -174,6 +175,7 @@ func registryModelInfoToPluginModelInfo(model *registry.ModelInfo) pluginapi.Mod
 		ContextLength:              int64(model.ContextLength),
 		MaxCompletionTokens:        int64(model.MaxCompletionTokens),
 		SupportedParameters:        cloneStringSlice(model.SupportedParameters),
+		UnsupportedParameters:      cloneStringSlice(model.UnsupportedParameters),
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   registryThinkingSupportToPluginThinkingSupport(model.Thinking),
@@ -195,10 +197,10 @@ func registryThinkingSupportToPluginThinkingSupport(thinking *registry.ThinkingS
 }
 
 func cloneStringSlice(in []string) []string {
-	if len(in) == 0 {
+	if in == nil {
 		return nil
 	}
-	return append([]string(nil), in...)
+	return append([]string{}, in...)
 }
 
 func cloneRegistryModels(in []*registry.ModelInfo) []*registry.ModelInfo {
@@ -213,6 +215,7 @@ func cloneRegistryModels(in []*registry.ModelInfo) []*registry.ModelInfo {
 		copyModel := *model
 		copyModel.SupportedGenerationMethods = cloneStringSlice(model.SupportedGenerationMethods)
 		copyModel.SupportedParameters = cloneStringSlice(model.SupportedParameters)
+		copyModel.UnsupportedParameters = cloneStringSlice(model.UnsupportedParameters)
 		copyModel.SupportedInputModalities = cloneStringSlice(model.SupportedInputModalities)
 		copyModel.SupportedOutputModalities = cloneStringSlice(model.SupportedOutputModalities)
 		if model.Thinking != nil {

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -138,6 +138,7 @@ func pluginModelInfoToRegistryModelInfo(model pluginapi.ModelInfo) *registry.Mod
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   pluginThinkingSupportToRegistryThinkingSupport(model.Thinking),
+		ReasoningSupported:         cloneBoolPointer(model.ReasoningSupported),
 		UserDefined:                model.UserDefined,
 	}
 }
@@ -179,6 +180,7 @@ func registryModelInfoToPluginModelInfo(model *registry.ModelInfo) pluginapi.Mod
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   registryThinkingSupportToPluginThinkingSupport(model.Thinking),
+		ReasoningSupported:         cloneBoolPointer(model.ReasoningSupported),
 		UserDefined:                model.UserDefined,
 	}
 }
@@ -203,6 +205,14 @@ func cloneStringSlice(in []string) []string {
 	return append([]string{}, in...)
 }
 
+func cloneBoolPointer(in *bool) *bool {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
 func cloneRegistryModels(in []*registry.ModelInfo) []*registry.ModelInfo {
 	if len(in) == 0 {
 		return nil
@@ -223,6 +233,7 @@ func cloneRegistryModels(in []*registry.ModelInfo) []*registry.ModelInfo {
 			thinking.Levels = cloneStringSlice(model.Thinking.Levels)
 			copyModel.Thinking = &thinking
 		}
+		copyModel.ReasoningSupported = cloneBoolPointer(model.ReasoningSupported)
 		out = append(out, &copyModel)
 	}
 	return out

--- a/internal/pluginhost/adapters_executors.go
+++ b/internal/pluginhost/adapters_executors.go
@@ -369,6 +369,21 @@ func (h *Host) modelProvider(pluginID string) string {
 	return h.modelProviders[pluginID]
 }
 
+// PluginExecutorProvider returns the provider identity registered by an executor plugin.
+func (h *Host) PluginExecutorProvider(pluginID string) string {
+	if provider := h.modelProvider(pluginID); provider != "" {
+		return provider
+	}
+	for _, record := range h.activeRecords() {
+		if record.id != pluginID || record.plugin.Capabilities.Executor == nil {
+			continue
+		}
+		provider, _ := h.executorProvider(record, record.plugin.Capabilities.Executor)
+		return provider
+	}
+	return ""
+}
+
 type executorAdapter struct {
 	host          *Host
 	pluginID      string

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -92,6 +93,26 @@ func TestPluginModelInfoToRegistryModelInfoPreservesKnownEmptySlices(t *testing.
 	if got.SupportedParameters == nil || got.UnsupportedParameters == nil || got.SupportedInputModalities == nil || got.SupportedOutputModalities == nil {
 		t.Fatalf("known-empty slices became unknown: %#v", got)
 	}
+}
+
+func TestPluginModelInfoTransportsExplicitNonReasoningCapability(t *testing.T) {
+	var model pluginapi.ModelInfo
+	if err := json.Unmarshal([]byte(`{"ID":"plugin/non-reasoning","ReasoningSupported":false}`), &model); err != nil {
+		t.Fatal(err)
+	}
+	got := pluginModelInfoToRegistryModelInfo(model)
+	capability := registry.GetGlobalRegistry()
+	capability.RegisterClient("plugin-explicit-non-reasoning", "plugin", []*registry.ModelInfo{got})
+	t.Cleanup(func() { capability.UnregisterClient("plugin-explicit-non-reasoning") })
+	for _, info := range capability.GetAvailableModelCapabilities() {
+		if info.ID == model.ID && info.Provider == "plugin" {
+			if info.Reasoning == nil || info.Reasoning.Supported {
+				t.Fatalf("reasoning support = %#v, want explicit false", info.Reasoning)
+			}
+			return
+		}
+	}
+	t.Fatal("registered plugin capability missing")
 }
 
 func TestCloneRegistryModelsClonesUnsupportedParameters(t *testing.T) {

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -41,6 +41,7 @@ func TestPluginModelInfoToRegistryModelInfoClonesThinkingAndSlices(t *testing.T)
 		ContextLength:              300,
 		MaxCompletionTokens:        400,
 		SupportedParameters:        []string{"temperature"},
+		UnsupportedParameters:      []string{"top_p"},
 		SupportedInputModalities:   []string{"text"},
 		SupportedOutputModalities:  []string{"image"},
 		Thinking: &pluginapi.ThinkingSupport{
@@ -69,13 +70,36 @@ func TestPluginModelInfoToRegistryModelInfoClonesThinkingAndSlices(t *testing.T)
 
 	model.SupportedGenerationMethods[0] = "mutated"
 	model.SupportedParameters[0] = "mutated"
+	model.UnsupportedParameters[0] = "mutated"
 	model.SupportedInputModalities[0] = "mutated"
 	model.SupportedOutputModalities[0] = "mutated"
 	model.Thinking.Levels[0] = "mutated"
-	if got.SupportedGenerationMethods[0] != "generate" || got.SupportedParameters[0] != "temperature" ||
+	if got.SupportedGenerationMethods[0] != "generate" || got.SupportedParameters[0] != "temperature" || got.UnsupportedParameters[0] != "top_p" ||
 		got.SupportedInputModalities[0] != "text" || got.SupportedOutputModalities[0] != "image" ||
 		got.Thinking.Levels[0] != "low" {
 		t.Fatalf("converted model kept aliases to plugin slices: %#v", got)
+	}
+}
+
+func TestPluginModelInfoToRegistryModelInfoPreservesKnownEmptySlices(t *testing.T) {
+	got := pluginModelInfoToRegistryModelInfo(pluginapi.ModelInfo{
+		ID:                        "known-empty",
+		SupportedParameters:       []string{},
+		UnsupportedParameters:     []string{},
+		SupportedInputModalities:  []string{},
+		SupportedOutputModalities: []string{},
+	})
+	if got.SupportedParameters == nil || got.UnsupportedParameters == nil || got.SupportedInputModalities == nil || got.SupportedOutputModalities == nil {
+		t.Fatalf("known-empty slices became unknown: %#v", got)
+	}
+}
+
+func TestCloneRegistryModelsClonesUnsupportedParameters(t *testing.T) {
+	original := []*registry.ModelInfo{{ID: "model", UnsupportedParameters: []string{"temperature"}}}
+	cloned := cloneRegistryModels(original)
+	original[0].UnsupportedParameters[0] = "mutated"
+	if cloned[0].UnsupportedParameters[0] != "temperature" {
+		t.Fatalf("clone retained unsupported-parameters alias: %#v", cloned[0])
 	}
 }
 
@@ -133,6 +157,7 @@ func TestRegisterModelsRegistersProviderModelsAndClientID(t *testing.T) {
 						ContextLength:              300,
 						MaxCompletionTokens:        400,
 						SupportedParameters:        []string{"temperature"},
+						UnsupportedParameters:      []string{"top_p"},
 						SupportedInputModalities:   []string{"text"},
 						SupportedOutputModalities:  []string{"text"},
 						Thinking: &pluginapi.ThinkingSupport{
@@ -165,7 +190,7 @@ func TestRegisterModelsRegistersProviderModelsAndClientID(t *testing.T) {
 	if model.ID != "model-1" || model.Object != "model" || model.Created != 123 || model.OwnedBy != "owner" || model.Type != "chat" ||
 		model.DisplayName != "Model One" || model.Name != "native-model-1" || model.Version != "v1" || model.Description != "description" ||
 		model.InputTokenLimit != 100 || model.OutputTokenLimit != 200 || model.ContextLength != 300 || model.MaxCompletionTokens != 400 ||
-		model.SupportedGenerationMethods[0] != "generate" || model.SupportedParameters[0] != "temperature" ||
+		model.SupportedGenerationMethods[0] != "generate" || model.SupportedParameters[0] != "temperature" || model.UnsupportedParameters[0] != "top_p" ||
 		model.SupportedInputModalities[0] != "text" || model.SupportedOutputModalities[0] != "text" || !model.UserDefined {
 		t.Fatalf("registered model = %#v, want converted fields", model)
 	}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -928,17 +928,17 @@ func (h *Host) rollbackReplacement(lp *loadedPlugin, item runtimeItemConfig) (ca
 		return capabilityRecord{}, pluginFile{}, false
 	}
 	return capabilityRecord{
-			id:       lp.id,
-			path:     lp.path,
-			version:  lp.version,
-			priority: item.Priority,
-			meta:     plugin.Metadata,
-			plugin:   plugin,
-		}, pluginFile{
-			ID:      lp.id,
-			Path:    lp.path,
-			Version: lp.version,
-		}, true
+		id:       lp.id,
+		path:     lp.path,
+		version:  lp.version,
+		priority: item.Priority,
+		meta:     plugin.Metadata,
+		plugin:   plugin,
+	}, pluginFile{
+		ID:      lp.id,
+		Path:    lp.path,
+		Version: lp.version,
+	}, true
 }
 
 func (h *Host) callRegister(ctx context.Context, lp *loadedPlugin, item runtimeItemConfig) (pluginapi.Plugin, bool) {

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -172,37 +172,43 @@ func codexBuiltinImageModelInfo() *ModelInfo {
 
 func codexBuiltinImage25FlareModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImage25FlareModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 2.5 Flare",
-		Version:     codexBuiltinImage25FlareModelID,
+		ID:                        codexBuiltinImage25FlareModelID,
+		Object:                    "model",
+		Created:                   1704067200, // 2024-01-01
+		OwnedBy:                   "openai",
+		Type:                      "openai",
+		DisplayName:               "GPT Image 2.5 Flare",
+		Version:                   codexBuiltinImage25FlareModelID,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func codexBuiltinImage25SunburstModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImage25SunburstModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 2.5 Sunburst",
-		Version:     codexBuiltinImage25SunburstModelID,
+		ID:                        codexBuiltinImage25SunburstModelID,
+		Object:                    "model",
+		Created:                   1704067200, // 2024-01-01
+		OwnedBy:                   "openai",
+		Type:                      "openai",
+		DisplayName:               "GPT Image 2.5 Sunburst",
+		Version:                   codexBuiltinImage25SunburstModelID,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func codexBuiltinImage25ModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImage25ModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 2.5",
-		Version:     codexBuiltinImage25ModelID,
+		ID:                        codexBuiltinImage25ModelID,
+		Object:                    "model",
+		Created:                   1704067200, // 2024-01-01
+		OwnedBy:                   "openai",
+		Type:                      "openai",
+		DisplayName:               "GPT Image 2.5",
+		Version:                   codexBuiltinImage25ModelID,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -144,25 +144,29 @@ func normalizeAntigravityCapabilityModelID(modelID string) string {
 
 func codexBuiltinImage15ModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImage15ModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 1.5",
-		Version:     codexBuiltinImage15ModelID,
+		ID:                        codexBuiltinImage15ModelID,
+		Object:                    "model",
+		Created:                   1704067200, // 2024-01-01
+		OwnedBy:                   "openai",
+		Type:                      "openai",
+		DisplayName:               "GPT Image 1.5",
+		Version:                   codexBuiltinImage15ModelID,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func codexBuiltinImageModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          codexBuiltinImageModelID,
-		Object:      "model",
-		Created:     1704067200, // 2024-01-01
-		OwnedBy:     "openai",
-		Type:        "openai",
-		DisplayName: "GPT Image 2",
-		Version:     codexBuiltinImageModelID,
+		ID:                        codexBuiltinImageModelID,
+		Object:                    "model",
+		Created:                   1704067200, // 2024-01-01
+		OwnedBy:                   "openai",
+		Type:                      "openai",
+		DisplayName:               "GPT Image 2",
+		Version:                   codexBuiltinImageModelID,
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
@@ -204,79 +208,91 @@ func codexBuiltinImage25ModelInfo() *ModelInfo {
 
 func xaiBuiltinImageModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinImageModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Image",
-		Name:        xaiBuiltinImageModelID,
-		Description: "xAI Grok image generation model.",
+		ID:                        xaiBuiltinImageModelID,
+		Object:                    "model",
+		Created:                   1735689600, // 2025-01-01
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Image",
+		Name:                      xaiBuiltinImageModelID,
+		Description:               "xAI Grok image generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func xaiBuiltinImageQualityModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinImageQualityModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Image Quality",
-		Name:        xaiBuiltinImageQualityModelID,
-		Description: "xAI Grok higher-fidelity image generation model.",
+		ID:                        xaiBuiltinImageQualityModelID,
+		Object:                    "model",
+		Created:                   1735689600, // 2025-01-01
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Image Quality",
+		Name:                      xaiBuiltinImageQualityModelID,
+		Description:               "xAI Grok higher-fidelity image generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func xaiBuiltinImage20ModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinImage20ModelID,
-		Object:      "model",
-		Created:     1786060800, // 2026-08-07
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Image 2.0",
-		Name:        xaiBuiltinImage20ModelID,
-		Description: "xAI Grok image generation model.",
+		ID:                        xaiBuiltinImage20ModelID,
+		Object:                    "model",
+		Created:                   1786060800, // 2026-08-07
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Image 2.0",
+		Name:                      xaiBuiltinImage20ModelID,
+		Description:               "xAI Grok image generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"image"},
 	}
 }
 
 func xaiBuiltinVideoModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinVideoModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Video",
-		Name:        xaiBuiltinVideoModelID,
-		Description: "xAI Grok video generation model.",
+		ID:                        xaiBuiltinVideoModelID,
+		Object:                    "model",
+		Created:                   1735689600, // 2025-01-01
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Video",
+		Name:                      xaiBuiltinVideoModelID,
+		Description:               "xAI Grok video generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"video"},
 	}
 }
 
 func xaiBuiltinVideo15ModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinVideo15ModelID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Video 1.5",
-		Name:        xaiBuiltinVideo15ModelID,
-		Description: "xAI Grok video generation model.",
+		ID:                        xaiBuiltinVideo15ModelID,
+		Object:                    "model",
+		Created:                   1735689600, // 2025-01-01
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Video 1.5",
+		Name:                      xaiBuiltinVideo15ModelID,
+		Description:               "xAI Grok video generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"video"},
 	}
 }
 
 func xaiBuiltinVideo15PreviewModelInfo() *ModelInfo {
 	return &ModelInfo{
-		ID:          xaiBuiltinVideo15PreviewID,
-		Object:      "model",
-		Created:     1735689600, // 2025-01-01
-		OwnedBy:     "xai",
-		Type:        "xai",
-		DisplayName: "Grok Imagine Video 1.5 Preview",
-		Name:        xaiBuiltinVideo15PreviewID,
-		Description: "Compatibility alias for the xAI Grok video generation model.",
+		ID:                        xaiBuiltinVideo15PreviewID,
+		Object:                    "model",
+		Created:                   1735689600, // 2025-01-01
+		OwnedBy:                   "xai",
+		Type:                      "xai",
+		DisplayName:               "Grok Imagine Video 1.5 Preview",
+		Name:                      xaiBuiltinVideo15PreviewID,
+		Description:               "Compatibility alias for the xAI Grok video generation model.",
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"video"},
 	}
 }
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -162,6 +162,9 @@ func TestGeneratedMediaBuiltinsDeclareOutputModalities(t *testing.T) {
 		want  string
 	}{
 		{name: "codex image", model: codexBuiltinImageModelInfo(), want: "image"},
+		{name: "codex image 2.5 flare", model: codexBuiltinImage25FlareModelInfo(), want: "image"},
+		{name: "codex image 2.5 sunburst", model: codexBuiltinImage25SunburstModelInfo(), want: "image"},
+		{name: "codex image 2.5", model: codexBuiltinImage25ModelInfo(), want: "image"},
 		{name: "xai image", model: xaiBuiltinImageModelInfo(), want: "image"},
 		{name: "xai video", model: xaiBuiltinVideoModelInfo(), want: "video"},
 	}

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -154,3 +154,34 @@ func TestWithCodexBuiltinsIncludesImage25Models(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratedMediaBuiltinsDeclareOutputModalities(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *ModelInfo
+		want  string
+	}{
+		{name: "codex image", model: codexBuiltinImageModelInfo(), want: "image"},
+		{name: "xai image", model: xaiBuiltinImageModelInfo(), want: "image"},
+		{name: "xai video", model: xaiBuiltinVideoModelInfo(), want: "video"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.model.SupportedOutputModalities) != 1 || tt.model.SupportedOutputModalities[0] != tt.want {
+				t.Fatalf("output modalities = %#v, want [%s]", tt.model.SupportedOutputModalities, tt.want)
+			}
+		})
+	}
+}
+
+func TestStaticChatModelsDeclareTextModalities(t *testing.T) {
+	for _, id := range []string{"claude-3-5-haiku-20241022", "grok-composer-2.5-fast"} {
+		model := LookupStaticModelInfo(id)
+		if model == nil {
+			t.Fatalf("model %q missing", id)
+		}
+		if len(model.SupportedInputModalities) == 0 || len(model.SupportedOutputModalities) != 1 || model.SupportedOutputModalities[0] != "text" {
+			t.Fatalf("model %q modalities = input %#v output %#v", id, model.SupportedInputModalities, model.SupportedOutputModalities)
+		}
+	}
+}

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -1328,7 +1328,9 @@ func modelCapabilityFromInfo(info *ModelInfo, provider string) ModelCapability {
 			Levels:    []string{},
 		}
 		if info.Thinking != nil {
-			capability.Reasoning.Levels = normalizedCapabilityStrings(info.Thinking.Levels)
+			if levels := normalizedCapabilityStrings(info.Thinking.Levels); len(levels) > 0 {
+				capability.Reasoning.Levels = levels
+			}
 			capability.Reasoning.ZeroAllowed = info.Thinking.ZeroAllowed
 			capability.Reasoning.DynamicAllowed = info.Thinking.DynamicAllowed
 			if info.Thinking.Min > 0 {

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -71,6 +71,8 @@ type ModelInfo struct {
 	// Thinking holds provider-specific reasoning/thinking budget capabilities.
 	// This is optional and currently used for Gemini thinking budget normalization.
 	Thinking *ThinkingSupport `json:"thinking,omitempty"`
+	// ReasoningSupported distinguishes known support from unknown metadata.
+	ReasoningSupported *bool `json:"reasoning_supported,omitempty"`
 
 	// Config holds model-specific runtime overrides loaded from models.json.
 	Config *ModelConfig `json:"config,omitempty"`
@@ -669,6 +671,10 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 			copyThinking.Levels = append([]string(nil), model.Thinking.Levels...)
 		}
 		copyModel.Thinking = &copyThinking
+	}
+	if model.ReasoningSupported != nil {
+		reasoningSupported := *model.ReasoningSupported
+		copyModel.ReasoningSupported = &reasoningSupported
 	}
 	if model.Config != nil {
 		copyConfig := *model.Config
@@ -1312,18 +1318,25 @@ func modelCapabilityFromInfo(info *ModelInfo, provider string) ModelCapability {
 		capability.MaxOutputTokens = intPointer(maxOutputTokens)
 	}
 
-	if info.Thinking != nil {
+	if info.ReasoningSupported != nil || info.Thinking != nil {
+		supported := info.Thinking != nil
+		if info.ReasoningSupported != nil {
+			supported = *info.ReasoningSupported
+		}
 		capability.Reasoning = &ModelReasoningCapability{
-			Supported:      true,
-			Levels:         normalizedCapabilityStrings(info.Thinking.Levels),
-			ZeroAllowed:    info.Thinking.ZeroAllowed,
-			DynamicAllowed: info.Thinking.DynamicAllowed,
+			Supported: supported,
+			Levels:    []string{},
 		}
-		if info.Thinking.Min > 0 {
-			capability.Reasoning.MinTokens = intPointer(info.Thinking.Min)
-		}
-		if info.Thinking.Max > 0 {
-			capability.Reasoning.MaxTokens = intPointer(info.Thinking.Max)
+		if info.Thinking != nil {
+			capability.Reasoning.Levels = normalizedCapabilityStrings(info.Thinking.Levels)
+			capability.Reasoning.ZeroAllowed = info.Thinking.ZeroAllowed
+			capability.Reasoning.DynamicAllowed = info.Thinking.DynamicAllowed
+			if info.Thinking.Min > 0 {
+				capability.Reasoning.MinTokens = intPointer(info.Thinking.Min)
+			}
+			if info.Thinking.Max > 0 {
+				capability.Reasoning.MaxTokens = intPointer(info.Thinking.Max)
+			}
 		}
 	}
 	return capability

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -58,6 +58,8 @@ type ModelInfo struct {
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 	// SupportedParameters lists supported parameters
 	SupportedParameters []string `json:"supported_parameters,omitempty"`
+	// UnsupportedParameters lists request parameters known to be unsupported.
+	UnsupportedParameters []string `json:"unsupported_parameters,omitempty"`
 	// SupportedInputModalities lists supported input modalities (e.g., TEXT, IMAGE, VIDEO, AUDIO)
 	SupportedInputModalities []string `json:"supportedInputModalities,omitempty"`
 	// SupportedOutputModalities lists supported output modalities (e.g., TEXT, IMAGE)
@@ -109,6 +111,30 @@ type ThinkingSupport struct {
 	// Levels defines discrete reasoning effort levels (e.g., "low", "medium", "high").
 	// When set, the model uses level-based reasoning instead of token budgets.
 	Levels []string `json:"levels,omitempty" yaml:"levels,omitempty"`
+}
+
+// ModelCapability describes one provider-specific, routable model.
+// Nil fields are unknown; empty slices are known to have no values.
+type ModelCapability struct {
+	ID                    string                    `json:"id"`
+	Provider              string                    `json:"provider"`
+	ContextWindow         *int                      `json:"context_window"`
+	MaxOutputTokens       *int                      `json:"max_output_tokens"`
+	InputModalities       []string                  `json:"input_modalities"`
+	OutputModalities      []string                  `json:"output_modalities"`
+	Reasoning             *ModelReasoningCapability `json:"reasoning"`
+	SupportedParameters   []string                  `json:"supported_parameters"`
+	UnsupportedParameters []string                  `json:"unsupported_parameters"`
+}
+
+// ModelReasoningCapability describes known reasoning controls for a model.
+type ModelReasoningCapability struct {
+	Supported      bool     `json:"supported"`
+	Levels         []string `json:"levels"`
+	MinTokens      *int     `json:"min_tokens"`
+	MaxTokens      *int     `json:"max_tokens"`
+	ZeroAllowed    bool     `json:"zero_allowed"`
+	DynamicAllowed bool     `json:"dynamic_allowed"`
 }
 
 // ModelRegistration tracks a model's availability
@@ -627,6 +653,9 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 	}
 	if len(model.SupportedParameters) > 0 {
 		copyModel.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+	}
+	if len(model.UnsupportedParameters) > 0 {
+		copyModel.UnsupportedParameters = append([]string(nil), model.UnsupportedParameters...)
 	}
 	if len(model.SupportedInputModalities) > 0 {
 		copyModel.SupportedInputModalities = append([]string(nil), model.SupportedInputModalities...)
@@ -1196,6 +1225,128 @@ func (r *ModelRegistry) GetAvailableModelInfos() []*ModelInfo {
 	return result
 }
 
+// GetAvailableModelCapabilities returns one row per available model/provider pair.
+// Multiple rows may share an ID when more than one provider can route that ID.
+func (r *ModelRegistry) GetAvailableModelCapabilities() []ModelCapability {
+	now := time.Now()
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	result := make([]ModelCapability, 0, len(r.models))
+	for modelID, registration := range r.models {
+		if registration == nil {
+			continue
+		}
+		for provider, count := range registration.Providers {
+			if count <= 0 || !r.modelProviderAvailableLocked(registration, provider, count, now) {
+				continue
+			}
+			info := registration.InfoByProvider[provider]
+			if info == nil {
+				info = &ModelInfo{ID: modelID}
+			}
+			result = append(result, modelCapabilityFromInfo(info, provider))
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ID == result[j].ID {
+			return result[i].Provider < result[j].Provider
+		}
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+func (r *ModelRegistry) modelProviderAvailableLocked(registration *ModelRegistration, provider string, count int, now time.Time) bool {
+	expiredClients := 0
+	for clientID, quotaTime := range registration.QuotaExceededClients {
+		if r.clientProviders[clientID] == provider && quotaTime != nil && now.Before(quotaTime.Add(modelQuotaExceededWindow)) {
+			expiredClients++
+		}
+	}
+
+	cooldownSuspended := 0
+	otherSuspended := 0
+	for clientID, reason := range registration.SuspendedClients {
+		if r.clientProviders[clientID] != provider {
+			continue
+		}
+		if strings.EqualFold(reason, "quota") {
+			cooldownSuspended++
+		} else {
+			otherSuspended++
+		}
+	}
+
+	effectiveClients := count - expiredClients - otherSuspended
+	return effectiveClients > 0 || (count > 0 && (expiredClients > 0 || cooldownSuspended > 0) && otherSuspended == 0)
+}
+
+func modelCapabilityFromInfo(info *ModelInfo, provider string) ModelCapability {
+	capability := ModelCapability{
+		ID:                    strings.TrimSpace(info.ID),
+		Provider:              strings.ToLower(strings.TrimSpace(provider)),
+		InputModalities:       normalizedCapabilityStrings(info.SupportedInputModalities),
+		OutputModalities:      normalizedCapabilityStrings(info.SupportedOutputModalities),
+		SupportedParameters:   normalizedCapabilityStrings(info.SupportedParameters),
+		UnsupportedParameters: normalizedCapabilityStrings(info.UnsupportedParameters),
+	}
+
+	contextWindow := info.MaxContextLength
+	if contextWindow <= 0 {
+		contextWindow = info.ContextLength
+	}
+	if contextWindow <= 0 {
+		contextWindow = info.InputTokenLimit
+	}
+	if contextWindow > 0 {
+		capability.ContextWindow = intPointer(contextWindow)
+	}
+
+	maxOutputTokens := info.MaxCompletionTokens
+	if maxOutputTokens <= 0 {
+		maxOutputTokens = info.OutputTokenLimit
+	}
+	if maxOutputTokens > 0 {
+		capability.MaxOutputTokens = intPointer(maxOutputTokens)
+	}
+
+	if info.Thinking != nil {
+		capability.Reasoning = &ModelReasoningCapability{
+			Supported:      true,
+			Levels:         normalizedCapabilityStrings(info.Thinking.Levels),
+			ZeroAllowed:    info.Thinking.ZeroAllowed,
+			DynamicAllowed: info.Thinking.DynamicAllowed,
+		}
+		if info.Thinking.Min > 0 {
+			capability.Reasoning.MinTokens = intPointer(info.Thinking.Min)
+		}
+		if info.Thinking.Max > 0 {
+			capability.Reasoning.MaxTokens = intPointer(info.Thinking.Max)
+		}
+	}
+	return capability
+}
+
+func normalizedCapabilityStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func intPointer(value int) *int {
+	return &value
+}
+
 func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.Time) ([]map[string]any, time.Time) {
 	models := make([]map[string]any, 0, len(r.models))
 	var expiresAt time.Time
@@ -1488,6 +1639,21 @@ func (r *ModelRegistry) GetModelInfo(modelID, provider string) *ModelInfo {
 		return cloneModelInfo(reg.Info)
 	}
 	return nil
+}
+
+// GetProviderModelInfo returns metadata only when it belongs to the selected provider.
+func (r *ModelRegistry) GetProviderModelInfo(modelID, provider string) *ModelInfo {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return nil
+	}
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	reg := r.models[strings.TrimSpace(modelID)]
+	if reg == nil || reg.Providers[provider] <= 0 || reg.InfoByProvider == nil {
+		return nil
+	}
+	return cloneModelInfo(reg.InfoByProvider[provider])
 }
 
 // convertModelToMap converts ModelInfo to the appropriate format for different handler types

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -156,6 +156,83 @@ func TestGetAvailableModelsIncludesMaxContextLengthOverride(t *testing.T) {
 	}
 }
 
+func TestGetAvailableModelCapabilitiesKeepsProviderSpecificMetadata(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("factory-client", "factory", []*ModelInfo{{
+		ID:                        "shared-model",
+		ContextLength:             1050000,
+		MaxCompletionTokens:       128000,
+		SupportedParameters:       []string{"max_output_tokens", "tools"},
+		UnsupportedParameters:     []string{"temperature", "top_p"},
+		SupportedInputModalities:  []string{"TEXT", "IMAGE"},
+		SupportedOutputModalities: []string{"TEXT"},
+		Thinking:                  &ThinkingSupport{Levels: []string{"low", "HIGH"}},
+	}})
+	r.RegisterClient("cursor-client", "cursor", []*ModelInfo{{
+		ID:                        "shared-model",
+		ContextLength:             256000,
+		MaxCompletionTokens:       64000,
+		SupportedParameters:       []string{},
+		UnsupportedParameters:     []string{},
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"text"},
+	}})
+
+	models := r.GetAvailableModelCapabilities()
+	if len(models) != 2 {
+		t.Fatalf("GetAvailableModelCapabilities() returned %d rows, want 2: %#v", len(models), models)
+	}
+
+	byProvider := make(map[string]ModelCapability, len(models))
+	for _, model := range models {
+		byProvider[model.Provider] = model
+	}
+	factory := byProvider["factory"]
+	if factory.ID != "shared-model" {
+		t.Fatalf("factory row = %#v, want factory/shared-model", factory)
+	}
+	if factory.ContextWindow == nil || *factory.ContextWindow != 1050000 {
+		t.Fatalf("factory context_window = %#v, want 1050000", factory.ContextWindow)
+	}
+	if factory.MaxOutputTokens == nil || *factory.MaxOutputTokens != 128000 {
+		t.Fatalf("factory max_output_tokens = %#v, want 128000", factory.MaxOutputTokens)
+	}
+	if got := factory.UnsupportedParameters; len(got) != 2 || got[0] != "temperature" || got[1] != "top_p" {
+		t.Fatalf("factory unsupported_parameters = %#v", got)
+	}
+	if got := factory.InputModalities; len(got) != 2 || got[0] != "text" || got[1] != "image" {
+		t.Fatalf("factory input_modalities = %#v", got)
+	}
+	if factory.Reasoning == nil || len(factory.Reasoning.Levels) != 2 || factory.Reasoning.Levels[1] != "high" {
+		t.Fatalf("factory reasoning = %#v", factory.Reasoning)
+	}
+
+	cursor := byProvider["cursor"]
+	if cursor.Provider != "cursor" || cursor.ContextWindow == nil || *cursor.ContextWindow != 256000 {
+		t.Fatalf("second row = %#v, want cursor-specific metadata", cursor)
+	}
+	if cursor.Reasoning != nil {
+		t.Fatalf("cursor reasoning = %#v, want nil (unknown)", cursor.Reasoning)
+	}
+	if cursor.SupportedParameters == nil || cursor.UnsupportedParameters == nil {
+		t.Fatalf("known empty parameter lists must remain [], got supported=%#v unsupported=%#v", cursor.SupportedParameters, cursor.UnsupportedParameters)
+	}
+}
+
+func TestGetAvailableModelCapabilitiesUsesNullForUnknownValues(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("unknown-client", "unknown-provider", []*ModelInfo{{ID: "unknown-model"}})
+
+	models := r.GetAvailableModelCapabilities()
+	if len(models) != 1 {
+		t.Fatalf("GetAvailableModelCapabilities() returned %d rows, want 1", len(models))
+	}
+	model := models[0]
+	if model.ContextWindow != nil || model.MaxOutputTokens != nil || model.InputModalities != nil || model.OutputModalities != nil || model.SupportedParameters != nil || model.UnsupportedParameters != nil || model.Reasoning != nil {
+		t.Fatalf("unknown capability fields must remain nil: %#v", model)
+	}
+}
+
 func TestLookupModelInfoReturnsCloneForStaticDefinitions(t *testing.T) {
 	first := LookupModelInfo("claude-sonnet-4-6")
 	if first == nil || first.Thinking == nil || len(first.Thinking.Levels) == 0 {

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -233,6 +233,20 @@ func TestGetAvailableModelCapabilitiesUsesNullForUnknownValues(t *testing.T) {
 	}
 }
 
+func TestStaticKnownNonReasoningCapabilityIsExplicitFalse(t *testing.T) {
+	info := LookupStaticModelInfo("claude-3-5-haiku-20241022")
+	if info == nil {
+		t.Fatal("expected static Claude Haiku model")
+	}
+	capability := modelCapabilityFromInfo(info, "claude")
+	if capability.Reasoning == nil || capability.Reasoning.Supported {
+		t.Fatalf("reasoning = %#v, want explicit supported=false", capability.Reasoning)
+	}
+	if capability.Reasoning.Levels == nil || len(capability.Reasoning.Levels) != 0 {
+		t.Fatalf("reasoning levels = %#v, want known-empty []", capability.Reasoning.Levels)
+	}
+}
+
 func TestLookupModelInfoReturnsCloneForStaticDefinitions(t *testing.T) {
 	first := LookupModelInfo("claude-sonnet-4-6")
 	if first == nil || first.Thinking == nil || len(first.Thinking.Levels) == 0 {

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -247,6 +247,44 @@ func TestStaticKnownNonReasoningCapabilityIsExplicitFalse(t *testing.T) {
 	}
 }
 
+func TestBudgetOnlyReasoningCapabilityUsesKnownEmptyLevels(t *testing.T) {
+	capability := modelCapabilityFromInfo(&ModelInfo{
+		ID:       "budget-only",
+		Thinking: &ThinkingSupport{Min: 1024, Max: 64000},
+	}, "test")
+	if capability.Reasoning == nil || !capability.Reasoning.Supported {
+		t.Fatalf("reasoning = %#v, want supported", capability.Reasoning)
+	}
+	if capability.Reasoning.Levels == nil || len(capability.Reasoning.Levels) != 0 {
+		t.Fatalf("reasoning levels = %#v, want known-empty []", capability.Reasoning.Levels)
+	}
+}
+
+func TestStaticReasoningNormalizationPreservesUnknown(t *testing.T) {
+	known := &ModelInfo{ID: "known", Thinking: &ThinkingSupport{Levels: []string{"low"}}}
+	unknown := &ModelInfo{ID: "unknown"}
+	data := &staticModelsJSON{XAI: []*ModelInfo{known, unknown}}
+	normalizeStaticReasoningCapabilities(data)
+	if known.ReasoningSupported == nil || !*known.ReasoningSupported {
+		t.Fatalf("known reasoning = %#v, want true", known.ReasoningSupported)
+	}
+	if unknown.ReasoningSupported != nil {
+		t.Fatalf("unknown reasoning = %#v, want nil", unknown.ReasoningSupported)
+	}
+}
+
+func TestStaticFixedReasoningModelsAreExplicit(t *testing.T) {
+	for id, want := range map[string]bool{
+		"grok-4.20-0309-reasoning":     true,
+		"grok-4.20-0309-non-reasoning": false,
+	} {
+		info := LookupStaticModelInfo(id)
+		if info == nil || info.ReasoningSupported == nil || *info.ReasoningSupported != want {
+			t.Fatalf("model %q reasoning = %#v, want %t", id, info, want)
+		}
+	}
+}
+
 func TestLookupModelInfoReturnsCloneForStaticDefinitions(t *testing.T) {
 	first := LookupModelInfo("claude-sonnet-4-6")
 	if first == nil || first.Thinking == nil || len(first.Thinking.Levels) == 0 {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -179,6 +179,7 @@ func fetchModelsFromRemote(ctx context.Context) (*staticModelsJSON, string) {
 			log.Warnf("models parse failed from %s: %v", url, err)
 			continue
 		}
+		normalizeStaticReasoningCapabilities(&parsed)
 		if err := validateModelsCatalog(&parsed); err != nil {
 			log.Warnf("models validate failed from %s: %v", url, err)
 			continue
@@ -300,6 +301,7 @@ func loadModelsFromBytes(data []byte, source string) error {
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		return fmt.Errorf("%s: decode models catalog: %w", source, err)
 	}
+	normalizeStaticReasoningCapabilities(&parsed)
 	if err := validateModelsCatalog(&parsed); err != nil {
 		return fmt.Errorf("%s: validate models catalog: %w", source, err)
 	}
@@ -308,6 +310,26 @@ func loadModelsFromBytes(data []byte, source string) error {
 	modelsCatalogStore.data = &parsed
 	modelsCatalogStore.mu.Unlock()
 	return nil
+}
+
+func normalizeStaticReasoningCapabilities(data *staticModelsJSON) {
+	if data == nil {
+		return
+	}
+	sections := [][]*ModelInfo{
+		data.Claude, data.Gemini, data.Vertex, data.AIStudio,
+		data.CodexFree, data.CodexTeam, data.CodexPlus, data.CodexPro,
+		data.Kimi, data.Antigravity, data.XAI,
+	}
+	for _, models := range sections {
+		for _, model := range models {
+			if model == nil || model.ReasoningSupported != nil {
+				continue
+			}
+			supported := model.Thinking != nil
+			model.ReasoningSupported = &supported
+		}
+	}
 }
 
 func getModels() *staticModelsJSON {

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -323,10 +323,10 @@ func normalizeStaticReasoningCapabilities(data *staticModelsJSON) {
 	}
 	for _, models := range sections {
 		for _, model := range models {
-			if model == nil || model.ReasoningSupported != nil {
+			if model == nil || model.ReasoningSupported != nil || model.Thinking == nil {
 				continue
 			}
-			supported := model.Thinking != nil
+			supported := true
 			model.ReasoningSupported = &supported
 		}
 	}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -394,7 +394,14 @@
       "type": "claude",
       "display_name": "Claude 3.5 Haiku",
       "context_length": 128000,
-      "max_completion_tokens": 8192
+      "max_completion_tokens": 8192,
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "gemini": [
@@ -3871,7 +3878,14 @@
       "name": "grok-composer-2.5-fast",
       "description": "xAI Composer 2.5 Fast model for the Responses API.",
       "context_length": 200000,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ]
 }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -395,6 +395,7 @@
       "display_name": "Claude 3.5 Haiku",
       "context_length": 128000,
       "max_completion_tokens": 8192,
+      "reasoning_supported": false,
       "supportedInputModalities": [
         "text",
         "image"
@@ -3610,6 +3611,13 @@
       "description": "GPT-OSS 120B (Medium)",
       "context_length": 114000,
       "max_completion_tokens": 32768,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
       "supportedInputModalities": [
         "text"
       ],
@@ -3691,6 +3699,13 @@
       "description": "Grok Build 0.1 is xAI’s fast coding model trained specifically for agentic software engineering workflows.",
       "context_length": 256000,
       "max_completion_tokens": 256000,
+      "thinking": {
+        "levels": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
       "supportedInputModalities": [
         "text",
         "image"
@@ -3765,6 +3780,7 @@
       "description": "xAI Grok 4.20 0309 reasoning model for the Responses API.",
       "context_length": 2000000,
       "max_completion_tokens": 65536,
+      "reasoning_supported": true,
       "supportedInputModalities": [
         "text",
         "image"
@@ -3784,6 +3800,7 @@
       "description": "xAI Grok 4.20 0309 non-reasoning model for the Responses API.",
       "context_length": 2000000,
       "max_completion_tokens": 65536,
+      "reasoning_supported": false,
       "supportedInputModalities": [
         "text",
         "image"
@@ -3879,6 +3896,7 @@
       "description": "xAI Composer 2.5 Fast model for the Responses API.",
       "context_length": 200000,
       "max_completion_tokens": 32768,
+      "reasoning_supported": false,
       "supportedInputModalities": [
         "text",
         "image"

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -33,17 +33,17 @@ func claudeReplayTestAuth(baseURL string) *cliproxyauth.Auth {
 
 func claudeReplayTestRequest(payload []byte, sessionID string, isCompat bool, source sdktranslator.Format) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
 	return cliproxyexecutor.Request{
-			Model:   "claude-synthetic-4772",
-			Payload: payload,
-			Metadata: map[string]any{
-				claudeReplayResolvedModelInfoKey: &registry.ModelInfo{IsCompat: isCompat},
-			},
-		}, cliproxyexecutor.Options{
-			SourceFormat: source,
-			Metadata: map[string]any{
-				cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
-			},
-		}
+		Model:   "claude-synthetic-4772",
+		Payload: payload,
+		Metadata: map[string]any{
+			claudeReplayResolvedModelInfoKey: &registry.ModelInfo{IsCompat: isCompat},
+		},
+	}, cliproxyexecutor.Options{
+		SourceFormat: source,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+		},
+	}
 }
 
 func TestClaudeThinkingReplayEnabledRequiresCompatClaudeAPIKey(t *testing.T) {

--- a/internal/runtime/executor/codex_executor_instructions_test.go
+++ b/internal/runtime/executor/codex_executor_instructions_test.go
@@ -121,3 +121,17 @@ func TestCodexExecutorCountTokensTreatsNullInstructionsAsEmpty(t *testing.T) {
 		t.Fatalf("token count payload mismatch:\nnull=%s\nempty=%s", string(nullResp.Payload), string(emptyResp.Payload))
 	}
 }
+
+func TestCountCodexInputTokensCountsStringInput(t *testing.T) {
+	enc, err := tokenizerForCodexModel("gpt-5.4")
+	if err != nil {
+		t.Fatalf("tokenizerForCodexModel() error: %v", err)
+	}
+	got, err := countCodexInputTokens(enc, []byte(`{"input":"hello"}`))
+	if err != nil {
+		t.Fatalf("countCodexInputTokens() error: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("countCodexInputTokens() = 0, want a count for string input")
+	}
+}

--- a/internal/runtime/executor/codex_executor_tokens.go
+++ b/internal/runtime/executor/codex_executor_tokens.go
@@ -88,7 +88,11 @@ func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 	}
 
 	inputItems := root.Get("input")
-	if inputItems.IsArray() {
+	if inputItems.Type == gjson.String {
+		if input := strings.TrimSpace(inputItems.String()); input != "" {
+			segments = append(segments, input)
+		}
+	} else if inputItems.IsArray() {
 		arr := inputItems.Array()
 		for i := range arr {
 			item := arr[i]

--- a/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
+++ b/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
@@ -37,12 +37,12 @@ func codexTestAuth(baseURL string) *cliproxyauth.Auth {
 
 func codexTestRequest() (cliproxyexecutor.Request, cliproxyexecutor.Options) {
 	return cliproxyexecutor.Request{
-			Model:   "gpt-5.6-terra",
-			Payload: []byte(`{"model":"gpt-5.6-terra","input":"hello"}`),
-		}, cliproxyexecutor.Options{
-			SourceFormat: sdktranslator.FromString("openai-response"),
-			Stream:       true,
-		}
+		Model:   "gpt-5.6-terra",
+		Payload: []byte(`{"model":"gpt-5.6-terra","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	}
 }
 
 // codexSSEServer streams the supplied event payloads as an HTTP 200 SSE response.
@@ -83,11 +83,11 @@ func codexWebsocketServer(t *testing.T, frames ...string) *httptest.Server {
 
 func codexWebsocketRequest() (cliproxyexecutor.Request, cliproxyexecutor.Options) {
 	return cliproxyexecutor.Request{
-			Model:   "gpt-5.6-terra",
-			Payload: []byte(`{"model":"gpt-5.6-terra","input":[{"type":"message","role":"user","content":"hello"}]}`),
-		}, cliproxyexecutor.Options{
-			SourceFormat: sdktranslator.FromString("openai-response"),
-		}
+		Model:   "gpt-5.6-terra",
+		Payload: []byte(`{"model":"gpt-5.6-terra","input":[{"type":"message","role":"user","content":"hello"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	}
 }
 
 // drainChunks collects every payload and the first error from a stream result.

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -27,6 +27,10 @@ type pluginExecutorFormatResolver interface {
 	PluginExecutorRequestToFormat(string, coreexecutor.Request, coreexecutor.Options) sdktranslator.Format
 }
 
+type pluginExecutorProviderResolver interface {
+	PluginExecutorProvider(string) string
+}
+
 // ExecuteWithAuthManager executes a non-streaming request via the core auth manager.
 // This path is the only supported execution route.
 func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string) ([]byte, http.Header, *interfaces.ErrorMessage) {
@@ -290,32 +294,54 @@ func (h *BaseAPIHandler) pluginExecutorRequest(ctx context.Context, entryProtoco
 }
 
 func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx context.Context, host PluginExecutorHost, executorPluginID, entryProtocol, originalRequestedModel, requestID string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options, *interfaces.ErrorMessage) {
-	if !requestInterceptorsEnabled(h.interceptorHost()) {
-		return req, opts, nil
-	}
-	toFormat := sdktranslator.FromString(entryProtocol)
-	if resolver, ok := host.(pluginExecutorFormatResolver); ok && resolver != nil {
-		if resolved := resolver.PluginExecutorRequestToFormat(executorPluginID, req, opts); resolved != "" {
-			toFormat = resolved
+	if requestInterceptorsEnabled(h.interceptorHost()) {
+		toFormat := sdktranslator.FromString(entryProtocol)
+		if resolver, ok := host.(pluginExecutorFormatResolver); ok && resolver != nil {
+			if resolved := resolver.PluginExecutorRequestToFormat(executorPluginID, req, opts); resolved != "" {
+				toFormat = resolved
+			}
+		}
+		resp := h.applyRequestInterceptorsAfterAuth(ctx, coreexecutor.RequestAfterAuthInterceptRequest{
+			SourceFormat:   opts.SourceFormat,
+			ToFormat:       toFormat,
+			Model:          req.Model,
+			RequestedModel: originalRequestedModel,
+			Stream:         opts.Stream,
+			Headers:        cloneHeader(opts.Headers),
+			Body:           cloneBytes(req.Payload),
+			Metadata:       opts.Metadata,
+		}, requestID, skipPluginID)
+		opts.Headers = mergeRequestInterceptorHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
+		if len(resp.Body) > 0 {
+			req.Payload = cloneBytes(resp.Body)
+			opts.OriginalRequest = cloneBytes(resp.Body)
+		}
+		if resp.Terminate {
+			return req, opts, directTerminationError(resp.StatusCode, resp.ResponseHeaders, resp.ResponseBody)
 		}
 	}
-	resp := h.applyRequestInterceptorsAfterAuth(ctx, coreexecutor.RequestAfterAuthInterceptRequest{
+	provider := executorPluginID
+	if resolver, ok := host.(pluginExecutorProviderResolver); ok && resolver != nil {
+		if resolved := resolver.PluginExecutorProvider(executorPluginID); resolved != "" {
+			provider = resolved
+		}
+	}
+	policyResp := applyModelCapabilityPolicy(coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:       provider,
 		SourceFormat:   opts.SourceFormat,
-		ToFormat:       toFormat,
 		Model:          req.Model,
 		RequestedModel: originalRequestedModel,
 		Stream:         opts.Stream,
 		Headers:        cloneHeader(opts.Headers),
 		Body:           cloneBytes(req.Payload),
 		Metadata:       opts.Metadata,
-	}, requestID, skipPluginID)
-	opts.Headers = mergeRequestInterceptorHeaders(opts.Headers, resp.Headers, resp.ClearHeaders)
-	if len(resp.Body) > 0 {
-		req.Payload = cloneBytes(resp.Body)
-		opts.OriginalRequest = cloneBytes(resp.Body)
+	})
+	if policyResp.Terminate {
+		return req, opts, directTerminationError(policyResp.StatusCode, policyResp.ResponseHeaders, policyResp.ResponseBody)
 	}
-	if resp.Terminate {
-		return req, opts, directTerminationError(resp.StatusCode, resp.ResponseHeaders, resp.ResponseBody)
+	if len(policyResp.Body) > 0 {
+		req.Payload = cloneBytes(policyResp.Body)
+		opts.OriginalRequest = cloneBytes(policyResp.Body)
 	}
 	return req, opts, nil
 }

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -492,11 +492,23 @@ func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context,
 }
 
 func (h *BaseAPIHandler) requestAfterAuthInterceptor(capture *requestAfterAuthCapture, requestID, skipPluginID string) coreexecutor.RequestAfterAuthInterceptor {
-	if !requestInterceptorsEnabled(h.interceptorHost()) {
-		return nil
-	}
 	return func(ctx context.Context, req coreexecutor.RequestAfterAuthInterceptRequest) coreexecutor.RequestAfterAuthInterceptResponse {
-		resp := h.applyRequestInterceptorsAfterAuth(ctx, req, requestID, skipPluginID)
+		resp := coreexecutor.RequestAfterAuthInterceptResponse{}
+		if requestInterceptorsEnabled(h.interceptorHost()) {
+			resp = h.applyRequestInterceptorsAfterAuth(ctx, req, requestID, skipPluginID)
+		}
+		if !resp.Terminate {
+			policyReq := req
+			if len(resp.Body) > 0 {
+				policyReq.Body = cloneBytes(resp.Body)
+			}
+			policyResp := applyModelCapabilityPolicy(policyReq)
+			if policyResp.Terminate {
+				resp = policyResp
+			} else if len(policyResp.Body) > 0 {
+				resp.Body = policyResp.Body
+			}
+		}
 		if capture != nil {
 			capture.record(req, resp)
 		}

--- a/sdk/api/handlers/handlers_model_router_test.go
+++ b/sdk/api/handlers/handlers_model_router_test.go
@@ -87,10 +87,11 @@ func (h *handlerRouterOnlyTestHost) HasModelRouters() bool {
 
 type handlerDirectExecutorRouteHost struct {
 	handlerRouterOnlyTestHost
-	lastPluginID string
-	lastRequest  coreexecutor.Request
-	lastOptions  coreexecutor.Options
-	stream       func(context.Context, string, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error)
+	lastPluginID     string
+	lastRequest      coreexecutor.Request
+	lastOptions      coreexecutor.Options
+	executorProvider string
+	stream           func(context.Context, string, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error)
 }
 
 type handlerSkipAwareDirectExecutorRouteHost struct {
@@ -134,10 +135,18 @@ func (h *handlerDirectExecutorRouteHost) CountPluginExecutor(ctx context.Context
 	return coreexecutor.Response{Payload: []byte("7")}, nil
 }
 
+func (h *handlerDirectExecutorRouteHost) PluginExecutorProvider(pluginID string) string {
+	if h.executorProvider != "" {
+		return h.executorProvider
+	}
+	return pluginID
+}
+
 type handlerDirectExecutorInterceptorHost struct {
 	handlerDirectExecutorRouteHost
 	afterAuthCalled bool
 	afterAuthReq    pluginapi.RequestInterceptRequest
+	afterAuthBody   []byte
 }
 
 func (h *handlerDirectExecutorInterceptorHost) HasRequestInterceptors() bool { return true }
@@ -156,7 +165,11 @@ func (h *handlerDirectExecutorInterceptorHost) InterceptRequestAfterAuth(ctx con
 		headers = make(http.Header)
 	}
 	headers.Set("X-After-Auth", "yes")
-	return pluginapi.RequestInterceptResponse{Headers: headers, Body: []byte(`{"after":true}`)}
+	body := h.afterAuthBody
+	if len(body) == 0 {
+		body = []byte(`{"after":true}`)
+	}
+	return pluginapi.RequestInterceptResponse{Headers: headers, Body: body}
 }
 
 func (h *handlerDirectExecutorInterceptorHost) InterceptResponse(ctx context.Context, req pluginapi.ResponseInterceptRequest) pluginapi.ResponseInterceptResponse {

--- a/sdk/api/handlers/model_capability_policy.go
+++ b/sdk/api/handlers/model_capability_policy.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var removableUnsupportedParameters = map[string]struct{}{
+	"frequency_penalty": {},
+	"presence_penalty":  {},
+	"seed":              {},
+	"stop":              {},
+	"temperature":       {},
+	"top_k":             {},
+	"top_p":             {},
+}
+
+func applyModelCapabilityPolicy(req coreexecutor.RequestAfterAuthInterceptRequest) coreexecutor.RequestAfterAuthInterceptResponse {
+	modelID, info := providerModelInfo(req)
+	if info == nil || len(req.Body) == 0 {
+		return coreexecutor.RequestAfterAuthInterceptResponse{}
+	}
+
+	if limit := modelOutputTokenLimit(info); limit > 0 {
+		for _, field := range outputTokenFields(req.SourceFormat.String()) {
+			value := gjson.GetBytes(req.Body, field.path)
+			if value.Type == gjson.Number && value.Int() > int64(limit) {
+				return capabilityLimitError(req.Provider, modelID, field.parameter, value.Int(), limit)
+			}
+		}
+	}
+	if info.Thinking != nil && len(info.Thinking.Levels) > 0 {
+		if parameter, effort := requestedReasoningEffort(req.SourceFormat.String(), req.Body); effort != "" && !containsCapabilityValue(info.Thinking.Levels, effort) {
+			return capabilityRequestError(
+				"unsupported_reasoning_effort",
+				parameter,
+				fmt.Sprintf("reasoning effort %q is not supported by %s/%s", effort, req.Provider, modelID),
+			)
+		}
+	}
+
+	body := req.Body
+	changed := false
+	for _, parameter := range info.UnsupportedParameters {
+		parameter = strings.ToLower(strings.TrimSpace(parameter))
+		if _, removable := removableUnsupportedParameters[parameter]; !removable {
+			continue
+		}
+		for _, path := range unsupportedParameterPaths(req.SourceFormat.String(), parameter) {
+			if !gjson.GetBytes(body, path).Exists() {
+				continue
+			}
+			updated, errDelete := sjson.DeleteBytes(body, path)
+			if errDelete != nil {
+				continue
+			}
+			body = updated
+			changed = true
+		}
+	}
+	if !changed {
+		return coreexecutor.RequestAfterAuthInterceptResponse{}
+	}
+	return coreexecutor.RequestAfterAuthInterceptResponse{Body: body}
+}
+
+func providerModelInfo(req coreexecutor.RequestAfterAuthInterceptRequest) (string, *registry.ModelInfo) {
+	for _, candidate := range []string{req.Model, req.RequestedModel} {
+		modelID := strings.TrimSpace(thinking.ParseSuffix(candidate).ModelName)
+		if modelID == "" {
+			continue
+		}
+		if info := registry.GetGlobalRegistry().GetProviderModelInfo(modelID, req.Provider); info != nil {
+			return modelID, info
+		}
+	}
+	return "", nil
+}
+
+func modelOutputTokenLimit(info *registry.ModelInfo) int {
+	if info.MaxCompletionTokens > 0 {
+		return info.MaxCompletionTokens
+	}
+	return info.OutputTokenLimit
+}
+
+type outputTokenField struct {
+	parameter string
+	path      string
+}
+
+func outputTokenFields(sourceFormat string) []outputTokenField {
+	switch strings.ToLower(strings.TrimSpace(sourceFormat)) {
+	case "openai", "openai-response", "responses":
+		return []outputTokenField{
+			{parameter: "max_output_tokens", path: "max_output_tokens"},
+			{parameter: "max_completion_tokens", path: "max_completion_tokens"},
+			{parameter: "max_tokens", path: "max_tokens"},
+		}
+	case "claude":
+		return []outputTokenField{{parameter: "max_tokens", path: "max_tokens"}}
+	case "gemini":
+		return []outputTokenField{
+			{parameter: "max_output_tokens", path: "generationConfig.maxOutputTokens"},
+			{parameter: "max_output_tokens", path: "generation_config.max_output_tokens"},
+		}
+	default:
+		return nil
+	}
+}
+
+func unsupportedParameterPaths(sourceFormat, parameter string) []string {
+	switch strings.ToLower(strings.TrimSpace(sourceFormat)) {
+	case "openai", "openai-response", "responses", "claude":
+		return []string{parameter}
+	case "gemini":
+		switch parameter {
+		case "frequency_penalty":
+			return []string{"generationConfig.frequencyPenalty", "generation_config.frequency_penalty"}
+		case "presence_penalty":
+			return []string{"generationConfig.presencePenalty", "generation_config.presence_penalty"}
+		case "stop":
+			return []string{"generationConfig.stopSequences", "generation_config.stop_sequences"}
+		case "top_p":
+			return []string{"generationConfig.topP", "generation_config.top_p"}
+		case "top_k":
+			return []string{"generationConfig.topK", "generation_config.top_k"}
+		default:
+			return []string{"generationConfig." + parameter, "generation_config." + parameter}
+		}
+	default:
+		return nil
+	}
+}
+
+func requestedReasoningEffort(sourceFormat string, body []byte) (string, string) {
+	var paths []string
+	switch strings.ToLower(strings.TrimSpace(sourceFormat)) {
+	case "openai-response", "responses":
+		paths = []string{"reasoning.effort", "reasoning_effort"}
+	case "openai":
+		paths = []string{"reasoning_effort", "reasoning.effort"}
+	case "gemini":
+		paths = []string{"generationConfig.thinkingConfig.thinkingLevel", "generation_config.thinking_config.thinking_level"}
+	default:
+		return "", ""
+	}
+	for _, path := range paths {
+		value := gjson.GetBytes(body, path)
+		if value.Type == gjson.String && strings.TrimSpace(value.String()) != "" {
+			return path, strings.ToLower(strings.TrimSpace(value.String()))
+		}
+	}
+	return "", ""
+}
+
+func containsCapabilityValue(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func capabilityLimitError(provider, model, parameter string, requested int64, limit int) coreexecutor.RequestAfterAuthInterceptResponse {
+	return capabilityRequestError(
+		"max_output_tokens_exceeded",
+		parameter,
+		fmt.Sprintf("%s %d exceeds the %s/%s limit of %d", parameter, requested, provider, model, limit),
+	)
+}
+
+func capabilityRequestError(code, parameter, message string) coreexecutor.RequestAfterAuthInterceptResponse {
+	body, _ := json.Marshal(map[string]any{
+		"error": map[string]any{
+			"message": message,
+			"type":    "invalid_request_error",
+			"param":   parameter,
+			"code":    code,
+		},
+	})
+	return coreexecutor.RequestAfterAuthInterceptResponse{
+		Terminate:       true,
+		StatusCode:      http.StatusBadRequest,
+		ResponseHeaders: http.Header{"Content-Type": []string{"application/json"}},
+		ResponseBody:    body,
+	}
+}

--- a/sdk/api/handlers/model_capability_policy_test.go
+++ b/sdk/api/handlers/model_capability_policy_test.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestModelCapabilityPolicyRejectsExcessiveOutputAfterProviderSelection(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const modelID = "shared-capability-policy-model"
+	modelRegistry.RegisterClient("policy-factory-client", "factory", []*registry.ModelInfo{{ID: modelID, MaxCompletionTokens: 100}})
+	modelRegistry.RegisterClient("policy-cursor-client", "cursor", []*registry.ModelInfo{{ID: modelID, MaxCompletionTokens: 200}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("policy-factory-client")
+		modelRegistry.UnregisterClient("policy-cursor-client")
+	})
+
+	interceptor := (&BaseAPIHandler{}).requestAfterAuthInterceptor(nil, "request-1", "")
+	if interceptor == nil {
+		t.Fatal("after-auth interceptor is nil; capability policy would be skipped")
+	}
+	resp := interceptor(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         []byte(`{"model":"shared-capability-policy-model","max_output_tokens":101}`),
+	})
+
+	if !resp.Terminate || resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("response = %#v, want terminating 400", resp)
+	}
+	var body struct {
+		Error struct {
+			Code  string `json:"code"`
+			Param string `json:"param"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(resp.ResponseBody, &body); err != nil {
+		t.Fatalf("decode response body: %v: %s", err, resp.ResponseBody)
+	}
+	if body.Error.Code != "max_output_tokens_exceeded" || body.Error.Param != "max_output_tokens" {
+		t.Fatalf("error = %#v", body.Error)
+	}
+}
+
+func TestModelCapabilityPolicyRemovesOnlyExplicitlyUnsupportedSamplingParameters(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-unsupported-client"
+	const modelID = "factory/policy-unsupported-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{
+		{
+			ID:                    modelID,
+			MaxCompletionTokens:   100,
+			UnsupportedParameters: []string{"temperature", "top_p", "tools"},
+		},
+	})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	interceptor := (&BaseAPIHandler{}).requestAfterAuthInterceptor(nil, "request-2", "")
+	original := []byte(`{"model":"factory/policy-unsupported-model","temperature":0.4,"top_p":0.9,"tools":[{"type":"function","function":{"name":"inspect"}}],"input":"hi"}`)
+	resp := interceptor(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         original,
+	})
+
+	if resp.Terminate {
+		t.Fatalf("response unexpectedly terminated: %#v", resp)
+	}
+	if gjson.GetBytes(resp.Body, "temperature").Exists() || gjson.GetBytes(resp.Body, "top_p").Exists() {
+		t.Fatalf("unsupported sampling parameters remain: %s", resp.Body)
+	}
+	if !gjson.GetBytes(resp.Body, "tools").Exists() {
+		t.Fatalf("tool use was stripped: %s", resp.Body)
+	}
+}
+
+func TestModelCapabilityPolicyPassesUnknownMetadataThroughUnchanged(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-unknown-client"
+	const modelID = "unknown/policy-model"
+	modelRegistry.RegisterClient(clientID, "unknown", []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	interceptor := (&BaseAPIHandler{}).requestAfterAuthInterceptor(nil, "request-3", "")
+	original := []byte(`{"model":"unknown/policy-model","temperature":0.4,"max_output_tokens":999999}`)
+	resp := interceptor(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "unknown",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         original,
+	})
+	if resp.Terminate || len(resp.Body) != 0 {
+		t.Fatalf("unknown metadata changed request: %#v", resp)
+	}
+}
+
+func TestModelCapabilityPolicyUsesRequestedModelForAliasedUpstreamModel(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-alias-client"
+	const requestedModel = "factory/policy-alias-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{ID: requestedModel, MaxCompletionTokens: 100}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	resp := applyModelCapabilityPolicy(coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:       "factory",
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		Model:          "upstream-model",
+		RequestedModel: requestedModel,
+		Body:           []byte(`{"model":"upstream-model","max_output_tokens":101}`),
+	})
+	if !resp.Terminate || resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("response = %#v, want terminating 400", resp)
+	}
+}
+
+func TestModelCapabilityPolicyRunsAfterPluginRequestInterceptor(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-order-client"
+	const modelID = "factory/policy-order-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{ID: modelID, MaxCompletionTokens: 100}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		interceptRequestAfterAuth: func(_ context.Context, req pluginapi.RequestInterceptRequest) pluginapi.RequestInterceptResponse {
+			return pluginapi.RequestInterceptResponse{Headers: req.Headers, Body: []byte(`{"max_output_tokens":101}`)}
+		},
+	})
+	resp := handler.requestAfterAuthInterceptor(nil, "request-order", "")(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         []byte(`{"max_output_tokens":50}`),
+	})
+	if !resp.Terminate || resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("response = %#v, want post-interceptor capability 400", resp)
+	}
+}
+
+func TestModelCapabilityPolicyRemovesGeminiSamplingFields(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-gemini-client"
+	const modelID = "factory/policy-gemini-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{
+		{ID: modelID, UnsupportedParameters: []string{"frequency_penalty", "presence_penalty", "stop"}},
+	})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	resp := applyModelCapabilityPolicy(coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("gemini"),
+		Model:        modelID,
+		Body:         []byte(`{"generationConfig":{"frequencyPenalty":1,"presencePenalty":1,"stopSequences":["stop"]}}`),
+	})
+	if resp.Terminate || gjson.GetBytes(resp.Body, "generationConfig.frequencyPenalty").Exists() ||
+		gjson.GetBytes(resp.Body, "generationConfig.presencePenalty").Exists() || gjson.GetBytes(resp.Body, "generationConfig.stopSequences").Exists() {
+		t.Fatalf("Gemini unsupported parameters remain: %s", resp.Body)
+	}
+}
+
+func TestPluginExecutorRouteAppliesModelCapabilityPolicy(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-plugin-executor-client"
+	const modelID = "factory/policy-plugin-executor-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{ID: modelID, MaxCompletionTokens: 50}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	req := coreexecutor.Request{Model: modelID, Payload: []byte(`{"model":"factory/policy-plugin-executor-model","max_output_tokens":51}`)}
+	opts := coreexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+	_, _, errMsg := (&BaseAPIHandler{}).applyRequestInterceptorsAfterPluginExecutorRoute(context.Background(), nil, "factory", "openai-response", modelID, "request-4", req, opts, "")
+	if errMsg == nil || errMsg.StatusCode != http.StatusBadRequest {
+		t.Fatalf("error = %#v, want capability 400", errMsg)
+	}
+}
+
+func TestPluginExecutorRouteUsesRegisteredProviderAndValidatesFinalBody(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-plugin-provider-client"
+	const modelID = "factory/policy-plugin-provider-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{ID: modelID, MaxCompletionTokens: 50}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	host := &handlerDirectExecutorInterceptorHost{
+		handlerDirectExecutorRouteHost: handlerDirectExecutorRouteHost{executorProvider: "factory"},
+		afterAuthBody:                  []byte(`{"max_output_tokens":51}`),
+	}
+	handler := &BaseAPIHandler{}
+	handler.SetPluginHost(host)
+	req := coreexecutor.Request{Model: modelID, Payload: []byte(`{"max_output_tokens":10}`)}
+	opts := coreexecutor.Options{SourceFormat: sdktranslator.FromString("openai-response")}
+	_, _, errMsg := handler.applyRequestInterceptorsAfterPluginExecutorRoute(context.Background(), host, "factory-plugin", "openai-response", modelID, "request-provider", req, opts, "")
+	if errMsg == nil || errMsg.StatusCode != http.StatusBadRequest {
+		t.Fatalf("error = %#v, want post-interceptor capability 400", errMsg)
+	}
+}
+
+func TestModelCapabilityPolicyRejectsUnsupportedReasoningEffort(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "policy-reasoning-client"
+	const modelID = "factory/policy-reasoning-model"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{
+		ID:       modelID,
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "high"}},
+	}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(clientID) })
+
+	interceptor := (&BaseAPIHandler{}).requestAfterAuthInterceptor(nil, "request-5", "")
+	resp := interceptor(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         []byte(`{"model":"factory/policy-reasoning-model","reasoning":{"effort":"medium"}}`),
+	})
+	if !resp.Terminate || resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("response = %#v, want terminating 400", resp)
+	}
+	if gjson.GetBytes(resp.ResponseBody, "error.code").String() != "unsupported_reasoning_effort" || gjson.GetBytes(resp.ResponseBody, "error.param").String() != "reasoning.effort" {
+		t.Fatalf("response body = %s", resp.ResponseBody)
+	}
+
+	valid := interceptor(context.Background(), coreexecutor.RequestAfterAuthInterceptRequest{
+		Provider:     "factory",
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Model:        modelID,
+		Body:         []byte(`{"model":"factory/policy-reasoning-model","reasoning":{"effort":"HIGH"}}`),
+	})
+	if valid.Terminate {
+		t.Fatalf("valid reasoning effort rejected: %#v", valid)
+	}
+}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -64,6 +64,14 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 		c.JSON(http.StatusOK, h.codexClientModelsResponse(clientVersion))
 		return
 	}
+	if c.Query("capabilities") == "true" {
+		c.JSON(http.StatusOK, gin.H{
+			"object":         "model_capability_list",
+			"schema_version": 1,
+			"data":           registry.GetGlobalRegistry().GetAvailableModelCapabilities(),
+		})
+		return
+	}
 
 	// Get all available models
 	allModels := h.Models()

--- a/sdk/api/handlers/openai/openai_models_capabilities_test.go
+++ b/sdk/api/handlers/openai/openai_models_capabilities_test.go
@@ -1,0 +1,93 @@
+package openai
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestOpenAIModelsCapabilitiesReturnsVersionedProviderRows(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	modelRegistry := registry.GetGlobalRegistry()
+	const clientID = "models-capabilities-handler-test-client"
+	modelRegistry.RegisterClient(clientID, "factory", []*registry.ModelInfo{{
+		ID:                        "factory/test-capability-model",
+		ContextLength:             1050000,
+		MaxCompletionTokens:       128000,
+		SupportedParameters:       []string{"tools"},
+		UnsupportedParameters:     []string{"temperature"},
+		SupportedInputModalities:  []string{"text", "image"},
+		SupportedOutputModalities: []string{"text"},
+		Thinking:                  &registry.ThinkingSupport{Levels: []string{"low", "high"}},
+	}})
+	defer modelRegistry.UnregisterClient(clientID)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v1/models?capabilities=true", nil)
+	(&OpenAIAPIHandler{}).OpenAIModels(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Object        string                     `json:"object"`
+		SchemaVersion int                        `json:"schema_version"`
+		Data          []registry.ModelCapability `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Object != "model_capability_list" || response.SchemaVersion != 1 {
+		t.Fatalf("response header = object %q schema %d", response.Object, response.SchemaVersion)
+	}
+	for _, model := range response.Data {
+		if model.ID != "factory/test-capability-model" || model.Provider != "factory" {
+			continue
+		}
+		if model.ContextWindow == nil || *model.ContextWindow != 1050000 || model.MaxOutputTokens == nil || *model.MaxOutputTokens != 128000 {
+			t.Fatalf("capability row has wrong limits: %#v", model)
+		}
+		return
+	}
+	t.Fatalf("factory capability row missing: %#v", response.Data)
+}
+
+func TestModelCapabilitiesV1FixtureDefinesSharedAndUnknownSemantics(t *testing.T) {
+	raw, err := os.ReadFile("testdata/model_capabilities_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		Object        string                     `json:"object"`
+		SchemaVersion int                        `json:"schema_version"`
+		Data          []registry.ModelCapability `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if response.Object != "model_capability_list" || response.SchemaVersion != 1 {
+		t.Fatalf("fixture header = object %q schema %d", response.Object, response.SchemaVersion)
+	}
+	sharedProviders := map[string]bool{}
+	unknownFound := false
+	for _, model := range response.Data {
+		if model.ID == "shared/example-model" {
+			sharedProviders[model.Provider] = true
+		}
+		if model.ID == "unknown/example-model" {
+			unknownFound = model.ContextWindow == nil && model.MaxOutputTokens == nil && model.InputModalities == nil && model.OutputModalities == nil && model.Reasoning == nil && model.SupportedParameters == nil && model.UnsupportedParameters == nil
+		}
+	}
+	if !sharedProviders["provider-a"] || !sharedProviders["provider-b"] {
+		t.Fatalf("fixture must represent shared IDs as separate provider rows: %#v", sharedProviders)
+	}
+	if !unknownFound {
+		t.Fatal("fixture must represent unknown capability fields as null")
+	}
+}

--- a/sdk/api/handlers/openai/openai_models_capabilities_test.go
+++ b/sdk/api/handlers/openai/openai_models_capabilities_test.go
@@ -76,9 +76,13 @@ func TestModelCapabilitiesV1FixtureDefinesSharedAndUnknownSemantics(t *testing.T
 	}
 	sharedProviders := map[string]bool{}
 	unknownFound := false
+	knownNonReasoningFound := false
 	for _, model := range response.Data {
 		if model.ID == "shared/example-model" {
 			sharedProviders[model.Provider] = true
+			if model.Provider == "provider-a" {
+				knownNonReasoningFound = model.Reasoning != nil && !model.Reasoning.Supported && model.Reasoning.Levels != nil && len(model.Reasoning.Levels) == 0
+			}
 		}
 		if model.ID == "unknown/example-model" {
 			unknownFound = model.ContextWindow == nil && model.MaxOutputTokens == nil && model.InputModalities == nil && model.OutputModalities == nil && model.Reasoning == nil && model.SupportedParameters == nil && model.UnsupportedParameters == nil
@@ -89,5 +93,8 @@ func TestModelCapabilitiesV1FixtureDefinesSharedAndUnknownSemantics(t *testing.T
 	}
 	if !unknownFound {
 		t.Fatal("fixture must represent unknown capability fields as null")
+	}
+	if !knownNonReasoningFound {
+		t.Fatal("fixture must represent known non-reasoning as supported=false with empty levels")
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"github.com/tiktoken-go/tokenizer"
 )
 
 func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
@@ -630,8 +631,46 @@ func (h *OpenAIResponsesAPIHandler) InputTokens(c *gin.Context) {
 		return
 	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-	_, _ = c.Writer.Write(resp)
+	if count, ok := responsesInputTokenCount(resp, rawJSON); ok {
+		_, _ = fmt.Fprintf(c.Writer, `{"object":"response.input_tokens","input_tokens":%d}`, count)
+		cliCancel()
+		return
+	}
+	h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("token count response did not include input_tokens")})
 	cliCancel()
+}
+
+func responsesInputTokenCount(response, request []byte) (int64, bool) {
+	var count int64
+	found := false
+	for _, path := range []string{"input_tokens", "response.input_tokens", "usage.input_tokens", "response.usage.input_tokens", "total_tokens"} {
+		if value := gjson.GetBytes(response, path); value.Exists() {
+			count, found = value.Int(), true
+			break
+		}
+	}
+	if count > 0 {
+		return count, true
+	}
+
+	parts := make([]string, 0, 4)
+	for _, path := range []string{"instructions", "input", "tools", "text.format"} {
+		if value := gjson.GetBytes(request, path); value.Exists() && value.Raw != "" && value.Raw != `""` && value.Raw != "[]" && value.Raw != "null" {
+			parts = append(parts, value.Raw)
+		}
+	}
+	if len(parts) == 0 {
+		return count, found
+	}
+	enc, err := tokenizer.Get(tokenizer.O200kBase)
+	if err != nil {
+		return count, found
+	}
+	estimate, err := enc.Count(strings.Join(parts, "\n"))
+	if err != nil {
+		return count, found
+	}
+	return int64(estimate), true
 }
 
 // handleNonStreamingResponse handles non-streaming chat completion responses

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -611,6 +611,29 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	cliCancel()
 }
 
+func (h *OpenAIResponsesAPIHandler) InputTokens(c *gin.Context) {
+	rawJSON, err := handlers.ReadRequestBody(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request: %v", err), Type: "invalid_request_error"},
+		})
+		return
+	}
+
+	c.Header("Content-Type", "application/json")
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	resp, upstreamHeaders, errMsg := h.ExecuteCountWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		cliCancel(errMsg.Error)
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(resp)
+	cliCancel()
+}
+
 // handleNonStreamingResponse handles non-streaming chat completion responses
 // for Gemini models. It selects a client from the pool, sends the request, and
 // aggregates the response before sending it back to the client in OpenAIResponses format.

--- a/sdk/api/handlers/openai/testdata/model_capabilities_v1.json
+++ b/sdk/api/handlers/openai/testdata/model_capabilities_v1.json
@@ -27,7 +27,14 @@
       "max_output_tokens": 32000,
       "input_modalities": ["text"],
       "output_modalities": ["text"],
-      "reasoning": null,
+      "reasoning": {
+        "supported": false,
+        "levels": [],
+        "min_tokens": null,
+        "max_tokens": null,
+        "zero_allowed": false,
+        "dynamic_allowed": false
+      },
       "supported_parameters": [],
       "unsupported_parameters": []
     },

--- a/sdk/api/handlers/openai/testdata/model_capabilities_v1.json
+++ b/sdk/api/handlers/openai/testdata/model_capabilities_v1.json
@@ -1,0 +1,57 @@
+{
+  "object": "model_capability_list",
+  "schema_version": 1,
+  "data": [
+    {
+      "id": "factory/gpt-5.6-luna",
+      "provider": "factory",
+      "context_window": 1050000,
+      "max_output_tokens": 128000,
+      "input_modalities": ["text", "image"],
+      "output_modalities": ["text"],
+      "reasoning": {
+        "supported": true,
+        "levels": ["none", "low", "medium", "high", "xhigh", "max"],
+        "min_tokens": null,
+        "max_tokens": null,
+        "zero_allowed": false,
+        "dynamic_allowed": false
+      },
+      "supported_parameters": ["max_output_tokens", "stream", "tools"],
+      "unsupported_parameters": ["temperature", "top_p"]
+    },
+    {
+      "id": "shared/example-model",
+      "provider": "provider-a",
+      "context_window": 200000,
+      "max_output_tokens": 32000,
+      "input_modalities": ["text"],
+      "output_modalities": ["text"],
+      "reasoning": null,
+      "supported_parameters": [],
+      "unsupported_parameters": []
+    },
+    {
+      "id": "shared/example-model",
+      "provider": "provider-b",
+      "context_window": 128000,
+      "max_output_tokens": 16000,
+      "input_modalities": ["text", "image"],
+      "output_modalities": ["text"],
+      "reasoning": null,
+      "supported_parameters": [],
+      "unsupported_parameters": []
+    },
+    {
+      "id": "unknown/example-model",
+      "provider": "unknown-provider",
+      "context_window": null,
+      "max_output_tokens": null,
+      "input_modalities": null,
+      "output_modalities": null,
+      "reasoning": null,
+      "supported_parameters": null,
+      "unsupported_parameters": null
+    }
+  ]
+}

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -368,6 +368,9 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 	if !auth.NextRefreshAfter.IsZero() && now.Before(auth.NextRefreshAfter) {
 		return auth.NextRefreshAfter, true
 	}
+	if !auth.NextRefreshAfter.IsZero() {
+		return now, true
+	}
 
 	if evaluator, ok := auth.Runtime.(RefreshEvaluator); ok && evaluator != nil {
 		if interval <= 0 {

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -88,6 +88,27 @@ func TestNextRefreshCheckAt_NextRefreshAfterGate(t *testing.T) {
 	}
 }
 
+func TestNextRefreshCheckAt_NextRefreshAfterDue(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	auth := &Auth{
+		ID:               "a1",
+		Provider:         "plugin-provider",
+		NextRefreshAfter: now.Add(-time.Second),
+		Metadata:         map[string]any{"auth_kind": "oauth"},
+	}
+
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	if !ok {
+		t.Fatal("nextRefreshCheckAt() ok = false, want true for due explicit refresh")
+	}
+	if !got.Equal(now) {
+		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, now)
+	}
+	if !(&Manager{}).shouldRefresh(auth, now) {
+		t.Fatal("shouldRefresh() = false, want true for due explicit refresh")
+	}
+}
+
 func TestNextRefreshCheckAt_PreferredInterval_PicksEarliestCandidate(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	expiry := now.Add(20 * time.Minute)

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -330,6 +330,7 @@ func applyRequestAfterAuthInterceptor(ctx context.Context, executor ProviderExec
 	}
 	toFormat := requestToFormat(provider, executor, req, opts)
 	resp := opts.RequestAfterAuthInterceptor(ctx, cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		Provider:       provider,
 		SourceFormat:   opts.SourceFormat,
 		ToFormat:       toFormat,
 		Model:          req.Model,

--- a/sdk/cliproxy/auth/conductor_execution_quota_test.go
+++ b/sdk/cliproxy/auth/conductor_execution_quota_test.go
@@ -211,6 +211,7 @@ func TestSyncMetadataSessionToContext(t *testing.T) {
 }
 
 func TestApplyRequestAfterAuthInterceptorSessionClearing(t *testing.T) {
+	var selectedProvider string
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5.6-luna",
 		Payload: nil,
@@ -224,6 +225,7 @@ func TestApplyRequestAfterAuthInterceptorSessionClearing(t *testing.T) {
 			cliproxyexecutor.ParentSessionIDMetadataKey:    "session:initial-parent",
 		},
 		RequestAfterAuthInterceptor: func(ctx context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			selectedProvider = req.Provider
 			return cliproxyexecutor.RequestAfterAuthInterceptResponse{
 				ClearHeaders: []string{"X-Session-ID"},
 			}
@@ -233,6 +235,9 @@ func TestApplyRequestAfterAuthInterceptorSessionClearing(t *testing.T) {
 	finalReq, finalOpts, err := applyRequestAfterAuthInterceptor(context.Background(), nil, "openai", req, opts, "gpt-5.6-luna")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if selectedProvider != "openai" {
+		t.Fatalf("selected provider = %q, want openai", selectedProvider)
 	}
 	if len(finalOpts.Headers) != 0 {
 		t.Fatalf("headers not cleared: %v", finalOpts.Headers)

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -124,6 +124,9 @@ func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
 	if !a.NextRefreshAfter.IsZero() && now.Before(a.NextRefreshAfter) {
 		return false
 	}
+	if !a.NextRefreshAfter.IsZero() {
+		return true
+	}
 	if evaluator, ok := a.Runtime.(RefreshEvaluator); ok && evaluator != nil {
 		return evaluator.ShouldRefresh(now, a)
 	}

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -541,7 +541,9 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		updated.Runtime = auth.Runtime
 	}
 	updated.LastRefreshedAt = now
-	updated.NextRefreshAfter = time.Time{}
+	if !updated.NextRefreshAfter.After(now) {
+		updated.NextRefreshAfter = time.Time{}
+	}
 	updated.LastError = nil
 	updated.StatusMessage = ""
 	updated.Unavailable = false

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -38,6 +38,38 @@ func (e schedulerProviderTestExecutor) HttpRequest(ctx context.Context, auth *Au
 	return nil, nil
 }
 
+type scheduledRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+	nextRefresh time.Time
+}
+
+func (e scheduledRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	auth.NextRefreshAfter = e.nextRefresh
+	return auth, nil
+}
+
+func TestManager_RefreshAuthPreservesPluginSchedule(t *testing.T) {
+	ctx := context.Background()
+	nextRefresh := time.Now().Add(time.Hour).Truncate(time.Second)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(scheduledRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "factory"},
+		nextRefresh:                   nextRefresh,
+	})
+	auth := &Auth{ID: "scheduled-plugin-refresh", Provider: "factory", Status: StatusActive}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+	if errRefresh != nil {
+		t.Fatalf("refresh auth: %v", errRefresh)
+	}
+	if !refreshed.NextRefreshAfter.Equal(nextRefresh) {
+		t.Fatalf("NextRefreshAfter = %s, want plugin schedule %s", refreshed.NextRefreshAfter, nextRefresh)
+	}
+}
+
 type unauthorizedRefreshTestExecutor struct {
 	schedulerProviderTestExecutor
 }

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -95,6 +95,8 @@ type RequestAfterAuthInterceptor func(context.Context, RequestAfterAuthIntercept
 
 // RequestAfterAuthInterceptRequest describes a selected-auth request before executor translation.
 type RequestAfterAuthInterceptRequest struct {
+	// Provider is the selected credential provider for this execution attempt.
+	Provider string
 	// SourceFormat is the original client protocol format.
 	SourceFormat sdktranslator.Format
 	// ToFormat is the selected upstream protocol format.

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -176,6 +176,8 @@ type ModelInfo struct {
 	SupportedOutputModalities []string
 	// Thinking describes optional reasoning controls for the model.
 	Thinking *ThinkingSupport
+	// ReasoningSupported distinguishes known support from unknown metadata.
+	ReasoningSupported *bool
 	// UserDefined reports whether the model was provided by user configuration.
 	UserDefined bool
 }

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -168,6 +168,8 @@ type ModelInfo struct {
 	MaxCompletionTokens int64
 	// SupportedParameters lists request parameters supported by the model.
 	SupportedParameters []string
+	// UnsupportedParameters lists request parameters known to be unsupported by the model.
+	UnsupportedParameters []string
 	// SupportedInputModalities lists accepted input modality names.
 	SupportedInputModalities []string
 	// SupportedOutputModalities lists produced output modality names.

--- a/sdk/pluginhost/host.go
+++ b/sdk/pluginhost/host.go
@@ -311,6 +311,7 @@ func registryModelToPluginModel(model *internalregistry.ModelInfo) ModelInfo {
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   thinkingSupportToPlugin(model.Thinking),
+		ReasoningSupported:         cloneBoolPointer(model.ReasoningSupported),
 		UserDefined:                model.UserDefined,
 	}
 }
@@ -333,6 +334,14 @@ func cloneStringSlice(in []string) []string {
 		return nil
 	}
 	return append([]string{}, in...)
+}
+
+func cloneBoolPointer(in *bool) *bool {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func cloneStringSliceMap(in map[string][]string) map[string][]string {

--- a/sdk/pluginhost/host.go
+++ b/sdk/pluginhost/host.go
@@ -147,6 +147,14 @@ func (h *Host) ModelsForProvider(provider string) []ModelInfo {
 	return registryModelsToPluginModels(h.inner.ModelsForProvider(provider))
 }
 
+// PluginExecutorProvider returns the provider identity registered by an executor plugin.
+func (h *Host) PluginExecutorProvider(pluginID string) string {
+	if h == nil || h.inner == nil {
+		return ""
+	}
+	return h.inner.PluginExecutorProvider(pluginID)
+}
+
 // RefreshAuth lets plugin auth providers refresh a credential.
 func (h *Host) RefreshAuth(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, bool, error) {
 	if h == nil || h.inner == nil {
@@ -299,6 +307,7 @@ func registryModelToPluginModel(model *internalregistry.ModelInfo) ModelInfo {
 		ContextLength:              int64(model.ContextLength),
 		MaxCompletionTokens:        int64(model.MaxCompletionTokens),
 		SupportedParameters:        cloneStringSlice(model.SupportedParameters),
+		UnsupportedParameters:      cloneStringSlice(model.UnsupportedParameters),
 		SupportedInputModalities:   cloneStringSlice(model.SupportedInputModalities),
 		SupportedOutputModalities:  cloneStringSlice(model.SupportedOutputModalities),
 		Thinking:                   thinkingSupportToPlugin(model.Thinking),
@@ -320,10 +329,10 @@ func thinkingSupportToPlugin(thinking *internalregistry.ThinkingSupport) *Thinki
 }
 
 func cloneStringSlice(in []string) []string {
-	if len(in) == 0 {
+	if in == nil {
 		return nil
 	}
-	return append([]string(nil), in...)
+	return append([]string{}, in...)
 }
 
 func cloneStringSliceMap(in map[string][]string) map[string][]string {


### PR DESCRIPTION
## Summary
- add schema-versioned capabilities output at `GET /v1/models?capabilities=true`
- preserve provider-specific rows for shared model IDs and explicit null/empty semantics
- distinguish supported, unsupported, and unknown reasoning capabilities across core/plugin boundaries
- classify built-in image/video models by output modality
- enforce provider output/reasoning limits after routing and plugin rewrites
- remove only explicitly unsupported optional sampling parameters
- support hot plugin refresh without restarting the proxy
- return canonical, non-zero counts from `/v1/responses/input_tokens`, including string-form Responses input and plugin-backed providers

## Validation
- `gofmt -w .`
- `go test ./...` (7,160 tests across 122 packages)
- `go build -o test-output ./cmd/server`
- Aside sync contract: 39 tests passed against the shared fixture
- deployed commit `e56dbd5` with all plugins rebuilt against the same source
- live capability response: schema v1, 72 provider-specific rows
- live token count smoke tests: Codex `input_tokens: 1`; Factory `input_tokens: 3`
- live Factory completion: HTTP 200 with non-zero usage

The response contract is locked by `sdk/api/handlers/openai/testdata/model_capabilities_v1.json`.