### PR TITLE
perf(codex): batch tool schema rewrites

### DIFF
--- a/internal/runtime/executor/helps/codex_tool_schema.go
+++ b/internal/runtime/executor/helps/codex_tool_schema.go
@@ -2,7 +2,6 @@ package helps
 
 import (
 	"math/big"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -23,50 +22,58 @@ const (
 // Only unions mathematically proven to be semantically equivalent to enum definitions
 // are modified; all other structures, property names, types, and constraints remain untouched.
 func NormalizeCodexToolSchemas(body []byte) []byte {
-	tools := gjson.GetBytes(body, "tools")
-	if !tools.Exists() || !tools.IsArray() || len(tools.Array()) == 0 {
+	updatedTools, changed := normalizeCodexToolList(gjson.GetBytes(body, "tools"))
+	if !changed {
 		return body
 	}
+	out, errSet := sjson.SetRawBytes(body, "tools", updatedTools)
+	if errSet != nil {
+		return body
+	}
+	log.Debugf("codex: normalized tool schemas to prevent upstream failure")
+	return out
+}
 
-	toolsArray := tools.Array()
-	changed := false
-	for i, tool := range toolsArray {
-		updatedTool, toolChanged := normalizeCodexTool(tool)
-		if toolChanged {
-			var errSet error
-			body, errSet = sjson.SetRawBytes(body, "tools."+strconv.Itoa(i), updatedTool)
-			if errSet == nil {
-				changed = true
-			}
+// normalizeCodexToolList batches changed elements so a long request (or a wide
+// namespace) is copied once rather than once per tool. Copy the gaps verbatim
+// to retain array formatting and unchanged declarations.
+func normalizeCodexToolList(tools gjson.Result) ([]byte, bool) {
+	if !tools.IsArray() {
+		return nil, false
+	}
+	var out []byte
+	offset := 0
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		updated, changed := normalizeCodexTool(tool)
+		if !changed {
+			return true
 		}
+		if out == nil {
+			out = make([]byte, 0, len(tools.Raw))
+		}
+		// ForEach indexes share the source of the containing array's index.
+		start := tool.Index - tools.Index
+		out = append(out, tools.Raw[offset:start]...)
+		out = append(out, updated...)
+		offset = start + len(tool.Raw)
+		return true
+	})
+	if out == nil {
+		return nil, false
 	}
-	if changed {
-		log.Debugf("codex: normalized tool schemas to prevent upstream failure")
-	}
-	return body
+	return append(out, tools.Raw[offset:]...), true
 }
 
 func normalizeCodexTool(tool gjson.Result) ([]byte, bool) {
 	toolType := tool.Get("type").String()
 	// Handle namespace tools (e.g. multi-agent nested tools)
 	if toolType == "namespace" {
-		nestedTools := tool.Get("tools")
-		if nestedTools.IsArray() && len(nestedTools.Array()) > 0 {
-			changed := false
-			raw := []byte(tool.Raw)
-			for j, nestedTool := range nestedTools.Array() {
-				updatedNested, nestedChanged := normalizeCodexTool(nestedTool)
-				if nestedChanged {
-					var errSet error
-					raw, errSet = sjson.SetRawBytes(raw, "tools."+strconv.Itoa(j), updatedNested)
-					if errSet == nil {
-						changed = true
-					}
-				}
-			}
-			return raw, changed
+		updatedTools, changed := normalizeCodexToolList(tool.Get("tools"))
+		if !changed {
+			return nil, false
 		}
-		return nil, false
+		updated, errSet := sjson.SetRawBytes([]byte(tool.Raw), "tools", updatedTools)
+		return updated, errSet == nil
 	}
 
 	if toolType != "function" && toolType != "custom" {

--- a/internal/runtime/executor/helps/codex_tool_schema_batch_test.go
+++ b/internal/runtime/executor/helps/codex_tool_schema_batch_test.go
@@ -1,0 +1,131 @@
+package helps
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const codexBatchUnionTool = `{"type":"function","name":"choose","parameters":{"type":"object","properties":{"action":{"oneOf":[{"const":"a"},{"const":"b"},{"const":"c"},{"const":"d"},{"const":"e"},{"const":"f"},{"const":"g"},{"const":"h"}]}}}}`
+const codexBatchSimpleTool = `{"type":"function","name":"read","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}`
+
+func TestNormalizeCodexToolSchemasMatchesSequentialEdits(t *testing.T) {
+	namespace := func(tools string) string {
+		return `{"type":"namespace", "name":"workspace", "tools": [ ` + tools + ` ]}`
+	}
+	request := func(tools string) string {
+		return "{\r\n  \"input\": \"tool_search \\u5de5\", \"tools\": [\n\t" + tools + "\n  ], \"metadata\": {\"number\": 900719925474099312345, \"value\": 1.00e+9}\r\n}"
+	}
+	inputs := []string{
+		"", `{}`, `{"tools":null}`, `{"tools":[]}`, `{"tools":"unchanged"}`, `{"tools":{}}`,
+		request(codexBatchSimpleTool),
+		request(codexBatchUnionTool),
+		request(codexBatchSimpleTool + ", \n" + codexBatchUnionTool + ",\t" + codexBatchSimpleTool),
+		request(codexBatchUnionTool + ", \n" + codexBatchSimpleTool + ",\t" + codexBatchUnionTool),
+		request(namespace(codexBatchUnionTool + ", \n" + codexBatchSimpleTool + ",\t" + codexBatchUnionTool)),
+		request(namespace(namespace(codexBatchUnionTool)+",\t"+codexBatchUnionTool) + ",\n" + codexBatchUnionTool),
+		request(`null, 123, {"type":"namespace","tools":[]}, ` + codexBatchUnionTool),
+		`{"tools":[` + codexBatchUnionTool + `],"tools":[` + codexBatchSimpleTool + `]}`,
+		`{"tools":[` + codexBatchUnionTool + `],"incomplete":`,
+		`{"tools":[` + codexBatchUnionTool + `,`,
+	}
+	for index, input := range inputs {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
+			body := []byte(input)
+			want := codexSequentialToolSchemas(body)
+			got := NormalizeCodexToolSchemas(body)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("output differs from sequential edits:\ngot  %s\nwant %s", got, want)
+			}
+			if string(body) != input {
+				t.Fatal("normalization mutated caller payload")
+			}
+			if bytes.Equal(got, body) && len(body) > 0 && &got[0] != &body[0] {
+				t.Fatal("unchanged payload was copied")
+			}
+		})
+	}
+}
+
+func BenchmarkNormalizeCodexToolSchemas(b *testing.B) {
+	for _, tt := range []struct {
+		name      string
+		count     int
+		namespace bool
+		change    bool
+	}{
+		{name: "flat_1", count: 1, change: true},
+		{name: "flat_32", count: 32, change: true},
+		{name: "flat_128", count: 128, change: true},
+		{name: "namespace_128", count: 128, namespace: true, change: true},
+		{name: "unchanged_128", count: 128},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			tool := codexBatchSimpleTool
+			if tt.change {
+				tool = codexBatchUnionTool
+			}
+			var declarations []string
+			for index := 0; index < tt.count; index++ {
+				declarations = append(declarations, strings.Replace(tool, `"name":"`, fmt.Sprintf(`"name":"tool_%d_`, index), 1))
+			}
+			tools := strings.Join(declarations, ",")
+			if tt.namespace {
+				tools = `{"type":"namespace","name":"workspace","tools":[` + tools + `]}`
+			}
+			body := []byte(`{"input":"` + strings.Repeat("x", 1<<20) + `","tools":[` + tools + `]}`)
+			want := codexSequentialToolSchemas(body)
+			if got := NormalizeCodexToolSchemas(body); !bytes.Equal(got, want) {
+				b.Fatal("normalization differs from sequential edits")
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			b.ResetTimer()
+			for b.Loop() {
+				NormalizeCodexToolSchemas(body)
+			}
+		})
+	}
+}
+
+// Frozen pre-batching traversal: compare exact bytes and benchmark the same
+// input before/after without changing the schema normalization policy.
+func codexSequentialToolSchemas(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return body
+	}
+	for index, tool := range tools.Array() {
+		if updated, changed := codexSequentialTool(tool); changed {
+			if out, errSet := sjson.SetRawBytes(body, fmt.Sprintf("tools.%d", index), updated); errSet == nil {
+				body = out
+			}
+		}
+	}
+	return body
+}
+
+func codexSequentialTool(tool gjson.Result) ([]byte, bool) {
+	if tool.Get("type").String() != "namespace" {
+		return normalizeCodexTool(tool)
+	}
+	nested := tool.Get("tools")
+	if !nested.IsArray() || len(nested.Array()) == 0 {
+		return nil, false
+	}
+	raw := []byte(tool.Raw)
+	changed := false
+	for index, child := range nested.Array() {
+		if updated, childChanged := codexSequentialTool(child); childChanged {
+			if out, errSet := sjson.SetRawBytes(raw, fmt.Sprintf("tools.%d", index), updated); errSet == nil {
+				raw = out
+				changed = true
+			}
+		}
+	}
+	return raw, changed
+}


### PR DESCRIPTION
Codex schema normalization currently calls `sjson.SetRawBytes(body, "tools.N", ...)` once per changed tool. Each call rewrites the entire request, including the conversation. Namespace normalization repeats the same pattern inside the namespace.

Batch changed elements in each tool array, then replace that array once. Copy the original gaps between elements verbatim, so unchanged declarations, formatting, key order and raw number/Unicode representations remain intact. Requests needing no normalization still return the original buffer. The union-to-enum rules are unchanged.

Measured on a synthetic request with 1 MiB of input and distinct function declarations containing eligible eight-branch constant unions. Median allocated bytes from three runs on the same machine:

| Case | Before B/op | After B/op | Reduction |
| --- | ---: | ---: | ---: |
| 1 changed tool | 1,070,543 | 1,070,488 | ~0% |
| 32 changed tools | 34,264,867 | 1,495,676 | 95.6% |
| 128 changed tools | 306,927,976 | 4,131,107 | 98.7% |
| 128 changed tools in a namespace | 8,846,205 | 4,206,984 | 52.4% |
| 128 unchanged tools | 208,545 | 160,192 | 23.2% |

These are helper allocation measurements, not an end-to-end latency claim.

Validation:
- Existing schema semantic tests pass.
- Also applied the patch to current dev `db01159` after #5677 merged: it applies cleanly, and the full executor tests (including the new Unicode-pattern tests) and server build pass together.
- 16 byte-exact comparisons against the pre-batching traversal cover mixed changed/unchanged tools, nested namespaces, CRLF/whitespace, large numbers, escaped Unicode, duplicate keys, incomplete JSON and no-op inputs. They also verify caller payload immutability and reuse on no-op inputs.
- Each benchmark checks its output against the sequential traversal before timing.
- `go test ./internal/runtime/executor/helps -run '^TestNormalizeCodexToolSchemas' -bench '^BenchmarkNormalizeCodexToolSchemas$' -benchmem -benchtime=300ms -count=3` passed before and after.
- `go test ./internal/runtime/executor/... -count=1` passed.
- `go build -buildvcs=false -o test-output ./cmd/server` passed; VCS stamping is unavailable in this worktree environment.
- gofmt and `git diff --check` passed.

Prepared and tested with Codex assistance.