### PR TITLE
fix(session): recognize OpenCode conversation headers and document forwarding

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -358,6 +358,7 @@ nonstream-keepalive-interval: 0
 #       # Values starting with "$" dynamically copy the header value from downstream client requests.
 #       # If the client did not send the specified header, the header is omitted.
 #       # X-Claude-Code-Session-Id: "$ABC" # copies client's "ABC" header
+#       # OpenCode Go client/session header examples: examples/opencode-go/README.md
 #     proxy-url: "socks5://proxy.example.com:1080"
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential
 #     models:

--- a/examples/opencode-go/README.md
+++ b/examples/opencode-go/README.md
@@ -1,0 +1,73 @@
+# OpenCode Go through CLIProxyAPI
+
+OpenCode Go asks coding clients to identify themselves and send a stable
+conversation ID for routing and prompt caching. Its [client requirements](https://opencode.ai/docs/go/#where-can-i-use-it)
+also document support for Claude Code's and Codex's native session headers.
+
+CLIProxyAPI can forward those headers with its existing dynamic custom-header
+configuration. A `$Header-Name` value copies that incoming request header; when
+the client omits it, CLIProxyAPI omits the corresponding custom header.
+
+## Chat Completions models
+
+Add the following provider to `config.yaml`, replacing the API key with your
+OpenCode Go key. Choose a model whose [documented endpoint](https://opencode.ai/docs/go/#endpoints)
+is `/chat/completions`:
+
+```yaml
+openai-compatibility:
+  - name: "opencode-go"
+    base-url: "https://opencode.ai/zen/go/v1"
+    headers:
+      User-Agent: "$User-Agent"
+      X-Opencode-Session: "$X-Opencode-Session"
+      X-Claude-Code-Session-Id: "$X-Claude-Code-Session-Id"
+      Session_id: "$Session_id"
+      Session-Id: "$Session-Id"
+    api-key-entries:
+      - api-key: "YOUR_OPENCODE_GO_API_KEY"
+    models:
+      - name: "deepseek-v4-flash"
+        alias: "go-deepseek-v4-flash"
+```
+
+Select `go-deepseek-v4-flash` in the coding client connected to CLIProxyAPI.
+The header names are case-insensitive; `Session_id` and `Session-Id` remain
+distinct names, so both Codex spellings are included. The user agent is the
+real caller's value. This configuration does not impersonate another client.
+
+This provider example uses the Chat Completions upstream path. Do not copy a
+Responses-only or Messages-only model into it: select the matching upstream
+protocol separately. Session headers do not change the model's wire protocol.
+
+## Clients with another conversation header
+
+For a client that sends its conversation ID as `X-Session-ID`, replace the
+`X-Opencode-Session` mapping above with:
+
+```yaml
+headers:
+  User-Agent: "$User-Agent"
+  X-Opencode-Session: "$X-Session-ID"
+```
+
+Use the actual header sent by your client. `$Header-Name` reads an HTTP header;
+it does not interpolate task metadata or expressions such as `${task-id}`.
+Keep the ID stable across turns in one conversation and change it for a new
+conversation. Do not configure a single static ID shared by all conversations.
+
+For a custom client or SDK caller, send your own user agent and a stable
+`X-Opencode-Session` header on every model request, including auxiliary requests
+that belong to the same conversation. A proxy cannot recover a missing explicit
+conversation ID merely by copying headers.
+
+## Checking the configuration
+
+If Go still reports a missing session, inspect a redacted request log and check
+both the incoming and outgoing header sets. At least one session header
+recognized by Go must survive every proxy hop. In particular, forwarding
+`$X-Opencode-Session` alone does nothing when the client only sends its native
+Claude Code or Codex header.
+
+The provider API key belongs in `api-key-entries`. Header forwarding supplies
+client and conversation metadata; it does not replace upstream authentication.

--- a/examples/opencode-go/README.md
+++ b/examples/opencode-go/README.md
@@ -8,6 +8,12 @@ CLIProxyAPI can forward those headers with its existing dynamic custom-header
 configuration. A `$Header-Name` value copies that incoming request header; when
 the client omits it, CLIProxyAPI omits the corresponding custom header.
 
+The session extractor also recognizes `X-Opencode-Session` as an explicit
+conversation identity for local affinity, using the same namespace as
+`X-Session-Affinity`. If both are supplied, the existing affinity header keeps
+precedence. This local recognition and upstream header forwarding are separate:
+configure the forwarding below so Go receives the original session signal.
+
 ## Chat Completions models
 
 Add the following provider to `config.yaml`, replacing the API key with your

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -2215,6 +2215,11 @@ func TestExtractSessionIDNativeSignals(t *testing.T) {
 			want:    "affinity:ses_opencode",
 		},
 		{
+			name:    "OpenCode native session header",
+			headers: http.Header{"X-Opencode-Session": []string{"ses_opencode_native"}},
+			want:    "affinity:ses_opencode_native",
+		},
+		{
 			name:    "prompt cache key",
 			payload: `{"prompt_cache_key":"prompt-session"}`,
 			want:    "pck:prompt-session",

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -354,6 +354,7 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"X-Http-Session-Id",
 		"X-Session-ID",
 		"X-Session-Affinity",
+		"X-Opencode-Session",
 		"X-Parent-Session-ID",
 		"X-Parent-Session-Id",
 		"X-Parent-Session-Affinity",

--- a/sdk/cliproxy/session/info.go
+++ b/sdk/cliproxy/session/info.go
@@ -37,7 +37,7 @@ type SessionTreeInfo = SessionInfo
 //  2. Claude Code metadata.user_id session
 //  3. Session-Id / Session_id (Codex and compatible clients)
 //  4. X-Http-Session-Id (Antigravity CLI)
-//  5. X-Session-ID / X-Session-Affinity / X-Slot-Session-Id
+//  5. X-Session-ID / X-Session-Affinity / X-Opencode-Session / X-Slot-Session-Id
 //  6. X-Conversation-Id / X-Thread-Id / X-Client-Request-Id
 //  7. Gemini cachedContent
 //  8. OpenAI thread_id
@@ -449,7 +449,11 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		}
 		return finalizeSessionInfo(info)
 	}
-	if sid := sessionHeaderValue(headers, "X-Session-Affinity"); sid != "" {
+	affinitySessionID := sessionHeaderValue(headers, "X-Session-Affinity")
+	if affinitySessionID == "" {
+		affinitySessionID = sessionHeaderValue(headers, "X-Opencode-Session")
+	}
+	if sid := affinitySessionID; sid != "" {
 		info.ClientType = "opencode"
 		info.SessionID = "affinity:" + sid
 		parentAffinity := sessionHeaderValue(headers, "X-Parent-Session-Affinity")

--- a/sdk/cliproxy/session/opencode_header_test.go
+++ b/sdk/cliproxy/session/opencode_header_test.go
@@ -1,0 +1,65 @@
+package session
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestExtractSessionInfoOpenCodeNativeHeader(t *testing.T) {
+	t.Parallel()
+	// OpenCode Go requires the conversation header used by current Pi clients (#5690).
+	for _, tt := range []struct {
+		name    string
+		headers http.Header
+		want    string
+	}{
+		{name: "native", headers: http.Header{"X-Opencode-Session": {"ses_native"}}, want: "affinity:ses_native"},
+		{name: "lowercase", headers: http.Header{"x-opencode-session": {"ses_lower"}}, want: "affinity:ses_lower"},
+		{name: "later valid value", headers: http.Header{"X-Opencode-Session": {"bad\nvalue", "ses_valid"}}, want: "affinity:ses_valid"},
+		{name: "existing affinity precedence", headers: http.Header{"X-Session-Affinity": {"ses_existing"}, "X-Opencode-Session": {"ses_native"}}, want: "affinity:ses_existing"},
+		{name: "empty", headers: http.Header{"X-Opencode-Session": {" "}}},
+		{name: "oversized", headers: http.Header{"X-Opencode-Session": {strings.Repeat("x", 257)}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info, ok := ExtractSessionInfo(tt.headers, nil, nil)
+			if info.SessionID != tt.want || ok != (tt.want != "") {
+				t.Fatalf("ExtractSessionInfo() = (%q, %v), want (%q, %v)", info.SessionID, ok, tt.want, tt.want != "")
+			}
+			if ok && info.ClientType != "opencode" {
+				t.Fatalf("client type = %q, want opencode", info.ClientType)
+			}
+		})
+	}
+}
+
+func TestEnrichOpenCodeHeaderSeparatesIdenticalPromptsAndSurvivesCompaction(t *testing.T) {
+	t.Parallel()
+	for _, sessionID := range []string{"session-a", "session-b"} {
+		for _, payload := range []string{
+			`{"messages":[{"role":"user","content":"Fix the failing test"}]}`,
+			`{"messages":[{"role":"user","content":"Compacted conversation summary"}]}`,
+		} {
+			req, opts := Enrich(
+				cliproxyexecutor.Request{Payload: []byte(payload)},
+				cliproxyexecutor.Options{
+					SourceFormat: sdktranslator.FormatOpenAI,
+					Headers:      http.Header{"X-Opencode-Session": {sessionID}},
+					Metadata:     map[string]any{cliproxyexecutor.DerivedSessionIDMetadataKey: "ctx:v1:stale-root"},
+				},
+			)
+			for _, metadata := range []map[string]any{req.Metadata, opts.Metadata} {
+				if got := metadata[cliproxyexecutor.CanonicalSessionIDMetadataKey]; got != "affinity:"+sessionID {
+					t.Fatalf("canonical identity = %v, want affinity:%s", got, sessionID)
+				}
+				if got := DerivedID(metadata); got != "" {
+					t.Fatalf("explicit OpenCode session retained derived identity %q", got)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Current Pi clients send `X-Opencode-Session` for OpenCode requests, but CLIProxyAPI only recognizes `X-Session-Affinity`. A native-header-only conversation therefore falls back to prompt-derived identity; separate conversations with identical opening prompts can share that identity, and compaction can change it.

This recognizes `X-Opencode-Session` in both explicit-session detection and hierarchy extraction, reusing the existing `affinity:` namespace and preserving `X-Session-Affinity` precedence. It uses the existing validation for case-insensitive, multi-value, empty, control-bearing and oversized headers. No new upstream session is invented.

The accompanying example documents existing `$Header-Name` forwarding for OpenCode Go, Claude Code and Codex, including real user-agent forwarding and the distinction between local affinity and sending the header upstream. The example uses a documented Chat Completions model and explains protocol selection and missing-header behavior.

Refs #5690. Automatic metadata-to-header generation remains a separate request.

Validation:
- Reproduced missing native-header extraction and absent canonical identity before the fix; regression tests now pass.
- Complete session, auth, and API-handler package tests pass.
- Focused session/auth tests pass with `-race -count=20`.
- Existing custom-header forwarding tests pass; both YAML examples parse.
- Server build passes with `-buildvcs=false` (this environment cannot obtain VCS status).
- Requirements and model endpoint verified against [OpenCode Go documentation](https://opencode.ai/docs/go/). No paid-provider request was made.