### PR TITLE
fix(compat): support per-model completion token parameters

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -667,6 +667,7 @@ nonstream-keepalive-interval: 0
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients. Use [text] for upstreams that reject multimodal tool result content.
 #         output-modalities: [text]       # optional: declare output modalities when known
 #         is-compat: false                # optional: preserve Claude thinking blocks for compatible upstreams
+#         use-max-completion-tokens: false # optional: rename max_tokens to max_completion_tokens in Chat Completions requests, preserving its value; an explicit max_completion_tokens wins
 #         thinking:                      # optional: omit to default to levels ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -762,6 +762,10 @@ type OpenAICompatibilityModel struct {
 	// Default false keeps the normal signature validation behavior.
 	IsCompat bool `yaml:"is-compat,omitempty" json:"is-compat,omitempty"`
 
+	// UseMaxCompletionTokens renames max_tokens for this model's Chat Completions requests.
+	// The request's value is preserved; an explicit max_completion_tokens takes precedence.
+	UseMaxCompletionTokens bool `yaml:"use-max-completion-tokens,omitempty" json:"use-max-completion-tokens,omitempty"`
+
 	// Thinking configures the thinking/reasoning capability for this model.
 	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`

--- a/internal/modelconfig/model_hash.go
+++ b/internal/modelconfig/model_hash.go
@@ -20,7 +20,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + "|" + fmt.Sprintf("use-max-completion-tokens=%t", model.UseMaxCompletionTokens) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)

--- a/internal/runtime/executor/helps/openai_compat_token_limit.go
+++ b/internal/runtime/executor/helps/openai_compat_token_limit.go
@@ -1,0 +1,49 @@
+package helps
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// NormalizeOpenAICompletionTokenLimit moves the caller's max_tokens value to
+// max_completion_tokens when the selected upstream model explicitly requires it.
+// Apply this after payload rules and only to Chat Completions requests.
+func NormalizeOpenAICompletionTokenLimit(payload []byte, compat *config.OpenAICompatibility, upstreamModel string) []byte {
+	if compat == nil {
+		return payload
+	}
+	legacy := gjson.GetBytes(payload, "max_tokens")
+	if !legacy.Exists() {
+		return payload
+	}
+	modelName := normalizeOpenAICompatibilityModelName(upstreamModel)
+	if modelName == "" {
+		return payload
+	}
+	// The executor receives the resolved upstream name. Matching a client alias
+	// could apply one pool member's setting to a different upstream model.
+	for _, model := range compat.Models {
+		if !strings.EqualFold(modelName, normalizeOpenAICompatibilityModelName(model.Name)) {
+			continue
+		}
+		if !model.UseMaxCompletionTokens {
+			return payload
+		}
+		out := payload
+		if !gjson.GetBytes(out, "max_completion_tokens").Exists() {
+			var err error
+			out, err = sjson.SetRawBytes(out, "max_completion_tokens", []byte(legacy.Raw))
+			if err != nil {
+				return payload
+			}
+		}
+		if updated, err := sjson.DeleteBytes(out, "max_tokens"); err == nil {
+			return updated
+		}
+		return payload
+	}
+	return payload
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -130,6 +130,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
 	if opts.Alt != "responses/compact" {
+		translated = helps.NormalizeOpenAICompletionTokenLimit(translated, e.resolveCompatConfig(auth), baseModel)
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)
 		if err != nil {
 			return resp, err
@@ -344,6 +345,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
 	if opts.Alt != "responses/compact" {
+		translated = helps.NormalizeOpenAICompletionTokenLimit(translated, e.resolveCompatConfig(auth), baseModel)
 		translated, err = e.applyPromptCacheKey(ctx, auth, from, baseModel, req, opts, translated)
 		if err != nil {
 			return nil, err

--- a/internal/runtime/executor/openai_compat_executor_token_limit_test.go
+++ b/internal/runtime/executor/openai_compat_executor_token_limit_test.go
@@ -1,0 +1,152 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAICompatExecutorCompletionTokenParameter(t *testing.T) {
+	const configYAML = `
+openai-compatibility:
+  - name: compat
+    models:
+      - name: reasoning-model
+        alias: claude-client
+        use-max-completion-tokens: true
+      - name: legacy-model
+        alias: claude-client
+  - name: other-provider
+    models:
+      - name: reasoning-model
+        alias: claude-client
+`
+	tests := []struct {
+		name           string
+		format         sdktranslator.Format
+		payload        string
+		model          string
+		provider       string
+		alt            string
+		override       map[string]any
+		filter         []string
+		wantLegacy     string
+		wantCompletion string
+		wantOutput     string
+	}{
+		{name: "Claude client limit", format: sdktranslator.FormatClaude, payload: `{"model":"claude-client","max_tokens":8192,"messages":[{"role":"user","content":"hi"}]}`, wantCompletion: "8192"},
+		{name: "Claude different client limit", format: sdktranslator.FormatClaude, payload: `{"model":"claude-client","max_tokens":32768,"messages":[{"role":"user","content":"hi"}]}`, wantCompletion: "32768"},
+		{name: "Responses client limit", format: sdktranslator.FormatOpenAIResponse, payload: `{"model":"claude-client","max_output_tokens":16384,"input":"hi"}`, wantCompletion: "16384"},
+		{name: "Chat client limit", payload: `{"max_tokens":4096,"messages":[{"role":"user","content":"hi"}]}`, wantCompletion: "4096"},
+		{name: "explicit modern limit wins", payload: `{"max_tokens":4096,"max_completion_tokens":2048,"messages":[]}`, wantCompletion: "2048"},
+		{name: "explicit modern null wins", payload: `{"max_tokens":4096,"max_completion_tokens":null,"messages":[]}`, wantCompletion: "null"},
+		{name: "modern limit only", payload: `{"max_completion_tokens":1024,"messages":[]}`, wantCompletion: "1024"},
+		{name: "null legacy limit", payload: `{"max_tokens":null,"messages":[]}`, wantCompletion: "null"},
+		{name: "no limit added", payload: `{"messages":[]}`},
+		{name: "disabled model in same alias pool", model: "legacy-model", payload: `{"model":"claude-client","max_tokens":4096,"messages":[]}`, wantLegacy: "4096"},
+		{name: "unconfigured upstream sharing client alias", model: "unknown-model", payload: `{"model":"claude-client","max_tokens":4096,"messages":[]}`, wantLegacy: "4096"},
+		{name: "same model on other provider", provider: "other-provider", payload: `{"max_tokens":4096,"messages":[]}`, wantLegacy: "4096"},
+		{name: "unconfigured provider", provider: "unknown-provider", payload: `{"max_tokens":4096,"messages":[]}`, wantLegacy: "4096"},
+		{name: "thinking suffix", model: "reasoning-model(high)", payload: `{"max_tokens":4096,"messages":[]}`, wantCompletion: "4096"},
+		{name: "legacy payload override", payload: `{"max_tokens":4096,"messages":[]}`, override: map[string]any{"max_tokens": 3072}, wantCompletion: "3072"},
+		{name: "modern payload override", payload: `{"max_tokens":4096,"messages":[]}`, override: map[string]any{"max_completion_tokens": 2048}, wantCompletion: "2048"},
+		{name: "payload filter removes limit", payload: `{"max_tokens":4096,"messages":[]}`, filter: []string{"max_tokens"}},
+		{name: "Responses compact keeps native limit", format: sdktranslator.FormatOpenAIResponse, alt: "responses/compact", payload: `{"input":[],"max_output_tokens":8192}`, wantOutput: "8192"},
+	}
+	for _, tt := range tests {
+		for _, stream := range []bool{false, true} {
+			if stream && tt.alt != "" {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/stream=%t", tt.name, stream), func(t *testing.T) {
+				var cfg config.Config
+				if err := yaml.Unmarshal([]byte(configYAML), &cfg); err != nil {
+					t.Fatal(err)
+				}
+				if tt.override != nil {
+					cfg.Payload.Override = []config.PayloadRule{{Models: []config.PayloadModelRule{{Name: "*", Protocol: "openai"}}, Params: tt.override}}
+				}
+				if tt.filter != nil {
+					cfg.Payload.Filter = []config.PayloadFilterRule{{Models: []config.PayloadModelRule{{Name: "*", Protocol: "openai"}}, Params: tt.filter}}
+				}
+				provider := tt.provider
+				if provider == "" {
+					provider = "compat"
+				}
+				model := tt.model
+				if model == "" {
+					model = "reasoning-model"
+				}
+				format := tt.format
+				if format == "" {
+					format = sdktranslator.FormatOpenAI
+				}
+				var gotBody []byte
+				ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					var err error
+					gotBody, err = io.ReadAll(req.Body)
+					if err != nil {
+						return nil, err
+					}
+					wantPath := "/v1/chat/completions"
+					if tt.alt != "" {
+						wantPath = "/v1/" + tt.alt
+					}
+					if req.URL.Path != wantPath {
+						t.Errorf("upstream path = %q, want %q", req.URL.Path, wantPath)
+					}
+					body := `{"id":"chatcmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`
+					contentType := "application/json"
+					if stream {
+						body = "data: [DONE]\n\n"
+						contentType = "text/event-stream"
+					} else if tt.alt != "" {
+						body = `{"id":"resp_1","object":"response.compaction","output":[]}`
+					}
+					return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {contentType}}, Body: io.NopCloser(strings.NewReader(body))}, nil
+				}))
+				executor := NewOpenAICompatExecutor(provider, &cfg)
+				auth := &cliproxyauth.Auth{Provider: provider, Attributes: map[string]string{"base_url": "https://upstream.example/v1", "compat_name": provider}}
+				req := cliproxyexecutor.Request{Model: model, Payload: []byte(tt.payload)}
+				opts := cliproxyexecutor.Options{
+					SourceFormat:   format,
+					ResponseFormat: sdktranslator.FormatOpenAI,
+					Stream:         stream,
+					Alt:            tt.alt,
+					Metadata:       map[string]any{cliproxyexecutor.RequestedModelMetadataKey: "claude-client"},
+				}
+				if stream {
+					result, err := executor.ExecuteStream(ctx, auth, req, opts)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for chunk := range result.Chunks {
+						if chunk.Err != nil {
+							t.Fatal(chunk.Err)
+						}
+					}
+				} else if _, err := executor.Execute(ctx, auth, req, opts); err != nil {
+					t.Fatal(err)
+				}
+				if len(gotBody) == 0 {
+					t.Fatal("upstream request was not sent")
+				}
+				for path, want := range map[string]string{"max_tokens": tt.wantLegacy, "max_completion_tokens": tt.wantCompletion, "max_output_tokens": tt.wantOutput} {
+					if got := gjson.GetBytes(gotBody, path).Raw; got != want {
+						t.Errorf("%s = %q, want %q; body=%s", path, got, want, gotBody)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -50,6 +50,15 @@ func TestComputeOpenAICompatModelsHashIncludesModalities(t *testing.T) {
 	}
 }
 
+func TestComputeOpenAICompatModelsHashIncludesCompletionTokenParameter(t *testing.T) {
+	models := []config.OpenAICompatibilityModel{{Name: "reasoning-model", Alias: "claude-client"}}
+	before := ComputeOpenAICompatModelsHash(models)
+	models[0].UseMaxCompletionTokens = true
+	if before == ComputeOpenAICompatModelsHash(models) {
+		t.Fatal("changing the token parameter setting must trigger a model configuration update")
+	}
+}
+
 func TestComputeOpenAICompatModelsHashPreservesRoutingOrderAndDuplicates(t *testing.T) {
 	a := []config.OpenAICompatibilityModel{
 		{Name: "gpt-4", Alias: "gpt4"},


### PR DESCRIPTION
Closes #5005.

Claude clients send a dynamic `max_tokens` limit. Translation to an OpenAI-compatible Chat Completions upstream preserves that field, which fails for models that require `max_completion_tokens`. A fixed payload override cannot preserve the limit selected by each request.

This adds an opt-in `use-max-completion-tokens` setting to individual `openai-compatibility.models` entries. After translation and payload rules, both execution paths move the original value to `max_completion_tokens` and remove `max_tokens`. An explicitly supplied `max_completion_tokens` takes precedence, including an explicit null. Requests without a limit remain unchanged.

```yaml
openai-compatibility:
  - name: my-provider
    base-url: https://provider.example/v1
    api-key-entries:
      - api-key: YOUR_API_KEY
    models:
      - name: actual-upstream-model
        alias: claude-client
        use-max-completion-tokens: true
```

The option defaults to false and matches the selected provider and resolved upstream model, so models sharing a client alias can use different token parameters. Native `/responses/compact` requests keep their format. The model configuration hash includes the setting for hot reload.

The choice is explicit because a model catalog's numeric token ceiling does not specify which request parameter an arbitrary compatible provider accepts. The [OpenAI Chat Completions reference](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create) documents the two parameters and the legacy parameter's incompatibility with o-series models.

Validation:
- 35 outbound-request cases cover Claude, Responses and Chat inputs; different client limits; streaming and non-streaming; null/missing/both parameters; model pools; provider isolation; thinking suffixes; payload overrides/filters; and compact passthrough. 20 cases reproduced the unsupported legacy parameter before the fix.
- Added a regression check that changing the option changes the model configuration hash.
- `go test ./internal/runtime/executor ./internal/runtime/executor/helps ./internal/config ./internal/modelconfig ./internal/watcher/diff -count=1` passed.
- `go build -buildvcs=false -o /workspace/scratch/902c8d9b01a1/toolchains/cliproxy-completion-tokens-build ./cmd/server` passed.