### PR TITLE
perf(codex): avoid discarded copies of SSE data lines

### DIFF
--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -163,11 +163,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			translatedLine := bytes.Clone(line)
+			var translatedLine []byte
 			isHandshake := false
 			terminalSuccess := false
 
-			if transformed, ok := grokbuild.TransformKeepaliveSSELine(translatedLine, isGrokClient); ok {
+			if transformed, ok := grokbuild.TransformKeepaliveSSELine(line, isGrokClient); ok {
 				translatedLine = transformed
 				isHandshake = true
 			} else if bytes.HasPrefix(line, dataTag) {
@@ -228,6 +228,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					translatedLine = append([]byte("data: "), data...)
 				}
 			} else {
+				// Non-data lines also need owned storage before translation can retain them.
+				translatedLine = bytes.Clone(line)
 				isHandshake = true
 			}
 
@@ -305,10 +307,10 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			translatedLine := bytes.Clone(line)
+			var translatedLine []byte
 			terminalSuccess := false
 
-			if transformed, ok := grokbuild.TransformKeepaliveSSELine(translatedLine, isGrokClient); ok {
+			if transformed, ok := grokbuild.TransformKeepaliveSSELine(line, isGrokClient); ok {
 				translatedLine = transformed
 			} else if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
@@ -365,6 +367,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					}
 					translatedLine = append([]byte("data: "), data...)
 				}
+			} else {
+				translatedLine = bytes.Clone(line)
 			}
 
 			translatedLine = applyCodexIdentityExposeResponsePayload(translatedLine, identityState)

--- a/internal/runtime/executor/codex_executor_stream_alloc_test.go
+++ b/internal/runtime/executor/codex_executor_stream_alloc_test.go
@@ -1,0 +1,128 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func codexAllocationStream(deltas, deltaSize int) string {
+	var stream strings.Builder
+	stream.WriteString("event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_alloc\",\"model\":\"gpt-5.4\"}}\n\n")
+	stream.WriteString("data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"msg_alloc\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[]}}\n\n")
+	stream.WriteString("data: {\"type\":\"response.content_part.added\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n\n")
+	for i := 0; i < deltas; i++ {
+		fmt.Fprintf(&stream, ": comment-%04d\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"content_index\":0,\"delta\":%q}\n\n", i, strings.Repeat(string(rune('a'+i%26)), deltaSize))
+	}
+	stream.WriteString("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_alloc\",\"model\":\"gpt-5.4\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":128,\"total_tokens\":133}}}\n\n")
+	return stream.String()
+}
+
+type codexAllocationTransport struct{ stream string }
+
+func (tr codexAllocationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(tr.stream)),
+		Request:    req,
+	}, nil
+}
+
+func TestCodexStreamChunksRemainOwnedAfterScannerAdvances(t *testing.T) {
+	const deltas = 48
+	const deltaSize = 512
+	for _, buffered := range []bool{false, true} {
+		for _, format := range []sdktranslator.Format{sdktranslator.FormatClaude, sdktranslator.FormatOpenAIResponse, "test-codex-raw-ownership"} {
+			t.Run(fmt.Sprintf("buffered=%t/%s", buffered, format), func(t *testing.T) {
+				cfg := &config.Config{}
+				cfg.Codex.StreamBootstrapBuffering = buffered
+				executor := NewCodexExecutor(cfg)
+				ctx := context.WithValue(t.Context(), "cliproxy.roundtripper", codexAllocationTransport{stream: codexAllocationStream(deltas, deltaSize)})
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test"}}
+				result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{Model: "gpt-5.4", Payload: []byte(`{"model":"gpt-5.4","input":"hello"}`)}, cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: format})
+				if err != nil {
+					t.Fatal(err)
+				}
+				var retained [][]byte
+				var snapshots []string
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatal(chunk.Err)
+					}
+					retained = append(retained, chunk.Payload)
+					snapshots = append(snapshots, string(chunk.Payload))
+				}
+				if len(retained) == 0 {
+					t.Fatal("stream emitted no chunks")
+				}
+				var text strings.Builder
+				for index, chunk := range retained {
+					if string(chunk) != snapshots[index] {
+						t.Fatalf("chunk %d changed after scanner advanced", index)
+					}
+					for _, line := range bytes.Split(chunk, []byte("\n")) {
+						if !bytes.HasPrefix(line, []byte("data:")) {
+							continue
+						}
+						data := bytes.TrimSpace(line[5:])
+						switch gjson.GetBytes(data, "type").String() {
+						case "response.output_text.delta":
+							text.WriteString(gjson.GetBytes(data, "delta").String())
+						case "content_block_delta":
+							text.WriteString(gjson.GetBytes(data, "delta.text").String())
+						}
+					}
+				}
+				var want strings.Builder
+				for i := 0; i < deltas; i++ {
+					want.WriteString(strings.Repeat(string(rune('a'+i%26)), deltaSize))
+				}
+				if text.String() != want.String() {
+					t.Fatalf("retained text differs: got %d bytes, want %d", text.Len(), want.Len())
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkCodexExecuteStreamAllocations(b *testing.B) {
+	for _, buffered := range []bool{false, true} {
+		for _, format := range []sdktranslator.Format{sdktranslator.FormatClaude, sdktranslator.FormatOpenAIResponse} {
+			b.Run(fmt.Sprintf("buffered=%t/%s", buffered, format), func(b *testing.B) {
+				stream := codexAllocationStream(256, 1024)
+				cfg := &config.Config{}
+				cfg.Codex.StreamBootstrapBuffering = buffered
+				executor := NewCodexExecutor(cfg)
+				ctx := context.WithValue(b.Context(), "cliproxy.roundtripper", codexAllocationTransport{stream: stream})
+				auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test"}}
+				request := cliproxyexecutor.Request{Model: "gpt-5.4", Payload: []byte(`{"model":"gpt-5.4","input":"hello"}`)}
+				opts := cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: format}
+				b.ReportAllocs()
+				b.SetBytes(int64(len(stream)))
+				b.ResetTimer()
+				for b.Loop() {
+					result, err := executor.ExecuteStream(ctx, auth, request, opts)
+					if err != nil {
+						b.Fatal(err)
+					}
+					for chunk := range result.Chunks {
+						if chunk.Err != nil {
+							b.Fatal(chunk.Err)
+						}
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Both Codex streaming loops clone every scanner line before inspecting it. For `data:` lines that clone is immediately replaced by the separately allocated normalized SSE line; converted Grok keepalives also allocate their own output. The first copy adds allocation churn without providing ownership to anything that survives.

Allocate the defensive clone only for other line types. Data events and converted keepalives continue to have independently owned buffers before translation. This also preserves the ownership requirement for fallback/plugin response translators that may retain their input. No borrowed scanner slice reaches the translation boundary.

Refs #4671, allocation slice. This is a smaller optimization of the current stream implementation: it removes copies that are immediately discarded, and does not introduce an immutable logging API or borrow buffers across translator calls.

Benchmarks (`go test ./internal/runtime/executor -run '^TestCodexStreamChunksRemainOwnedAfterScannerAdvances$' -bench '^BenchmarkCodexExecuteStreamAllocations$' -benchmem -benchtime=500ms -count=3`, Linux/amd64 Go 1.26.1):

Fixture: 256 text deltas of 1 KiB, including SSE comments/event lines and a terminal response. Median allocated bytes per complete ExecuteStream call:

| Response format | Bootstrap buffering | Before B/op | After B/op | Reduction |
| --- | --- | ---: | ---: | ---: |
| Claude | off | 2,451,963 | 2,156,304 | 12.1% |
| Claude | on | 2,452,024 | 2,156,363 | 12.1% |
| Responses | off | 1,303,085 | 1,007,407 | 22.7% |
| Responses | on | 1,303,386 | 1,007,730 | 22.7% |

This saves about 296 KB and 260 allocations per call for this fixture. Timing varies across runs; the result claimed here is reduced allocation, not a general latency improvement.

Validation:
- Six ownership cases retain emitted byte slices until the scanner has finished, then verify every chunk and the complete expected text: Claude, Responses and untranslated fallback, each with buffering on/off.
- Temporarily replacing the remaining non-data clones with borrowed slices makes both fallback ownership cases fail; the committed version passes.
- `go test -race ./internal/runtime/executor -run '^TestCodexStreamChunksRemainOwnedAfterScannerAdvances$' -count=1` passed.
- `go test ./internal/runtime/executor/... -count=1` passed, including existing Grok keepalive and Codex stream regressions.
- `go build -buildvcs=false -o test-output ./cmd/server` passed (VCS stamping disabled for this test environment).
- gofmt and `git diff --check` passed.

Prepared and tested with Codex assistance.