### PR TITLE
fix(claude): align early errors and request IDs

### DIFF
--- a/internal/api/server_claude_auth_test.go
+++ b/internal/api/server_claude_auth_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeRoutesUseStructuredAuthErrors(t *testing.T) {
+	server := newTestServer(t)
+	for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens"} {
+		for _, key := range []string{"", "wrong-key"} {
+			t.Run(path+"/"+key, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodPost, path+"?beta=true", strings.NewReader(`{"model":"test-model","messages":[]}`))
+				if key != "" {
+					req.Header.Set("X-Api-Key", key)
+				}
+				recorder := httptest.NewRecorder()
+				server.engine.ServeHTTP(recorder, req)
+				if recorder.Code != http.StatusUnauthorized {
+					t.Fatalf("status = %d, want 401", recorder.Code)
+				}
+				body := recorder.Body.Bytes()
+				if gjson.GetBytes(body, "type").String() != "error" || gjson.GetBytes(body, "error.type").String() != "authentication_error" {
+					t.Fatalf("expected Anthropic authentication error, got %s", body)
+				}
+				wantMessage := "Missing API key"
+				if key != "" {
+					wantMessage = "Invalid API key"
+				}
+				if got := gjson.GetBytes(body, "error.message").String(); got != wantMessage {
+					t.Errorf("error.message = %q, want %q", got, wantMessage)
+				}
+			})
+		}
+	}
+}
+
+type claudeAuthErrorProvider struct {
+	err *sdkaccess.AuthError
+}
+
+func (p claudeAuthErrorProvider) Identifier() string { return "claude-auth-error-test" }
+
+func (p claudeAuthErrorProvider) Authenticate(context.Context, *http.Request) (*sdkaccess.Result, *sdkaccess.AuthError) {
+	return nil, p.err
+}
+
+func TestClaudeAuthErrorsPreserveStatusAndSafeMessage(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		err      *sdkaccess.AuthError
+		wantType string
+	}{
+		{name: "service failure", err: sdkaccess.NewInternalAuthError("Authentication service unavailable", errors.New("private cause")), wantType: "api_error"},
+		{name: "permission denied", err: &sdkaccess.AuthError{StatusCode: http.StatusForbidden, Message: "Access denied"}, wantType: "permission_error"},
+		{name: "rate limited", err: &sdkaccess.AuthError{StatusCode: http.StatusTooManyRequests, Message: "Too many authentication attempts"}, wantType: "rate_limit_error"},
+	} {
+		for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens"} {
+			t.Run(tt.name+path, func(t *testing.T) {
+				manager := sdkaccess.NewManager()
+				manager.SetProviders([]sdkaccess.Provider{claudeAuthErrorProvider{err: tt.err}})
+				router := gin.New()
+				router.Use(AuthMiddleware(manager))
+				router.POST(path, func(c *gin.Context) { t.Error("rejected request reached endpoint") })
+				recorder := httptest.NewRecorder()
+				router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, path, nil))
+				if recorder.Code != tt.err.HTTPStatusCode() {
+					t.Fatalf("status = %d, want %d", recorder.Code, tt.err.HTTPStatusCode())
+				}
+				body := recorder.Body.Bytes()
+				if gjson.GetBytes(body, "type").String() != "error" || gjson.GetBytes(body, "error.type").String() != tt.wantType {
+					t.Fatalf("expected %s error, got %s", tt.wantType, body)
+				}
+				if got := gjson.GetBytes(body, "error.message").String(); got != tt.err.Message {
+					t.Errorf("error.message = %q, want public message %q", got, tt.err.Message)
+				}
+				if strings.Contains(string(body), "private cause") {
+					t.Error("private authentication cause was returned to client")
+				}
+			})
+		}
+	}
+}
+
+func TestNonClaudeAuthErrorsKeepExistingEnvelope(t *testing.T) {
+	server := newTestServer(t)
+	for _, path := range []string{"/v1/responses", "/v1/chat/completions", "/v1beta/models/test:generateContent"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set("Anthropic-Version", "2023-06-01")
+			recorder := httptest.NewRecorder()
+			server.engine.ServeHTTP(recorder, req)
+			if recorder.Code != http.StatusUnauthorized || gjson.GetBytes(recorder.Body.Bytes(), "error").String() != "Missing API key" {
+				t.Fatalf("existing auth response changed: %d %s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}

--- a/internal/api/server_claude_auth_test.go
+++ b/internal/api/server_claude_auth_test.go
@@ -62,6 +62,10 @@ func TestClaudeAuthErrorsPreserveStatusAndSafeMessage(t *testing.T) {
 		{name: "service failure", err: sdkaccess.NewInternalAuthError("Authentication service unavailable", errors.New("private cause")), wantType: "api_error"},
 		{name: "permission denied", err: &sdkaccess.AuthError{StatusCode: http.StatusForbidden, Message: "Access denied"}, wantType: "permission_error"},
 		{name: "rate limited", err: &sdkaccess.AuthError{StatusCode: http.StatusTooManyRequests, Message: "Too many authentication attempts"}, wantType: "rate_limit_error"},
+		{name: "JSON-shaped public message", err: &sdkaccess.AuthError{StatusCode: http.StatusUnauthorized, Message: `{"error":{"type":"rate_limit_error","message":"x"}}`}, wantType: "authentication_error"},
+		{name: "top-level JSON message", err: &sdkaccess.AuthError{StatusCode: http.StatusForbidden, Message: `{"type":"api_error","message":"x"}`}, wantType: "permission_error"},
+		{name: "public message whitespace", err: &sdkaccess.AuthError{StatusCode: http.StatusUnauthorized, Message: "  Access denied  "}, wantType: "authentication_error"},
+		{name: "empty public message", err: &sdkaccess.AuthError{StatusCode: http.StatusUnauthorized}, wantType: "authentication_error"},
 	} {
 		for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens"} {
 			t.Run(tt.name+path, func(t *testing.T) {

--- a/internal/api/server_middleware.go
+++ b/internal/api/server_middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/safemode"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/claude"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -193,6 +194,11 @@ func accessAuthMiddleware(manager *sdkaccess.Manager, realtimeError bool) gin.Ha
 				"param":   nil,
 				"code":    code,
 			}})
+			return
+		}
+		if c.Request.URL.Path == "/v1/messages" || c.Request.URL.Path == "/v1/messages/count_tokens" {
+			c.Data(statusCode, "application/json", claude.BuildErrorResponse(statusCode, err.Message))
+			c.Abort()
 			return
 		}
 		c.AbortWithStatusJSON(statusCode, gin.H{"error": err.Message})

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -395,11 +395,17 @@ func (h *ClaudeCodeAPIHandler) WriteErrorResponse(c *gin.Context, msg *interface
 			}
 		}
 		body := bytes.Clone(msg.Body)
-		requestID := claudeRequestIDFromText(string(body))
+		bodyRequestID := claudeRequestIDFromText(string(body))
+		requestID := bodyRequestID
 		if requestID == "" {
 			requestID = filteredHeaders.Get(claudeRequestIDHeader)
 		}
-		setClaudeRequestID(c, requestID)
+		wireRequestID := setClaudeRequestID(c, requestID)
+		if bodyRequestID != "" && bodyRequestID != wireRequestID {
+			// A non-stream keep-alive may have committed the local ID before
+			// this native Claude error arrived. Reconcile only the ID field.
+			body, _ = sjson.SetBytes(body, "request_id", wireRequestID)
+		}
 		appendClaudeAPIResponse(c, body)
 		if !c.Writer.Written() && c.Writer.Header().Get("Content-Type") == "" {
 			c.Writer.Header().Set("Content-Type", "application/json")

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -344,8 +344,16 @@ func (h *ClaudeCodeAPIHandler) toClaudeError(msg *interfaces.ErrorMessage) claud
 
 // BuildErrorResponse builds an Anthropic error envelope for failures that occur
 // before execution, such as authentication or reading the request body.
+// It preserves the public message literally; JSON-shaped text cannot override
+// the status-derived error type as an upstream error envelope could.
 func BuildErrorResponse(status int, message string) []byte {
-	body, _ := json.Marshal(newClaudeErrorResponse(status, message))
+	body, _ := json.Marshal(claudeErrorResponse{
+		Type: "error",
+		Error: claudeErrorDetail{
+			Type:    claudeErrorTypeFromStatus(status),
+			Message: message,
+		},
+	})
 	return body
 }
 

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -72,12 +72,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 	rawJSON, err := c.GetRawData()
 	// If data retrieval fails, return a 400 Bad Request error.
 	if err != nil {
-		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
-			Error: handlers.ErrorDetail{
-				Message: fmt.Sprintf("Invalid request: %v", err),
-				Type:    "invalid_request_error",
-			},
-		})
+		c.Data(http.StatusBadRequest, "application/json", BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid request: %v", err)))
 		return
 	}
 
@@ -104,12 +99,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 	rawJSON, err := c.GetRawData()
 	// If data retrieval fails, return a 400 Bad Request error.
 	if err != nil {
-		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
-			Error: handlers.ErrorDetail{
-				Message: fmt.Sprintf("Invalid request: %v", err),
-				Type:    "invalid_request_error",
-			},
-		})
+		c.Data(http.StatusBadRequest, "application/json", BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid request: %v", err)))
 		return
 	}
 
@@ -349,6 +339,17 @@ func (h *ClaudeCodeAPIHandler) toClaudeError(msg *interfaces.ErrorMessage) claud
 			}
 		}
 	}
+	return newClaudeErrorResponse(status, errText)
+}
+
+// BuildErrorResponse builds an Anthropic error envelope for failures that occur
+// before execution, such as authentication or reading the request body.
+func BuildErrorResponse(status int, message string) []byte {
+	body, _ := json.Marshal(newClaudeErrorResponse(status, message))
+	return body
+}
+
+func newClaudeErrorResponse(status int, errText string) claudeErrorResponse {
 	errType, message := claudeErrorDetailFromText(status, errText)
 	return claudeErrorResponse{
 		Type: "error",

--- a/sdk/api/handlers/claude/code_handlers_error_test.go
+++ b/sdk/api/handlers/claude/code_handlers_error_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,37 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/tidwall/gjson"
 )
+
+type claudeFailingRequestBody struct{}
+
+func (claudeFailingRequestBody) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (claudeFailingRequestBody) Close() error { return nil }
+
+func TestClaudeRequestReadErrorsUseClaudeEnvelope(t *testing.T) {
+	handler := &ClaudeCodeAPIHandler{}
+	for name, handle := range map[string]func(*gin.Context){
+		"messages":     handler.ClaudeMessages,
+		"count tokens": handler.ClaudeCountTokens,
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			c.Request.Body = claudeFailingRequestBody{}
+			handle(c)
+			body := recorder.Body.Bytes()
+			if recorder.Code != http.StatusBadRequest || gjson.GetBytes(body, "type").String() != "error" || gjson.GetBytes(body, "error.type").String() != "invalid_request_error" {
+				t.Fatalf("expected Anthropic request error, got %d %s", recorder.Code, body)
+			}
+			if got := gjson.GetBytes(body, "error.message").String(); got != "Invalid request: unexpected EOF" {
+				t.Errorf("error.message = %q", got)
+			}
+		})
+	}
+}
 
 func TestClaudeErrorExtractsOpenAIStyleUpstreamJSON(t *testing.T) {
 	handler := &ClaudeCodeAPIHandler{}

--- a/sdk/api/handlers/claude/request_id_test.go
+++ b/sdk/api/handlers/claude/request_id_test.go
@@ -80,6 +80,45 @@ func TestClaudeDirectErrorPreservesRequestIDAndBody(t *testing.T) {
 	}
 }
 
+func TestClaudeCommittedDirectErrorUsesWireRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, tt := range []struct {
+		name    string
+		body    string
+		rewrite bool
+	}{
+		{name: "Claude error", body: `{ "type": "error", "error": {"type":"rate_limit_error","message":"wait"}, "request_id": "req_direct", "extra": true }`, rewrite: true},
+		{name: "opaque response", body: `{"message":"custom response","request_id":"opaque"}`},
+		{name: "matching ID", body: `{ "type": "error", "error": {"message":"wait"}, "request_id": "req_abc12345" }`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			logging.SetGinRequestID(c, "abc12345")
+			EnsureRequestID(c)
+			// Model the header commitment performed by non-stream keep-alive.
+			c.Writer.Flush()
+			handler := NewClaudeCodeAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+			handler.WriteErrorResponse(c, &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests, DirectResponse: true, Body: []byte(tt.body),
+				Headers: http.Header{"Request-Id": {"req_upstream_header"}},
+			})
+			if recorder.Code != http.StatusOK || recorder.Result().Header.Get("Request-Id") != "req_abc12345" {
+				t.Fatalf("committed response changed: %d %v", recorder.Code, recorder.Result().Header)
+			}
+			body := recorder.Body.String()
+			if tt.rewrite {
+				if gjson.Get(body, "request_id").String() != "req_abc12345" || !gjson.Get(body, "extra").Bool() || gjson.Get(body, "error.message").String() != "wait" {
+					t.Errorf("direct error did not retain wire ID and error details: %s", body)
+				}
+			} else if body != tt.body {
+				t.Errorf("direct body changed: %s", body)
+			}
+		})
+	}
+}
+
 type claudeRequestIDExecutor struct {
 	mode    string
 	flushed <-chan struct{}


### PR DESCRIPTION
Claude authentication and request-body read failures bypass the existing Claude error writer, leaving clients without an Anthropic error envelope. Generated execution errors also lack a request ID, so clients cannot correlate the error body with the response header.

Return Anthropic envelopes for authentication failures on `/v1/messages` and `/v1/messages/count_tokens` and body-read failures in both handlers. Public authentication messages remain literal, including JSON-shaped text; private causes are not exposed. Other protocols retain their authentication response shapes.

Assign a `req_`-prefixed response ID at Claude handler/authentication ingress, using the existing logging ID when available. Expose `Request-Id` through CORS and include the same ID in generated JSON and SSE errors. A valid ID from an upstream Claude error is retained while headers remain writable. After a keep-alive or SSE flush, errors retain the ID already sent to the client. Incoming client IDs and later addon headers cannot replace it. Before commitment, a native direct error's embedded ID takes precedence over its request-ID header. If keep-alive has already committed a different local ID, only the recognized Claude error's request_id field is reconciled with that wire ID; opaque direct responses retain their bytes.

Refs #4671, slice 3. This combines the authentication-envelope fix with its request-ID follow-up and does not port the fork's request validator. The request-ID approach is adapted from [steipete's implementation](https://github.com/steipete/CLIProxyAPI/commit/fd175e4b682296650de4543f2b7b06f3a3f92f20) to the current handler and direct-response paths. The response shape follows the [Claude error reference](https://platform.claude.com/docs/en/api/errors).

Validation on the September 9 dev base (`db011593`):
- 4 real-router authentication cases, including exact CORS exposure; 14 middleware error cases covering status, public-message fidelity, private-cause non-disclosure and abort behavior.
- 2 failing-body-reader cases and 3 unchanged non-Claude protocol controls.
- 6 local/upstream request-ID cases covering header commitment, malformed/numeric IDs, unrelated provider envelopes and conflicting addon headers; a byte-preserving direct-response case.
- 7 manager-to-handler cases covering Messages/count success and failure, streaming success, early failure and failure after a synchronized downstream flush. No sleeps or live providers are required.
- The 34 request-ID cases failed before the propagation change and pass afterward. A follow-up committed-direct-error regression also failed before its fix; opaque-body and matching-ID controls pass unchanged.
- `go test ./internal/api ./sdk/api/handlers/... -count=1` passed.
- Focused `go test -race` for Claude request IDs and authentication passed.
- `go build -buildvcs=false -o test-output ./cmd/server` passed; VCS stamping is disabled for this test environment.
- gofmt and `git diff --check` passed.

Prepared and tested with Codex assistance.