### PR TITLE
feat: add GitHub Copilot provider with device login and quota

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -80,6 +80,7 @@ func main() {
 	var oauthCallbackPort int
 	var antigravityLogin bool
 	var kimiLogin bool
+	var copilotLogin bool
 	var xaiLogin bool
 	var vertexImport string
 	var vertexImportPrefix string
@@ -98,6 +99,7 @@ func main() {
 	flag.BoolVar(&noBrowser, "no-browser", false, "Don't open browser automatically for OAuth")
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
+	flag.BoolVar(&copilotLogin, "github-copilot-login", false, "Login to GitHub Copilot using a device code")
 	flag.BoolVar(&kimiLogin, "kimi-login", false, "Login to Kimi using OAuth")
 	flag.BoolVar(&xaiLogin, "xai-login", false, "Login to xAI using OAuth")
 	flag.StringVar(&configPath, "config", DefaultConfigPath, "Configure File Path")
@@ -588,7 +590,7 @@ func main() {
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || copilotLogin || xaiLogin
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -658,6 +660,8 @@ func main() {
 	} else if claudeLogin {
 		// Handle Claude login
 		cmd.DoClaudeLogin(cfg, options)
+	} else if copilotLogin {
+		cmd.DoCopilotLogin(cfg, options)
 	} else if kimiLogin {
 		cmd.DoKimiLogin(cfg, options)
 	} else if xaiLogin {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -706,7 +706,7 @@ nonstream-keepalive-interval: 0
 
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.
-# Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, xai.
+# Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, github-copilot, xai.
 # NOTE: Aliases do not apply to gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, or vertex-api-key.
 # NOTE: Because aliases affect the merged /v1 model list and merged request routing, overlapping
 # client-visible names can become ambiguous across providers. For strict backend pinning, use

--- a/docs/github-copilot.md
+++ b/docs/github-copilot.md
@@ -1,0 +1,37 @@
+# GitHub Copilot
+
+GitHub Copilot accounts can serve models through the existing proxy APIs. This lets people use their Copilot account alongside other providers and see its remaining allowance in the same management interface.
+
+## Sign in
+
+Run the server's device login command:
+
+```sh
+cli-proxy-api --github-copilot-login --config config.yaml
+```
+
+Open the GitHub URL printed in the terminal, enter the device code, and approve access. Add `--no-browser` on a remote machine. The TUI also lists GitHub Copilot in OAuth Login.
+
+The companion management center adds a GitHub Copilot card under OAuth Login. It displays the device code and waits for GitHub approval; no callback URL needs to be pasted. The updated management center must be installed to use this card and its quota display.
+
+Credentials are saved in the configured auth directory. Signing into the same GitHub account updates its existing file. Different accounts participate in the existing credential selection, cooldown, proxy, and refresh mechanisms.
+
+## Models and requests
+
+The provider key is `github-copilot`. Model discovery uses the account's Copilot model catalog instead of a hard-coded list. Only chat models with a supported HTTP endpoint are registered. The executor chooses Chat Completions, Responses, or Messages according to the model's advertised endpoints, then reuses the existing protocol translators and usage accounting.
+
+Existing OAuth model aliases, excluded models, and account prefixes also apply. Use `/v1/models` to find the models available to the connected account. Image generation, Responses compaction, and models available only over WebSocket are not advertised as supported.
+
+GitHub OAuth credentials stay on the server. Inference uses a separate short-lived Copilot token, cached per account and proxy. Concurrent exchanges share one request, and the short-lived token is not written into the credential file.
+
+## Allowance and usage
+
+Quota Management and Auth Files show GitHub's reported allowance, amount used, percentage remaining, unlimited quotas, reset date, and paid-overage status when provided. Quotas are fetched on demand through the authenticated `/v0/management/github-copilot-quota?auth_index=...` endpoint.
+
+Request token usage is recorded through the existing usage system. Copilot allowance is reported in GitHub's own units; it is not converted into an estimated dollar balance. Missing values remain unknown. Exhausted allowances use the existing account cooldown and failover path.
+
+## Compatibility
+
+GitHub's device authorization flow is documented, but the Copilot token, catalog, and quota endpoints are internal interfaces used by its clients. They may change. Available models and allowances depend on the signed-in account and organization policy.
+
+Protocol references: [GitHub device authorization](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow), [Copilot token exchange](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/authentication/node/copilotTokenManager.ts), and [model catalog](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/endpoint/common/endpointProvider.ts).

--- a/internal/api/handlers/management/copilot.go
+++ b/internal/api/handlers/management/copilot.go
@@ -1,0 +1,87 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/copilot"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+func (h *Handler) RequestCopilotToken(c *gin.Context) {
+	client := copilot.NewClient(h.cfg, "")
+	code, err := client.StartDeviceFlow(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	state := "github-copilot-" + uuid.NewString()
+	RegisterOAuthSession(state, copilot.Provider)
+	ctx := PopulateAuthContext(context.Background(), c)
+	go func() {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go watchOAuthSessionCancel(ctx, cancel, state, copilot.Provider)
+		githubToken, errWait := client.WaitForAuthorization(ctx, code)
+		if errWait != nil {
+			if IsOAuthSessionPending(state, copilot.Provider) {
+				SetOAuthSessionError(state, errWait.Error())
+			}
+			return
+		}
+		metadata, errLogin := client.Login(ctx, githubToken)
+		if errLogin != nil {
+			if IsOAuthSessionPending(state, copilot.Provider) {
+				SetOAuthSessionError(state, errLogin.Error())
+			}
+			return
+		}
+		if errGuard := guardOAuthSessionPendingForSave(state, copilot.Provider); errGuard != nil {
+			return
+		}
+		if _, errSave := h.saveTokenRecord(ctx, sdkAuth.NewCopilotAuthRecord(metadata)); errSave != nil {
+			log.WithError(errSave).Error("github-copilot: could not save credentials")
+			SetOAuthSessionError(state, "Could not save GitHub Copilot credentials")
+			return
+		}
+		CompleteOAuthSession(state)
+	}()
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "url": code.VerificationURI, "state": state, "flow": "device", "user_code": code.UserCode, "expires_in": code.ExpiresIn})
+}
+
+// GetCopilotQuota keeps the GitHub token on the server and uses the account proxy.
+func (h *Handler) GetCopilotQuota(c *gin.Context) {
+	index := strings.TrimSpace(c.Query("auth_index"))
+	if index == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "auth_index is required"})
+		return
+	}
+	if h.authManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
+		return
+	}
+	auth := h.authByIndex(index)
+	if auth == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "auth not found"})
+		return
+	}
+	if auth.Provider != copilot.Provider {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "credential is not a GitHub Copilot account"})
+		return
+	}
+	token, _ := auth.Metadata["access_token"].(string)
+	if token == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "GitHub token is missing"})
+		return
+	}
+	quota, err := copilot.NewClient(h.cfg, auth.ProxyURL).Quota(c.Request.Context(), token)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", quota)
+}

--- a/internal/api/handlers/management/copilot_test.go
+++ b/internal/api/handlers/management/copilot_test.go
@@ -1,0 +1,33 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestCopilotQuotaValidatesAccountBeforeRequest(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	auth, err := manager.Register(context.Background(), &coreauth.Auth{ID: "other-provider", Provider: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth.EnsureIndex()
+	h := &Handler{authManager: manager}
+	for _, tc := range []struct {
+		query  string
+		status int
+	}{{"", 400}, {"?auth_index=missing", 404}, {"?auth_index=" + auth.Index, 400}} {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/github-copilot-quota"+tc.query, nil)
+		h.GetCopilotQuota(c)
+		if w.Code != tc.status {
+			t.Errorf("query %s: status=%d body=%s", tc.query, w.Code, w.Body)
+		}
+	}
+}

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -176,6 +176,8 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/anthropic-auth-url", s.mgmt.RequestAnthropicToken)
 		mgmt.GET("/codex-auth-url", s.mgmt.RequestCodexToken)
 		mgmt.GET("/antigravity-auth-url", s.mgmt.RequestAntigravityToken)
+		mgmt.GET("/github-copilot-auth-url", s.mgmt.RequestCopilotToken)
+		mgmt.GET("/github-copilot-quota", s.mgmt.GetCopilotQuota)
 		mgmt.GET("/kimi-auth-url", s.mgmt.RequestKimiToken)
 		mgmt.GET("/xai-auth-url", s.mgmt.RequestXAIToken)
 		mgmt.GET("/get-auth-status", s.mgmt.GetAuthStatus)

--- a/internal/auth/copilot/copilot.go
+++ b/internal/auth/copilot/copilot.go
@@ -97,6 +97,10 @@ func (c *Client) request(ctx context.Context, method, endpoint, token string, fo
 		return fmt.Errorf("github-copilot: create request: %w", err)
 	}
 	SetHeaders(req.Header)
+	if endpoint == c.apiURL+"/user" {
+		// GitHub's account API rejects the version used by Copilot's internal APIs.
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	}
 	if token != "" {
 		if !strings.HasPrefix(token, "Bearer ") {
 			token = "token " + token

--- a/internal/auth/copilot/copilot.go
+++ b/internal/auth/copilot/copilot.go
@@ -1,0 +1,295 @@
+// Package copilot implements GitHub device login and Copilot token exchange.
+package copilot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	Provider     = "github-copilot"
+	ClientID     = "Iv1.b507a08c87ecfe98"
+	APIBaseURL   = "https://api.githubcopilot.com"
+	GitHubAPIURL = "https://api.github.com"
+	RefreshLead  = time.Minute
+)
+
+type DeviceCode struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type Token struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	Endpoints struct {
+		API string `json:"api"`
+	} `json:"endpoints"`
+}
+
+func (t Token) BaseURL() string {
+	if t.Endpoints.API != "" {
+		return strings.TrimRight(t.Endpoints.API, "/")
+	}
+	return APIBaseURL
+}
+
+// HTTPError deliberately omits response bodies, which may contain credentials.
+type HTTPError struct{ Code int }
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("github-copilot: upstream returned HTTP %d", e.Code)
+}
+func (e *HTTPError) StatusCode() int { return e.Code }
+
+type Client struct {
+	httpClient *http.Client
+	githubURL  string
+	apiURL     string
+	proxyURL   string
+}
+
+func NewClient(cfg *config.Config, proxyURL string) *Client {
+	var sdkCfg config.SDKConfig
+	if cfg != nil {
+		sdkCfg = cfg.SDKConfig
+	}
+	if strings.TrimSpace(proxyURL) != "" {
+		sdkCfg.ProxyURL = proxyURL
+	}
+	return &Client{httpClient: util.SetProxy(&sdkCfg, &http.Client{}), githubURL: "https://github.com", apiURL: GitHubAPIURL, proxyURL: sdkCfg.ProxyURL}
+}
+
+func SetHeaders(h http.Header) {
+	h.Set("Accept", "application/json")
+	h.Set("User-Agent", "GitHubCopilotChat/0.40.0")
+	h.Set("Editor-Version", "vscode/1.104.0")
+	h.Set("Editor-Plugin-Version", "copilot-chat/0.40.0")
+	h.Set("Copilot-Integration-Id", "vscode-chat")
+	h.Set("X-GitHub-Api-Version", "2025-04-01")
+}
+
+func (c *Client) request(ctx context.Context, method, endpoint, token string, form url.Values, out any) error {
+	var body io.Reader
+	if form != nil {
+		body = strings.NewReader(form.Encode())
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("github-copilot: create request: %w", err)
+	}
+	SetHeaders(req.Header)
+	if token != "" {
+		if !strings.HasPrefix(token, "Bearer ") {
+			token = "token " + token
+		}
+		req.Header.Set("Authorization", token)
+	}
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	resp, errDo := c.httpClient.Do(req)
+	if errDo != nil {
+		return fmt.Errorf("github-copilot: request failed: %w", errDo)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.WithError(errClose).Debug("github-copilot: close response")
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &HTTPError{Code: resp.StatusCode}
+	}
+	if errDecode := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(out); errDecode != nil {
+		return fmt.Errorf("github-copilot: invalid response: %w", errDecode)
+	}
+	return nil
+}
+
+func (c *Client) StartDeviceFlow(ctx context.Context) (*DeviceCode, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var code DeviceCode
+	if err := c.request(ctx, http.MethodPost, c.githubURL+"/login/device/code", "", url.Values{"client_id": {ClientID}, "scope": {"read:user"}}, &code); err != nil {
+		return nil, err
+	}
+	if code.DeviceCode == "" || code.UserCode == "" || code.VerificationURI == "" || code.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("github-copilot: incomplete device code response")
+	}
+	if code.Interval <= 0 {
+		code.Interval = 5
+	}
+	return &code, nil
+}
+
+func (c *Client) WaitForAuthorization(ctx context.Context, code *DeviceCode) (string, error) {
+	if code == nil || code.ExpiresIn <= 0 {
+		return "", fmt.Errorf("github-copilot: invalid device code")
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(code.ExpiresIn)*time.Second)
+	defer cancel()
+	interval := time.Duration(code.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	for {
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+		token, oauthError, err := c.pollToken(ctx, code.DeviceCode)
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			var networkError net.Error
+			var httpError *HTTPError
+			if errors.As(err, &networkError) || (errors.As(err, &httpError) && httpError.Code >= 500) {
+				interval = min(interval*2, time.Minute)
+				continue
+			}
+			return "", err
+		}
+		switch oauthError {
+		case "":
+			return token, nil
+		case "authorization_pending":
+		case "slow_down":
+			interval += 5 * time.Second
+		case "access_denied":
+			return "", fmt.Errorf("github-copilot: authorization declined")
+		case "expired_token":
+			return "", fmt.Errorf("github-copilot: device code expired; start login again")
+		default:
+			return "", fmt.Errorf("github-copilot: device authorization failed")
+		}
+	}
+}
+
+func (c *Client) pollToken(ctx context.Context, deviceCode string) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var result struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	err := c.request(ctx, http.MethodPost, c.githubURL+"/login/oauth/access_token", "", url.Values{"client_id": {ClientID}, "device_code": {deviceCode}, "grant_type": {"urn:ietf:params:oauth:grant-type:device_code"}}, &result)
+	if err == nil && result.Error == "" && strings.TrimSpace(result.AccessToken) == "" {
+		err = fmt.Errorf("github-copilot: empty GitHub token")
+	}
+	return result.AccessToken, result.Error, err
+}
+
+func (c *Client) Login(ctx context.Context, githubToken string) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var user struct {
+		Login string `json:"login"`
+		ID    int64  `json:"id"`
+	}
+	if err := c.request(ctx, http.MethodGet, c.apiURL+"/user", githubToken, nil, &user); err != nil {
+		return nil, err
+	}
+	if user.ID <= 0 || user.Login == "" {
+		return nil, fmt.Errorf("github-copilot: missing GitHub account identity")
+	}
+	token, err := c.CopilotToken(ctx, githubToken, false)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"type": Provider, "auth_kind": "oauth", "access_token": githubToken, "github_login": user.Login, "github_id": user.ID, "email": user.Login, "expired": time.Unix(token.ExpiresAt, 0).UTC().Format(time.RFC3339)}, nil
+}
+
+var tokenCache = struct {
+	sync.Mutex
+	entries map[[32]byte]Token
+}{entries: make(map[[32]byte]Token)}
+var tokenFlights singleflight.Group
+
+// CopilotToken caches short-lived tokens per account and proxy. Concurrent refreshes
+// share one exchange; cancelling a caller does not cancel other callers' credentials.
+func (c *Client) CopilotToken(ctx context.Context, githubToken string, force bool) (Token, error) {
+	if strings.TrimSpace(githubToken) == "" {
+		return Token{}, fmt.Errorf("github-copilot: missing GitHub token; log in again")
+	}
+	key := sha256.Sum256([]byte(c.apiURL + "\x00" + c.proxyURL + "\x00" + githubToken))
+	lookup := func() (Token, bool) {
+		tokenCache.Lock()
+		defer tokenCache.Unlock()
+		token, ok := tokenCache.entries[key]
+		return token, ok && time.Now().Add(RefreshLead).Unix() < token.ExpiresAt
+	}
+	if !force {
+		if token, ok := lookup(); ok {
+			return token, nil
+		}
+	}
+	result := tokenFlights.DoChan(string(key[:]), func() (any, error) {
+		if !force {
+			if token, ok := lookup(); ok {
+				return token, nil
+			}
+		}
+		exchangeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		var token Token
+		if err := c.request(exchangeCtx, http.MethodGet, c.apiURL+"/copilot_internal/v2/token", githubToken, nil, &token); err != nil {
+			return Token{}, err
+		}
+		if token.Token == "" || token.ExpiresAt <= time.Now().Unix() {
+			return Token{}, fmt.Errorf("github-copilot: invalid Copilot token response")
+		}
+		if token.Endpoints.API != "" {
+			endpoint, errParse := url.Parse(token.Endpoints.API)
+			if errParse != nil || endpoint.Scheme != "https" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || !(endpoint.Hostname() == "githubcopilot.com" || strings.HasSuffix(endpoint.Hostname(), ".githubcopilot.com")) {
+				return Token{}, fmt.Errorf("github-copilot: invalid API endpoint")
+			}
+		}
+		tokenCache.Lock()
+		for k, cached := range tokenCache.entries {
+			if cached.ExpiresAt <= time.Now().Unix() {
+				delete(tokenCache.entries, k)
+			}
+		}
+		tokenCache.entries[key] = token
+		tokenCache.Unlock()
+		return token, nil
+	})
+	select {
+	case <-ctx.Done():
+		return Token{}, ctx.Err()
+	case result := <-result:
+		if result.Err != nil {
+			return Token{}, result.Err
+		}
+		return result.Val.(Token), nil
+	}
+}
+
+// Quota returns GitHub's account snapshot without converting it into token costs.
+func (c *Client) Quota(ctx context.Context, githubToken string) (json.RawMessage, error) {
+	var result json.RawMessage
+	err := c.request(ctx, http.MethodGet, c.apiURL+"/copilot_internal/user", githubToken, nil, &result)
+	return result, err
+}

--- a/internal/auth/copilot/copilot_test.go
+++ b/internal/auth/copilot/copilot_test.go
@@ -1,0 +1,237 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func response(body string) *http.Response {
+	return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}
+}
+func testClient(t *testing.T, fn roundTripFunc) *Client {
+	t.Helper()
+	return &Client{httpClient: &http.Client{Transport: fn}, githubURL: "https://github.test", apiURL: "https://api.github.test/" + t.Name()}
+}
+
+func TestDeviceAuthorizationAndSlowDown(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var polls []time.Time
+		client := testClient(t, func(r *http.Request) (*http.Response, error) {
+			if r.Header.Get("Accept") != "application/json" {
+				t.Error("missing JSON accept header")
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if r.Form.Get("client_id") != ClientID {
+				t.Error("wrong OAuth app")
+			}
+			if strings.HasSuffix(r.URL.Path, "/device/code") {
+				return response(`{"device_code":"secret-code","user_code":"ABCD-EFGH","verification_uri":"https://github.com/login/device","expires_in":900,"interval":1}`), nil
+			}
+			if r.Form.Get("device_code") != "secret-code" || r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+				t.Error("wrong device grant")
+			}
+			polls = append(polls, time.Now())
+			switch len(polls) {
+			case 1:
+				return response(`{"error":"authorization_pending"}`), nil
+			case 2:
+				return response(`{"error":"slow_down"}`), nil
+			}
+			return response(`{"access_token":"github-token"}`), nil
+		})
+		code, err := client.StartDeviceFlow(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		token, err := client.WaitForAuthorization(context.Background(), code)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if token != "github-token" || len(polls) != 3 {
+			t.Fatalf("token=%q polls=%d", token, len(polls))
+		}
+		if polls[1].Sub(polls[0]) != time.Second || polls[2].Sub(polls[1]) != 6*time.Second {
+			t.Fatalf("polling did not honor slow_down: %v", polls)
+		}
+	})
+}
+
+func TestDeviceAuthorizationDeniedExpiredAndCancelled(t *testing.T) {
+	for _, code := range []string{"access_denied", "expired_token", "unknown_error", ""} {
+		t.Run(code, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				client := testClient(t, func(*http.Request) (*http.Response, error) { return response(fmt.Sprintf(`{"error":%q}`, code)), nil })
+				_, err := client.WaitForAuthorization(context.Background(), &DeviceCode{DeviceCode: "code", ExpiresIn: 30, Interval: 1})
+				if err == nil {
+					t.Fatal("accepted failed authorization")
+				}
+			})
+		})
+	}
+	client := testClient(t, func(*http.Request) (*http.Response, error) {
+		t.Fatal("cancelled login sent a request")
+		return nil, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := client.WaitForAuthorization(ctx, &DeviceCode{ExpiresIn: 30}); err != context.Canceled {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestDeviceAuthorizationRetriesTransientFailures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var polls []time.Time
+		client := testClient(t, func(*http.Request) (*http.Response, error) {
+			polls = append(polls, time.Now())
+			switch len(polls) {
+			case 1:
+				return nil, &net.DNSError{IsTimeout: true}
+			case 2:
+				res := response(`{}`)
+				res.StatusCode = http.StatusServiceUnavailable
+				return res, nil
+			default:
+				return response(`{"access_token":"github-token"}`), nil
+			}
+		})
+		token, err := client.WaitForAuthorization(context.Background(), &DeviceCode{DeviceCode: "code", ExpiresIn: 30, Interval: 1})
+		if err != nil || token != "github-token" {
+			t.Fatalf("authorization did not recover: %v", err)
+		}
+		if len(polls) != 3 || polls[1].Sub(polls[0]) != 2*time.Second || polls[2].Sub(polls[1]) != 4*time.Second {
+			t.Fatalf("retry did not back off: %v", polls)
+		}
+	})
+}
+
+func TestTokenCacheCoalescesAndRenews(t *testing.T) {
+	var exchanges atomic.Int32
+	client := testClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Authorization") != "token github-token" {
+			t.Error("token exchange used wrong credential")
+		}
+		exchanges.Add(1)
+		return response(fmt.Sprintf(`{"token":"copilot-token","expires_at":%d,"endpoints":{"api":"https://api.business.githubcopilot.com"}}`, time.Now().Add(time.Hour).Unix())), nil
+	})
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			token, err := client.CopilotToken(context.Background(), "github-token", false)
+			if err != nil || token.Token != "copilot-token" {
+				t.Errorf("token=%v err=%v", token, err)
+			}
+		})
+	}
+	wg.Wait()
+	if exchanges.Load() != 1 {
+		t.Fatalf("exchanges=%d", exchanges.Load())
+	}
+	if _, err := client.CopilotToken(context.Background(), "github-token", true); err != nil {
+		t.Fatal(err)
+	}
+	if exchanges.Load() != 2 {
+		t.Fatalf("forced refresh exchanges=%d", exchanges.Load())
+	}
+	other := *client
+	other.proxyURL = "http://other-proxy.test"
+	if _, err := other.CopilotToken(context.Background(), "github-token", false); err != nil {
+		t.Fatal(err)
+	}
+	if exchanges.Load() != 3 {
+		t.Fatal("cache shared across proxies")
+	}
+}
+
+func TestTokenValidationAndErrorRedaction(t *testing.T) {
+	for _, endpoint := range []string{"http://api.githubcopilot.com", "https://githubcopilot.com.evil.test", "https://user:pass@api.githubcopilot.com", "https://api.githubcopilot.com?token=secret"} {
+		t.Run(endpoint, func(t *testing.T) {
+			client := testClient(t, func(*http.Request) (*http.Response, error) {
+				return response(fmt.Sprintf(`{"token":"copilot-token","expires_at":%d,"endpoints":{"api":%q}}`, time.Now().Add(time.Hour).Unix(), endpoint)), nil
+			})
+			if _, err := client.CopilotToken(context.Background(), "github-token", false); err == nil {
+				t.Fatal("accepted unsafe endpoint")
+			}
+		})
+	}
+	client := testClient(t, func(*http.Request) (*http.Response, error) {
+		r := response(`{"access_token":"must-not-leak"}`)
+		r.StatusCode = 403
+		return r, nil
+	})
+	_, err := client.CopilotToken(context.Background(), "github-token", false)
+	if err == nil || strings.Contains(err.Error(), "must-not-leak") {
+		t.Fatalf("unsafe error=%v", err)
+	}
+}
+
+func TestAccountIdentityAndQuota(t *testing.T) {
+	client := testClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Authorization") != "token github-token" {
+			t.Error("wrong GitHub credential")
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/copilot_internal/user"):
+			return response(`{"copilot_plan":"individual","quota_snapshots":{"premium_interactions":{"entitlement":300,"remaining":225,"percent_remaining":75}}}`), nil
+		case strings.HasSuffix(r.URL.Path, "/v2/token"):
+			return response(fmt.Sprintf(`{"token":"short-lived","expires_at":%d}`, time.Now().Add(time.Hour).Unix())), nil
+		default:
+			return response(`{"login":"octocat","id":42}`), nil
+		}
+	})
+	metadata, err := client.Login(context.Background(), "github-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metadata["github_id"] != int64(42) || metadata["access_token"] != "github-token" {
+		t.Fatalf("wrong persistent account metadata")
+	}
+	if _, ok := metadata["token"]; ok {
+		t.Fatal("persisted short-lived token")
+	}
+	quota, err := client.Quota(context.Background(), "github-token")
+	if err != nil || !json.Valid(quota) {
+		t.Fatalf("quota err=%v", err)
+	}
+}
+
+func TestModelDiscoveryCapabilitiesAndEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		endpoints []string
+		want      string
+	}{{nil, "/chat/completions"}, {[]string{"/responses"}, "/responses"}, {[]string{"/v1/messages"}, "/v1/messages"}, {[]string{"ws:/responses"}, ""}} {
+		model := Model{ID: "example", SupportedEndpoints: tc.endpoints}
+		model.Capabilities.Type = "chat"
+		model.Capabilities.Supports.ReasoningEffort = []string{"low", "high"}
+		model.Capabilities.Supports.Vision = true
+		info := model.ModelInfo()
+		if tc.want == "" {
+			if info != nil {
+				t.Fatal("advertised unsupported model")
+			}
+			continue
+		}
+		if info == nil || info.UpstreamEndpoint != tc.want || info.Thinking == nil || len(info.SupportedInputModalities) != 2 {
+			t.Fatalf("bad model info: %+v", info)
+		}
+		model.Capabilities.Type = "embeddings"
+		if model.ModelInfo() != nil {
+			t.Fatal("advertised embeddings as chat")
+		}
+	}
+}

--- a/internal/auth/copilot/copilot_test.go
+++ b/internal/auth/copilot/copilot_test.go
@@ -187,10 +187,22 @@ func TestAccountIdentityAndQuota(t *testing.T) {
 		}
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/copilot_internal/user"):
+			if got := r.Header.Get("X-GitHub-Api-Version"); got != "2025-04-01" {
+				t.Errorf("Copilot quota API version = %q, want 2025-04-01", got)
+			}
 			return response(`{"copilot_plan":"individual","quota_snapshots":{"premium_interactions":{"entitlement":300,"remaining":225,"percent_remaining":75}}}`), nil
 		case strings.HasSuffix(r.URL.Path, "/v2/token"):
+			if got := r.Header.Get("X-GitHub-Api-Version"); got != "2025-04-01" {
+				t.Errorf("Copilot token API version = %q, want 2025-04-01", got)
+			}
 			return response(fmt.Sprintf(`{"token":"short-lived","expires_at":%d}`, time.Now().Add(time.Hour).Unix())), nil
 		default:
+			// GitHub REST rejects the version used by Copilot's internal APIs.
+			if r.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+				res := response(`{"message":"Bad Request","errors":"Unsupported X-GitHub-Api-Version","status":"400"}`)
+				res.StatusCode = http.StatusBadRequest
+				return res, nil
+			}
 			return response(`{"login":"octocat","id":42}`), nil
 		}
 	})

--- a/internal/auth/copilot/models.go
+++ b/internal/auth/copilot/models.go
@@ -1,0 +1,87 @@
+package copilot
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+type Model struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Vendor             string   `json:"vendor"`
+	SupportedEndpoints []string `json:"supported_endpoints"`
+	Capabilities       struct {
+		Type   string `json:"type"`
+		Limits struct {
+			Context int `json:"max_context_window_tokens"`
+			Input   int `json:"max_prompt_tokens"`
+			Output  int `json:"max_output_tokens"`
+		} `json:"limits"`
+		Supports struct {
+			Vision          bool     `json:"vision"`
+			ToolCalls       bool     `json:"tool_calls"`
+			Thinking        bool     `json:"thinking"`
+			MinThinking     int      `json:"min_thinking_budget"`
+			MaxThinking     int      `json:"max_thinking_budget"`
+			ReasoningEffort []string `json:"reasoning_effort"`
+		} `json:"supports"`
+	} `json:"capabilities"`
+}
+
+// ModelInfo only advertises chat models with an endpoint the proxy can execute.
+func (m Model) ModelInfo() *registry.ModelInfo {
+	if m.ID == "" || m.Capabilities.Type != "chat" {
+		return nil
+	}
+	endpoint := "/chat/completions"
+	if len(m.SupportedEndpoints) > 0 && !slices.Contains(m.SupportedEndpoints, endpoint) {
+		switch {
+		case slices.Contains(m.SupportedEndpoints, "/responses"):
+			endpoint = "/responses"
+		case slices.Contains(m.SupportedEndpoints, "/v1/messages"):
+			endpoint = "/v1/messages"
+		default:
+			return nil
+		}
+	}
+	info := &registry.ModelInfo{ID: m.ID, Object: "model", OwnedBy: m.Vendor, Type: Provider, DisplayName: m.Name, ContextLength: m.Capabilities.Limits.Context, InputTokenLimit: m.Capabilities.Limits.Input, OutputTokenLimit: m.Capabilities.Limits.Output, MaxCompletionTokens: m.Capabilities.Limits.Output, UpstreamEndpoint: endpoint, SupportedInputModalities: []string{"text"}, SupportedOutputModalities: []string{"text"}}
+	if m.Capabilities.Supports.Vision {
+		info.SupportedInputModalities = append(info.SupportedInputModalities, "image")
+	}
+	if m.Capabilities.Supports.ToolCalls {
+		info.SupportedParameters = append(info.SupportedParameters, "tools", "tool_choice")
+	}
+	if levels := m.Capabilities.Supports.ReasoningEffort; len(levels) > 0 {
+		info.Thinking = &registry.ThinkingSupport{Levels: levels, ZeroAllowed: slices.Contains(levels, "none")}
+	} else if m.Capabilities.Supports.Thinking {
+		info.Thinking = &registry.ThinkingSupport{Min: m.Capabilities.Supports.MinThinking, Max: m.Capabilities.Supports.MaxThinking, DynamicAllowed: true, ZeroAllowed: true}
+	}
+	return info
+}
+
+func (c *Client) Models(ctx context.Context, githubToken string) ([]*registry.ModelInfo, error) {
+	token, err := c.CopilotToken(ctx, githubToken, false)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Data []Model `json:"data"`
+	}
+	if err := c.request(ctx, http.MethodGet, token.BaseURL()+"/models", "Bearer "+token.Token, nil, &result); err != nil {
+		return nil, err
+	}
+	models := make([]*registry.ModelInfo, 0, len(result.Data))
+	for _, model := range result.Data {
+		if info := model.ModelInfo(); info != nil {
+			models = append(models, info)
+		}
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("github-copilot: no supported chat models available for this account")
+	}
+	return models, nil
+}

--- a/internal/cmd/auth_manager.go
+++ b/internal/cmd/auth_manager.go
@@ -17,6 +17,7 @@ func newAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewClaudeAuthenticator(),
 		sdkAuth.NewAntigravityAuthenticator(),
 		sdkAuth.NewKimiAuthenticator(),
+		sdkAuth.NewCopilotAuthenticator(),
 		sdkAuth.NewXAIAuthenticator(),
 	)
 	return manager

--- a/internal/cmd/copilot_login.go
+++ b/internal/cmd/copilot_login.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/copilot"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+func DoCopilotLogin(cfg *config.Config, options *LoginOptions) {
+	if options == nil {
+		options = &LoginOptions{}
+	}
+	record, path, err := newAuthManager().Login(context.Background(), copilot.Provider, cfg, &sdkAuth.LoginOptions{NoBrowser: options.NoBrowser})
+	if err != nil {
+		log.WithError(err).Error("GitHub Copilot authentication failed")
+		return
+	}
+	fmt.Printf("Authenticated as %s. Credentials saved to %s\n", record.Label, path)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,14 +157,14 @@ type Config struct {
 
 	// OAuthModelAlias defines global model name aliases for OAuth/file-backed auth channels.
 	// These aliases affect both model listing and model routing for supported channels:
-	// vertex, aistudio, antigravity, claude, codex, kimi, xai.
+	// vertex, aistudio, antigravity, claude, codex, kimi, github-copilot, xai.
 	//
 	// NOTE: This does not apply to existing per-credential model alias features under:
 	// gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, and vertex-api-key.
 	OAuthModelAlias map[string][]OAuthModelAlias `yaml:"oauth-model-alias,omitempty" json:"oauth-model-alias,omitempty"`
 
 	// OAuthRequestScopedErrors defines per-provider request-scoped error rules applied to OAuth/file-backed auth entries.
-	// Supported channels include: vertex, aistudio, antigravity, claude, codex, kimi, xai, and OAuth plugin provider keys.
+	// Supported channels include: vertex, aistudio, antigravity, claude, codex, kimi, github-copilot, xai, and OAuth plugin provider keys.
 	//
 	// NOTE: This applies only to OAuth credentials and does not affect per-credential request-scoped-errors under *-api-key.
 	OAuthRequestScopedErrors map[string][]RequestScopedErrorRule `yaml:"oauth-request-scoped-errors,omitempty" json:"oauth-request-scoped-errors,omitempty"`

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -25,6 +25,8 @@ const (
 
 // ModelInfo represents information about an available model
 type ModelInfo struct {
+	// UpstreamEndpoint selects the provider protocol for dynamically discovered models.
+	UpstreamEndpoint string `json:"-"`
 	// ID is the unique identifier for the model
 	ID string `json:"id"`
 	// Object type for the model (typically "model")

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -1643,6 +1643,14 @@ func (r *ModelRegistry) ClientRegistrationEpoch(clientID string) uint64 {
 	return r.clientEpochs[clientID]
 }
 
+// GetModelForClient returns a copy of the client's own model metadata, without
+// falling back to another client's definition of the same model.
+func (r *ModelRegistry) GetModelForClient(clientID, modelID string) *ModelInfo {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return cloneModelInfo(r.clientModelInfos[clientID][modelID])
+}
+
 // GetModelsForClient returns the models registered for a specific client.
 // Parameters:
 //   - clientID: The client identifier (typically auth file name or auth ID)

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -56,6 +56,29 @@ func TestGetModelsForClientReturnsClones(t *testing.T) {
 	}
 }
 
+func TestGetModelForClientIsIsolatedAndReturnsClone(t *testing.T) {
+	r := newTestModelRegistry()
+	r.RegisterClient("first", "github-copilot", []*ModelInfo{{ID: "shared", UpstreamEndpoint: "/responses", Thinking: &ThinkingSupport{Levels: []string{"high"}}}})
+	r.RegisterClient("second", "github-copilot", []*ModelInfo{{ID: "shared", UpstreamEndpoint: "/chat/completions"}})
+	first := r.GetModelForClient("first", "shared")
+	if first == nil || first.UpstreamEndpoint != "/responses" {
+		t.Fatalf("wrong client metadata: %+v", first)
+	}
+	first.UpstreamEndpoint = "changed"
+	first.Thinking.Levels[0] = "changed"
+	again := r.GetModelForClient("first", "shared")
+	if again.UpstreamEndpoint != "/responses" || again.Thinking.Levels[0] != "high" {
+		t.Fatal("caller mutated registered metadata")
+	}
+	if r.GetModelForClient("missing", "shared") != nil || r.GetModelForClient("first", "missing") != nil {
+		t.Fatal("unknown client or model inherited another registration")
+	}
+	r.UnregisterClient("first")
+	if r.GetModelForClient("first", "shared") != nil {
+		t.Fatal("removed client inherited another registration")
+	}
+}
+
 func TestGetAvailableModelsByProviderReturnsClones(t *testing.T) {
 	r := newTestModelRegistry()
 	r.RegisterClient("client-1", "gemini", []*ModelInfo{{

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -21,6 +21,7 @@ import (
 // ClaudeExecutor is a stateless executor for Anthropic Claude over the messages API.
 // If api_key is unavailable on auth, it falls back to legacy via ClientAdapter.
 type ClaudeExecutor struct {
+	provider                string
 	cfg                     *config.Config
 	requestLogProvider      string
 	upstreamModelNormalizer func(string) string
@@ -138,7 +139,12 @@ const defaultModelMaxTokens = 1024
 
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
-func (e *ClaudeExecutor) Identifier() string { return "claude" }
+func (e *ClaudeExecutor) Identifier() string {
+	if e.provider != "" {
+		return e.provider
+	}
+	return "claude"
+}
 
 func (e *ClaudeExecutor) upstreamRequestLogProvider() string {
 	if provider := strings.TrimSpace(e.requestLogProvider); provider != "" {

--- a/internal/runtime/executor/copilot_executor.go
+++ b/internal/runtime/executor/copilot_executor.go
@@ -1,0 +1,166 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/copilot"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	exec "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// CopilotExecutor supplies Copilot credentials to the existing protocol executors.
+type CopilotExecutor struct {
+	cfg         *config.Config
+	tokenSource func(context.Context, *coreauth.Auth, bool) (copilot.Token, error)
+}
+
+func NewCopilotExecutor(cfg *config.Config) *CopilotExecutor { return &CopilotExecutor{cfg: cfg} }
+func (*CopilotExecutor) Identifier() string                  { return copilot.Provider }
+
+func (e *CopilotExecutor) RequestToFormat(req exec.Request, _ exec.Options) translator.Format {
+	if model := registry.LookupModelInfo(thinking.ParseSuffix(req.Model).ModelName, copilot.Provider); model != nil {
+		switch model.UpstreamEndpoint {
+		case "/responses":
+			return translator.FormatOpenAIResponse
+		case "/v1/messages":
+			return translator.FormatClaude
+		}
+	}
+	return translator.FormatOpenAI
+}
+
+func (e *CopilotExecutor) Models(ctx context.Context, auth *coreauth.Auth) ([]*registry.ModelInfo, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("github-copilot: missing credential")
+	}
+	token, _ := auth.Metadata["access_token"].(string)
+	return copilot.NewClient(e.cfg, auth.ProxyURL).Models(ctx, token)
+}
+
+func (e *CopilotExecutor) preparedAuth(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("github-copilot: missing credential")
+	}
+	token, err := e.copilotToken(ctx, auth, false)
+	if err != nil {
+		return nil, err
+	}
+	prepared := auth.Clone()
+	if prepared.Attributes == nil {
+		prepared.Attributes = make(map[string]string)
+	}
+	prepared.Attributes["base_url"] = token.BaseURL()
+	prepared.Attributes["api_key"] = token.Token
+	prepared.Attributes["auth_kind"] = "oauth"
+	headers := make(http.Header)
+	copilot.SetHeaders(headers)
+	headers.Set("Authorization", "Bearer "+token.Token)
+	headers.Set("X-Request-Id", uuid.NewString())
+	headers.Set("Openai-Intent", "conversation-panel")
+	for key, values := range headers {
+		prepared.Attributes["header:"+key] = values[0]
+	}
+	return prepared, nil
+}
+
+func (e *CopilotExecutor) delegate(req exec.Request, opts exec.Options) coreauth.ProviderExecutor {
+	format := e.RequestToFormat(req, opts)
+	if format == translator.FormatClaude {
+		return &ClaudeExecutor{cfg: e.cfg, provider: copilot.Provider, requestLogProvider: copilot.Provider}
+	}
+	return &OpenAICompatExecutor{provider: copilot.Provider, cfg: e.cfg, upstreamFormat: format}
+}
+
+func (e *CopilotExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req exec.Request, opts exec.Options) (exec.Response, error) {
+	if opts.Alt == "responses/compact" || openAICompatImageEndpointPath(opts) != "" {
+		return exec.Response{}, statusErr{code: http.StatusNotImplemented, msg: "github-copilot: endpoint is not supported"}
+	}
+	prepared, err := e.preparedAuth(ctx, auth)
+	if err != nil {
+		return exec.Response{}, err
+	}
+	response, err := e.delegate(req, opts).Execute(ctx, prepared, req, opts)
+	return response, helps.CopilotQuotaError(err)
+}
+
+func (e *CopilotExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, req exec.Request, opts exec.Options) (*exec.StreamResult, error) {
+	if opts.Alt == "responses/compact" || openAICompatImageEndpointPath(opts) != "" {
+		return nil, statusErr{code: http.StatusNotImplemented, msg: "github-copilot: endpoint is not supported"}
+	}
+	prepared, err := e.preparedAuth(ctx, auth)
+	if err != nil {
+		return nil, err
+	}
+	response, err := e.delegate(req, opts).ExecuteStream(ctx, prepared, req, opts)
+	return response, helps.CopilotQuotaError(err)
+}
+
+func (e *CopilotExecutor) CountTokens(ctx context.Context, auth *coreauth.Auth, req exec.Request, opts exec.Options) (exec.Response, error) {
+	return NewOpenAICompatExecutor(copilot.Provider, e.cfg).CountTokens(ctx, auth, req, opts)
+}
+
+func (e *CopilotExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	if refreshed, handled, err := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		return refreshed, err
+	}
+	if auth == nil {
+		return nil, fmt.Errorf("github-copilot: missing credential")
+	}
+	token, err := e.copilotToken(ctx, auth, true)
+	if err != nil {
+		return nil, err
+	}
+	updated := auth.Clone()
+	updated.Metadata["expired"] = time.Unix(token.ExpiresAt, 0).UTC().Format(time.RFC3339)
+	updated.LastRefreshedAt = time.Now().UTC()
+	return updated, nil
+}
+
+func (e *CopilotExecutor) copilotToken(ctx context.Context, auth *coreauth.Auth, force bool) (copilot.Token, error) {
+	if e.tokenSource != nil {
+		return e.tokenSource(ctx, auth, force)
+	}
+	githubToken, _ := auth.Metadata["access_token"].(string)
+	return copilot.NewClient(e.cfg, auth.ProxyURL).CopilotToken(ctx, githubToken, force)
+}
+
+func (e *CopilotExecutor) PrepareRequest(req *http.Request, auth *coreauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	prepared, err := e.preparedAuth(req.Context(), auth)
+	if err != nil {
+		return err
+	}
+	// Never forward the GitHub OAuth credential to a Copilot inference endpoint.
+	req.Header.Set("Authorization", "Bearer "+prepared.Attributes["api_key"])
+	copilot.SetHeaders(req.Header)
+	return nil
+}
+
+func (e *CopilotExecutor) HttpRequest(ctx context.Context, auth *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("github-copilot: missing request")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	req = req.Clone(ctx)
+	if req.URL == nil || req.URL.Scheme != "https" || req.URL.User != nil || !strings.HasSuffix(req.URL.Hostname(), ".githubcopilot.com") {
+		return nil, fmt.Errorf("github-copilot: unsupported request host")
+	}
+	if err := e.PrepareRequest(req, auth); err != nil {
+		return nil, err
+	}
+	return helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0).Do(req)
+}

--- a/internal/runtime/executor/copilot_executor.go
+++ b/internal/runtime/executor/copilot_executor.go
@@ -27,8 +27,21 @@ type CopilotExecutor struct {
 func NewCopilotExecutor(cfg *config.Config) *CopilotExecutor { return &CopilotExecutor{cfg: cfg} }
 func (*CopilotExecutor) Identifier() string                  { return copilot.Provider }
 
-func (e *CopilotExecutor) RequestToFormat(req exec.Request, _ exec.Options) translator.Format {
-	if model := registry.LookupModelInfo(thinking.ParseSuffix(req.Model).ModelName, copilot.Provider); model != nil {
+func (e *CopilotExecutor) RequestToFormat(req exec.Request, opts exec.Options) translator.Format {
+	authID, _ := opts.Metadata[exec.SelectedAuthMetadataKey].(string)
+	return e.requestToFormatForClient(authID, req, opts)
+}
+
+func (*CopilotExecutor) requestToFormatForClient(authID string, req exec.Request, opts exec.Options) translator.Format {
+	r := registry.GetGlobalRegistry()
+	// The registry contains public aliases and prefixes, while req.Model has
+	// already been resolved to the upstream name by the scheduler.
+	requestedModel, _ := opts.Metadata[exec.RequestedModelMetadataKey].(string)
+	model := r.GetModelForClient(authID, thinking.ParseSuffix(requestedModel).ModelName)
+	if model == nil {
+		model = r.GetModelForClient(authID, thinking.ParseSuffix(req.Model).ModelName)
+	}
+	if model != nil {
 		switch model.UpstreamEndpoint {
 		case "/responses":
 			return translator.FormatOpenAIResponse
@@ -73,8 +86,8 @@ func (e *CopilotExecutor) preparedAuth(ctx context.Context, auth *coreauth.Auth)
 	return prepared, nil
 }
 
-func (e *CopilotExecutor) delegate(req exec.Request, opts exec.Options) coreauth.ProviderExecutor {
-	format := e.RequestToFormat(req, opts)
+func (e *CopilotExecutor) delegate(auth *coreauth.Auth, req exec.Request, opts exec.Options) coreauth.ProviderExecutor {
+	format := e.requestToFormatForClient(auth.ID, req, opts)
 	if format == translator.FormatClaude {
 		return &ClaudeExecutor{cfg: e.cfg, provider: copilot.Provider, requestLogProvider: copilot.Provider}
 	}
@@ -89,7 +102,7 @@ func (e *CopilotExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req 
 	if err != nil {
 		return exec.Response{}, err
 	}
-	response, err := e.delegate(req, opts).Execute(ctx, prepared, req, opts)
+	response, err := e.delegate(auth, req, opts).Execute(ctx, prepared, req, opts)
 	return response, helps.CopilotQuotaError(err)
 }
 
@@ -101,7 +114,7 @@ func (e *CopilotExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth
 	if err != nil {
 		return nil, err
 	}
-	response, err := e.delegate(req, opts).ExecuteStream(ctx, prepared, req, opts)
+	response, err := e.delegate(auth, req, opts).ExecuteStream(ctx, prepared, req, opts)
 	return response, helps.CopilotQuotaError(err)
 }
 

--- a/internal/runtime/executor/copilot_executor.go
+++ b/internal/runtime/executor/copilot_executor.go
@@ -16,6 +16,7 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	exec "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
 )
 
 // CopilotExecutor supplies Copilot credentials to the existing protocol executors.
@@ -132,6 +133,10 @@ func (e *CopilotExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*co
 	token, err := e.copilotToken(ctx, auth, true)
 	if err != nil {
 		return nil, err
+	}
+	githubToken, _ := auth.Metadata["access_token"].(string)
+	if _, errQuota := copilot.NewClient(e.cfg, auth.ProxyURL).Quota(ctx, githubToken); errQuota != nil {
+		log.WithError(errQuota).Debugf("github-copilot: quota refresh failed for auth %s", auth.ID)
 	}
 	updated := auth.Clone()
 	updated.Metadata["expired"] = time.Unix(token.ExpiresAt, 0).UTC().Format(time.RFC3339)

--- a/internal/runtime/executor/copilot_executor_test.go
+++ b/internal/runtime/executor/copilot_executor_test.go
@@ -45,6 +45,13 @@ func TestCopilotProtocolRoutingAndCredentialIsolation(t *testing.T) {
 			e, auth := newTestCopilot()
 			registry.GetGlobalRegistry().RegisterClient(auth.ID, copilot.Provider, []*registry.ModelInfo{{ID: "test-model", UpstreamEndpoint: tc.endpoint}})
 			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			otherEndpoint := "/chat/completions"
+			if tc.endpoint == otherEndpoint {
+				otherEndpoint = "/responses"
+			}
+			otherID := auth.ID + "-other"
+			registry.GetGlobalRegistry().RegisterClient(otherID, copilot.Provider, []*registry.ModelInfo{{ID: "test-model", UpstreamEndpoint: otherEndpoint}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(otherID) })
 			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", copilotRoundTripper(func(r *http.Request) (*http.Response, error) {
 				if r.URL.Host != "api.githubcopilot.com" || r.URL.Path != tc.endpoint {
 					t.Errorf("wrong endpoint: %s", r.URL)
@@ -65,8 +72,11 @@ func TestCopilotProtocolRoutingAndCredentialIsolation(t *testing.T) {
 				return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(tc.response))}, nil
 			}))
 			req := exec.Request{Model: "test-model", Payload: []byte(tc.payload)}
-			opts := exec.Options{SourceFormat: tc.format, OriginalRequest: req.Payload}
-			if got := e.delegate(req, opts).Identifier(); got != copilot.Provider {
+			opts := exec.Options{SourceFormat: tc.format, OriginalRequest: req.Payload, Metadata: map[string]any{exec.SelectedAuthMetadataKey: auth.ID}}
+			if got := e.RequestToFormat(req, opts); got != tc.format {
+				t.Errorf("selected account format = %q, want %q", got, tc.format)
+			}
+			if got := e.delegate(auth, req, opts).Identifier(); got != copilot.Provider {
 				t.Errorf("usage attributed to %s", got)
 			}
 			resp, err := e.Execute(ctx, auth, req, opts)
@@ -90,6 +100,9 @@ func TestCopilotResponsesStreamTerminalAndUsage(t *testing.T) {
 			e, auth := newTestCopilot()
 			registry.GetGlobalRegistry().RegisterClient(auth.ID, copilot.Provider, []*registry.ModelInfo{{ID: "test-response", UpstreamEndpoint: "/responses"}})
 			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			otherID := auth.ID + "-other"
+			registry.GetGlobalRegistry().RegisterClient(otherID, copilot.Provider, []*registry.ModelInfo{{ID: "test-response", UpstreamEndpoint: "/chat/completions"}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(otherID) })
 			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", copilotRoundTripper(func(r *http.Request) (*http.Response, error) {
 				body, _ := io.ReadAll(r.Body)
 				if r.URL.Path != "/responses" || gjson.GetBytes(body, "stream_options").Exists() {
@@ -137,5 +150,26 @@ func TestCopilotQuotaFailureUsesAccountFailover(t *testing.T) {
 	})
 	if !ok || status.StatusCode() != 429 || !status.IsCredentialScoped() {
 		t.Fatalf("quota error=%v", err)
+	}
+}
+
+func TestCopilotFormatUsesSelectedAccountAlias(t *testing.T) {
+	e, auth := newTestCopilot()
+	r := registry.GetGlobalRegistry()
+	r.RegisterClient(auth.ID, copilot.Provider, []*registry.ModelInfo{{ID: "team/public-model", UpstreamEndpoint: "/responses"}})
+	otherID := auth.ID + "-other"
+	r.RegisterClient(otherID, copilot.Provider, []*registry.ModelInfo{{ID: "team/public-model", UpstreamEndpoint: "/chat/completions"}})
+	t.Cleanup(func() { r.UnregisterClient(auth.ID); r.UnregisterClient(otherID) })
+	req := exec.Request{Model: "upstream-model(high)"}
+	opts := exec.Options{Metadata: map[string]any{
+		exec.SelectedAuthMetadataKey:   auth.ID,
+		exec.RequestedModelMetadataKey: "team/public-model(high)",
+	}}
+	if got := e.RequestToFormat(req, opts); got != translator.FormatOpenAIResponse {
+		t.Fatalf("aliased account format = %q, want Responses", got)
+	}
+	opts.Metadata[exec.SelectedAuthMetadataKey] = otherID
+	if got := e.RequestToFormat(req, opts); got != translator.FormatOpenAI {
+		t.Fatalf("other account format = %q, want Chat Completions", got)
 	}
 }

--- a/internal/runtime/executor/copilot_executor_test.go
+++ b/internal/runtime/executor/copilot_executor_test.go
@@ -1,0 +1,141 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/copilot"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	exec "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type copilotRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f copilotRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newTestCopilot() (*CopilotExecutor, *coreauth.Auth) {
+	e := NewCopilotExecutor(&config.Config{})
+	e.tokenSource = func(context.Context, *coreauth.Auth, bool) (copilot.Token, error) {
+		return copilot.Token{Token: "short-copilot-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}, nil
+	}
+	auth := &coreauth.Auth{ID: "copilot-test", Provider: copilot.Provider, Metadata: map[string]any{"access_token": "persistent-github-token", "email": "octocat", "auth_kind": "oauth"}}
+	return e, auth
+}
+
+func TestCopilotProtocolRoutingAndCredentialIsolation(t *testing.T) {
+	for _, tc := range []struct {
+		endpoint          string
+		format            translator.Format
+		payload, response string
+	}{
+		{"/chat/completions", translator.FormatOpenAI, `{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`, `{"id":"chat-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}`},
+		{"/responses", translator.FormatOpenAIResponse, `{"model":"test-model","input":"hello"}`, `{"id":"resp-1","object":"response","status":"completed","output":[],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}`},
+		{"/v1/messages", translator.FormatClaude, `{"model":"test-model","max_tokens":20,"messages":[{"role":"user","content":"hello"}]}`, `{"id":"msg-1","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":1}}`},
+	} {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			e, auth := newTestCopilot()
+			registry.GetGlobalRegistry().RegisterClient(auth.ID, copilot.Provider, []*registry.ModelInfo{{ID: "test-model", UpstreamEndpoint: tc.endpoint}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", copilotRoundTripper(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Host != "api.githubcopilot.com" || r.URL.Path != tc.endpoint {
+					t.Errorf("wrong endpoint: %s", r.URL)
+				}
+				if r.Header.Get("Authorization") != "Bearer short-copilot-token" {
+					t.Errorf("wrong inference credential: %q", r.Header.Get("Authorization"))
+				}
+				if r.Header.Get("Copilot-Integration-Id") != "vscode-chat" {
+					t.Error("missing Copilot headers")
+				}
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Contains(string(body), "persistent-github-token") {
+					t.Error("leaked GitHub credential")
+				}
+				return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(tc.response))}, nil
+			}))
+			req := exec.Request{Model: "test-model", Payload: []byte(tc.payload)}
+			opts := exec.Options{SourceFormat: tc.format, OriginalRequest: req.Payload}
+			if got := e.delegate(req, opts).Identifier(); got != copilot.Provider {
+				t.Errorf("usage attributed to %s", got)
+			}
+			resp, err := e.Execute(ctx, auth, req, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !gjson.ValidBytes(resp.Payload) {
+				t.Fatalf("invalid response: %s", resp.Payload)
+			}
+			if auth.Attributes["api_key"] != "" || auth.Metadata["access_token"] != "persistent-github-token" {
+				t.Fatal("request mutated persisted credentials")
+			}
+		})
+	}
+}
+
+func TestCopilotResponsesStreamTerminalAndUsage(t *testing.T) {
+	for _, terminal := range []string{"completed", "incomplete", ""} {
+		t.Run(terminal, func(t *testing.T) {
+			complete := terminal != ""
+			e, auth := newTestCopilot()
+			registry.GetGlobalRegistry().RegisterClient(auth.ID, copilot.Provider, []*registry.ModelInfo{{ID: "test-response", UpstreamEndpoint: "/responses"}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", copilotRoundTripper(func(r *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(r.Body)
+				if r.URL.Path != "/responses" || gjson.GetBytes(body, "stream_options").Exists() {
+					t.Errorf("bad Responses request: %s %s", r.URL, body)
+				}
+				sse := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\",\"object\":\"response\",\"status\":\"in_progress\",\"output\":[]}}\n\n"
+				if complete {
+					sse += "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"object\":\"response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":2,\"output_tokens\":1,\"total_tokens\":3}}}\n\n"
+					sse = strings.ReplaceAll(sse, "completed", terminal)
+				}
+				return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(sse))}, nil
+			}))
+			req := exec.Request{Model: "test-response", Payload: []byte(`{"model":"test-response","input":"hi","stream":true}`)}
+			stream, err := e.ExecuteStream(ctx, auth, req, exec.Options{SourceFormat: translator.FormatOpenAIResponse, OriginalRequest: req.Payload, Stream: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			failed := false
+			var output strings.Builder
+			for chunk := range stream.Chunks {
+				if chunk.Err != nil {
+					failed = true
+				}
+				output.Write(chunk.Payload)
+			}
+			if failed == complete {
+				t.Fatalf("complete=%v failed=%v", complete, failed)
+			}
+			if complete && !strings.Contains(output.String(), "response."+terminal) {
+				t.Fatal("missing terminal event")
+			}
+		})
+	}
+}
+
+func TestCopilotQuotaFailureUsesAccountFailover(t *testing.T) {
+	e, auth := newTestCopilot()
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", copilotRoundTripper(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 402, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"error":{"message":"quota exhausted"}}`))}, nil
+	}))
+	_, err := e.Execute(ctx, auth, exec.Request{Model: "test", Payload: []byte(`{"model":"test","messages":[]}`)}, exec.Options{SourceFormat: translator.FormatOpenAI})
+	status, ok := err.(interface {
+		StatusCode() int
+		IsCredentialScoped() bool
+	})
+	if !ok || status.StatusCode() != 429 || !status.IsCredentialScoped() {
+		t.Fatalf("quota error=%v", err)
+	}
+}

--- a/internal/runtime/executor/helps/copilot.go
+++ b/internal/runtime/executor/helps/copilot.go
@@ -1,0 +1,22 @@
+package helps
+
+import (
+	"errors"
+	"net/http"
+)
+
+type copilotQuotaError struct{ error }
+
+func (e copilotQuotaError) StatusCode() int          { return http.StatusTooManyRequests }
+func (e copilotQuotaError) IsCredentialScoped() bool { return true }
+func (e copilotQuotaError) Unwrap() error            { return e.error }
+
+// CopilotQuotaError sends exhausted Copilot allowances through the usual cooldown
+// and account failover path. Policy denials (403) retain their original meaning.
+func CopilotQuotaError(err error) error {
+	var status interface{ StatusCode() int }
+	if errors.As(err, &status) && status.StatusCode() == http.StatusPaymentRequired {
+		return copilotQuotaError{err}
+	}
+	return err
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -40,8 +40,9 @@ const (
 // It performs request/response translation and executes against the provider base URL
 // using per-auth credentials (API key) and per-auth HTTP transport (proxy) from context.
 type OpenAICompatExecutor struct {
-	provider string
-	cfg      *config.Config
+	provider       string
+	cfg            *config.Config
+	upstreamFormat sdktranslator.Format
 }
 
 // NewOpenAICompatExecutor creates an executor bound to a provider key (e.g., "openrouter").
@@ -103,8 +104,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
-	to := sdktranslator.FromString("openai")
-	endpoint := "/chat/completions"
+	to, endpoint := e.upstream()
 	if opts.Alt == "responses/compact" {
 		to = sdktranslator.FromString("openai-response")
 		endpoint = "/responses/compact"
@@ -135,7 +135,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 			return resp, err
 		}
 	}
-	if opts.Alt == "responses/compact" {
+	if to == sdktranslator.FormatOpenAIResponse {
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
 		}
@@ -322,7 +322,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
-	to := sdktranslator.FromString("openai")
+	to, endpoint := e.upstream()
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -352,10 +352,12 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
-	translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
+	if to == sdktranslator.FormatOpenAI {
+		translated = helps.SetBoolIfDifferent(translated, "stream_options.include_usage", true)
+	}
 	reporter.SetTranslatedReasoningEffort(translated, to.String())
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -480,6 +482,11 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 				}
 			}
 
+			if to == sdktranslator.FormatOpenAIResponse && !isDone {
+				streamUsage.Observe(helps.ParseCodexUsage(dataPayload))
+			}
+			eventType := gjson.GetBytes(dataPayload, "type").String()
+			terminal := isDone || (to == sdktranslator.FormatOpenAIResponse && (eventType == "response.completed" || eventType == "response.incomplete"))
 			streamLine := append([]byte("data: "), dataPayload...)
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
 			for i := range chunks {
@@ -490,7 +497,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 					return true
 				}
 			}
-			if isDone {
+			if terminal {
 				seenDone = true
 				return true
 			}
@@ -501,7 +508,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			streamUsage.ObserveOpenAIStream(line)
+			if to == sdktranslator.FormatOpenAI {
+				streamUsage.ObserveOpenAIStream(line)
+			}
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
 				if processFrame() {
@@ -542,7 +551,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		} else if !seenDone {
 			// Responses clients require an explicit terminal event. Treat a clean
 			// upstream EOF without [DONE] as a failed stream instead of completing it.
-			if responseFormat == sdktranslator.FormatOpenAIResponse {
+			if responseFormat == sdktranslator.FormatOpenAIResponse || to == sdktranslator.FormatOpenAIResponse {
 				streamErr := statusErr{code: http.StatusBadGateway, msg: "upstream stream closed before [DONE]"}
 				helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 				reporter.PublishFailure(ctx, streamErr)
@@ -913,6 +922,13 @@ func (e *OpenAICompatExecutor) applyPromptCacheKey(ctx context.Context, auth *cl
 	}, "\x00")
 	promptCacheKey := uuid.NewSHA1(uuid.NameSpaceOID, []byte(identity)).String()
 	return helps.SetStringIfDifferent(translated, "prompt_cache_key", promptCacheKey), nil
+}
+
+func (e *OpenAICompatExecutor) upstream() (sdktranslator.Format, string) {
+	if e.upstreamFormat == sdktranslator.FormatOpenAIResponse {
+		return sdktranslator.FormatOpenAIResponse, "/responses"
+	}
+	return sdktranslator.FormatOpenAI, "/chat/completions"
 }
 
 func (e *OpenAICompatExecutor) resolveCredentials(auth *cliproxyauth.Auth) (baseURL, apiKey string) {

--- a/internal/tui/oauth_tab.go
+++ b/internal/tui/oauth_tab.go
@@ -23,6 +23,7 @@ var oauthProviders = []oauthProvider{
 	{"Claude (Anthropic)", "anthropic-auth-url", "🟧", false},
 	{"Codex (OpenAI)", "codex-auth-url", "🟩", false},
 	{"Antigravity", "antigravity-auth-url", "🟪", false},
+	{"GitHub Copilot", "github-copilot-auth-url", "🐙", true},
 	{"Kimi", "kimi-auth-url", "🟫", true},
 	{"xAI", "xai-auth-url", "⬛", true},
 }

--- a/internal/tui/oauth_tab_test.go
+++ b/internal/tui/oauth_tab_test.go
@@ -7,6 +7,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+func TestCopilotUsesDeviceLoginInTUI(t *testing.T) {
+	for _, provider := range oauthProviders {
+		if provider.apiPath == "github-copilot-auth-url" {
+			if !provider.deviceFlow || provider.name != "GitHub Copilot" {
+				t.Fatal("incorrect Copilot login configuration")
+			}
+			return
+		}
+	}
+	t.Fatal("GitHub Copilot is missing from provider list")
+}
+
 func TestShouldAcceptOAuthPollFiltersStaleMessages(t *testing.T) {
 	msg := oauthPollMsg{state: "state-a", generation: 1, done: true, message: "ok"}
 

--- a/sdk/api/management.go
+++ b/sdk/api/management.go
@@ -21,6 +21,7 @@ type ManagementTokenRequester interface {
 	RequestAnthropicToken(*gin.Context)
 	RequestCodexToken(*gin.Context)
 	RequestAntigravityToken(*gin.Context)
+	RequestCopilotToken(*gin.Context)
 	RequestKimiToken(*gin.Context)
 	GetAuthStatus(c *gin.Context)
 	PostOAuthCallback(c *gin.Context)
@@ -57,6 +58,10 @@ func (m *managementTokenRequester) RequestCodexToken(c *gin.Context) {
 
 func (m *managementTokenRequester) RequestAntigravityToken(c *gin.Context) {
 	m.handler.RequestAntigravityToken(c)
+}
+
+func (m *managementTokenRequester) RequestCopilotToken(c *gin.Context) {
+	m.handler.RequestCopilotToken(c)
 }
 
 func (m *managementTokenRequester) RequestKimiToken(c *gin.Context) {

--- a/sdk/auth/copilot.go
+++ b/sdk/auth/copilot.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/copilot"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/browser"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+type CopilotAuthenticator struct{}
+
+func NewCopilotAuthenticator() Authenticator             { return &CopilotAuthenticator{} }
+func (CopilotAuthenticator) Provider() string            { return copilot.Provider }
+func (CopilotAuthenticator) RefreshLead() *time.Duration { lead := copilot.RefreshLead; return &lead }
+
+func (CopilotAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *LoginOptions) (*coreauth.Auth, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("github-copilot: configuration is required")
+	}
+	client := copilot.NewClient(cfg, "")
+	code, err := client.StartDeviceFlow(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("To sign in to GitHub Copilot, visit %s and enter code %s\n", code.VerificationURI, code.UserCode)
+	if (opts == nil || !opts.NoBrowser) && browser.IsAvailable() {
+		if errOpen := browser.OpenURL(code.VerificationURI); errOpen != nil {
+			log.WithError(errOpen).Warn("github-copilot: could not open browser")
+		}
+	}
+	githubToken, err := client.WaitForAuthorization(ctx, code)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := client.Login(ctx, githubToken)
+	if err != nil {
+		return nil, err
+	}
+	return NewCopilotAuthRecord(metadata), nil
+}
+
+// NewCopilotAuthRecord uses GitHub's stable account ID so signing in again updates
+// the existing credential while separate accounts remain available for rotation.
+func NewCopilotAuthRecord(metadata map[string]any) *coreauth.Auth {
+	name := fmt.Sprintf("github-copilot-%v.json", metadata["github_id"])
+	label, _ := metadata["github_login"].(string)
+	return &coreauth.Auth{ID: name, FileName: name, Provider: copilot.Provider, Label: label, Metadata: metadata}
+}

--- a/sdk/auth/refresh_registry.go
+++ b/sdk/auth/refresh_registry.go
@@ -10,6 +10,7 @@ func init() {
 	registerRefreshLead("codex", func() Authenticator { return NewCodexAuthenticator() })
 	registerRefreshLead("claude", func() Authenticator { return NewClaudeAuthenticator() })
 	registerRefreshLead("antigravity", func() Authenticator { return NewAntigravityAuthenticator() })
+	registerRefreshLead("github-copilot", func() Authenticator { return NewCopilotAuthenticator() })
 	registerRefreshLead("kimi", func() Authenticator { return NewKimiAuthenticator() })
 	registerRefreshLead("xai", func() Authenticator { return NewXAIAuthenticator() })
 }

--- a/sdk/cliproxy/copilot_models.go
+++ b/sdk/cliproxy/copilot_models.go
@@ -8,11 +8,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *Service) fetchCopilotModels(ctx context.Context, auth *coreauth.Auth) []*ModelInfo {
+func (s *Service) fetchCopilotModels(ctx context.Context, auth *coreauth.Auth) ([]*ModelInfo, error) {
 	models, err := executor.NewCopilotExecutor(s.cfg).Models(ctx, auth)
 	if err != nil {
 		log.WithError(err).WithField("provider", "github-copilot").Warn("could not refresh account models")
-		return GlobalModelRegistry().GetModelsForClient(auth.ID)
 	}
-	return models
+	return models, err
 }

--- a/sdk/cliproxy/copilot_models.go
+++ b/sdk/cliproxy/copilot_models.go
@@ -1,0 +1,18 @@
+package cliproxy
+
+import (
+	"context"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *Service) fetchCopilotModels(ctx context.Context, auth *coreauth.Auth) []*ModelInfo {
+	models, err := executor.NewCopilotExecutor(s.cfg).Models(ctx, auth)
+	if err != nil {
+		log.WithError(err).WithField("provider", "github-copilot").Warn("could not refresh account models")
+		return GlobalModelRegistry().GetModelsForClient(auth.ID)
+	}
+	return models
+}

--- a/sdk/cliproxy/copilot_models_test.go
+++ b/sdk/cliproxy/copilot_models_test.go
@@ -1,0 +1,47 @@
+package cliproxy
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestCopilotCatalogFailurePreservesRegistration(t *testing.T) {
+	for _, tc := range []struct {
+		name, prefix string
+		aliases      []config.OAuthModelAlias
+	}{
+		{name: "prefix", prefix: "team"},
+		{name: "alias", aliases: []config.OAuthModelAlias{{Name: "model", Alias: "public-model"}, {Name: "public-model", Alias: "second-alias"}}},
+		{name: "alias and prefix", prefix: "team", aliases: []config.OAuthModelAlias{{Name: "model", Alias: "public-model"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{cfg: &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"github-copilot": tc.aliases}}}
+			s.cfg.ForceModelPrefix = true
+			auth := &coreauth.Auth{ID: t.Name(), Provider: "github-copilot", Prefix: tc.prefix, Metadata: map[string]any{"auth_kind": "oauth"}}
+			models := []*ModelInfo{{ID: "model", UpstreamEndpoint: "/responses"}}
+			models = applyOAuthModelAliasForAuth(s.cfg, auth.Provider, auth.AuthKind(), nil, models)
+			models = applyModelPrefixes(models, auth.Prefix, true)
+			r := registry.GetGlobalRegistry()
+			r.RegisterClient(auth.ID, auth.Provider, models)
+			t.Cleanup(func() { r.UnregisterClient(auth.ID) })
+			before, epoch := r.GetModelsAndEpochForClient(auth.ID)
+			r.SuspendClientModel(auth.ID, before[0].ID, "test suspension")
+			for range 2 {
+				// Missing credentials fail catalog acquisition without network access.
+				s.registerModelsForAuth(context.Background(), auth)
+				after, newEpoch := r.GetModelsAndEpochForClient(auth.ID)
+				if !reflect.DeepEqual(after, before) {
+					t.Fatalf("catalog failure changed registration: before=%+v after=%+v", before[0], after)
+				}
+				if newEpoch != epoch || !r.IsModelSuspendedForClient(auth.ID, before[0].ID) {
+					t.Fatal("catalog failure replaced the existing registration state")
+				}
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -22,6 +22,7 @@ func newDefaultAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewCodexAuthenticator(),
 		sdkAuth.NewClaudeAuthenticator(),
 		sdkAuth.NewXAIAuthenticator(),
+		sdkAuth.NewCopilotAuthenticator(),
 	)
 }
 

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -208,6 +208,7 @@ func baselineExecutorAuths() []*coreauth.Auth {
 		"aistudio",
 		"antigravity",
 		"kimi",
+		"github-copilot",
 		"xai",
 		"openai-compatibility",
 	}
@@ -290,6 +291,8 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 		s.coreManager.RegisterExecutor(executor.NewAntigravityExecutor(cfg))
 	case "claude":
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(cfg))
+	case "github-copilot":
+		s.coreManager.RegisterExecutor(executor.NewCopilotExecutor(cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(cfg))
 	case "xai":

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -142,7 +142,13 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "github-copilot":
-		models = s.fetchCopilotModels(ctx, a)
+		var err error
+		models, err = s.fetchCopilotModels(ctx, a)
+		if err != nil {
+			// Preserve the existing registration. Its aliases and prefixes have
+			// already been applied and must not pass through this pipeline again.
+			return
+		}
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -141,6 +141,9 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			models = registry.GetCodexProModels()
 		}
 		models = applyExcludedModels(models, excluded)
+	case "github-copilot":
+		models = s.fetchCopilotModels(ctx, a)
+		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()
 		models = applyExcludedModels(models, excluded)


### PR DESCRIPTION
GitHub Copilot users can now connect their account to CLIProxyAPI and use its models alongside the other providers. This puts Copilot login, request usage, and remaining allowance in the same workflow people already use.

Companion management UI: https://github.com/router-for-me/Cli-Proxy-API-Management-Center/pull/425

- Add device-code sign-in through the CLI, TUI, and management API.
- Discover the account's models and reuse the existing Chat Completions, Responses, and Claude executors for inference and streaming.
- Cache short-lived Copilot tokens per account and proxy, with one shared exchange for concurrent requests. Keep the GitHub credential on the server.
- Reuse account rotation, refresh, model aliases, exclusions, token accounting, and cooldown after allowance exhaustion.
- Expose GitHub's quota snapshot for the companion management UI, including allowance used, remaining quota, reset date, and overage status. No guessed dollar balance.

Setup and protocol details are in [docs/github-copilot.md](docs/github-copilot.md). Copilot uses internal GitHub endpoints, so availability depends on the account and GitHub may change the protocol.

### Screenshots

The companion UI uses the existing login and quota components. Screenshots use demonstration data and a fake device code.

![Copilot device login](https://raw.githubusercontent.com/NaveDanan/Cli-Proxy-API-Management-Center/b6944265ec5c673d38ba33897cdb0c92900ffe67/docs/screenshots/github-copilot-login.png)

![Copilot allowance](https://raw.githubusercontent.com/NaveDanan/Cli-Proxy-API-Management-Center/b6944265ec5c673d38ba33897cdb0c92900ffe67/docs/screenshots/github-copilot-quota.png)

### Validation

- `gofmt -w .`, the required local server build, and the GitHub PR build check passed.
- Focused auth, protocol routing, streaming, quota, management, TUI, and shared OpenAI-compatible executor tests passed.
- Full `go test ./...` ran. Nine Windows network/proxy failures reproduce on unchanged main across management, pluginhost, executor, and proxyutil. One additional xAI image test failed intermittently and passed on the unchanged baseline.
- Companion UI: 444 tests, lint, TypeScript, and production build passed. Browser checks covered device-code copy, authorization state changes, quota values, failed-refresh recovery, mobile layout, and dark mode.
- Live GitHub device-code issuance and account authorization succeeded. Live inference has not been verified; browser quota screenshots use fixtures.

The browser additions require the companion management-center change; the existing released management HTML will not gain these cards from a backend update alone.
