### PR TITLE
fix(auth): distinguish Cloudflare origin failures from challenges

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -172,8 +172,10 @@ disable-cooling: false
 # Default is false; when false, cooldown status is kept in memory only.
 save-cooldown-status: false
 
-# Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
-# Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
+# Cooldown duration in seconds for transient upstream errors, including ordinary Cloudflare HTML 5xx pages.
+# Set to 0 for the 60-second default (10 seconds for Cloudflare origin errors).
+# A positive value overrides both defaults; set to -1 to disable transient error cooldowns.
+# Actual Cloudflare challenges retain their separate challenge backoff.
 transient-error-cooldown-seconds: 0
 
 # When true, globally disable Claude request cloaking (the Claude Code CLI disguise and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,7 +69,8 @@ type Config struct {
 	SaveCooldownStatus bool `yaml:"save-cooldown-status" json:"save-cooldown-status"`
 
 	// TransientErrorCooldownSeconds controls cooldowns for transient upstream errors.
-	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.
+	// 0 keeps the 60s default, or 10s for ordinary Cloudflare HTML 5xx pages.
+	// Negative values disable these cooldowns.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
 
 	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.

--- a/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
+++ b/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const cloudflareOriginPage = `<html><body><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></body></html>`
+
+func TestCloudflareChallengeRequiresExplicitEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name, message string
+		want          bool
+	}{
+		{"520 origin page", cloudflareOriginPage, false},
+		{"generic Cloudflare HTML", `<html><body>Cloudflare: upstream unavailable</body></html>`, false},
+		{"Cloudflare plain text", "Cloudflare: upstream unavailable", false},
+		{"unrelated HTML", `<html><title>Just a moment</title><body>upstream unavailable</body></html>`, false},
+		{"challenge script", `<html><script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script></html>`, true},
+		{"challenge header", "CF-Mitigated: challenge", true},
+		{"explicit challenge message", "upstream returned a Cloudflare challenge", true},
+		{"Cloudflare challenge title", `<html><title>Just a moment...</title><body>Cloudflare</body></html>`, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCloudflareChallengeErrorMessage(tt.message); got != tt.want {
+				t.Errorf("challenge = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagerCloudflareOriginUsesTransientCooldown(t *testing.T) {
+	previousCooling := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousCooling)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, model := range []string{"", "gpt-cloudflare-origin"} {
+		for _, tt := range []struct {
+			name           string
+			status         int
+			seconds        int64
+			disableCooling bool
+			wantWait       time.Duration
+		}{
+			{name: "520 default", status: 520, wantWait: 10 * time.Second},
+			{name: "502 default", status: http.StatusBadGateway, wantWait: 10 * time.Second},
+			{name: "524 default", status: 524, wantWait: 10 * time.Second},
+			{name: "configured shorter", status: 520, seconds: 3, wantWait: 3 * time.Second},
+			{name: "configured longer", status: 520, seconds: 30, wantWait: 30 * time.Second},
+			{name: "transient cooling disabled", status: 520, seconds: -1},
+			{name: "all cooling disabled", status: 520, disableCooling: true},
+		} {
+			t.Run(fmt.Sprintf("model=%s/%s", model, tt.name), func(t *testing.T) {
+				transientErrorCooldownSeconds.Store(tt.seconds)
+				quotaCooldownDisabled.Store(tt.disableCooling)
+				manager := NewManager(nil, nil, nil)
+				credential := &Auth{ID: t.Name(), Provider: "codex"}
+				if _, err := manager.Register(context.Background(), credential); err != nil {
+					t.Fatal(err)
+				}
+				before := time.Now()
+				for range 2 {
+					manager.MarkResult(context.Background(), Result{AuthID: credential.ID, Provider: "codex", Model: model, Error: &Error{HTTPStatus: tt.status, Message: cloudflareOriginPage}})
+				}
+				after := time.Now()
+				updated, _ := manager.GetByID(credential.ID)
+				quota, next, unavailable := updated.Quota, updated.NextRetryAfter, updated.Unavailable
+				lastError, message := updated.LastError, updated.StatusMessage
+				if model != "" {
+					state := updated.ModelStates[model]
+					if state == nil {
+						t.Fatal("transient model state was not recorded")
+					}
+					quota, next, unavailable = state.Quota, state.NextRetryAfter, state.Unavailable
+					lastError, message = state.LastError, state.StatusMessage
+				}
+				if quota.Exceeded || quota.Reason != "" || quota.BackoffLevel != 0 || !quota.NextRecoverAt.IsZero() {
+					t.Errorf("origin failure recorded as quota/challenge: %+v", quota)
+				}
+				if lastError == nil || lastError.HTTPStatus != tt.status || lastError.Message != cloudflareOriginPage || message != cloudflareOriginPage {
+					t.Errorf("original diagnosis was lost: error=%+v message=%q", lastError, message)
+				}
+				if tt.wantWait == 0 {
+					if !next.IsZero() || unavailable {
+						t.Errorf("disabled cooling: next=%v unavailable=%t", next, unavailable)
+					}
+				} else if !unavailable || next.Before(before.Add(tt.wantWait)) || next.After(after.Add(tt.wantWait)) {
+					t.Errorf("next=%v unavailable=%t, want %s transient cooldown", next, unavailable, tt.wantWait)
+				}
+			})
+		}
+	}
+}
+
+func TestCloudflareOriginRetainsLongerExistingCooldown(t *testing.T) {
+	previous := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previous) })
+	now := time.Date(2026, time.September, 9, 0, 0, 0, 0, time.UTC)
+	deadline := now.Add(5 * time.Minute)
+	credential := &Auth{NextRetryAfter: deadline}
+	applyAuthFailureState(credential, &Error{HTTPStatus: 520, Message: cloudflareOriginPage}, nil, now, false)
+	if !credential.NextRetryAfter.Equal(deadline) {
+		t.Fatalf("existing cooldown shortened: %v", credential.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
+++ b/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 const cloudflareOriginPage = `<html><body><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></body></html>`
@@ -152,5 +154,96 @@ func TestManagerCloudflareChallengeResponseHeader(t *testing.T) {
 				})
 			}
 		}
+	}
+}
+
+type cloudflareCompactExecutor struct {
+	*compactTestExecutor
+	headers http.Header
+}
+
+func (e *cloudflareCompactExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	internallogging.SetResponseHeaders(ctx, e.headers)
+	return e.compactTestExecutor.Execute(ctx, auth, req, opts)
+}
+
+func TestManagerCloudflareCompactCooldown(t *testing.T) {
+	previousCooling := quotaCooldownDisabled.Load()
+	previousTransient := transientErrorCooldownSeconds.Load()
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(previousCooling)
+		transientErrorCooldownSeconds.Store(previousTransient)
+	})
+	for _, tt := range []struct {
+		name                string
+		status              int
+		body                string
+		header              string
+		seconds             int64
+		disabled, challenge bool
+		wait                time.Duration
+	}{
+		{name: "origin 520", status: 520, body: cloudflareOriginPage, wait: 10 * time.Second},
+		{name: "origin 502", status: 502, body: cloudflareOriginPage, wait: 10 * time.Second},
+		{name: "origin 501", status: 501, body: cloudflareOriginPage, wait: 10 * time.Second},
+		{name: "configured origin", status: 520, body: cloudflareOriginPage, seconds: 3, wait: 3 * time.Second},
+		{name: "disabled transient", status: 520, body: cloudflareOriginPage, seconds: -1},
+		{name: "disabled cooling", status: 520, body: cloudflareOriginPage, disabled: true},
+		{name: "header challenge", status: 520, body: "<html>blocked</html>", header: "challenge", challenge: true, wait: 10 * time.Second},
+		{name: "body challenge", status: 520, body: "<html>Cloudflare challenge</html>", challenge: true, wait: 10 * time.Second},
+		{name: "ordinary compact failure", status: 520, body: "temporary compact failure"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			quotaCooldownDisabled.Store(tt.disabled)
+			transientErrorCooldownSeconds.Store(tt.seconds)
+			headers := make(http.Header)
+			if tt.header != "" {
+				headers.Set("Cf-Mitigated", tt.header)
+			}
+			executor := &cloudflareCompactExecutor{compactTestExecutor: &compactTestExecutor{compactErr: compactTestStatusError{code: tt.status, msg: tt.body}}, headers: headers}
+			manager := NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			const model = "gpt-cloudflare-compact"
+			ids := []string{t.Name() + "/a", t.Name() + "/b"}
+			for _, id := range ids {
+				credential := &Auth{ID: id, Provider: executor.Identifier(), Status: StatusActive}
+				if _, err := manager.Register(t.Context(), credential); err != nil {
+					t.Fatal(err)
+				}
+				registry.GetGlobalRegistry().RegisterClient(id, credential.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(id) })
+			}
+			before := time.Now()
+			_, err := manager.Execute(t.Context(), []string{executor.Identifier()}, cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}, cliproxyexecutor.Options{Alt: "responses/compact"})
+			after := time.Now()
+			if err == nil {
+				t.Fatal("expected compact failure")
+			}
+			if executor.calls != 2 {
+				t.Errorf("upstream calls=%d, want failover across both credentials", executor.calls)
+			}
+			for _, id := range ids {
+				updated, _ := manager.GetByID(id)
+				state := updated.ModelStates[model]
+				if tt.wait == 0 {
+					if state != nil && (state.Unavailable || !state.NextRetryAfter.IsZero() || state.Quota.Exceeded) {
+						t.Fatalf("unexpected cooldown: %+v", state)
+					}
+					continue
+				}
+				if state == nil {
+					t.Fatal("compact failure bypassed cooldown handling")
+				}
+				if !state.Unavailable || state.NextRetryAfter.Before(before.Add(tt.wait)) || state.NextRetryAfter.After(after.Add(tt.wait)) {
+					t.Errorf("retry=%v unavailable=%t, want %v cooldown", state.NextRetryAfter, state.Unavailable, tt.wait)
+				}
+				if state.Quota.Exceeded != tt.challenge || (state.Quota.Reason == "cloudflare challenge") != tt.challenge {
+					t.Errorf("quota=%+v, want challenge=%t", state.Quota, tt.challenge)
+				}
+				if state.LastError == nil || state.LastError.HTTPStatus != tt.status || state.LastError.Message != tt.body {
+					t.Errorf("original error lost: %+v", state.LastError)
+				}
+			}
+		})
 	}
 }

--- a/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
+++ b/sdk/cliproxy/auth/cloudflare_origin_cooldown_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 )
 
 const cloudflareOriginPage = `<html><body><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></body></html>`
@@ -108,5 +110,47 @@ func TestCloudflareOriginRetainsLongerExistingCooldown(t *testing.T) {
 	applyAuthFailureState(credential, &Error{HTTPStatus: 520, Message: cloudflareOriginPage}, nil, now, false)
 	if !credential.NextRetryAfter.Equal(deadline) {
 		t.Fatalf("existing cooldown shortened: %v", credential.NextRetryAfter)
+	}
+}
+
+func TestManagerCloudflareChallengeResponseHeader(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+	for _, model := range []string{"", "gpt-header-challenge"} {
+		for _, status := range []int{http.StatusForbidden, 520} {
+			for _, tt := range []struct {
+				value string
+				want  bool
+			}{
+				{"challenge", true},
+				{" CHALLENGE ", true},
+				{"", false},
+				{"other", false},
+			} {
+				t.Run(fmt.Sprintf("model=%s/status=%d/header=%q", model, status, tt.value), func(t *testing.T) {
+					manager := NewManager(nil, nil, nil)
+					credential := &Auth{ID: t.Name(), Provider: "codex"}
+					if _, err := manager.Register(t.Context(), credential); err != nil {
+						t.Fatal(err)
+					}
+					ctx := internallogging.WithResponseHeadersHolder(t.Context())
+					headers := make(http.Header)
+					if tt.value != "" {
+						headers.Set("Cf-Mitigated", tt.value)
+					}
+					internallogging.SetResponseHeaders(ctx, headers)
+					manager.MarkResult(ctx, Result{AuthID: credential.ID, Provider: "codex", Model: model, Error: &Error{HTTPStatus: status, Message: `<html><body>blocked</body></html>`}})
+					updated, _ := manager.GetByID(credential.ID)
+					quota, message := updated.Quota, updated.StatusMessage
+					if model != "" {
+						quota, message = updated.ModelStates[model].Quota, updated.ModelStates[model].StatusMessage
+					}
+					if got := quota.Exceeded && quota.Reason == "cloudflare challenge" && message == "cloudflare challenge"; got != tt.want {
+						t.Errorf("challenge = %t, want %t; quota=%+v message=%q", got, tt.want, quota, message)
+					}
+				})
+			}
+		}
 	}
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -807,7 +807,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					if isModelSupportResultError(result.Error) {
 						next := now.Add(12 * time.Hour)
 						state.NextRetryAfter = next
-					} else if isCloudflareChallengeResultError(result.Error) {
+					} else if isCloudflareChallengeResultError(result.Error, responseHeaders) {
 						next, backoffLevel := nextCloudflareCooldown(state.Quota.BackoffLevel, disableCooling, now)
 						state.NextRetryAfter = next
 						state.StatusMessage = "cloudflare challenge"
@@ -934,7 +934,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, responseHeaders)
 			}
 		}
 
@@ -1687,9 +1687,14 @@ func isCloudflareChallengeError(err error) bool {
 	return isCloudflareChallengeErrorMessage(err.Error())
 }
 
-func isCloudflareChallengeResultError(err *Error) bool {
+func isCloudflareChallengeResultError(err *Error, responseHeaders ...http.Header) bool {
 	if err == nil {
 		return false
+	}
+	for _, headers := range responseHeaders {
+		if strings.EqualFold(strings.TrimSpace(headers.Get("Cf-Mitigated")), "challenge") {
+			return true
+		}
 	}
 	return isCloudflareChallengeErrorMessage(err.Message)
 }
@@ -2028,7 +2033,7 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool, responseHeaders ...http.Header) {
 	if auth == nil {
 		return
 	}
@@ -2052,7 +2057,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		}
 	}
 	statusCode := statusCodeFromResult(resultErr)
-	if isCloudflareChallengeResultError(resultErr) {
+	if isCloudflareChallengeResultError(resultErr, responseHeaders...) {
 		auth.StatusMessage = "cloudflare challenge"
 		next, backoffLevel := nextCloudflareCooldown(auth.Quota.BackoffLevel, disableCooling, now)
 		applyCooldownFields(&auth.Quota, QuotaState{

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1766,13 +1766,18 @@ func isResponsesCompactRequest(opts cliproxyexecutor.Options) bool {
 	return opts.Alt == "responses/compact"
 }
 
-func isResponsesCompactRequestFaultError(opts cliproxyexecutor.Options, err error) bool {
+func isResponsesCompactRequestFaultError(opts cliproxyexecutor.Options, err error, responseHeaders ...http.Header) bool {
 	if !isResponsesCompactRequest(opts) || err == nil {
 		return false
 	}
 	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
 		return false
 	}
+	resultErr := resultErrorFromError(err)
+	if isCloudflareOriginResultError(resultErr) || isCloudflareChallengeResultError(resultErr, responseHeaders...) {
+		return false
+	}
+
 	status := statusCodeFromError(err)
 	if clienterror.IsRequestFault(status, err) {
 		return true
@@ -1791,7 +1796,7 @@ func isResponsesCompactRequestFaultError(opts cliproxyexecutor.Options, err erro
 	}
 }
 
-func isResponsesCompactAvailabilityNeutralError(opts cliproxyexecutor.Options, err error, resultErr *Error) bool {
+func isResponsesCompactAvailabilityNeutralError(opts cliproxyexecutor.Options, err error, resultErr *Error, responseHeaders ...http.Header) bool {
 	if !isResponsesCompactRequest(opts) {
 		return false
 	}
@@ -1801,7 +1806,7 @@ func isResponsesCompactAvailabilityNeutralError(opts cliproxyexecutor.Options, e
 	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
 		return false
 	}
-	if resultErr != nil && (isCloudflareChallengeResultError(resultErr) || isInvalidGrantResultError(resultErr)) {
+	if resultErr != nil && (isCloudflareChallengeResultError(resultErr, responseHeaders...) || isCloudflareOriginResultError(resultErr) || isInvalidGrantResultError(resultErr)) {
 		return false
 	}
 	status := statusCodeFromError(err)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -30,8 +30,9 @@ func SetQuotaCooldownDisabled(disable bool) {
 	quotaCooldownDisabled.Store(disable)
 }
 
-// SetTransientErrorCooldownSeconds configures cooldowns for 408/500/502/503/504.
-// 0 keeps the legacy default; negative values disable transient error cooldowns.
+// SetTransientErrorCooldownSeconds configures transient upstream cooldowns.
+// 0 keeps the 60s default (10s for ordinary Cloudflare HTML 5xx pages);
+// negative values disable transient error cooldowns.
 func SetTransientErrorCooldownSeconds(seconds int) {
 	transientErrorCooldownSeconds.Store(int64(seconds))
 }
@@ -819,6 +820,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							NextRecoverAt: next,
 							BackoffLevel:  backoffLevel,
 						})
+					} else if isCloudflareOriginResultError(result.Error) {
+						state.NextRetryAfter = cloudflareOriginRetryAfter(now, disableCooling)
+						state.Unavailable = !state.NextRetryAfter.IsZero()
 					} else if isInvalidGrantResultError(result.Error) {
 						if disableCooling {
 							state.NextRetryAfter = time.Time{}
@@ -1673,7 +1677,7 @@ func isCloudflareChallengeErrorMessage(message string) bool {
 	return strings.Contains(lower, "challenge-platform") ||
 		strings.Contains(lower, "cf-mitigated") ||
 		strings.Contains(lower, "cloudflare challenge") ||
-		(strings.Contains(lower, "cloudflare") && strings.Contains(lower, "<html"))
+		(strings.Contains(lower, "cloudflare") && strings.Contains(lower, "just a moment"))
 }
 
 func isCloudflareChallengeError(err error) bool {
@@ -1688,6 +1692,29 @@ func isCloudflareChallengeResultError(err *Error) bool {
 		return false
 	}
 	return isCloudflareChallengeErrorMessage(err.Message)
+}
+
+// Cloudflare's ordinary HTML 5xx pages describe upstream failures, not an
+// authentication challenge. Explicit challenge evidence always takes priority.
+func isCloudflareOriginResultError(err *Error) bool {
+	if err == nil || err.HTTPStatus < 500 || err.HTTPStatus > 599 || isCloudflareChallengeResultError(err) {
+		return false
+	}
+	lower := strings.ToLower(err.Message)
+	return strings.Contains(lower, "cloudflare") && strings.Contains(lower, "<html")
+}
+
+func cloudflareOriginRetryAfter(now time.Time, disableCooling bool) time.Time {
+	seconds := transientErrorCooldownSeconds.Load()
+	if disableCooling || seconds < 0 {
+		return time.Time{}
+	}
+	if seconds > 0 {
+		return now.Add(time.Duration(seconds) * time.Second)
+	}
+	// Keep the former initial 10s delay without entering the challenge/quota
+	// backoff ladder or falling through to the generic 60s transient default.
+	return now.Add(10 * time.Second)
 }
 
 func nextCloudflareCooldown(backoffLevel int, disableCooling bool, now time.Time) (time.Time, int) {
@@ -2035,6 +2062,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			BackoffLevel:  backoffLevel,
 		})
 		auth.NextRetryAfter = next
+	} else if isCloudflareOriginResultError(resultErr) {
+		auth.NextRetryAfter = cloudflareOriginRetryAfter(now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	} else if isInvalidGrantResultError(resultErr) {
 		auth.StatusMessage = "invalid_grant"
 		if disableCooling {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -610,7 +610,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				action, okAction := matchRequestScopedErrorAction(auth, errExec, m.runtimeConfigSnapshot())
 				applyRequestScopedActionToResult(action, okAction, &result)
-				if isResponsesCompactAvailabilityNeutralError(execOpts, errExec, result.Error) {
+				if isResponsesCompactAvailabilityNeutralError(execOpts, errExec, result.Error, logging.GetResponseHeaders(execCtx)) {
 					m.recordAvailabilityNeutralResult(execCtx, result)
 				} else {
 					m.MarkResult(execCtx, result)
@@ -625,7 +625,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					}
 					continue
 				}
-				if isResponsesCompactRequestFaultError(execOpts, errExec) || isRequestInvalidError(errExec) {
+				if isResponsesCompactRequestFaultError(execOpts, errExec, logging.GetResponseHeaders(execCtx)) || isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec


### PR DESCRIPTION
Fixes #5681.

A branded Cloudflare HTML error page currently satisfies the challenge predicate even when it contains only an origin failure. This overwrites the 520 diagnosis with `cloudflare challenge` and advances quota/challenge backoff.

Require explicit challenge evidence instead: the actual `CF-Mitigated: challenge` response header, existing challenge script/message markers, or Cloudflare's “Just a moment” text. Both model-level and credential-level result handling inspect the captured response headers. Ordinary Cloudflare HTML 5xx failures keep their original status/message and use transient cooldown handling at both model and credential level.

The retry policy is explicit:
- Default (`transient-error-cooldown-seconds: 0`): a 10-second transient delay, preserving the former initial delay instead of falling through to the generic 60-second default.
- A positive configured duration applies to these failures too.
- Negative transient cooldown values or `disable-cooling` disable this delay.
- Origin failures do not create quota/challenge state or advance its backoff level. Existing longer cooldowns remain intact.
- Actual challenges retain their separate backoff.
- Compact requests also reach the origin/challenge cooldown handlers; ordinary compact 5xx errors remain availability-neutral.

This retains temporary availability backoff for origin failures; it does not make every request immediately retryable. The config comments describe the policy.

Cloudflare documents [520 as an unexpected origin response](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520/) and [explicit challenge identification](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/).

Validation:
- Eight classification cases, fourteen manager cases (model and credential paths) and an existing-cooldown preservation case.
- Sixteen subcases fail before the change; all pass after. The manager cases apply two consecutive failures and verify the original status/message, no challenge/quota state, and exact bounded retry deadlines without sleeping.
- Sixteen additional response-header cases cover model/credential handling, HTTP 403/520, case/whitespace normalization and absent/non-challenge header controls. Eight fail before the header fix; all pass after.
- Nine compact cases exercise Manager.Execute across two credentials, covering origin 501/502/520, configured/disabled cooling, body/header challenges and an ordinary compact failure control. Five cases fail before the compact fix; all pass after. Origin 501 errors also preserve fallback instead of being mistaken for compact request faults.
- Existing challenge, generic transient-error and cooldown monotonicity tests pass.
- `go test ./sdk/cliproxy/auth ./internal/runtime/executor/... -count=1` passed.
- `go build -buildvcs=false -o test-output ./cmd/server` passed; VCS stamping is unavailable in this worktree environment.
- gofmt and `git diff --check` passed.

Uses the sanitized HTML reproducer from the issue; no live provider account was needed. Prepared and tested with Codex assistance.