### PR TITLE
test(auth): use virtual time for session cache TTL refresh

### DIFF
--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -2043,38 +2044,41 @@ func TestSessionAffinitySelector_CrossProviderIsolation(t *testing.T) {
 func TestSessionCache_GetAndRefresh(t *testing.T) {
 	t.Parallel()
 
-	cache := NewSessionCache(100 * time.Millisecond)
-	defer cache.Stop()
+	// Keep the cache cleanup loop and all TTL checks on the same virtual clock.
+	// Scheduler delays must not consume the 40ms margin between accesses.
+	synctest.Test(t, func(t *testing.T) {
+		cache := NewSessionCache(100 * time.Millisecond)
+		defer cache.Stop()
 
-	cache.Set("session1", "auth1")
+		cache.Set("session1", "auth1")
 
-	// Verify initial value
-	got, ok := cache.GetAndRefresh("session1")
-	if !ok || got != "auth1" {
-		t.Fatalf("GetAndRefresh() = %q, %v, want auth1, true", got, ok)
-	}
+		// Verify initial value
+		got, ok := cache.GetAndRefresh("session1")
+		if !ok || got != "auth1" {
+			t.Fatalf("GetAndRefresh() = %q, %v, want auth1, true", got, ok)
+		}
 
-	// Wait half TTL and access again (should refresh)
-	time.Sleep(60 * time.Millisecond)
-	got, ok = cache.GetAndRefresh("session1")
-	if !ok || got != "auth1" {
-		t.Fatalf("GetAndRefresh() after 60ms = %q, %v, want auth1, true", got, ok)
-	}
+		// Advance virtual time within the TTL and refresh the binding.
+		time.Sleep(60 * time.Millisecond)
+		got, ok = cache.GetAndRefresh("session1")
+		if !ok || got != "auth1" {
+			t.Fatalf("GetAndRefresh() after 60ms = %q, %v, want auth1, true", got, ok)
+		}
 
-	// Wait another 60ms (total 120ms from original, but TTL refreshed at 60ms)
-	// Entry should still be valid because TTL was refreshed
-	time.Sleep(60 * time.Millisecond)
-	got, ok = cache.GetAndRefresh("session1")
-	if !ok || got != "auth1" {
-		t.Fatalf("GetAndRefresh() after refresh = %q, %v, want auth1, true (TTL should have been refreshed)", got, ok)
-	}
+		// Advance past the original deadline, but stay within the refreshed TTL.
+		time.Sleep(60 * time.Millisecond)
+		got, ok = cache.GetAndRefresh("session1")
+		if !ok || got != "auth1" {
+			t.Fatalf("GetAndRefresh() after refresh = %q, %v, want auth1, true (TTL should have been refreshed)", got, ok)
+		}
 
-	// Now wait full TTL without access
-	time.Sleep(110 * time.Millisecond)
-	got, ok = cache.GetAndRefresh("session1")
-	if ok {
-		t.Fatalf("GetAndRefresh() after expiry = %q, %v, want '', false", got, ok)
-	}
+		// Let the refreshed TTL expire without further access.
+		time.Sleep(110 * time.Millisecond)
+		got, ok = cache.GetAndRefresh("session1")
+		if ok {
+			t.Fatalf("GetAndRefresh() after expiry = %q, %v, want '', false", got, ok)
+		}
+	})
 }
 
 func TestSessionAffinitySelector_RoundRobinDistribution(t *testing.T) {


### PR DESCRIPTION
`TestSessionCache_GetAndRefresh` failed during validation of #5688 on the current `dev` base. It sleeps for 60 ms twice against a 100 ms TTL; scheduler delays can consume the 40 ms margin and expire a correctly refreshed binding. The failure was:

```text
GetAndRefresh() after refresh = "", false, want auth1, true (TTL should have been refreshed)
```

Run this existing test inside `testing/synctest` so its accesses, expiration checks and background cleanup loop share a virtual clock. Preserve the original 60/60/110 ms timeline and all assertions. The test remains parallel, and production cache code is unchanged.

Validation:

- Full auth package passes.
- Focused test passes with `-race -count=100` and completes without real TTL waits.
- A mutation that preserves the old expiry instead of extending it makes the revised test fail at the access past the original deadline; the mutation was removed.
- Required server build passes.

Only the existing test and its imports/comments change.