### PR TITLE
fix(antigravity): support native google search grounding for claude web_search requests

### DIFF
--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -89,7 +89,8 @@ func AntigravityWebSearchModelFor(modelID string) string {
 	if modelID == "" {
 		return ""
 	}
-	for _, model := range GetGlobalRegistry().GetAvailableModelsByProvider("antigravity") {
+	models := GetGlobalRegistry().GetAvailableModelsByProvider("antigravity")
+	for _, model := range models {
 		if model == nil {
 			continue
 		}
@@ -102,6 +103,28 @@ func AntigravityWebSearchModelFor(modelID string) string {
 				return currentModelID
 			}
 			return ""
+		}
+	}
+	altModelID := strings.TrimSuffix(modelID, "-high")
+	if altModelID != modelID {
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			currentModelID := normalizeAntigravityCapabilityModelID(model.ID)
+			if currentModelID == altModelID && model.SupportsWebSearch {
+				return currentModelID
+			}
+		}
+	}
+	altModelIDHigh := modelID + "-high"
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		currentModelID := normalizeAntigravityCapabilityModelID(model.ID)
+		if currentModelID == altModelIDHigh && model.SupportsWebSearch {
+			return currentModelID
 		}
 	}
 	return ""

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -104,6 +104,9 @@ func TestAntigravityWebSearchModelForRequiresRequestedModelCapability(t *testing
 	if got := AntigravityWebSearchModelFor("gemini-web-search-test"); got != "gemini-web-search-test" {
 		t.Fatalf("AntigravityWebSearchModelFor capable model = %q, want itself", got)
 	}
+	if got := AntigravityWebSearchModelFor("gemini-web-search-test-high"); got != "gemini-web-search-test" {
+		t.Fatalf("AntigravityWebSearchModelFor capable model with -high suffix = %q, want gemini-web-search-test", got)
+	}
 	if got := AntigravityWebSearchModelFor("gemini-cross-provider-route"); got != "" {
 		t.Fatalf("cross-provider model should not get Antigravity web search model, got %q", got)
 	}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -3424,6 +3424,7 @@
       "display_name": "Gemini 3.7 Flash",
       "name": "gemini-3.7-flash-high",
       "description": "Gemini 3.7 Flash (High)",
+      "supports_web_search": true,
       "context_length": 1048576,
       "max_completion_tokens": 65536,
       "thinking": {
@@ -3454,6 +3455,7 @@
       "display_name": "Gemini 3.8 Flash",
       "name": "gemini-3.8-flash-high",
       "description": "Gemini 3.8 Flash (High)",
+      "supports_web_search": true,
       "context_length": 1048576,
       "max_completion_tokens": 65536,
       "thinking": {

--- a/internal/translator/antigravity/claude/antigravity_claude_request.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request.go
@@ -309,7 +309,7 @@ func ConvertClaudeRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	enableThoughtTranslate := true
 	rawJSON := inputRawJSON
 	if shouldBuildAntigravityWebSearchRequest(modelName, rawJSON) {
-		return buildAntigravityWebSearchRequest(modelName, rawJSON)
+		return buildAntigravityWebSearchRequest(antigravityWebSearchTargetModel(modelName), rawJSON)
 	}
 	functionNameMap := util.SanitizedFunctionNameMap(rawJSON)
 

--- a/internal/translator/antigravity/claude/antigravity_claude_request_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_request_test.go
@@ -351,6 +351,24 @@ func TestConvertClaudeRequestToAntigravity_UsesDefaultWebSearchMaxResultCountWit
 	}
 }
 
+func TestConvertClaudeRequestToAntigravity_StripsPerformWebSearchPrefix(t *testing.T) {
+	registry.GetGlobalRegistry().RegisterClient("test-antigravity-claude-websearch-prefix", "antigravity", []*registry.ModelInfo{
+		{ID: "gemini-3.1-flash-lite", SupportsWebSearch: true},
+	})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient("test-antigravity-claude-websearch-prefix") })
+
+	inputJSON := []byte(`{
+		"model": "gemini-3.1-flash-lite",
+		"messages": [{"role": "user", "content": "Perform a web search for the query: golang 1.24 release notes"}],
+		"tools": [{"type": "web_search_20250305", "name": "web_search"}]
+	}`)
+
+	output := ConvertClaudeRequestToAntigravity("gemini-3.1-flash-lite", inputJSON, true)
+	if got := gjson.GetBytes(output, "request.contents.0.parts.0.text").String(); got != "golang 1.24 release notes" {
+		t.Fatalf("search query = %q, want stripped query: %s", got, output)
+	}
+}
+
 func TestConvertClaudeRequestToAntigravity_DoesNotMapTypedWebSearchWhenMixedWithCustomTools(t *testing.T) {
 	registry.GetGlobalRegistry().RegisterClient("test-antigravity-claude-websearch-mixed", "antigravity", []*registry.ModelInfo{
 		{ID: "gemini-3.1-flash-lite", SupportsWebSearch: true},

--- a/internal/translator/antigravity/claude/web_search.go
+++ b/internal/translator/antigravity/claude/web_search.go
@@ -30,6 +30,14 @@ func antigravitySupportsNativeGoogleSearch(model string) bool {
 	return registry.AntigravityWebSearchModelFor(model) != ""
 }
 
+func antigravityWebSearchTargetModel(model string) string {
+	target := registry.AntigravityWebSearchModelFor(model)
+	if target == "" {
+		return model
+	}
+	return target
+}
+
 func isClaudeTypedWebSearchToolType(toolType string) bool {
 	return toolType == "web_search_20250305" || toolType == "web_search_20260209"
 }
@@ -172,7 +180,12 @@ func extractClaudeWebSearchQuery(payload []byte) string {
 			continue
 		}
 		if query := extractClaudeTextContent(message.Get("content")); query != "" {
-			return query
+			const prefix = "perform a web search for the query:"
+			trimmed := strings.TrimSpace(query)
+			if strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+				return strings.TrimSpace(trimmed[len(prefix):])
+			}
+			return trimmed
 		}
 	}
 	return ""


### PR DESCRIPTION
### Summary
This PR addresses two issues when routing Claude Code's built-in web search (`web_search_20250305` / `web_search_20260209`) requests to Google Antigravity:

1. **Model capability resolution for aliased/suffixed models:**
   When using model aliases or suffixed variants like `gemini-3.8-flash-high` mapped from `gemini-3.8-flash`, `AntigravityWebSearchModelFor` could fail to resolve the model capability against the registered models list because of the `-high` suffix mismatch. `AntigravityWebSearchModelFor` now normalizes `-high` suffixes when looking up capability, and static models in `models.json` for Gemini 3.7/3.8 Flash High are marked with `"supports_web_search": true`.

2. **Query prefix stripping:**
   Claude Code prefixes synthetic web search user messages with `Perform a web search for the query: ...`. In `extractClaudeWebSearchQuery`, this prefix is now stripped so the actual search query is passed cleanly to Google Search grounding instead of the wrapper instruction text.

### Testing
- Added unit test in `internal/registry` verifying capability lookup with `-high` suffix.
- Added unit test in `internal/translator/antigravity/claude` verifying `Perform a web search for the query:` prefix stripping.
- Verified live streaming web search requests via Antigravity backend.