### PR TITLE
fix(compat): keep missing stream terminators request-scoped

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -543,7 +543,9 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			// Responses clients require an explicit terminal event. Treat a clean
 			// upstream EOF without [DONE] as a failed stream instead of completing it.
 			if responseFormat == sdktranslator.FormatOpenAIResponse {
-				streamErr := statusErr{code: http.StatusBadGateway, msg: "upstream stream closed before [DONE]"}
+				// A missing protocol terminator does not establish a credential failure.
+				// Keep the request failed without rotating or cooling otherwise valid keys.
+				streamErr := cliproxyauth.NewRequestScopedError("upstream stream closed before [DONE]", http.StatusBadGateway)
 				helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 				reporter.PublishFailure(ctx, streamErr)
 				select {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -954,6 +954,9 @@ func TestOpenAICompatExecutorResponsesStreamFailsOnEOFWithoutDone(t *testing.T) 
 	if !strings.Contains(streamErr.Error(), "closed before [DONE]") {
 		t.Fatalf("stream error does not explain the missing terminal marker: %v", streamErr)
 	}
+	if scoped, ok := streamErr.(cliproxyexecutor.RequestScopedError); !ok || !scoped.IsRequestScoped() {
+		t.Fatalf("missing [DONE] must be request-scoped, got %T: %v", streamErr, streamErr)
+	}
 }
 
 func TestOpenAICompatExecutorResponsesStreamPreservesUpstreamDataError(t *testing.T) {
@@ -1001,6 +1004,9 @@ func TestOpenAICompatExecutorResponsesStreamPreservesUpstreamDataError(t *testin
 			}
 			if streamErr == nil || !strings.Contains(streamErr.Error(), "upstream failed") {
 				t.Fatalf("terminal stream error = %v, want original upstream failure", streamErr)
+			}
+			if scoped, ok := streamErr.(cliproxyexecutor.RequestScopedError); ok && scoped.IsRequestScoped() {
+				t.Fatalf("explicit upstream error must retain its credential classification: %v", streamErr)
 			}
 		})
 	}

--- a/internal/runtime/executor/openai_compat_executor_cooldown_test.go
+++ b/internal/runtime/executor/openai_compat_executor_cooldown_test.go
@@ -1,0 +1,112 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestOpenAICompatExecutorMissingDoneKeepsCredentialsAvailable(t *testing.T) {
+	for _, partial := range []bool{false, true} {
+		t.Run(fmt.Sprintf("partial=%t", partial), func(t *testing.T) {
+			var calls atomic.Int32
+			transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				response := ""
+				if partial {
+					response = `data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"compat-test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"
+				}
+				return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(response)), Request: req}, nil
+			})
+			ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", http.RoundTripper(transport))
+			provider := "compat-missing-done"
+			model := "compat-test-model"
+			manager := cliproxyauth.NewManager(nil, nil, nil)
+			manager.SetRetryConfig(0, 0, 0)
+			manager.RegisterExecutor(NewOpenAICompatExecutor(provider, &config.Config{}))
+			reg := registry.GetGlobalRegistry()
+			var authIDs []string
+			for i := range 3 {
+				auth := &cliproxyauth.Auth{
+					ID:       fmt.Sprintf("compat-missing-done-%t-%d", partial, i),
+					Provider: provider,
+					Attributes: map[string]string{
+						"base_url": "https://compat.example/v1",
+						"api_key":  fmt.Sprintf("test-key-%d", i),
+					},
+				}
+				if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+					t.Fatal(errRegister)
+				}
+				reg.RegisterClient(auth.ID, provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+				authIDs = append(authIDs, auth.ID)
+			}
+
+			// More requests than credentials reproduce the transition to auth_unavailable
+			// if each protocol failure incorrectly cools down one otherwise valid key.
+			for attempt := range 4 {
+				payload := []byte(`{"model":"compat-test-model","input":"hi","stream":true}`)
+				result, errStream := manager.ExecuteStream(ctx, []string{provider}, cliproxyexecutor.Request{Model: model, Payload: payload}, cliproxyexecutor.Options{
+					SourceFormat:    sdktranslator.FormatOpenAIResponse,
+					ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+					OriginalRequest: payload,
+					Stream:          true,
+				})
+				var output strings.Builder
+				if result != nil {
+					for chunk := range result.Chunks {
+						output.Write(chunk.Payload)
+						if chunk.Err != nil {
+							errStream = chunk.Err
+						}
+					}
+				}
+				var status interface{ StatusCode() int }
+				if !errors.As(errStream, &status) || status.StatusCode() != http.StatusBadGateway {
+					t.Errorf("request %d: error = %v, want the original 502 protocol error", attempt, errStream)
+				}
+				if errStream == nil || !strings.Contains(errStream.Error(), "closed before [DONE]") {
+					t.Errorf("request %d: lost the missing [DONE] diagnostic: %v", attempt, errStream)
+				}
+				if strings.Contains(output.String(), "response.completed") {
+					t.Errorf("request %d: incomplete stream was reported as completed", attempt)
+				}
+				if partial && !strings.Contains(output.String(), "response.output_text.delta") {
+					t.Errorf("request %d: partial output was lost", attempt)
+				}
+				if got := calls.Load(); got != int32(attempt+1) {
+					t.Errorf("request %d: upstream calls = %d, want %d without credential fallback", attempt, got, attempt+1)
+				}
+			}
+			var failed int64
+			for _, id := range authIDs {
+				auth, ok := manager.GetByID(id)
+				if !ok {
+					t.Fatalf("credential %s disappeared", id)
+				}
+				failed += auth.Failed
+				if auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.ModelStates[model] != nil {
+					t.Errorf("credential %s was cooled down for a missing stream terminator", id)
+				}
+				if reg.IsModelSuspendedForClient(id, model) {
+					t.Errorf("model was suspended for credential %s", id)
+				}
+			}
+			if failed != 4 {
+				t.Errorf("recorded failures = %d, want 4", failed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #5283.

An OpenAI-compatible stream that reaches clean EOF without `[DONE]` still needs to fail for Responses clients. Currently that locally detected protocol error is also applied to credential health: a provider that consistently omits `[DONE]` drains the available key pool and later requests receive `auth_unavailable` instead of the original failure.

Mark this specific error as request-scoped using the existing auth error contract. The request continues to fail with HTTP 502 and the missing-terminator diagnostic; credential fallback/cooldown and model suspension are skipped. Failure counters are still recorded. Explicit upstream error payloads retain their existing classification, and the strict `[DONE]` requirement remains in place.

Validation:
- Reproduced the failure with the real OpenAICompatExecutor and auth Manager, three credentials and four consecutive requests, both before any output and after partial output. Both cases failed on the base revision and pass with the fix.
- Tests check one upstream attempt per request, retained partial output, no fabricated `response.completed`, original 502 errors on subsequent requests, healthy credentials/models and recorded failure counts.
- Added error-classification assertions to the existing missing-terminator and explicit-upstream-error tests.
- `go test ./internal/runtime/executor/... ./sdk/cliproxy/auth -count=1` passes.
- Server compilation passes with `go build -buildvcs=false` (workspace output `cliproxy-stream-scope-build`; VCS stamping is disabled for this worktree environment).

The regression uses a deterministic HTTP transport; no live MiniMax credentials are needed.