### PR TITLE
perf(codex): reuse finalized bodies for deferred request logs

### DIFF
--- a/internal/runtime/executor/codex_executor_deferred_log_test.go
+++ b/internal/runtime/executor/codex_executor_deferred_log_test.go
@@ -1,0 +1,122 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type codexDeferredLogTransport struct {
+	requestBody    []byte
+	mode           string
+	discardRequest bool
+}
+
+func (tr *codexDeferredLogTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var err error
+	if tr.discardRequest {
+		_, err = io.Copy(io.Discard, req.Body)
+	} else {
+		tr.requestBody, err = io.ReadAll(req.Body)
+	}
+	if err != nil {
+		return nil, err
+	}
+	status := http.StatusOK
+	body := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_log\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":2,\"output_tokens\":1,\"total_tokens\":3}}}\n\n"
+	switch tr.mode {
+	case "HTTP failure":
+		status = 503
+		body = `{"error":{"message":"unavailable"}}`
+	case "stream failure":
+		body = "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"server_error\",\"message\":\"unavailable\"}}}\n\n"
+	}
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": {"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+}
+
+func TestCodexDeferredLogRetainsFinalOutboundBody(t *testing.T) {
+	for _, buffered := range []bool{false, true} {
+		for _, source := range []sdktranslator.Format{sdktranslator.FormatClaude, sdktranslator.FormatOpenAIResponse} {
+			for _, mode := range []string{"success", "HTTP failure", "stream failure"} {
+				t.Run(fmt.Sprintf("buffered=%t/%s/%s", buffered, source, mode), func(t *testing.T) {
+					ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+					ctx := context.WithValue(t.Context(), "gin", ginCtx)
+					transport := &codexDeferredLogTransport{mode: mode}
+					ctx = context.WithValue(ctx, "cliproxy.roundtripper", transport)
+					cfg := &config.Config{}
+					cfg.Codex.StreamBootstrapBuffering = buffered
+					executor := NewCodexExecutor(cfg)
+					payload := []byte(`{"model":"gpt-5.4","input":"hello","prompt_cache_key":"log-test"}`)
+					if source == sdktranslator.FormatClaude {
+						payload = []byte(`{"model":"gpt-5.4","max_tokens":20,"messages":[{"role":"user","content":"hello"}]}`)
+					}
+					original := string(payload)
+					result, err := executor.ExecuteStream(ctx, &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test"}}, cliproxyexecutor.Request{Model: "gpt-5.4", Payload: payload}, cliproxyexecutor.Options{SourceFormat: source, ResponseFormat: source, Stream: true})
+					if result != nil {
+						for chunk := range result.Chunks {
+							if chunk.Err != nil {
+								err = chunk.Err
+							}
+						}
+					}
+					if (err != nil) != (mode != "success") {
+						t.Fatalf("error=%v for mode %s", err, mode)
+					}
+					if string(payload) != original {
+						t.Fatal("caller payload mutated")
+					}
+					value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey)
+					if !exists {
+						t.Fatal("missing deferred request")
+					}
+					captures := value.([]logging.DeferredAPIRequest)
+					if len(captures) != 1 {
+						t.Fatalf("captures=%d, want 1", len(captures))
+					}
+					log := string(captures[0]())
+					_, got, ok := strings.Cut(log, "\nBody:\n")
+					if !ok || got != string(transport.requestBody)+"\n\n" {
+						t.Fatalf("deferred body differs from actual outbound body:\n%s\nwant %s", got, transport.requestBody)
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkCodexDeferredRequestLogging(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	executor := NewCodexExecutor(cfg)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(b.Context(), "gin", ginCtx)
+	ctx = context.WithValue(ctx, "cliproxy.roundtripper", &codexDeferredLogTransport{mode: "success", discardRequest: true})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test"}}
+	req := cliproxyexecutor.Request{Model: "gpt-5.4", Payload: []byte(`{"model":"gpt-5.4","input":"` + strings.Repeat("x", 1<<20) + `","prompt_cache_key":"log-benchmark"}`)}
+	opts := cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatClaude}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ginCtx.Keys = nil
+		result, err := executor.ExecuteStream(ctx, auth, req, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				b.Fatal(chunk.Err)
+			}
+		}
+	}
+}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -95,7 +95,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		authLabel = auth.Label
 		authType, authValue = auth.AccountInfo()
 	}
-	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+	// cacheHelper has finalized upstreamBody; HTTP transport and stream translation
+	// only read request bytes from this point onward.
+	helps.RecordAPIRequestImmutableBody(ctx, e.cfg, helps.UpstreamRequestLog{
 		URL:       url,
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -63,6 +63,18 @@ func requestLogCaptureEnabled(cfg *config.Config) bool {
 
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	recordAPIRequest(ctx, cfg, info, false)
+}
+
+// RecordAPIRequestImmutableBody records a finalized request without copying its body
+// for deferred logging. The caller must keep the body immutable for the request's
+// lifetime. Truncated captures still copy their prefix to avoid retaining a larger
+// backing buffer. RecordAPIRequest retains snapshot semantics for general callers.
+func RecordAPIRequestImmutableBody(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	recordAPIRequest(ctx, cfg, info, true)
+}
+
+func recordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog, immutableBody bool) {
 	if cfg == nil || cfg.CommercialMode {
 		return
 	}
@@ -71,7 +83,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 		return
 	}
 	if !cfg.RequestLog {
-		deferAPIRequest(ginCtx, info)
+		deferAPIRequest(ginCtx, info, immutableBody)
 		return
 	}
 
@@ -125,7 +137,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 	}
 }
 
-func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
+func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog, immutableBody bool) {
 	if ginCtx == nil {
 		return
 	}
@@ -146,10 +158,17 @@ func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
 	if captureLength > remaining {
 		captureLength = remaining
 	}
-	capturedInfo.Body = bytes.Clone(info.Body[:captureLength])
+	retainedBytes := captureLength
+	if immutableBody && captureLength > 0 && captureLength == len(info.Body) && cap(info.Body) <= remaining {
+		capturedInfo.Body = info.Body
+		// Charge the retained capacity, including spare space, to the same budget.
+		retainedBytes = cap(info.Body)
+	} else {
+		capturedInfo.Body = bytes.Clone(info.Body[:captureLength])
+	}
 	bodyEmpty := len(info.Body) == 0
 	bodyTruncated := captureLength < len(info.Body)
-	ginCtx.Set(deferredAPIRequestBytesKey, bytesUsed+captureLength)
+	ginCtx.Set(deferredAPIRequestBytesKey, bytesUsed+retainedBytes)
 	requests = append(requests, func() []byte {
 		builder := newAPIRequestLogBuilder(index, capturedInfo, capturedAt)
 		if bodyEmpty {

--- a/internal/runtime/executor/helps/logging_immutable_body_test.go
+++ b/internal/runtime/executor/helps/logging_immutable_body_test.go
@@ -1,0 +1,117 @@
+package helps
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+)
+
+func TestImmutableRequestLogPreservesDeferredBudget(t *testing.T) {
+	for _, tt := range []struct {
+		name                                    string
+		length, capacity, remaining, wantCharge int
+		wantTruncated                           bool
+	}{
+		{name: "complete body", length: 8, capacity: 8, remaining: 16, wantCharge: 8},
+		{name: "spare capacity charged", length: 8, capacity: 12, remaining: 16, wantCharge: 12},
+		{name: "spare capacity exceeds budget", length: 8, capacity: 32, remaining: 16, wantCharge: 8},
+		{name: "truncated body", length: 8, capacity: 8, remaining: 4, wantCharge: 4, wantTruncated: true},
+		{name: "exhausted budget", length: 8, capacity: 8, wantTruncated: true},
+		{name: "empty body with spare capacity", capacity: 32, remaining: 16},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			ctx := context.WithValue(t.Context(), "gin", ginCtx)
+			initial := maxDeferredAPIRequestBodyBytes - tt.remaining
+			ginCtx.Set(deferredAPIRequestBytesKey, initial)
+			body := make([]byte, tt.length, tt.capacity)
+			copy(body, "abcdefgh")
+			RecordAPIRequestImmutableBody(ctx, &config.Config{}, UpstreamRequestLog{URL: "https://example.test/responses", Method: http.MethodPost, Body: body})
+			gotCharge, _ := ginCtx.Get(deferredAPIRequestBytesKey)
+			if gotCharge != initial+tt.wantCharge {
+				t.Errorf("retained bytes=%v, want %d", gotCharge, initial+tt.wantCharge)
+			}
+			raw, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey)
+			if !exists {
+				t.Fatal("missing deferred capture")
+			}
+			captures := raw.([]logging.DeferredAPIRequest)
+			if len(captures) != 1 {
+				t.Fatalf("captures=%d, want 1", len(captures))
+			}
+			result := string(captures[0]())
+			if strings.Contains(result, "TRUNCATED") != tt.wantTruncated {
+				t.Errorf("unexpected truncation: %s", result)
+			}
+			want := "<empty>"
+			if tt.length > 0 {
+				want = string(body[:min(tt.length, tt.remaining)])
+			}
+			if !strings.Contains(result, "\nBody:\n"+want) {
+				t.Errorf("missing captured body %q: %s", want, result)
+			}
+		})
+	}
+}
+
+func TestImmutableRequestLogMatchesSnapshotOutput(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprint(enabled), func(t *testing.T) {
+			cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: enabled}}
+			info := UpstreamRequestLog{URL: "https://example.test/responses", Method: http.MethodPost, Headers: http.Header{"X-Debug": {"one", "two"}}, Body: []byte(`{"model":"test","input":"hello"}`)}
+			var results []string
+			for _, record := range []func(context.Context, *config.Config, UpstreamRequestLog){RecordAPIRequest, RecordAPIRequestImmutableBody} {
+				ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+				record(context.WithValue(t.Context(), "gin", ginCtx), cfg, info)
+				var result string
+				if enabled {
+					result = string(ginCtx.MustGet(apiRequestKey).([]byte))
+				} else {
+					result = string(ginCtx.MustGet(logging.DeferredAPIRequestContextKey).([]logging.DeferredAPIRequest)[0]())
+				}
+				var lines []string
+				for _, line := range strings.Split(result, "\n") {
+					if !strings.HasPrefix(line, "Timestamp:") {
+						lines = append(lines, line)
+					}
+				}
+				results = append(results, strings.Join(lines, "\n"))
+			}
+			if results[0] != results[1] {
+				t.Fatalf("immutable log differs:\n%s\n%s", results[0], results[1])
+			}
+		})
+	}
+}
+
+func BenchmarkDeferredAPIRequestBody(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	for _, size := range []int{1024, 1 << 20, 8 << 20} {
+		for _, immutable := range []bool{false, true} {
+			b.Run(fmt.Sprintf("bytes=%d/immutable=%t", size, immutable), func(b *testing.B) {
+				ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+				ctx := context.WithValue(b.Context(), "gin", ginCtx)
+				cfg := &config.Config{}
+				info := UpstreamRequestLog{Body: bytes.Repeat([]byte("x"), size)}
+				record := RecordAPIRequest
+				if immutable {
+					record = RecordAPIRequestImmutableBody
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					ginCtx.Keys = nil
+					record(ctx, cfg, info)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Codex streaming requests clone the finalized upstream body into the deferred error-log capture even when full request logging is disabled. With large coding-agent contexts this allocates another full request-sized buffer on the successful path, although that finalized body is only read afterward.

Add an explicit immutable-body logging entry point and use it after Codex `cacheHelper` has completed request rewriting. The existing `RecordAPIRequest` continues taking a body snapshot for general callers. Immediate request logging is unchanged.

Deferred captures keep the 32 MiB per-request budget:
- Share only a complete body whose capacity fits in the remaining budget.
- Charge its retained capacity, including spare space, against that budget.
- Copy truncated prefixes and bodies whose spare capacity would exceed the budget, avoiding retention of an oversized backing allocation.
- Keep empty-body and truncation markers unchanged.

Refs #4671, the immutable request-log part of the allocation slice. This is a manual adaptation to the current split executor, separate from the SSE line-copy change in #5678.

Validation:
- Twelve executor cases compare the deferred log body byte-for-byte with the actual outbound body after success, HTTP failure and terminal SSE failure, across Claude/Responses clients and bootstrap buffering modes.
- Six capture-budget cases, immediate/deferred output equivalence, and the existing mutable-body snapshot regression pass.
- Full executor/helper, logging and API middleware tests pass.
- Focused ownership/logging tests pass with `-race`.
- Server build, gofmt and `git diff --check` pass.

`BenchmarkCodexDeferredRequestLogging` exercises the full streaming executor with a 1 MiB Responses input and a mock transport. Median of three 500 ms runs:

| Version | Allocated bytes/request |
| --- | ---: |
| Previous logging call | 14,812,694 |
| Immutable body capture | 13,756,218 |

This saves 1,056,476 bytes/request (about 7.1%) in this fixture. The benchmark file also includes isolated capture benchmarks. These measurements describe allocations, not live-provider latency.

Prepared and tested with Codex assistance. No live provider account was used.