### PR TITLE
docs: add PiCloud to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Browser agent that can connect to CLIProxyAPI's local OpenAI-compatible endpoint
 
 Native macOS menu bar app that runs a fleet of Claude accounts through CLIProxyAPI's Management API (claude-swap and 9Router too): 5h / 7d / per-model quota gauges, switch / hold / star from the popup, a run-rate forecast of when each window runs out, and an iPhone companion that mirrors it all - no API keys needed.
 
+### [PiCloud](https://github.com/cookerpapa/pi-cloud)
+
+Self-hosted coding-agent platform built on the Pi SDK, with a web UI, concurrent subagents, and CubeSandbox KVM workspaces. Uses CLIProxyAPI as its provider gateway, keeping provider credentials outside the guest workspaces.
+
 > [!NOTE]  
 > If you developed a project based on CLIProxyAPI, please open a PR to add it to this list.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -268,6 +268,10 @@ VS Code 扩展，可将你的 Claude、ChatGPT/Codex、Antigravity、Grok 和 Ki
 
 原生 macOS 菜单栏应用，通过 CLIProxyAPI 的管理 API 管理多个 Claude 账号（也支持 claude-swap 与 9Router）：5 小时 / 7 天 / 按模型的配额仪表，弹窗内切换 / 暂停 / 星标账号，按当前消耗速度预测各窗口何时耗尽，并可在 iPhone 上同步查看。
 
+### [PiCloud](https://github.com/cookerpapa/pi-cloud)
+
+基于 Pi SDK 的自托管编程 Agent 平台，提供 Web 界面、并发子 Agent 和 CubeSandbox KVM 工作空间。使用 CLIProxyAPI 作为模型供应商网关，将供应商凭据保留在客户机工作空间之外。
+
 > [!NOTE]  
 > 如果你开发了基于 CLIProxyAPI 的项目，请提交一个 PR（拉取请求）将其添加到此列表中。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -267,6 +267,10 @@ CLIProxyAPI のローカル OpenAI 互換エンドポイントをモデルプロ
 
 CLIProxyAPI の Management API 経由で複数の Claude アカウントを管理するネイティブ macOS メニューバーアプリ（claude-swap と 9Router にも対応）。5 時間 / 7 日 / モデル別のクォータゲージ、ポップアップからの切り替え / 保留 / スター、現在のペースから各ウィンドウが尽きる時刻を予測する機能に加え、iPhone からも同じ状態を確認できます。
 
+### [PiCloud](https://github.com/cookerpapa/pi-cloud)
+
+Pi SDK をベースにしたセルフホスト型コーディングエージェント基盤。Web UI、並列サブエージェント、CubeSandbox KVM ワークスペースを備えています。CLIProxyAPI をモデルプロバイダーへのゲートウェイとして利用し、プロバイダーの認証情報をゲストのワークスペースから分離します。
+
 > [!NOTE]
 > CLIProxyAPIをベースにプロジェクトを開発した場合は、PRを送ってこのリストに追加してください。
 


### PR DESCRIPTION
I maintain [PiCloud](https://github.com/cookerpapa/pi-cloud), a self-hosted coding-agent platform built on the Pi SDK. This adds it to the English, Chinese, and Japanese related-project lists, following the README's invitation to list projects built on CLIProxyAPI.

PiCloud runs CLIProxyAPI as its provider gateway: the [production Compose configuration](https://github.com/cookerpapa/pi-cloud/blob/2b2f62971e31c9cae5ec7e5c4f2d495a1d100815/deploy/production/compose.yaml) defines the `cli-proxy-api` service, and the supervisor's [model gateway](https://github.com/cookerpapa/pi-cloud/blob/2b2f62971e31c9cae5ec7e5c4f2d495a1d100815/packages/supervisor-host/src/model-gateway.ts) forwards scoped workspace requests to it. Provider credentials stay outside the guest workspaces.

Validation: checked the three entries against the linked implementation; `git diff --check` and `go build -buildvcs=false -o <temporary-output> ./cmd/server` passed. The build flag disables VCS metadata because this environment cannot resolve the worktree's VCS status.