### PR TITLE
fix(antigravity): keep thinking block open on empty text parts in claude stream

### DIFF
--- a/internal/translator/antigravity/claude/antigravity_claude_response.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response.go
@@ -326,18 +326,20 @@ func ConvertAntigravityResponseToClaude(ctx context.Context, _ string, originalR
 							data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
 							appendEvent("content_block_delta", string(data))
 							params.HasContent = true
-						} else {
+						} else if partText != "" {
+							// Only close the active block when a text block actually follows.
+							// Closing it for an empty text part would advance the index while
+							// leaving ResponseType set, so the next event targets a block
+							// that was never started.
 							if params.ResponseType != 0 {
 								appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, params.ResponseIndex))
 								params.ResponseIndex++
 							}
-							if partText != "" {
-								appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, params.ResponseIndex))
-								data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
-								appendEvent("content_block_delta", string(data))
-								params.ResponseType = 1
-								params.HasContent = true
-							}
+							appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, params.ResponseIndex))
+							data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
+							appendEvent("content_block_delta", string(data))
+							params.ResponseType = 1
+							params.HasContent = true
 						}
 					}
 					if partText != "" {

--- a/internal/translator/antigravity/claude/antigravity_claude_response_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response_test.go
@@ -252,6 +252,54 @@ func testEmptyAntigravityResponse() []byte {
 	}`)
 }
 
+func TestConvertAntigravityResponseToClaudeStream_EmptyTextPartKeepsThinkingBlockOpen(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-3-flash-agent"}`)
+	thinkingChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Thinking","thought":true}]}}],"responseId":"resp-1"}}`)
+	emptyTextChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]}}]}}`)
+	finishChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":100,"thoughtsTokenCount":20,"totalTokenCount":120}}}`)
+
+	var param any
+	ctx := context.Background()
+	var output []byte
+	for _, chunk := range [][]byte{thinkingChunk, emptyTextChunk, finishChunk, []byte("[DONE]")} {
+		output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, chunk, &param), nil)...)
+	}
+	outputText := string(output)
+
+	started := map[int64]bool{}
+	stops := 0
+	currentEvent := ""
+	for _, line := range strings.Split(outputText, "\n") {
+		if strings.HasPrefix(line, "event: ") {
+			currentEvent = strings.TrimPrefix(line, "event: ")
+			continue
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		index := gjson.Get(strings.TrimPrefix(line, "data: "), "index").Int()
+		switch currentEvent {
+		case "content_block_start":
+			started[index] = true
+		case "content_block_delta", "content_block_stop":
+			if !started[index] {
+				t.Fatalf("%s for index %d without content_block_start in:\n%s", currentEvent, index, outputText)
+			}
+			if currentEvent == "content_block_stop" {
+				stops++
+			}
+		}
+	}
+	if stops != 1 {
+		t.Fatalf("content_block_stop count = %d, want 1 in:\n%s", stops, outputText)
+	}
+
+	messageDelta := sseDataForEvent(t, outputText, "message_delta")
+	if got := gjson.Get(messageDelta, "delta.stop_reason").String(); got != "end_turn" {
+		t.Fatalf("stop_reason = %q, want end_turn: %s", got, messageDelta)
+	}
+}
+
 func TestWebSearchResultsFromGrounding_DeduplicatesAndSkipsEmptyURLs(t *testing.T) {
 	groundingMetadata := gjson.Parse(`{
 		"groundingChunks": [


### PR DESCRIPTION
## Summary

Claude Code aborts a streamed `/v1/messages` response through the Antigravity executor with `API Error: Content block not found` when Gemini sends an empty `{"text":""}` part while a thinking block is still open.

## Why

In `ConvertAntigravityResponseToClaude`, a non-thought text part with no `finishReason` closes the active block and bumps `ResponseIndex`, but only opens a new text block when the text is non-empty. For an empty part the index moves on while `ResponseType` still says "thinking", so the next `content_block_stop` (from `appendFinalEvents`) or `thinking_delta` targets an index that never received `content_block_start`:

```
content_block_start   index 0  thinking
content_block_delta   index 0
content_block_stop    index 0
content_block_stop    index 1   <- never started
message_delta / message_stop
```

Gemini emits these empty text parts during long thinking (observed on gemini-3.7/3.8-flash with the stream idle for 15-30s before the failure). The fix skips the close when no text block will follow. The `gemini/claude` translator is not affected because it always opens a new text block after closing.

## Verification

- New `TestConvertAntigravityResponseToClaudeStream_EmptyTextPartKeepsThinkingBlockOpen` fails on main at the `content_block_stop for index 1` assertion and passes with this change.
- `go test ./...` and `go build -o test-output ./cmd/server` pass.

Closes #5674
