### PR TITLE
feat(auth): restrict API keys to configured provider prefixes

### DIFF
--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -22,15 +22,21 @@ func Register(cfg *sdkconfig.SDKConfig) {
 		return
 	}
 
+	p := newProvider(sdkaccess.DefaultAccessProviderName, keys)
+	p.prefixes = make(map[string][]string, len(cfg.APIKeyPrefixes))
+	for key, prefixes := range cfg.APIKeyPrefixes {
+		p.prefixes[strings.TrimSpace(key)] = append([]string(nil), prefixes...)
+	}
 	sdkaccess.RegisterProvider(
 		sdkaccess.AccessProviderTypeConfigAPIKey,
-		newProvider(sdkaccess.DefaultAccessProviderName, keys),
+		p,
 	)
 }
 
 type provider struct {
-	name string
-	keys map[string]struct{}
+	name     string
+	keys     map[string]struct{}
+	prefixes map[string][]string
 }
 
 func newProvider(name string, keys []string) *provider {
@@ -91,8 +97,9 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 		}
 		if _, ok := p.keys[candidate.value]; ok {
 			return &sdkaccess.Result{
-				Provider:  p.Identifier(),
-				Principal: candidate.value,
+				Provider:        p.Identifier(),
+				Principal:       candidate.value,
+				AllowedPrefixes: append([]string(nil), p.prefixes[candidate.value]...),
 				Metadata: map[string]string{
 					"source": candidate.source,
 				},

--- a/internal/api/handlers/management/api_key_prefixes.go
+++ b/internal/api/handlers/management/api_key_prefixes.go
@@ -1,0 +1,66 @@
+package management
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (h *Handler) pruneAPIKeyPrefixes() {
+	keys := make(map[string]struct{}, len(h.cfg.APIKeys))
+	for _, key := range h.cfg.APIKeys {
+		keys[strings.TrimSpace(key)] = struct{}{}
+	}
+	for key := range h.cfg.APIKeyPrefixes {
+		if _, exists := keys[key]; !exists {
+			delete(h.cfg.APIKeyPrefixes, key)
+		}
+	}
+}
+
+// GetAPIKeyPrefixOptions lists configured upstream namespaces, including offline credentials.
+func (h *Handler) GetAPIKeyPrefixOptions(c *gin.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	seen := make(map[string]struct{})
+	add := func(prefix string) {
+		if prefix != "" {
+			seen[prefix] = struct{}{}
+		}
+	}
+	for _, entry := range h.cfg.GeminiKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.InteractionsKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.CodexKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.XAIKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.ClaudeKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.VertexCompatAPIKey {
+		add(entry.Prefix)
+	}
+	for _, entry := range h.cfg.OpenAICompatibility {
+		add(entry.Prefix)
+	}
+	if h.authManager != nil {
+		for _, entry := range h.authManager.List() {
+			if entry != nil {
+				add(entry.Prefix)
+			}
+		}
+	}
+	prefixes := make([]string, 0, len(seen))
+	for prefix := range seen {
+		prefixes = append(prefixes, prefix)
+	}
+	sort.Strings(prefixes)
+	c.JSON(200, gin.H{"prefixes": prefixes})
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -171,7 +171,7 @@ func (h *Handler) PatchAPIKeys(c *gin.Context) {
 	} else if body.Old != nil && body.New != nil {
 		value = strings.TrimSpace(*body.New)
 		for i, key := range h.cfg.APIKeys {
-			if key == *body.Old {
+			if strings.TrimSpace(key) == strings.TrimSpace(*body.Old) {
 				index = i
 				break
 			}
@@ -185,7 +185,7 @@ func (h *Handler) PatchAPIKeys(c *gin.Context) {
 		return
 	}
 	for i, key := range h.cfg.APIKeys {
-		if key == value && i != index {
+		if strings.TrimSpace(key) == value && i != index {
 			c.JSON(400, gin.H{"error": "API key already exists"})
 			return
 		}
@@ -193,7 +193,7 @@ func (h *Handler) PatchAPIKeys(c *gin.Context) {
 	if index < 0 {
 		h.cfg.APIKeys = append(h.cfg.APIKeys, value)
 	} else {
-		old := h.cfg.APIKeys[index]
+		old := strings.TrimSpace(h.cfg.APIKeys[index])
 		h.cfg.APIKeys[index] = value
 		if old != value {
 			if prefixes, exists := h.cfg.APIKeyPrefixes[old]; exists {

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -146,14 +146,70 @@ func (h *Handler) deleteFromStringList(c *gin.Context, target *[]string, after f
 func (h *Handler) GetAPIKeys(c *gin.Context) { c.JSON(200, gin.H{"api-keys": h.cfg.APIKeys}) }
 func (h *Handler) PutAPIKeys(c *gin.Context) {
 	h.putStringList(c, func(v []string) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
 		h.cfg.APIKeys = append([]string(nil), v...)
+		h.pruneAPIKeyPrefixes()
 	}, nil)
 }
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
-	h.patchStringList(c, &h.cfg.APIKeys, func() {})
+	var body struct {
+		Old   *string `json:"old"`
+		New   *string `json:"new"`
+		Index *int    `json:"index"`
+		Value *string `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	index, value := -1, ""
+	if body.Index != nil && body.Value != nil && *body.Index >= 0 && *body.Index < len(h.cfg.APIKeys) {
+		index, value = *body.Index, strings.TrimSpace(*body.Value)
+	} else if body.Old != nil && body.New != nil {
+		value = strings.TrimSpace(*body.New)
+		for i, key := range h.cfg.APIKeys {
+			if key == *body.Old {
+				index = i
+				break
+			}
+		}
+	} else {
+		c.JSON(400, gin.H{"error": "missing fields"})
+		return
+	}
+	if value == "" {
+		c.JSON(400, gin.H{"error": "API key must not be empty"})
+		return
+	}
+	for i, key := range h.cfg.APIKeys {
+		if key == value && i != index {
+			c.JSON(400, gin.H{"error": "API key already exists"})
+			return
+		}
+	}
+	if index < 0 {
+		h.cfg.APIKeys = append(h.cfg.APIKeys, value)
+	} else {
+		old := h.cfg.APIKeys[index]
+		h.cfg.APIKeys[index] = value
+		if old != value {
+			if prefixes, exists := h.cfg.APIKeyPrefixes[old]; exists {
+				h.cfg.APIKeyPrefixes[value] = prefixes
+				delete(h.cfg.APIKeyPrefixes, old)
+			}
+		}
+	}
+	h.persistLocked(c)
 }
 func (h *Handler) DeleteAPIKeys(c *gin.Context) {
-	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {})
+	h.deleteFromStringList(c, &h.cfg.APIKeys, func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		h.pruneAPIKeyPrefixes()
+	})
 }
 
 // gemini-api-key: []GeminiKey

--- a/internal/api/prefix_access.go
+++ b/internal/api/prefix_access.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -35,6 +37,7 @@ func authorizePrefixRequest(c *gin.Context) bool {
 		}
 	}
 	model := ""
+	liveSession := path == "/v1/live" || path == "/v1/realtime" || path == "/v1/realtime/calls"
 	if strings.HasPrefix(path, "/v1beta/models/") {
 		model = strings.TrimPrefix(path, "/v1beta/models/")
 		model, _, _ = strings.Cut(model, ":")
@@ -53,23 +56,45 @@ func authorizePrefixRequest(c *gin.Context) bool {
 		mediaType, params, _ := mime.ParseMediaType(c.GetHeader("Content-Type"))
 		if mediaType == "multipart/form-data" {
 			reader := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+			modelSeen := false
 			for {
 				part, errPart := reader.NextPart()
-				if errPart != nil {
+				if errPart == io.EOF {
 					break
 				}
-				if part.FormName() == "model" {
-					value, errValue := io.ReadAll(io.LimitReader(part, 4096))
-					if errValue == nil {
-						model = string(value)
+				if errPart != nil {
+					c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid multipart body"})
+					return false
+				}
+				if (liveSession && part.FormName() == "session") || (!liveSession && part.FormName() == "model" && part.FileName() == "" && !modelSeen) {
+					value, errValue := io.ReadAll(part)
+					if errValue != nil {
+						_ = part.Close()
+						c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "failed to read multipart field"})
+						return false
 					}
+					model = strings.TrimSpace(string(value))
+					if liveSession {
+						model = prefixLiveModel(value)
+					}
+					modelSeen = true
 				}
 				_ = part.Close()
 			}
+		} else if mediaType == "application/x-www-form-urlencoded" {
+			form, errForm := url.ParseQuery(string(body))
+			if errForm != nil {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid form body"})
+				return false
+			}
+			model = strings.TrimSpace(form.Get("model"))
 		} else {
 			model = gjson.GetBytes(body, "model").String()
 			if model == "" {
 				model = gjson.GetBytes(body, "session.model").String()
+			}
+			if liveSession {
+				model = prefixLiveModel(body)
 			}
 		}
 	}
@@ -87,4 +112,21 @@ func authorizePrefixRequest(c *gin.Context) bool {
 		"type":    "permission_error", "code": "model_not_allowed",
 	}})
 	return false
+}
+
+// Match Codex Live's nested-session precedence and JSON string validation.
+func prefixLiveModel(body []byte) string {
+	var payload struct {
+		Model   string `json:"model"`
+		Session struct {
+			Model string `json:"model"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	if model := strings.TrimSpace(payload.Session.Model); model != "" {
+		return model
+	}
+	return strings.TrimSpace(payload.Model)
 }

--- a/internal/api/prefix_access.go
+++ b/internal/api/prefix_access.go
@@ -73,6 +73,12 @@ func authorizePrefixRequest(c *gin.Context) bool {
 			}
 		}
 	}
+	if path == "/v1beta/interactions" {
+		model = strings.TrimSpace(model)
+		if strings.HasPrefix(model, "models/") && len(model) > len("models/") {
+			model = strings.TrimPrefix(model, "models/")
+		}
+	}
 	if sdkaccess.AllowsModel(c.Request.Context(), model) {
 		return true
 	}

--- a/internal/api/prefix_access.go
+++ b/internal/api/prefix_access.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	codexlive "github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/live"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/tidwall/gjson"
@@ -38,7 +39,12 @@ func authorizePrefixRequest(c *gin.Context) bool {
 	}
 	model := ""
 	liveSession := path == "/v1/live" || path == "/v1/realtime" || path == "/v1/realtime/calls"
-	if strings.HasPrefix(path, "/v1beta/models/") {
+	storedSession, _ := c.Get(codexlive.ClientSecretSessionContextKey)
+	session, _ := storedSession.(json.RawMessage)
+	if liveSession && c.Request.Method == http.MethodPost && len(session) > 0 {
+		// The Live handler replaces the HTTP call's session with the authenticated secret's session.
+		model = prefixLiveModel(session)
+	} else if strings.HasPrefix(path, "/v1beta/models/") {
 		model = strings.TrimPrefix(path, "/v1beta/models/")
 		model, _, _ = strings.Cut(model, ":")
 	} else if c.Request.Method == http.MethodGet && path == "/v1/realtime" {

--- a/internal/api/prefix_access.go
+++ b/internal/api/prefix_access.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	"github.com/tidwall/gjson"
+)
+
+// authorizePrefixRequest checks direct protocol routes as well as shared model execution.
+// Requests without a model cannot establish a namespace and fail closed for restricted keys.
+func authorizePrefixRequest(c *gin.Context) bool {
+	if len(sdkaccess.AllowedPrefixes(c.Request.Context())) == 0 {
+		return true
+	}
+	path := strings.TrimSuffix(c.Request.URL.Path, "/")
+	if strings.Contains(c.FullPath(), ":") {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "resource-only routes are unavailable for prefix-restricted API keys"})
+		return false
+	}
+	if c.Request.Method == http.MethodGet {
+		if path == "/v1/models" || path == "/v1beta/models" {
+			return true
+		}
+		// Responses WebSockets authorize each response.create after resolving inherited models.
+		if path == "/v1/responses" || path == "/backend-api/codex/responses" {
+			return true
+		}
+	}
+	model := ""
+	if strings.HasPrefix(path, "/v1beta/models/") {
+		model = strings.TrimPrefix(path, "/v1beta/models/")
+		model, _, _ = strings.Cut(model, ":")
+	} else if c.Request.Method == http.MethodGet && path == "/v1/realtime" {
+		model = c.Query("model")
+	} else if c.Request.Body != nil {
+		body, errRead := handlers.ReadRequestBody(c)
+		if errRead != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+			return false
+		}
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+		c.Request.ContentLength = int64(len(body))
+		c.Request.Header.Del("Content-Encoding")
+		c.Request.Header.Del("Content-Length")
+		mediaType, params, _ := mime.ParseMediaType(c.GetHeader("Content-Type"))
+		if mediaType == "multipart/form-data" {
+			reader := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+			for {
+				part, errPart := reader.NextPart()
+				if errPart != nil {
+					break
+				}
+				if part.FormName() == "model" {
+					value, errValue := io.ReadAll(io.LimitReader(part, 4096))
+					if errValue == nil {
+						model = string(value)
+					}
+				}
+				_ = part.Close()
+			}
+		} else {
+			model = gjson.GetBytes(body, "model").String()
+			if model == "" {
+				model = gjson.GetBytes(body, "session.model").String()
+			}
+		}
+	}
+	if sdkaccess.AllowsModel(c.Request.Context(), model) {
+		return true
+	}
+	c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{
+		"message": "model is not allowed for this API key; use an authorized prefix/model ID",
+		"type":    "permission_error", "code": "model_not_allowed",
+	}})
+	return false
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -77,6 +77,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.POST("/reset-quota", s.mgmt.ResetQuota)
 
 		mgmt.GET("/api-keys", s.mgmt.GetAPIKeys)
+		mgmt.GET("/api-key-prefix-options", s.mgmt.GetAPIKeyPrefixOptions)
 		mgmt.PUT("/api-keys", s.mgmt.PutAPIKeys)
 		mgmt.PATCH("/api-keys", s.mgmt.PatchAPIKeys)
 		mgmt.DELETE("/api-keys", s.mgmt.DeleteAPIKeys)

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -241,6 +241,7 @@ func realtimeAuthMiddleware(manager *sdkaccess.Manager, handler *codexlive.Handl
 			provider = "realtime-client-secret"
 		}
 		c.Set("userApiKey", principal)
+		c.Set(codexlive.ClientSecretSessionContextKey, authorization.Session)
 		if authorization.IssuerPrincipal != "" && manager != nil {
 			issuerRequest := c.Request.Clone(c.Request.Context())
 			issuerRequest.Header = make(http.Header)
@@ -257,7 +258,6 @@ func realtimeAuthMiddleware(manager *sdkaccess.Manager, handler *codexlive.Handl
 			}
 		}
 		c.Set("accessProvider", provider)
-		c.Set(codexlive.ClientSecretSessionContextKey, authorization.Session)
 		c.Set(codexlive.ClientSecretPrincipalContextKey, authorization.Principal)
 		c.Next()
 	}

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -166,8 +167,23 @@ func accessAuthMiddleware(manager *sdkaccess.Manager, realtimeError bool) gin.Ha
 		result, err := manager.Authenticate(c.Request.Context(), c.Request)
 		if err == nil {
 			if result != nil {
+				initialRequest := c.Request.Clone(c.Request.Context())
+				accessContext := sdkaccess.WithAccessRefresh(c.Request.Context(), func(ctx context.Context) ([]string, *sdkaccess.AuthError) {
+					current, errRefresh := manager.Authenticate(ctx, initialRequest.Clone(ctx))
+					if errRefresh != nil {
+						return nil, errRefresh
+					}
+					if current == nil || current.Principal != result.Principal || current.Provider != result.Provider {
+						return nil, sdkaccess.NewInvalidCredentialError()
+					}
+					return current.AllowedPrefixes, nil
+				})
+				c.Request = c.Request.WithContext(sdkaccess.WithAllowedPrefixes(accessContext, result.AllowedPrefixes))
 				c.Set("userApiKey", result.Principal)
 				c.Set("accessProvider", result.Provider)
+				if !authorizePrefixRequest(c) {
+					return
+				}
 				if len(result.Metadata) > 0 {
 					c.Set("accessMetadata", result.Metadata)
 				}
@@ -225,6 +241,21 @@ func realtimeAuthMiddleware(manager *sdkaccess.Manager, handler *codexlive.Handl
 			provider = "realtime-client-secret"
 		}
 		c.Set("userApiKey", principal)
+		if authorization.IssuerPrincipal != "" && manager != nil {
+			issuerRequest := c.Request.Clone(c.Request.Context())
+			issuerRequest.Header = make(http.Header)
+			issuerRequest.Header.Set("Authorization", "Bearer "+authorization.IssuerPrincipal)
+			issuerRequest.URL.RawQuery = ""
+			result, errIssuer := manager.Authenticate(issuerRequest.Context(), issuerRequest)
+			if errIssuer != nil || result == nil || result.Principal != authorization.IssuerPrincipal {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "client secret issuer is no longer authorized"})
+				return
+			}
+			c.Request = c.Request.WithContext(sdkaccess.WithAllowedPrefixes(c.Request.Context(), result.AllowedPrefixes))
+			if !authorizePrefixRequest(c) {
+				return
+			}
+		}
 		c.Set("accessProvider", provider)
 		c.Set(codexlive.ClientSecretSessionContextKey, authorization.Session)
 		c.Set(codexlive.ClientSecretPrincipalContextKey, authorization.Principal)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/gemini"
@@ -638,7 +639,13 @@ func (s *Server) handleGrokModels(c *gin.Context) {
 	} else {
 		models = grokModelsFromRegistryInfos(registry.GetGlobalRegistry().GetAvailableModelInfos())
 	}
-	c.JSON(http.StatusOK, grokbuild.BuildResponse(models))
+	visible := make([]grokbuild.ModelInfo, 0, len(models))
+	for _, model := range models {
+		if sdkaccess.AllowsModel(c.Request.Context(), model.ID) {
+			visible = append(visible, model)
+		}
+	}
+	c.JSON(http.StatusOK, grokbuild.BuildResponse(visible))
 }
 
 // handleHomeCodexClientModels builds the Codex client catalog from Home model IDs.
@@ -654,7 +661,7 @@ func (s *Server) handleHomeCodexClientModels(c *gin.Context, clientVersion strin
 		models = append(models, formatHomeCodexModel(entry))
 	}
 
-	c.JSON(http.StatusOK, codexmodels.BuildResponseForClient(models, nil, s.cfg.Codex.OptimizeMultiAgentV2, clientVersion))
+	c.JSON(http.StatusOK, codexmodels.BuildResponseForClient(sdkaccess.FilterModels(c.Request.Context(), models), nil, s.cfg.Codex.OptimizeMultiAgentV2, clientVersion))
 }
 
 func formatHomeCodexModel(entry homeModelEntry) map[string]any {
@@ -726,7 +733,7 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 
 	if isClaude {
 		disableCloaking := s.cfg != nil && s.cfg.ClaudeCode.DisableCloakingModelList
-		c.JSON(http.StatusOK, claudemodels.BuildResponse(formatHomeClaudeModels(entries), disableCloaking))
+		c.JSON(http.StatusOK, claudemodels.BuildResponse(sdkaccess.FilterModels(c.Request.Context(), formatHomeClaudeModels(entries)), disableCloaking || len(sdkaccess.AllowedPrefixes(c.Request.Context())) > 0))
 		return
 	}
 
@@ -746,7 +753,7 @@ func (s *Server) handleHomeModels(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   filtered,
+		"data":   sdkaccess.FilterModels(c.Request.Context(), filtered),
 	})
 }
 
@@ -793,7 +800,7 @@ func (s *Server) handleHomeGeminiModels(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"models": formatHomeGeminiModels(entries),
+		"models": sdkaccess.FilterModels(c.Request.Context(), formatHomeGeminiModels(entries)),
 	})
 }
 

--- a/internal/config/api_key_prefixes.go
+++ b/internal/config/api_key_prefixes.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateAPIKeyPrefixes rejects malformed restrictions instead of silently granting access.
+func (cfg *Config) ValidateAPIKeyPrefixes() error {
+	for key, prefixes := range cfg.APIKeyPrefixes {
+		if key == "" || strings.TrimSpace(key) != key {
+			return fmt.Errorf("api-key-prefixes contains an empty or untrimmed API key")
+		}
+		for _, prefix := range prefixes {
+			if prefix == "" || normalizeModelPrefix(prefix) != prefix {
+				return fmt.Errorf("api-key-prefixes requires nonempty normalized prefixes without slashes")
+			}
+		}
+	}
+	return nil
+}

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -88,6 +88,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
+	if errValidate := cfg.ValidateAPIKeyPrefixes(); errValidate != nil {
+		return nil, errValidate
+	}
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
 		return nil, errValidate

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -53,6 +53,7 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 	removeLegacyGenerativeLanguageKeys(original.Content[0])
 
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-excluded-models")
+	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "api-key-prefixes")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-model-alias")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-request-scoped-errors")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "plugins", "configs")

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -42,6 +42,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("parse config payload: %w", err)
 	}
 
+	if errValidate := cfg.ValidateAPIKeyPrefixes(); errValidate != nil {
+		return nil, errValidate
+	}
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
 		return nil, errValidate

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -54,6 +54,9 @@ type SDKConfig struct {
 	// APIKeys is a list of keys for authenticating clients to this proxy server.
 	APIKeys []string `yaml:"api-keys" json:"api-keys"`
 
+	// APIKeyPrefixes limits each client key to existing upstream prefixes. Empty lists allow all prefixes.
+	APIKeyPrefixes map[string][]string `yaml:"api-key-prefixes,omitempty" json:"api-key-prefixes,omitempty"`
+
 	// PassthroughHeaders controls whether upstream response headers are forwarded to downstream clients.
 	// Default is false (disabled).
 	PassthroughHeaders bool `yaml:"passthrough-headers" json:"passthrough-headers"`

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -184,6 +184,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	}
 
 	// API keys (redacted) and counts
+	if !reflect.DeepEqual(oldCfg.APIKeyPrefixes, newCfg.APIKeyPrefixes) {
+		changes = append(changes, "api-key-prefixes: permissions updated (keys redacted)")
+	}
 	if len(oldCfg.APIKeys) != len(newCfg.APIKeys) {
 		changes = append(changes, fmt.Sprintf("api-keys count: %d -> %d", len(oldCfg.APIKeys), len(newCfg.APIKeys)))
 	} else if !reflect.DeepEqual(trimStrings(oldCfg.APIKeys), trimStrings(newCfg.APIKeys)) {

--- a/sdk/access/prefixes.go
+++ b/sdk/access/prefixes.go
@@ -1,0 +1,78 @@
+package access
+
+import (
+	"context"
+	"strings"
+)
+
+type prefixContextKey struct{}
+type accessRefreshContextKey struct{}
+
+// WithAccessRefresh supplies authentication refresh for long-lived client connections.
+func WithAccessRefresh(ctx context.Context, refresh func(context.Context) ([]string, *AuthError)) context.Context {
+	return context.WithValue(ctx, accessRefreshContextKey{}, refresh)
+}
+
+// RefreshAccess checks the current credentials and returns their latest prefix policy.
+func RefreshAccess(ctx context.Context) (context.Context, *AuthError) {
+	if ctx == nil {
+		return ctx, nil
+	}
+	refresh, _ := ctx.Value(accessRefreshContextKey{}).(func(context.Context) ([]string, *AuthError))
+	if refresh == nil {
+		return ctx, nil
+	}
+	prefixes, err := refresh(ctx)
+	if err != nil {
+		return ctx, err
+	}
+	return WithAllowedPrefixes(ctx, prefixes), nil
+}
+
+// WithAllowedPrefixes attaches an immutable client authorization policy to a request.
+func WithAllowedPrefixes(ctx context.Context, prefixes []string) context.Context {
+	return context.WithValue(ctx, prefixContextKey{}, append([]string(nil), prefixes...))
+}
+
+// AllowedPrefixes returns a copy of the client authorization policy.
+func AllowedPrefixes(ctx context.Context) []string {
+	if ctx == nil {
+		return nil
+	}
+	prefixes, _ := ctx.Value(prefixContextKey{}).([]string)
+	return append([]string(nil), prefixes...)
+}
+
+// AllowsModel requires an explicit authorized prefix for restricted clients.
+func AllowsModel(ctx context.Context, model string) bool {
+	prefixes := AllowedPrefixes(ctx)
+	if len(prefixes) == 0 {
+		return true
+	}
+	for _, prefix := range prefixes {
+		prefix = strings.Trim(strings.TrimSpace(prefix), "/")
+		if prefix != "" && strings.HasPrefix(model, prefix+"/") && len(model) > len(prefix)+1 {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterModels preserves model metadata while removing unauthorized model IDs.
+func FilterModels(ctx context.Context, models []map[string]any) []map[string]any {
+	if len(AllowedPrefixes(ctx)) == 0 {
+		return models
+	}
+	filtered := make([]map[string]any, 0, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		if id == "" {
+			id, _ = model["name"].(string)
+			id = strings.TrimPrefix(id, "models/")
+		}
+		if AllowsModel(ctx, id) {
+			filtered = append(filtered, model)
+		}
+	}
+	return filtered
+}

--- a/sdk/access/registry.go
+++ b/sdk/access/registry.go
@@ -15,9 +15,10 @@ type Provider interface {
 
 // Result conveys authentication outcome.
 type Result struct {
-	Provider  string
-	Principal string
-	Metadata  map[string]string
+	Provider        string
+	Principal       string
+	Metadata        map[string]string
+	AllowedPrefixes []string
 }
 
 var (

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	log "github.com/sirupsen/logrus"
@@ -155,8 +156,12 @@ func rewriteClaudeDDModelInBody(rawJSON []byte) []byte {
 // Parameters:
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeModels(c *gin.Context) {
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
 	disableCloaking := h.Cfg != nil && h.Cfg.ClaudeCode.DisableCloakingModelList
-	c.JSON(http.StatusOK, claudemodels.BuildResponse(h.Models(), disableCloaking))
+	c.JSON(http.StatusOK, claudemodels.BuildResponse(sdkaccess.FilterModels(ctx, h.Models()), disableCloaking || len(sdkaccess.AllowedPrefixes(ctx)) > 0))
 }
 
 // handleNonStreamingResponse handles non-streaming content generation requests for Claude models.

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 )
 
@@ -48,7 +49,11 @@ func (h *GeminiAPIHandler) Models() []map[string]any {
 // GeminiModels handles the Gemini models listing endpoint.
 // It returns a JSON response containing available Gemini models and their specifications.
 func (h *GeminiAPIHandler) GeminiModels(c *gin.Context) {
-	rawModels := h.Models()
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	rawModels := sdkaccess.FilterModels(ctx, h.Models())
 	normalizedModels := make([]map[string]any, 0, len(rawModels))
 	defaultMethods := []string{"generateContent"}
 	for _, model := range rawModels {

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
@@ -435,6 +436,7 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 	var requestCtx context.Context
 	if c != nil && c.Request != nil {
 		requestCtx = c.Request.Context()
+		parentCtx = sdkaccess.WithAllowedPrefixes(parentCtx, sdkaccess.AllowedPrefixes(requestCtx))
 	}
 
 	if requestCtx != nil && logging.GetRequestID(parentCtx) == "" {

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -9,6 +9,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -43,6 +44,9 @@ func (h *BaseAPIHandler) executeWithAuthManager(ctx context.Context, handlerType
 }
 
 func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	if !sdkaccess.AllowsModel(ctx, modelName) {
+		return nil, nil, ModelPrefixAccessError()
+	}
 	originalRequestedModel := modelName
 	routeDecision := h.applyModelRouter(ctx, entryProtocol, modelName, rawJSON, false, execOptions)
 	responseProtocol := modelExecutionResponseProtocol(entryProtocol, exitProtocol)
@@ -50,6 +54,9 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 		return nil, nil, errMsg
 	}
 	if routeDecision.ExecutorPluginID != "" {
+		if len(sdkaccess.AllowedPrefixes(ctx)) > 0 {
+			return nil, nil, ModelPrefixAccessError()
+		}
 		return h.executeWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
 	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision, execOptions)
@@ -117,9 +124,15 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 }
 
 func (h *BaseAPIHandler) executeCountWithAuthManager(ctx context.Context, handlerType, modelName string, rawJSON []byte, alt string, execOptions modelExecutionOptions) ([]byte, http.Header, *interfaces.ErrorMessage) {
+	if !sdkaccess.AllowsModel(ctx, modelName) {
+		return nil, nil, ModelPrefixAccessError()
+	}
 	originalRequestedModel := modelName
 	routeDecision := h.applyModelRouter(ctx, handlerType, modelName, rawJSON, false, execOptions)
 	if routeDecision.ExecutorPluginID != "" {
+		if len(sdkaccess.AllowedPrefixes(ctx)) > 0 {
+			return nil, nil, ModelPrefixAccessError()
+		}
 		return h.countWithPluginExecutor(ctx, handlerType, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
 	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, false, routeDecision, execOptions)

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -295,6 +296,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManager(ctx context.Context, handl
 }
 
 func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context, entryProtocol, exitProtocol, modelName string, rawJSON []byte, alt string, allowImageModel bool, execOptions modelExecutionOptions) (<-chan []byte, http.Header, <-chan *interfaces.ErrorMessage) {
+	if !sdkaccess.AllowsModel(ctx, modelName) {
+		errChan := make(chan *interfaces.ErrorMessage, 1)
+		errChan <- ModelPrefixAccessError()
+		close(errChan)
+		return nil, nil, errChan
+	}
 	originalRequestedModel := modelName
 	routeDecision, preparedRoute := preparedModelRouteFromContext(ctx, execOptions.SkipRouterPluginID)
 	if !preparedRoute {
@@ -308,6 +315,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		return nil, nil, errChan
 	}
 	if routeDecision.ExecutorPluginID != "" {
+		if len(sdkaccess.AllowedPrefixes(ctx)) > 0 {
+			errChan := make(chan *interfaces.ErrorMessage, 1)
+			errChan <- ModelPrefixAccessError()
+			close(errChan)
+			return nil, nil, errChan
+		}
 		return h.streamWithPluginExecutor(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, routeDecision.ExecutorPluginID, execOptions)
 	}
 	providers, normalizedModel, errMsg := h.providersForExecution(modelName, originalRequestedModel, allowImageModel, routeDecision, execOptions)

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	responsesconverter "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -61,12 +62,16 @@ func (h *OpenAIAPIHandler) Models() []map[string]any {
 func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 	if _, ok := c.Request.URL.Query()["client_version"]; ok {
 		clientVersion := c.Query("client_version")
-		c.JSON(http.StatusOK, h.codexClientModelsResponse(clientVersion))
+		if len(sdkaccess.AllowedPrefixes(c.Request.Context())) == 0 {
+			c.JSON(http.StatusOK, h.codexClientModelsResponse(clientVersion))
+			return
+		}
+		c.JSON(http.StatusOK, CodexClientModelsResponseForClient(sdkaccess.FilterModels(c.Request.Context(), h.Models()), clientVersion, h.Cfg != nil && h.Cfg.CodexOptimizeMultiAgentV2))
 		return
 	}
 
 	// Get all available models
-	allModels := h.Models()
+	allModels := sdkaccess.FilterModels(c.Request.Context(), h.Models())
 
 	// Filter to only include the 4 required fields: id, object, created, owned_by
 	filteredModels := make([]map[string]any, len(allModels))

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -384,6 +385,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		pinnedAuthID = ""
 	}
 
+	accessContext := c.Request.Context()
 	for {
 		msgType, payload, errReadMessage := conn.ReadMessage()
 		if errReadMessage != nil {
@@ -407,6 +409,14 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		// )
 		wsTimelineLog.BeginRequest()
 		wsTimelineLog.Append("request", payload, time.Now())
+		requestContext, errRefresh := sdkaccess.RefreshAccess(accessContext)
+		if errRefresh != nil {
+			_, _ = writeResponsesWebsocketError(writer, wsTimelineLog, &interfaces.ErrorMessage{
+				StatusCode: errRefresh.HTTPStatusCode(), Error: errRefresh,
+			})
+			return
+		}
+		c.Request = c.Request.WithContext(requestContext)
 
 		explicitRequestModelName := strings.TrimSpace(gjson.GetBytes(payload, "model").String())
 		requestModelName := explicitRequestModelName
@@ -415,6 +425,13 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		}
 		if requestModelName == "" {
 			requestModelName = strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
+		}
+		if !sdkaccess.AllowsModel(c.Request.Context(), requestModelName) {
+			errMsg := handlers.ModelPrefixAccessError()
+			if _, errWrite := writeResponsesWebsocketError(writer, wsTimelineLog, errMsg); errWrite != nil {
+				return
+			}
+			continue
 		}
 		executionParent := context.WithValue(c.Request.Context(), "gin", c)
 		executionParent, routeOverridesModelResolution := h.PrepareStreamModelRoute(

--- a/sdk/api/handlers/prefix_access.go
+++ b/sdk/api/handlers/prefix_access.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+// ModelPrefixAccessError reports a client permission error without upstream quota semantics.
+func ModelPrefixAccessError() *interfaces.ErrorMessage {
+	body, _ := json.Marshal(ErrorResponse{Error: ErrorDetail{
+		Message: "model is not allowed for this API key; use an authorized prefix/model ID",
+		Type:    "permission_error",
+		Code:    "model_not_allowed",
+	}})
+	return &interfaces.ErrorMessage{
+		StatusCode: http.StatusForbidden,
+		Error:      errors.New(string(body)),
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
@@ -58,6 +59,7 @@ type authSelectionEligibility struct {
 	requiredKind     string
 	credentialPolicy string
 	disallowFreeAuth bool
+	allowedPrefixes  []string
 }
 
 func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
@@ -77,7 +79,7 @@ func credentialPolicyFromContext(ctx context.Context) string {
 }
 
 func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecutor.Options) authSelectionEligibility {
-	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata)}
+	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata), allowedPrefixes: sdkaccess.AllowedPrefixes(ctx)}
 	if ctx != nil {
 		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
 		eligibility.credentialPolicy, _ = ctx.Value(credentialPolicyContextKey{}).(string)
@@ -88,6 +90,18 @@ func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecut
 func (e authSelectionEligibility) allows(auth *Auth) bool {
 	if auth == nil {
 		return false
+	}
+	if len(e.allowedPrefixes) > 0 {
+		allowed := false
+		for _, prefix := range e.allowedPrefixes {
+			if strings.Trim(strings.TrimSpace(prefix), "/") != "" && strings.Trim(strings.TrimSpace(prefix), "/") == auth.Prefix {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false
+		}
 	}
 	if e.requiredKind != "" && auth.AuthKind() != e.requiredKind {
 		return false

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -296,6 +296,7 @@ func forceHomeRuntimeConfig(cfg *config.Config) {
 		return
 	}
 	cfg.APIKeys = nil
+	cfg.APIKeyPrefixes = nil
 	cfg.UsageStatisticsEnabled = true
 	cfg.DisableCooling = true
 	cfg.SaveCooldownStatus = false

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -610,6 +610,9 @@ func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix boo
 		}
 		clone := *model
 		clone.ID = trimmedPrefix + "/" + baseID
+		if strings.HasPrefix(clone.Name, "models/") {
+			clone.Name = "models/" + clone.ID
+		}
 		addModel(&clone)
 	}
 	return out


### PR DESCRIPTION
API keys currently share access to all configured upstream prefixes. This adds optional per-key prefix allowlists while preserving unrestricted access for existing keys without a policy.

An API key restricted to `test1` can list and request `test1/model`, while `test2/model` and unprefixed requests are rejected. Empty or omitted allowlists remain unrestricted. Policies are persisted in `config.yaml` through `api-key-prefixes`, without changing the existing `api-keys` string list or adding a group entity.

Authorization covers model catalogs, shared execution and credential selection. Established Responses WebSockets refresh authentication and prefix permissions for each message. Legacy key rename and deletion operations maintain the associated policy. Resource-only routes and direct plugin execution are unavailable to restricted keys when the namespace cannot be established.

Companion frontend branch: https://github.com/githubsyf3527/CLIProxyAPI-PrefixGuard-Management/tree/feat/api-key-prefix-access

Validation:
- Go 1.26 build and existing affected-package tests passed; access, API and Responses handler race checks passed.
- Live catalog checks returned 10 models for one prefix, 16 for the other, and 26 for unrestricted keys across OpenAI, Claude, Codex, Grok and Gemini catalog formats.
- Unauthorized model requests, configuration reload and restart persistence were checked. An established WebSocket reflected grants, revocations and key deletion.
- A user subsequently confirmed a successful non-streaming chat completion using `agnes/agnes-3.0-flash`. Earlier generation checks against other upstreams returned the same quota-exhausted 429 on the original and modified server. Successful SSE generation remains unverified.
- No new automated regression tests are included. Live upstream validation does not cover every provider type.
