### PR TITLE
fix(streaming): preserve split CRLF in Responses SSE validation

### DIFF
--- a/sdk/api/handlers/handlers_sse_validation_test.go
+++ b/sdk/api/handlers/handlers_sse_validation_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -35,6 +37,53 @@ func TestSSEJSONValidationSplitCRLF(t *testing.T) {
 				t.Fatalf("Finish(): %v", err)
 			}
 			if !bytes.Equal(got, want) {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestSSEJSONValidationPreservesFrameDelimiters(t *testing.T) {
+	const first = `data: {"type":"response.created"}`
+	const second = `data: {"type":"response.completed"}`
+	want := first + "\n\n" + second + "\n\n"
+	for _, ending := range []string{"\r\n", "\n", "\r"} {
+		wire := first + ending + ending + second + ending + ending
+		// Exercise every two-chunk boundary, including valid JSON immediately
+		// before CR, between CR and LF, and between the two delimiter line endings.
+		for split := 1; split < len(wire); split++ {
+			t.Run(fmt.Sprintf("ending=%q/split=%d", ending, split), func(t *testing.T) {
+				state := &sseJSONValidationState{}
+				var output strings.Builder
+				for _, chunk := range []string{wire[:split], wire[split:]} {
+					got, err := state.AddChunk([]byte(chunk))
+					if err != nil {
+						t.Fatal(err)
+					}
+					output.Write(got)
+				}
+				if err := state.Finish(); err != nil {
+					t.Fatal(err)
+				}
+				if got := output.String(); got != want {
+					t.Fatalf("output = %q, want two separate frames %q", got, want)
+				}
+			})
+		}
+		t.Run(fmt.Sprintf("ending=%q/bytewise", ending), func(t *testing.T) {
+			state := &sseJSONValidationState{}
+			var output strings.Builder
+			for i := range len(wire) {
+				got, err := state.AddChunk([]byte(wire[i : i+1]))
+				if err != nil {
+					t.Fatal(err)
+				}
+				output.Write(got)
+			}
+			if err := state.Finish(); err != nil {
+				t.Fatal(err)
+			}
+			if got := output.String(); got != want {
 				t.Fatalf("output = %q, want %q", got, want)
 			}
 		})

--- a/sdk/api/handlers/handlers_sse_validation_test.go
+++ b/sdk/api/handlers/handlers_sse_validation_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSSEJSONValidationSplitCRLF(t *testing.T) {
+	const firstLine = "data: {\"type\":\"response.completed\","
+	const secondLine = "data: \"response\":{\"status\":\"completed\"}}"
+	want := []byte(firstLine + "\n" + secondLine + "\n\n")
+
+	for _, tt := range []struct {
+		name   string
+		chunks []string
+	}{
+		{"unsplit", []string{firstLine + "\r\n" + secondLine + "\r\n\r\n"}},
+		{"split data line", []string{firstLine + "\r", "\n" + secondLine + "\r\n\r\n"}},
+		{"empty chunk between CR and LF", []string{firstLine + "\r", "", "\n" + secondLine + "\r\n\r\n"}},
+		{"LF in its own chunk", []string{firstLine + "\r", "\n", secondLine + "\r\n\r\n"}},
+		{"bare CR", []string{firstLine + "\r", secondLine + "\r\r"}},
+		{"LF", []string{firstLine + "\n", secondLine + "\n\n"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &sseJSONValidationState{}
+			var got []byte
+			for i, chunk := range tt.chunks {
+				output, err := state.AddChunk([]byte(chunk))
+				if err != nil {
+					t.Fatalf("AddChunk(%d): %v", i, err)
+				}
+				got = append(got, output...)
+			}
+			if err := state.Finish(); err != nil {
+				t.Fatalf("Finish(): %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -746,6 +746,7 @@ type sseJSONValidationState struct {
 	pending          []byte
 	pendingErr       error
 	lastChunkEndedCR bool
+	forwarded        bool
 }
 
 func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
@@ -791,11 +792,17 @@ func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
 			return nil, errValidate
 		}
 		output = append(output, frame...)
+		s.forwarded = true
 		copy(s.pending, s.pending[frameEnd:])
 		s.pending = s.pending[:len(s.pending)-frameEnd]
 	}
 
 	if len(bytes.TrimSpace(s.pending)) == 0 {
+		// Once part of a frame has been forwarded, a whitespace-only chunk may
+		// contain its remaining line ending or blank-line delimiter.
+		if s.forwarded {
+			output = append(output, s.pending...)
+		}
 		s.pending = s.pending[:0]
 		return output, nil
 	}
@@ -803,6 +810,7 @@ func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
 	payload = bytes.TrimSpace(payload)
 	if !found || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || json.Valid(payload) {
 		output = append(output, s.pending...)
+		s.forwarded = true
 		s.pending = s.pending[:0]
 	}
 	return output, nil
@@ -810,6 +818,7 @@ func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
 
 func (s *sseJSONValidationState) Finish() error {
 	s.lastChunkEndedCR = false
+	s.forwarded = false
 	if s.pendingErr != nil {
 		errPending := s.pendingErr
 		s.pendingErr = nil

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -743,8 +743,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 }
 
 type sseJSONValidationState struct {
-	pending    []byte
-	pendingErr error
+	pending          []byte
+	pendingErr       error
+	lastChunkEndedCR bool
 }
 
 func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
@@ -755,6 +756,13 @@ func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
 	}
 	if len(chunk) == 0 {
 		return nil, nil
+	}
+	// A CR already normalized by the previous chunk and this LF are one
+	// line ending, not the blank line that terminates an SSE frame.
+	skipLF := s.lastChunkEndedCR && chunk[0] == '\n'
+	s.lastChunkEndedCR = chunk[len(chunk)-1] == '\r'
+	if skipLF {
+		chunk = chunk[1:]
 	}
 	chunk = bytes.ReplaceAll(chunk, []byte("\r\n"), []byte("\n"))
 	chunk = bytes.ReplaceAll(chunk, []byte("\r"), []byte("\n"))
@@ -801,6 +809,7 @@ func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
 }
 
 func (s *sseJSONValidationState) Finish() error {
+	s.lastChunkEndedCR = false
 	if s.pendingErr != nil {
 		errPending := s.pendingErr
 		s.pendingErr = nil


### PR DESCRIPTION
Fixes #5657.

A valid multiline Responses SSE event is rejected when one chunk ends with CR and the next begins with LF. The validator normalizes each chunk independently, turning one CRLF into a blank line and returning `invalid SSE data JSON` before the JSON is complete. The same bytes pass when delivered in one chunk.

Track whether the previous nonempty chunk ended in CR and consume its matching leading LF before normalization. Reset that state on completion. The change is limited to the handler validator and its regression tests.

Validation on `dev` at `b064b832e2427173c2cb171ce42c9606ab8d684f`, Linux amd64 / Go 1.26.1:

- The three fragmented-CRLF regression cases fail before the fix and pass afterward.
- All six cases pass, including unsplit CRLF, an intervening empty chunk, a standalone LF chunk, bare CR, and LF.
- `go test ./sdk/api/handlers/... -count=1` — all four handler packages pass.
- `go build -o test-output ./cmd/server` — passes.
- `gofmt` on both changed files and `git diff --check` — clean.

The reproducer uses synthetic SSE chunks and requires no provider credentials.