### PR TITLE
feat: support GPT Image 2.5 models

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2095,6 +2095,8 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 		},
 		{ID: "grok-imagine-image-quality", Object: "model", OwnedBy: "xai", Type: "openai"},
 		{ID: "gpt-image-2", Object: "model", OwnedBy: "openai", Type: "openai"},
+		{ID: "gpt-image-2.5-flare", Object: "model", OwnedBy: "openai", Type: "openai"},
+		{ID: "gpt-image-2.5-sunburst", Object: "model", OwnedBy: "openai", Type: "openai"},
 		{ID: "grok-imagine-image", Object: "model", OwnedBy: "xai", Type: "openai"},
 		{ID: "grok-imagine-image-2.0", Object: "model", OwnedBy: "xai", Type: "openai"},
 		{ID: "grok-imagine-video", Object: "model", OwnedBy: "xai", Type: "openai"},
@@ -2199,6 +2201,8 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 	hiddenModels := map[string]bool{
 		"grok-imagine-image-quality":     false,
 		"gpt-image-2":                    false,
+		"gpt-image-2.5-flare":            false,
+		"gpt-image-2.5-sunburst":         false,
 		"grok-imagine-image":             false,
 		"grok-imagine-image-2.0":         false,
 		"grok-imagine-video":             false,

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -336,7 +336,7 @@ func codexClientThinkingSupport(model map[string]any) *registry.ThinkingSupport 
 
 func applyCodexClientVisibilityOverride(entry map[string]any, id string) {
 	switch strings.TrimSpace(id) {
-	case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-2.0", "grok-imagine-video", "grok-imagine-video-1.5", "grok-imagine-video-1.5-preview":
+	case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "grok-imagine-image", "grok-imagine-image-2.0", "grok-imagine-video", "grok-imagine-video-1.5", "grok-imagine-video-1.5-preview":
 		entry["visibility"] = "hide"
 	}
 }

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -7,14 +7,16 @@ import (
 )
 
 const (
-	codexBuiltinImage15ModelID    = "gpt-image-1.5"
-	codexBuiltinImageModelID      = "gpt-image-2"
-	xaiBuiltinImageModelID        = "grok-imagine-image"
-	xaiBuiltinImageQualityModelID = "grok-imagine-image-quality"
-	xaiBuiltinImage20ModelID      = "grok-imagine-image-2.0"
-	xaiBuiltinVideoModelID        = "grok-imagine-video"
-	xaiBuiltinVideo15ModelID      = "grok-imagine-video-1.5"
-	xaiBuiltinVideo15PreviewID    = "grok-imagine-video-1.5-preview"
+	codexBuiltinImage15ModelID       = "gpt-image-1.5"
+	codexBuiltinImageModelID         = "gpt-image-2"
+	codexBuiltinImageFlareModelID    = "gpt-image-2.5-flare"
+	codexBuiltinImageSunburstModelID = "gpt-image-2.5-sunburst"
+	xaiBuiltinImageModelID           = "grok-imagine-image"
+	xaiBuiltinImageQualityModelID    = "grok-imagine-image-quality"
+	xaiBuiltinImage20ModelID         = "grok-imagine-image-2.0"
+	xaiBuiltinVideoModelID           = "grok-imagine-video"
+	xaiBuiltinVideo15ModelID         = "grok-imagine-video-1.5"
+	xaiBuiltinVideo15PreviewID       = "grok-imagine-video-1.5-preview"
 )
 
 // staticModelsJSON mirrors the top-level structure of models.json.
@@ -116,7 +118,7 @@ func GetXAIModels() []*ModelInfo {
 // not depend on remote models.json updates. Built-ins replace any matching IDs
 // already present in the provided slice.
 func WithCodexBuiltins(models []*ModelInfo) []*ModelInfo {
-	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo())
+	return upsertModelInfos(models, codexBuiltinImage15ModelInfo(), codexBuiltinImageModelInfo(), codexBuiltinImageFlareModelInfo(), codexBuiltinImageSunburstModelInfo())
 }
 
 // WithXAIBuiltins injects hard-coded xAI image/video model definitions that should
@@ -154,6 +156,30 @@ func codexBuiltinImageModelInfo() *ModelInfo {
 		Type:        "openai",
 		DisplayName: "GPT Image 2",
 		Version:     codexBuiltinImageModelID,
+	}
+}
+
+func codexBuiltinImageFlareModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:          codexBuiltinImageFlareModelID,
+		Object:      "model",
+		Created:     1704067200, // 2024-01-01
+		OwnedBy:     "openai",
+		Type:        "openai",
+		DisplayName: "GPT Image 2.5 Flare",
+		Version:     codexBuiltinImageFlareModelID,
+	}
+}
+
+func codexBuiltinImageSunburstModelInfo() *ModelInfo {
+	return &ModelInfo{
+		ID:          codexBuiltinImageSunburstModelID,
+		Object:      "model",
+		Created:     1704067200, // 2024-01-01
+		OwnedBy:     "openai",
+		Type:        "openai",
+		DisplayName: "GPT Image 2.5 Sunburst",
+		Version:     codexBuiltinImageSunburstModelID,
 	}
 }
 

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -55,6 +55,26 @@ func TestWithXAIBuiltinsIncludesImage20(t *testing.T) {
 	t.Fatalf("expected xAI builtin model %s", xaiBuiltinImage20ModelID)
 }
 
+func TestWithCodexBuiltinsIncludesImage25Models(t *testing.T) {
+	models := WithCodexBuiltins(nil)
+	want := map[string]bool{
+		"gpt-image-2.5-flare":    false,
+		"gpt-image-2.5-sunburst": false,
+	}
+	for _, model := range models {
+		if model != nil {
+			if _, ok := want[model.ID]; ok {
+				want[model.ID] = true
+			}
+		}
+	}
+	for modelID, found := range want {
+		if !found {
+			t.Fatalf("expected Codex builtin model %s", modelID)
+		}
+	}
+}
+
 func TestWithXAIBuiltinsIncludesVideo15GAAndPreviewAlias(t *testing.T) {
 	models := WithXAIBuiltins(nil)
 	foundGA := false

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -34,6 +34,8 @@ const (
 	codexDirectImagesGenerations = "/images/generations"
 	codexDirectImagesEdit        = "/images/edits"
 	codexGPTImage15Model         = "gpt-image-1.5"
+	codexGPTImage25FlareModel    = "gpt-image-2.5-flare"
+	codexGPTImage25SunburstModel = "gpt-image-2.5-sunburst"
 	codexOpenAIImagesMainModel   = "gpt-5.4-mini"
 )
 
@@ -660,7 +662,7 @@ func codexOpenAIImageBaseModel(model string) string {
 
 func codexIsDirectOpenAIImageModel(model string) bool {
 	switch strings.ToLower(strings.TrimSpace(model)) {
-	case codexGPTImage15Model, codexDefaultImageToolModel:
+	case codexGPTImage15Model, codexDefaultImageToolModel, codexGPTImage25FlareModel, codexGPTImage25SunburstModel:
 		return true
 	default:
 		return false

--- a/internal/runtime/executor/codex_openai_images_test.go
+++ b/internal/runtime/executor/codex_openai_images_test.go
@@ -38,6 +38,14 @@ func codexOpenAIImageTestOptions(path string, stream bool) cliproxyexecutor.Opti
 	}
 }
 
+func TestCodexDirectOpenAIImageModelsIncludeImage25(t *testing.T) {
+	for _, model := range []string{"gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
+		if !codexIsDirectOpenAIImageModel(model) {
+			t.Fatalf("codexIsDirectOpenAIImageModel(%q) = false, want true", model)
+		}
+	}
+}
+
 func TestCodexExecutorDirectOpenAIImageGenerationUsesImagesEndpoint(t *testing.T) {
 	var gotPath string
 	var gotAuth string

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -166,6 +166,8 @@ func TestGetRequestDetails_ImageModelReturns503(t *testing.T) {
 	imageOnlyModels := []string{
 		"gpt-image-1.5",
 		"gpt-image-2",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-sunburst",
 		"codex/gpt-image-2",
 		"grok-imagine-image",
 		"xai/grok-imagine-image",
@@ -200,6 +202,8 @@ func TestValidateImageOnlyModel_AllowsImageEndpoints(t *testing.T) {
 	imageOnlyModels := []string{
 		"gpt-image-1.5",
 		"gpt-image-2",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-sunburst",
 		"codex/gpt-image-2",
 		"grok-imagine-image",
 		"xai/grok-imagine-image",
@@ -229,6 +233,8 @@ func TestIsOpenAIImageOnlyModel(t *testing.T) {
 	}{
 		{model: "gpt-image-1.5", want: true},
 		{model: "gpt-image-2", want: true},
+		{model: "gpt-image-2.5-flare", want: true},
+		{model: "gpt-image-2.5-sunburst", want: true},
 		{model: "codex/gpt-image-1.5", want: true},
 		{model: "grok-imagine-image", want: true},
 		{model: "xai/grok-imagine-image", want: true},
@@ -255,6 +261,8 @@ func TestExecuteImageWithAuthManager_AllowsImageOnlyModels(t *testing.T) {
 	imageOnlyModels := []string{
 		"gpt-image-1.5",
 		"gpt-image-2",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-sunburst",
 		"grok-imagine-image",
 		"grok-imagine-image-quality",
 		"xai/grok-imagine-image-quality",

--- a/sdk/api/handlers/handlers_routing.go
+++ b/sdk/api/handlers/handlers_routing.go
@@ -239,7 +239,7 @@ func (h *BaseAPIHandler) validateImageOnlyModel(modelName string, allowImageMode
 
 func isOpenAIImageOnlyModel(model string) bool {
 	switch strings.ToLower(strings.TrimSpace(routeModelBaseName(model))) {
-	case "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-image-2.0":
+	case "gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "grok-imagine-image", "grok-imagine-image-quality", "grok-imagine-image-2.0":
 		return true
 	default:
 		return false

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -29,6 +29,8 @@ const (
 	defaultImagesMainModel      = "gpt-5.4-mini"
 	gptImage15Model             = "gpt-image-1.5"
 	defaultImagesToolModel      = "gpt-image-2"
+	gptImage25FlareModel        = "gpt-image-2.5-flare"
+	gptImage25SunburstModel     = "gpt-image-2.5-sunburst"
 	defaultXAIImagesModel       = "grok-imagine-image"
 	xaiImagesQualityModel       = "grok-imagine-image-quality"
 	xaiImages20Model            = "grok-imagine-image-2.0"
@@ -239,7 +241,7 @@ func isSupportedImagesModel(model string) bool {
 
 func isCodexImagesToolModel(model string) bool {
 	baseModel := imagesModelBase(model)
-	return baseModel == gptImage15Model || baseModel == defaultImagesToolModel
+	return baseModel == gptImage15Model || baseModel == defaultImagesToolModel || baseModel == gptImage25FlareModel || baseModel == gptImage25SunburstModel
 }
 
 func isOpenAICompatImagesModel(model string) bool {
@@ -258,7 +260,7 @@ func rejectUnsupportedImagesModel(c *gin.Context, model string) bool {
 
 	c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
 		Error: handlers.ErrorDetail{
-			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s, %s, %s, %s, %s, or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, gptImage15Model, defaultImagesToolModel, defaultXAIImagesModel, xaiImagesQualityModel, xaiImages20Model),
+			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s, %s, %s, %s, %s, %s, %s, or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, gptImage15Model, defaultImagesToolModel, gptImage25FlareModel, gptImage25SunburstModel, defaultXAIImagesModel, xaiImagesQualityModel, xaiImages20Model),
 			Type:    "invalid_request_error",
 		},
 	})

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -46,7 +46,7 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 	}
 
 	message := gjson.GetBytes(resp.Body.Bytes(), "error.message").String()
-	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + gptImage15Model + ", " + defaultImagesToolModel + ", " + defaultXAIImagesModel + ", " + xaiImagesQualityModel + ", " + xaiImages20Model + ", or a configured openai-compatibility image model."
+	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + gptImage15Model + ", " + defaultImagesToolModel + ", " + gptImage25FlareModel + ", " + gptImage25SunburstModel + ", " + defaultXAIImagesModel + ", " + xaiImagesQualityModel + ", " + xaiImages20Model + ", or a configured openai-compatibility image model."
 	if message != expectedMessage {
 		t.Fatalf("error message = %q, want %q", message, expectedMessage)
 	}
@@ -56,7 +56,7 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 }
 
 func TestImagesModelValidationAllowsGPTImageAndXAIModels(t *testing.T) {
-	for _, model := range []string{"gpt-image-1.5", "codex/gpt-image-1.5", "gpt-image-2", "codex/gpt-image-2", "grok-imagine-image", "xai/grok-imagine-image", "grok-imagine-image-quality", "xai/grok-imagine-image-quality", "grok-imagine-image-2.0", "xai/grok-imagine-image-2.0"} {
+	for _, model := range []string{"gpt-image-1.5", "codex/gpt-image-1.5", "gpt-image-2", "codex/gpt-image-2", "gpt-image-2.5-flare", "codex/gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "codex/gpt-image-2.5-sunburst", "grok-imagine-image", "xai/grok-imagine-image", "grok-imagine-image-quality", "xai/grok-imagine-image-quality", "grok-imagine-image-2.0", "xai/grok-imagine-image-2.0"} {
 		if !isSupportedImagesModel(model) {
 			t.Fatalf("expected %s to be supported", model)
 		}

--- a/sdk/cliproxy/service_codex_models_test.go
+++ b/sdk/cliproxy/service_codex_models_test.go
@@ -29,7 +29,7 @@ func TestRegisterModelsForAuthCodexAPIKeyModels(t *testing.T) {
 			name:        "defaults without explicit models",
 			entry:       config.CodexKey{APIKey: "default-key"},
 			wantIDs:     codexModelIDSet(defaultModels),
-			wantPresent: []string{"gpt-image-1.5", "gpt-image-2"},
+			wantPresent: []string{"gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"},
 		},
 		{
 			name: "only explicitly configured models",
@@ -40,7 +40,7 @@ func TestRegisterModelsForAuthCodexAPIKeyModels(t *testing.T) {
 				}},
 			},
 			wantIDs:    map[string]struct{}{"configured-codex": {}},
-			wantAbsent: []string{"gpt-image-1.5", "gpt-image-2"},
+			wantAbsent: []string{"gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"},
 		},
 		{
 			name: "exclusions apply to defaults",
@@ -245,7 +245,7 @@ func TestRegisterConfigAPIKeyAuthsCodexModelModes(t *testing.T) {
 					t.Errorf("missing registered model %q", modelID)
 				}
 			}
-			for _, modelID := range []string{"gpt-image-1.5", "gpt-image-2"} {
+			for _, modelID := range []string{"gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst"} {
 				_, registered := registeredIDs[modelID]
 				if registered != testCase.wantImages {
 					t.Errorf("registered model %q = %t, want %t", modelID, registered, testCase.wantImages)


### PR DESCRIPTION
## Summary

- add `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` as built-in Codex image models
- route both models through the existing OpenAI image generation/edit path
- include model catalog, image validation, visibility, and routing tests

## Validation

- `go build -o /tmp/cliproxyapi-test ./cmd/server`
- `go test ./...`
- isolated Docker E2E on port 18317: both models returned HTTP 200 with one non-empty `b64_json` result

The locally running CLIProxyAPI on port 8317 was not stopped or modified.