### PR TITLE
fix(auth): bound manual refresh-all concurrency

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -203,6 +203,7 @@ disable-image-generation: false
 video-result-auth-cache-ttl: "3h"
 
 # Core auth auto-refresh worker pool size (OAuth/file-based auth token refresh).
+# Also limits concurrent refreshes within each management refresh-all batch.
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
 
-	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
+	// AuthAutoRefreshWorkers limits the core auth auto-refresh pool and each manual refresh-all batch.
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -55,11 +55,7 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 	}
 
 	ctx, cancelCtx := context.WithCancel(parent)
-	workers := refreshMaxConcurrency
-	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
-		workers = cfg.AuthAutoRefreshWorkers
-	}
-	loop := newAuthAutoRefreshLoop(m, interval, workers)
+	loop := newAuthAutoRefreshLoop(m, interval, m.authRefreshWorkers())
 
 	m.mu.Lock()
 	m.refreshCancel = cancelCtx
@@ -68,6 +64,13 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 
 	loop.rebuild(time.Now())
 	go loop.run(ctx)
+}
+
+func (m *Manager) authRefreshWorkers() int {
+	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
+		return cfg.AuthAutoRefreshWorkers
+	}
+	return refreshMaxConcurrency
 }
 
 // StopAutoRefresh cancels the background refresh loop, if running.
@@ -593,9 +596,13 @@ type ForceRefreshResult struct {
 }
 
 // ForceRefreshAll triggers an immediate refresh for all credentials that have refresh tokens or custom refresh evaluators.
+// Each batch uses the configured auth refresh worker count and skips queued refreshes after cancellation.
 func (m *Manager) ForceRefreshAll(ctx context.Context) []ForceRefreshResult {
 	if m == nil {
 		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	m.mu.RLock()
 	ids := make([]string, 0, len(m.auths))
@@ -607,19 +614,29 @@ func (m *Manager) ForceRefreshAll(ctx context.Context) []ForceRefreshResult {
 	m.mu.RUnlock()
 
 	results := make([]ForceRefreshResult, len(ids))
+	jobs := make(chan int)
 	var wg sync.WaitGroup
-	for i, id := range ids {
+	for range min(m.authRefreshWorkers(), len(ids)) {
 		wg.Add(1)
-		go func(index int, authID string) {
+		go func() {
 			defer wg.Done()
-			_, err := m.ForceRefreshAuth(ctx, authID)
-			res := ForceRefreshResult{ID: authID, Success: err == nil}
-			if err != nil {
-				res.Error = err.Error()
+			for index := range jobs {
+				errRefresh := ctx.Err()
+				if errRefresh == nil {
+					_, errRefresh = m.ForceRefreshAuth(ctx, ids[index])
+				}
+				res := ForceRefreshResult{ID: ids[index], Success: errRefresh == nil}
+				if errRefresh != nil {
+					res.Error = errRefresh.Error()
+				}
+				results[index] = res
 			}
-			results[index] = res
-		}(i, id)
+		}()
 	}
+	for index := range ids {
+		jobs <- index
+	}
+	close(jobs)
 	wg.Wait()
 	return results
 }

--- a/sdk/cliproxy/auth/force_refresh_concurrency_test.go
+++ b/sdk/cliproxy/auth/force_refresh_concurrency_test.go
@@ -1,0 +1,157 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+type blockedBatchRefreshExecutor struct {
+	countingRefreshExecutor
+	release <-chan struct{}
+	calls   atomic.Int32
+	failID  string
+}
+
+func (e *blockedBatchRefreshExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	e.calls.Add(1)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-e.release:
+	}
+	if auth.ID == e.failID {
+		return nil, errors.New("fixture refresh failure")
+	}
+	return e.countingRefreshExecutor.Refresh(ctx, auth)
+}
+
+func newBatchRefreshManager(t *testing.T, workers, credentials int, release <-chan struct{}) (*Manager, *blockedBatchRefreshExecutor) {
+	t.Helper()
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{AuthAutoRefreshWorkers: workers})
+	executor := &blockedBatchRefreshExecutor{
+		countingRefreshExecutor: countingRefreshExecutor{id: "batch-refresh"},
+		release:                 release,
+	}
+	manager.RegisterExecutor(executor)
+	for i := range credentials {
+		auth := &Auth{
+			ID:       fmt.Sprintf("batch-%d", i),
+			Provider: executor.Identifier(),
+			Metadata: map[string]any{"refresh_token": "fixture-refresh-token"},
+		}
+		if _, errRegister := manager.Register(t.Context(), auth); errRegister != nil {
+			t.Fatalf("register credential: %v", errRegister)
+		}
+	}
+	return manager, executor
+}
+
+func TestForceRefreshAllBoundsConcurrency(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		workers     int
+		credentials int
+		wantActive  int32
+	}{
+		{name: "default", credentials: 21, wantActive: 16},
+		{name: "negative uses default", workers: -1, credentials: 21, wantActive: 16},
+		{name: "serial", workers: 1, credentials: 7, wantActive: 1},
+		{name: "configured", workers: 3, credentials: 9, wantActive: 3},
+		{name: "fewer credentials than workers", workers: 99, credentials: 3, wantActive: 3},
+		{name: "empty", workers: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				release := make(chan struct{})
+				manager, executor := newBatchRefreshManager(t, tc.workers, tc.credentials, release)
+				executor.failID = "batch-0"
+				done := make(chan []ForceRefreshResult, 1)
+				go func() { done <- manager.ForceRefreshAll(t.Context()) }()
+				synctest.Wait()
+				if got := executor.calls.Load(); got != tc.wantActive {
+					t.Errorf("concurrent refresh calls = %d, want %d", got, tc.wantActive)
+				}
+				close(release)
+				results := <-done
+				if len(results) != tc.credentials {
+					t.Fatalf("results = %d, want %d", len(results), tc.credentials)
+				}
+				if got := executor.calls.Load(); got != int32(tc.credentials) {
+					t.Errorf("total refresh calls = %d, want %d", got, tc.credentials)
+				}
+				seen := make(map[string]bool)
+				for _, result := range results {
+					if seen[result.ID] || result.ID == "" {
+						t.Errorf("duplicate or empty result ID: %q", result.ID)
+					}
+					seen[result.ID] = true
+					if result.ID == executor.failID {
+						if result.Success || result.Error != "fixture refresh failure" {
+							t.Errorf("failed refresh result = %+v", result)
+						}
+					} else if !result.Success || result.Error != "" {
+						t.Errorf("successful refresh result = %+v", result)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestForceRefreshAllCancellationSkipsQueuedCredentials(t *testing.T) {
+	for _, canceledBeforeStart := range []bool{false, true} {
+		t.Run(fmt.Sprintf("canceled before start=%t", canceledBeforeStart), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				const workers, credentials = 2, 9
+				manager, executor := newBatchRefreshManager(t, workers, credentials, make(chan struct{}))
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				if canceledBeforeStart {
+					cancel()
+				}
+				done := make(chan []ForceRefreshResult, 1)
+				go func() { done <- manager.ForceRefreshAll(ctx) }()
+				synctest.Wait()
+				cancel()
+				results := <-done
+				wantCalls := int32(workers)
+				if canceledBeforeStart {
+					wantCalls = 0
+				}
+				if got := executor.calls.Load(); got != wantCalls {
+					t.Errorf("refresh calls = %d, want %d", got, wantCalls)
+				}
+				if len(results) != credentials {
+					t.Fatalf("results = %d, want %d", len(results), credentials)
+				}
+				for _, result := range results {
+					if result.ID == "" || result.Success || result.Error != context.Canceled.Error() {
+						t.Errorf("canceled refresh result = %+v", result)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestForceRefreshAllNilContext(t *testing.T) {
+	release := make(chan struct{})
+	close(release)
+	manager, executor := newBatchRefreshManager(t, 1, 2, release)
+	results := manager.ForceRefreshAll(nil)
+	if len(results) != 2 || executor.calls.Load() != 2 {
+		t.Fatalf("results = %+v, calls = %d", results, executor.calls.Load())
+	}
+	for _, result := range results {
+		if !result.Success {
+			t.Errorf("nil context refresh failed: %+v", result)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5687

The new management refresh-all operation starts one OAuth refresh per eligible credential at once. Large account pools bypass the concurrency bound used by automatic refresh, and an already-canceled request still enters every executor.

This PR uses a fixed worker pool for each manual batch, with the existing `auth-auto-refresh-workers` setting and default of 16. Automatic refresh and manual batches share the worker-count resolver. Queued credentials receive a cancellation result without entering their executor once the context is canceled; every selected credential still receives its own result, including failures. Nil contexts retain their existing background-context behavior.

The limit applies independently to each batch and the automatic pool; it is not a new process-wide quota. Credential eligibility and explicit single-credential refresh behavior are unchanged. The configuration comments now describe the manual-batch behavior.

### Validation

Nine new cases cover default/negative/configured worker counts, one worker, fewer credentials than workers, no credentials, partial failure, cancellation before and during a batch, and nil context. Concurrent tests use channel barriers and `testing/synctest`, with no wall-clock sleeps or network calls. Six cases fail on the unmodified base: e.g. configured concurrency 1 starts 7 calls, and an already-canceled batch starts all 9 calls.

- Auth, management-handler and configuration package tests pass. The first combined run hit the pre-existing `TestSessionCache_GetAndRefresh` wall-clock TTL flake; the auth package rerun passed.
- Focused refresh and refresh-scheduling tests pass with `-race -count=20`.
- Required server build passes.

Based on `60e5b8bd` (the new refresh-all endpoint).