### PR TITLE
fix(claude): preserve native subagent cache TTL opt-in

### DIFF
--- a/internal/runtime/executor/claude_executor_cache_ttl_test.go
+++ b/internal/runtime/executor/claude_executor_cache_ttl_test.go
@@ -1,0 +1,148 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func TestClaudeExecutor_SubagentExplicitCacheTTL(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		native  bool
+		header  bool
+		marker  bool
+		ttl     bool
+		ttlPath string
+		beta    bool
+		probe   bool
+		wantTTL bool
+	}{
+		{name: "native subagent", native: true, header: true, marker: true, ttl: true, beta: true, wantTTL: true},
+		{name: "header only subagent", native: true, header: true, ttl: true, beta: true, wantTTL: true},
+		{name: "billing only subagent", native: true, marker: true, ttl: true, beta: true, wantTTL: true},
+		{name: "tool breakpoint only", native: true, header: true, marker: true, ttl: true, ttlPath: "tools.0", beta: true, wantTTL: true},
+		{name: "system breakpoint only", native: true, header: true, marker: true, ttl: true, ttlPath: "system.1", beta: true, wantTTL: true},
+		{name: "message breakpoint only", native: true, header: true, marker: true, ttl: true, ttlPath: "messages.0.content.0", beta: true, wantTTL: true},
+		{name: "no explicit TTL", native: true, header: true, marker: true},
+		{name: "missing beta", native: true, header: true, marker: true, ttl: true},
+		{name: "beta without TTL", native: true, header: true, marker: true, beta: true},
+		{name: "unconfirmed caller", header: true, marker: true, ttl: true, beta: true},
+		{name: "probe", native: true, header: true, marker: true, ttl: true, beta: true, probe: true},
+		{name: "main conversation", native: true, ttl: true, beta: true, wantTTL: true},
+	} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", test.name, stream), func(t *testing.T) {
+				payload := []byte(`{"model":"claude-sonnet-5","max_tokens":1024,"tools":[{"name":"read_file","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}],"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.258; cc_entrypoint=cli; cch=00000;"},{"type":"text","text":"Inspect the repository.","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"Review the code.","cache_control":{"type":"ephemeral"}}]}]}`)
+				paths := []string{"tools.0", "system.1", "messages.0.content.0"}
+				if test.ttlPath != "" {
+					for _, path := range paths {
+						if path != test.ttlPath {
+							payload, _ = sjson.DeleteBytes(payload, path+".cache_control")
+						}
+					}
+					paths = []string{test.ttlPath}
+				}
+				if test.ttl {
+					for _, path := range paths {
+						payload, _ = sjson.SetBytes(payload, path+".cache_control.ttl", "1h")
+					}
+				}
+				if test.marker {
+					payload, _ = sjson.SetBytes(payload, "system.0.text", gjson.GetBytes(payload, "system.0.text").String()+" cc_is_subagent=true;")
+				}
+				if test.probe {
+					payload, _ = sjson.SetBytes(payload, "max_tokens", 1)
+					payload, _ = sjson.DeleteBytes(payload, "tools")
+					payload, _ = sjson.SetBytes(payload, "messages.0.content.0.text", "quota")
+				}
+				if got := helps.IsClaudeProbeOrHelperRequest(payload); got != test.probe {
+					t.Fatalf("fixture probe detection = %v, want %v", got, test.probe)
+				}
+				headers := http.Header{}
+				headers.Set("Anthropic-Beta", claudeCodeBeta)
+				if test.beta {
+					headers.Add("Anthropic-Beta", claudeExtendedCacheTTLBeta)
+				}
+				if test.header {
+					headers.Set("X-Claude-Code-Agent-Id", "test-subagent")
+				}
+				if test.native {
+					headers.Set("User-Agent", "claude-cli/2.1.258 (external, cli)")
+					headers.Set("X-App", "cli")
+					payload, _ = sjson.SetBytes(payload, "metadata.user_id", `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","account_uuid":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"11111111-2222-4333-8444-555555555555"}`)
+				}
+				if got := helps.DetectClaudeCodeRequest(headers, payload, false).Confirmed; got != test.native {
+					t.Fatalf("fixture native detection = %v, want %v", got, test.native)
+				}
+
+				var upstreamBody []byte
+				var upstreamHeaders http.Header
+				transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					var errRead error
+					upstreamBody, errRead = io.ReadAll(req.Body)
+					if errRead != nil {
+						return nil, errRead
+					}
+					upstreamHeaders = req.Header.Clone()
+					contentType := "application/json"
+					response := `{"id":"msg_test","type":"message","role":"assistant","model":"claude-sonnet-5","content":[],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":0}}`
+					if stream {
+						contentType = "text/event-stream"
+						response = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":" + response + "}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+					}
+					return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: io.NopCloser(strings.NewReader(response)), Request: req}, nil
+				})
+				ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+				auth := &cliproxyauth.Auth{ID: "subagent-cache-ttl", Metadata: claudeOAuthTestMetadata(), Attributes: map[string]string{"api_key": "sk-ant-oat-subagent-cache-ttl"}}
+				executor := NewClaudeExecutor(&config.Config{})
+				request := cliproxyexecutor.Request{Model: "claude-sonnet-5", Payload: payload}
+				options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Headers: headers, Stream: stream}
+				if stream {
+					result, errStream := executor.ExecuteStream(ctx, auth, request, options)
+					if errStream != nil {
+						t.Fatal(errStream)
+					}
+					for chunk := range result.Chunks {
+						if chunk.Err != nil {
+							t.Fatal(chunk.Err)
+						}
+					}
+				} else if _, errExecute := executor.Execute(ctx, auth, request, options); errExecute != nil {
+					t.Fatal(errExecute)
+				}
+				if upstreamBody == nil {
+					t.Fatal("request did not reach upstream")
+				}
+				betas := helps.HeaderValueCaseInsensitive(upstreamHeaders, "Anthropic-Beta")
+				if got := strings.Contains(betas, claudeExtendedCacheTTLBeta); got != test.wantTTL {
+					t.Errorf("extended cache beta = %v, want %v; betas=%s", got, test.wantTTL, betas)
+				}
+				if test.wantTTL {
+					for _, path := range paths {
+						if got := gjson.GetBytes(upstreamBody, path+".cache_control.ttl").String(); got != "1h" {
+							t.Errorf("%s cache TTL = %q, want 1h", path, got)
+						}
+					}
+				} else {
+					forEachClaudeCacheControlBlock(upstreamBody, func(path string, block gjson.Result) {
+						if got := block.Get("cache_control.ttl"); got.Exists() {
+							t.Errorf("%s cache TTL = %s, want omitted", path, got.Raw)
+						}
+					})
+				}
+			})
+		}
+	}
+}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -1402,8 +1402,8 @@ func applyCloakingInternal(
 		}
 	}
 
-	// Probes and subagents never use 1h cache in native Claude Code; ensure any
-	// caller-supplied 1h ttl is stripped to match extended-cache-ttl beta suppression.
+	// Cloaked subagents use the default 5m TTL. Confirmed native clients bypass
+	// cloaking and can explicitly opt in to 1h through subagentPromptCacheTtl.
 	if isSubagent || isProbeOrHelper {
 		payload = stripClaudeCacheControlTTL(payload)
 	}

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -237,12 +237,13 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Only a ttl the caller wrote out explicitly survives, because
 	// upgradeClaudeCacheControlTTL skips any block that already has one.
 	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	// In native Claude Code 2.1.258, 1h cache and extended-cache-ttl are restricted to main
-	// interaction queries (repl_main_thread*); subagents, side queries, and probes omit both.
+	// Subagents default to 5m, but a confirmed native client can explicitly request
+	// 1h via subagentPromptCacheTtl. Preserve that choice when paired with its beta.
 	isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, body)
+	preserveSubagentTTL := confirmedClaudeCode && helps.ClaudeRequestsExtendedCacheTTL(incomingHeaders, body)
 	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI && !isSubagent && !isProbeOrHelper {
 		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
-	} else if isSubagent || isProbeOrHelper {
+	} else if (isSubagent && !preserveSubagentTTL) || isProbeOrHelper {
 		body = stripClaudeCacheControlTTL(body)
 	}
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -895,7 +895,8 @@ func applyClaudeHeadersWithNativeProfile(
 		}
 		// Measured Haiku helper requests already carry the exact credential
 		// beta profile and intentionally omit extended-cache-ttl.
-		// Native Claude Code subagents and probes also omit extended-cache-ttl.
+		// Native subagents omit extended-cache-ttl by default; preserve an explicit
+		// caller choice below without adding it to the default subagent profile.
 		if useOAuthBetas && !helperProfile {
 			if countTokens {
 				baseBetas = withClaudeCountTokensOAuthBeta(baseBetas)
@@ -970,7 +971,8 @@ func applyClaudeHeadersWithNativeProfile(
 		if reqThinkingType == "disabled" {
 			baseBetas = withoutClaudeBeta(baseBetas, claudeThinkingDisplayUpdatesBeta)
 		}
-		if helps.IsClaudeSubagentRequest(nil, body) {
+		preserveSubagentTTL := confirmedClaudeCode && helps.ClaudeRequestsExtendedCacheTTL(incomingHeaders, body)
+		if helps.IsClaudeSubagentRequest(incomingHeaders, body) && !preserveSubagentTTL {
 			baseBetas = withoutClaudeBeta(baseBetas, claudeExtendedCacheTTLBeta)
 		}
 		reqModel := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "model").String()))

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -238,12 +238,13 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Only a ttl the caller wrote out explicitly survives, because
 	// upgradeClaudeCacheControlTTL skips any block that already has one.
 	// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
-	// In native Claude Code 2.1.258, 1h cache and extended-cache-ttl are restricted to main
-	// interaction queries (repl_main_thread*); subagents, side queries, and probes omit both.
+	// Subagents default to 5m, but a confirmed native client can explicitly request
+	// 1h via subagentPromptCacheTtl. Preserve that choice when paired with its beta.
 	isSubagent := helps.IsClaudeSubagentRequest(incomingHeaders, body)
+	preserveSubagentTTL := confirmedClaudeCode && helps.ClaudeRequestsExtendedCacheTTL(incomingHeaders, body)
 	if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI && !isSubagent && !isProbeOrHelper {
 		body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
-	} else if isSubagent || isProbeOrHelper {
+	} else if (isSubagent && !preserveSubagentTTL) || isProbeOrHelper {
 		body = stripClaudeCacheControlTTL(body)
 	}
 

--- a/internal/runtime/executor/helps/claude_cache_control.go
+++ b/internal/runtime/executor/helps/claude_cache_control.go
@@ -1,0 +1,42 @@
+package helps
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// ClaudeRequestsExtendedCacheTTL reports an explicit, paired 1h cache request.
+// Callers decide whether the client is trusted to own its cache policy.
+func ClaudeRequestsExtendedCacheTTL(headers http.Header, body []byte) bool {
+	hasBeta := false
+	for _, value := range HeaderValuesCaseInsensitive(headers, "Anthropic-Beta") {
+		for _, beta := range strings.Split(value, ",") {
+			if strings.TrimSpace(beta) == "extended-cache-ttl-2025-04-11" {
+				hasBeta = true
+			}
+		}
+	}
+	if !hasBeta {
+		return false
+	}
+	hasTTL := func(block gjson.Result) bool {
+		return block.Get("cache_control.type").String() == "ephemeral" && block.Get("cache_control.ttl").String() == "1h"
+	}
+	for _, field := range []string{"tools", "system"} {
+		for _, block := range gjson.GetBytes(body, field).Array() {
+			if hasTTL(block) {
+				return true
+			}
+		}
+	}
+	for _, message := range gjson.GetBytes(body, "messages").Array() {
+		for _, block := range message.Get("content").Array() {
+			if hasTTL(block) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #5629.

Claude Code supports `subagentPromptCacheTtl`, but the executor currently removes explicit `ttl: "1h"` cache markers from every subagent and drops the matching beta. That overrides the native client's choice and causes the 5-minute cache writes reported in the issue.

This preserves the existing 1h markers and `extended-cache-ttl-2025-04-11` when a confirmed native Claude Code client explicitly sends both. Execute and ExecuteStream use the same predicate, and header assembly checks both header and billing-based subagent identification. It does not upgrade default subagents or relax the probe policy; unconfirmed callers keep the existing cloaking behavior.

Reference: [Claude Code prompt caching — choose the TTL yourself](https://code.claude.com/docs/en/prompt-caching#choose-the-ttl-yourself).

Validation:
- Reproduced six failing outbound-request cases on the base revision before the fix.
- Added 24 Execute/ExecuteStream cases covering both subagent signals, tool/system/message cache markers, missing TTL or beta, unconfirmed callers, probes, and main conversations.
- `go test ./internal/runtime/executor/... -count=1` passes.
- Server compilation passes with `go build -buildvcs=false` (output: `cliproxy-ttl-build` in the workspace). `-buildvcs=false` is needed for VCS stamping in this worktree environment.

Tests use a deterministic HTTP transport; no live Anthropic billing/cache measurements were made.