### PR TITLE
fix(xai): omit Responses metadata on subscription HTTP requests

### DIFF
--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -38,6 +38,12 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		return resp, err
 	}
 
+	// Grok Build rejects top-level Responses metadata, including an empty object.
+	// Keep it intact for the official API path and in the original request context.
+	if !xaiUsingAPI(auth) {
+		prepared.body, _ = sjson.DeleteBytes(prepared.body, "metadata")
+	}
+
 	reporter := helps.NewExecutorUsageReporter(ctx, e, prepared.baseModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 	reporter.SetTranslatedReasoningEffort(prepared.body, e.Identifier())

--- a/internal/runtime/executor/xai_executor_metadata_test.go
+++ b/internal/runtime/executor/xai_executor_metadata_test.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestXAIHTTPResponsesMetadata(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, authCase := range []struct {
+			name  string
+			attrs map[string]string
+			strip bool
+		}{
+			{"subscription", map[string]string{"auth_kind": "oauth"}, true},
+			{"oauth_official_api", map[string]string{"auth_kind": "oauth", "using_api": "true"}, false},
+			{"api_key", map[string]string{"auth_kind": "api_key"}, false},
+		} {
+			for _, meta := range []string{"", `,"metadata":{}`, `,"metadata":{"conversation_id":"synthetic"}`} {
+				t.Run(fmt.Sprintf("%s/stream=%t/metadata=%s", authCase.name, stream, meta), func(t *testing.T) {
+					received := make(chan []byte, 1)
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						b, err := io.ReadAll(r.Body)
+						if err != nil {
+							t.Errorf("read body: %v", err)
+							w.WriteHeader(500)
+							return
+						}
+						received <- b
+						if authCase.strip && gjson.GetBytes(b, "metadata").Exists() {
+							w.WriteHeader(400)
+							_, _ = io.WriteString(w, `{"error":{"message":"Argument not supported: metadata"}}`)
+							return
+						}
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_metadata\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"grok-4.6\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"OK\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n")
+					}))
+					defer server.Close()
+					attrs := map[string]string{"base_url": server.URL}
+					for k, v := range authCase.attrs {
+						attrs[k] = v
+					}
+					auth := &cliproxyauth.Auth{ID: "metadata-test", Provider: "xai", Attributes: attrs, Metadata: map[string]any{"access_token": "synthetic-token"}}
+					payload := []byte(`{"model":"grok-4.6","input":[{"role":"user","content":"hello"}],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"metadata":{"type":"string"}}}}]` + meta + `}`)
+					before := bytes.Clone(payload)
+					req := cliproxyexecutor.Request{Model: "grok-4.6", Payload: payload}
+					opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Stream: stream, Metadata: map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "synthetic-session"}}
+					exec := NewXAIExecutor(&config.Config{})
+					if stream {
+						result, err := exec.ExecuteStream(context.Background(), auth, req, opts)
+						if err != nil {
+							t.Fatalf("ExecuteStream: %v", err)
+						}
+						for chunk := range result.Chunks {
+							if chunk.Err != nil {
+								t.Fatalf("stream chunk: %v", chunk.Err)
+							}
+						}
+					} else {
+						if _, err := exec.Execute(context.Background(), auth, req, opts); err != nil {
+							t.Fatalf("Execute: %v", err)
+						}
+					}
+					got := <-received
+					want := gjson.GetBytes(before, "metadata")
+					if authCase.strip {
+						if gjson.GetBytes(got, "metadata").Exists() {
+							t.Fatal("subscription metadata forwarded")
+						}
+					} else if gjson.GetBytes(got, "metadata").Raw != want.Raw {
+						t.Fatal("official API metadata changed")
+					}
+					if !bytes.Equal(payload, before) {
+						t.Fatal("original request mutated")
+					}
+					if opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey] != "synthetic-session" {
+						t.Fatal("local session context changed")
+					}
+					if gjson.GetBytes(got, "prompt_cache_key").String() != "synthetic-session" {
+						t.Fatal("session affinity lost")
+					}
+					if gjson.GetBytes(got, "tools.0.parameters.properties.metadata.type").String() != "string" {
+						t.Fatal("nested metadata schema changed")
+					}
+					if gjson.GetBytes(got, "input.0.content").String() != "hello" {
+						t.Fatal("input changed")
+					}
+				})
+			}
+		}
+	}
+}

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -13,6 +13,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
@@ -30,6 +31,12 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 	prepared, err := e.prepareResponsesRequest(ctx, req, opts, true)
 	if err != nil {
 		return nil, err
+	}
+
+	// Grok Build rejects top-level Responses metadata, including an empty object.
+	// Keep it intact for the official API path and in the original request context.
+	if !xaiUsingAPI(auth) {
+		prepared.body, _ = sjson.DeleteBytes(prepared.body, "metadata")
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, prepared.baseModel, auth)


### PR DESCRIPTION
## Problem and change

Grok subscription HTTP Responses requests fail with `400 Argument not supported: metadata` when top-level metadata is present, even as `{}`. The same request succeeds without it (direct reproduction in #5648).

Remove only top-level metadata after request preparation for the subscription HTTP path (`!xaiUsingAPI(auth)`), in both `Execute` and `ExecuteStream`. The original caller payload and local execution/session metadata remain intact. Official API mode, including OAuth with `using_api=true`, keeps its previous behavior. Nested fields named metadata, such as tool-schema properties, are preserved.

The change is confined to the xAI HTTP executors; it does not modify translator paths, WebSocket/compact transports, authentication, routing, or other providers. It introduces no model-name or deployment-address allowlist. This is a compatibility normalization, not an implementation of upstream metadata storage/retrieval.

Fixes #5648.

## Validation

- `go test ./...` passed.
- `go build -o /tmp/cpa-grok-test-output ./cmd/server` passed.
- `gofmt` and `git diff --cached --check` passed.
- New regression test fails on unmodified dev for populated/empty metadata on both subscription HTTP paths.
- New regression test passes after the fix: 18 cases across streaming/non-streaming, OAuth subscription/OAuth official API/API-key modes, and absent/empty/populated metadata.
- Tests verify original payload preservation, local session context and upstream session affinity, nested metadata schema preservation, and unchanged official API metadata.

The proposed CPA binary has not replaced the production CPA installation. Live reproduction in the issue used v7.2.154; this patch is based on current dev. The test upstream is a local synthetic HTTP server.
