### PR TITLE
fix(auth): allow affinity lookup without an active plugin scheduler

### DIFF
--- a/internal/pluginhost/affinity_callbacks_test.go
+++ b/internal/pluginhost/affinity_callbacks_test.go
@@ -23,8 +23,11 @@ func TestHostAffinityLookupCallback_Contract(t *testing.T) {
 	host := New()
 	manager := coreauth.NewManager(nil, nil, nil)
 	selector := coreauth.NewSessionAffinitySelector(nil)
+	defer selector.Stop()
 	manager.SetSelector(selector)
 	host.SetAuthManager(manager)
+	// Builder and Service attach the host even when no scheduler plugin is active.
+	manager.SetPluginScheduler(host)
 
 	authA := &coreauth.Auth{
 		ID:       "claude-owner-a@example.com.json",
@@ -529,4 +532,69 @@ func TestHostAffinityLookupCallback_Contract(t *testing.T) {
 		}
 		wg.Wait()
 	})
+}
+
+func TestHostAffinityLookupSchedulerCapability(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		scheduler bool
+		fused     bool
+		want      string
+	}{
+		{name: "ordinary plugin", want: pluginapi.HostAffinityStatusBound},
+		{name: "active scheduler", scheduler: true, want: pluginapi.HostAffinityStatusUnsupported},
+		{name: "fused scheduler", scheduler: true, fused: true, want: pluginapi.HostAffinityStatusBound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var schedulerCalls int
+			capabilities := pluginapi.Capabilities{}
+			if tt.scheduler {
+				capabilities.Scheduler = schedulerFunc(func(context.Context, pluginapi.SchedulerPickRequest) (pluginapi.SchedulerPickResponse, error) {
+					schedulerCalls++
+					return pluginapi.SchedulerPickResponse{}, nil
+				})
+			}
+			host := newHostWithRecords(capabilityRecord{id: "observer-test", plugin: pluginapi.Plugin{Capabilities: capabilities}})
+			if tt.fused {
+				host.fusePlugin("observer-test", "Scheduler.Pick", "test scheduler failure")
+			}
+			selector := coreauth.NewSessionAffinitySelector(nil)
+			defer selector.Stop()
+			manager := coreauth.NewManager(nil, selector, nil)
+			manager.SetPluginScheduler(host)
+			host.SetAuthManager(manager)
+			auth := &coreauth.Auth{ID: "affinity-observer-auth", Provider: "codex", Status: coreauth.StatusActive}
+			auth.EnsureIndex()
+			if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+				t.Fatal(errRegister)
+			}
+			_, errPick := selector.Pick(context.Background(), "codex", "test-model", cliproxyexecutor.Options{
+				Headers: map[string][]string{"Session-Id": {"test-session"}},
+			}, []*coreauth.Auth{auth})
+			if errPick != nil {
+				t.Fatal(errPick)
+			}
+			payload := []byte(`{"provider":"codex","model":"test-model","session_id":"test-session"}`)
+			raw, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, payload)
+			if errCall != nil {
+				t.Fatal(errCall)
+			}
+			response, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](raw)
+			if errDecode != nil {
+				t.Fatal(errDecode)
+			}
+			if response.Status != tt.want {
+				t.Errorf("status = %q, want %q", response.Status, tt.want)
+			}
+			if tt.want == pluginapi.HostAffinityStatusBound && response.AuthIndex != auth.Index {
+				t.Errorf("auth_index = %q, want %q", response.AuthIndex, auth.Index)
+			}
+			if tt.want != pluginapi.HostAffinityStatusBound && response.AuthIndex != "" {
+				t.Error("unsupported lookup returned a credential")
+			}
+			if schedulerCalls != 0 {
+				t.Errorf("observation invoked scheduler %d times", schedulerCalls)
+			}
+		})
+	}
 }

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -422,14 +422,12 @@ func (m *Manager) Selector() Selector {
 // LookupSessionAffinity observes the current session affinity binding without side effects.
 // It returns (auth, status) where status can be "bound", "unbound", "ambiguous", or "unsupported".
 func (m *Manager) LookupSessionAffinity(provider, model, sessionID string) (*Auth, string) {
-	if m == nil {
+	// The standard service always attaches a plugin host. Native affinity
+	// remains authoritative unless that host has an active scheduler capability.
+	if m == nil || m.hasPluginScheduler() {
 		return nil, "unsupported"
 	}
 	m.mu.RLock()
-	if m.pluginScheduler != nil {
-		m.mu.RUnlock()
-		return nil, "unsupported"
-	}
 	sel := m.selector
 	authProviderMap := make(map[string]string, len(m.auths))
 	for id, a := range m.auths {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -423,8 +423,8 @@ func (m *Manager) Selector() Selector {
 // It returns (auth, status) where status can be "bound", "unbound", "ambiguous", or "unsupported".
 func (m *Manager) LookupSessionAffinity(provider, model, sessionID string) (*Auth, string) {
 	// The standard service always attaches a plugin host. Native affinity
-	// remains authoritative unless that host has an active scheduler capability.
-	if m == nil || m.hasPluginScheduler() {
+	// remains authoritative unless Home or an active plugin owns selection.
+	if m == nil || m.HomeEnabled() || m.hasPluginScheduler() {
 		return nil, "unsupported"
 	}
 	m.mu.RLock()

--- a/sdk/cliproxy/auth/session_affinity_lookup_test.go
+++ b/sdk/cliproxy/auth/session_affinity_lookup_test.go
@@ -2,10 +2,12 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -104,6 +106,39 @@ func TestManagerLookupAffinityWithInactivePluginSchedulerDoesNotRefreshTTL(t *te
 	}
 	if scheduler.calls != 0 {
 		t.Errorf("lookup selected a credential %d times", scheduler.calls)
+	}
+}
+
+func TestManagerLookupAffinityIsUnsupportedWhileHomeOwnsRouting(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+	manager := NewManager(nil, selector, nil)
+	manager.SetPluginScheduler(&inactivePluginScheduler{})
+	auth := &Auth{ID: "local-affinity-auth", Provider: "codex", Status: StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatal(errRegister)
+	}
+	selector.cache.Set("codex::codex:known-session::test-model", auth.ID)
+	for _, enabled := range []bool{true, false} {
+		cfg := &internalconfig.Config{}
+		cfg.Home.Enabled = enabled
+		manager.SetConfig(cfg)
+		for _, sessionID := range []string{"known-session", "unknown-session"} {
+			t.Run(fmt.Sprintf("home=%t/%s", enabled, sessionID), func(t *testing.T) {
+				found, status := manager.LookupSessionAffinity("codex", "test-model", sessionID)
+				if enabled {
+					if status != "unsupported" || found != nil {
+						t.Errorf("Home lookup = %v, %q; want unsupported", found, status)
+					}
+				} else if sessionID == "known-session" {
+					if status != "bound" || found == nil || found.ID != auth.ID {
+						t.Errorf("native lookup = %v, %q; want bound auth", found, status)
+					}
+				} else if status != "unbound" || found != nil {
+					t.Errorf("native absent lookup = %v, %q; want unbound", found, status)
+				}
+			})
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/session_affinity_lookup_test.go
+++ b/sdk/cliproxy/auth/session_affinity_lookup_test.go
@@ -75,6 +75,38 @@ func TestSessionAffinitySelector_LookupAffinity(t *testing.T) {
 	})
 }
 
+func TestManagerLookupAffinityWithInactivePluginSchedulerDoesNotRefreshTTL(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+	manager := NewManager(nil, selector, nil)
+	scheduler := &inactivePluginScheduler{}
+	manager.SetPluginScheduler(scheduler)
+	auth := &Auth{ID: "observer-auth", Provider: "codex", Status: StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatal(errRegister)
+	}
+	const key = "codex::codex:observer-session::test-model"
+	selector.cache.Set(key, auth.ID)
+	selector.cache.mu.RLock()
+	expiresAt := selector.cache.entries[key].expiresAt
+	selector.cache.mu.RUnlock()
+	for i := 0; i < 5; i++ {
+		found, status := manager.LookupSessionAffinity("codex", "test-model", "observer-session")
+		if status != "bound" || found == nil || found.ID != auth.ID {
+			t.Fatalf("lookup = %v, %q; want bound auth", found, status)
+		}
+	}
+	selector.cache.mu.RLock()
+	after := selector.cache.entries[key].expiresAt
+	selector.cache.mu.RUnlock()
+	if !after.Equal(expiresAt) {
+		t.Errorf("lookup extended TTL: %v -> %v", expiresAt, after)
+	}
+	if scheduler.calls != 0 {
+		t.Errorf("lookup selected a credential %d times", scheduler.calls)
+	}
+}
+
 func TestManager_LookupSessionAffinity_RemovedAuth(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
 	selector := NewSessionAffinitySelector(nil)


### PR DESCRIPTION
The standard builder and service attach a plugin host as the manager's scheduler bridge even when no scheduling plugin is enabled. `LookupSessionAffinity` currently checks only whether that bridge is non-nil, so `host.affinity.lookup` always returns `unsupported` under normal service wiring despite native affinity being active.

Use the existing capability-aware `hasPluginScheduler` check before taking the manager read lock. Native bindings remain observable with an empty host, an ordinary non-scheduler plugin, or a fused scheduler. Home-owned routing, an active scheduler, and a custom scheduler without capability introspection produce `unsupported`.

Refs #5604; this fixes the standard-host integration of the existing callback.

Validation:
- Wire the existing host callback contract suite exactly like the builder (`manager.SetPluginScheduler(host)`). This reproduces failures for absent/bound sessions, normalization, rebinding, ambiguity, disabled credentials, LCP identities and concurrent reads before the fix.
- Add actual-host cases for ordinary, active-scheduler and fused-scheduler plugins, asserting that observation never calls the scheduler.
- Add repeated manager lookups with an inactive scheduler, asserting the binding's expiry is unchanged.
- Four Home-on/off cases cover stale local bindings and absent sessions; Home never exposes local affinity as authoritative. The two Home-on cases failed before the follow-up guard.
- Full `internal/pluginhost` and `sdk/cliproxy/auth` suites passed; focused affinity `-race` tests passed.
- The first combined run hit the existing one-second wait in `TestServiceConcurrentReplacementWaitsForInFlightDrain`. That service test then passed 10 consecutive runs, and the full `sdk/cliproxy` suite passed on rerun. The drain code is not changed.
- Server build, gofmt and `git diff --check` passed.

Prepared and tested with Codex assistance.