### PR TITLE
fix(auth): classify terminal upstream OAuth selection failures

### DIFF
--- a/examples/upstream-auth-errors/README.md
+++ b/examples/upstream-auth-errors/README.md
@@ -1,0 +1,42 @@
+# Upstream authentication errors
+
+When every eligible local OAuth credential is unavailable after a terminal
+unauthorized refresh failure, CLIProxyAPI returns HTTP 503 with
+`error.code: "upstream_authentication_required"`:
+
+```json
+{
+  "error": {
+    "type": "server_error",
+    "code": "upstream_authentication_required",
+    "message": "All eligible upstream credentials require reauthentication; ask the proxy operator to sign in again"
+  }
+}
+```
+
+The message can include a redacted diagnostic from the last upstream failure.
+Clients should match the code, not the message text. On this code, stop automatic
+retries for the current operation and ask the proxy operator to reauthenticate
+or replace the affected upstream credentials. Retry after that intervention.
+Changing the client's proxy API key does not repair upstream OAuth credentials.
+
+The HTTP status remains 503 because the proxy cannot serve the requested model.
+The code supplies the non-retryable client contract; a client that retries every
+5xx without inspecting the code will continue to retry. No `Retry-After` hint is
+generated for this condition. The same code is returned for initial streaming
+and non-streaming Responses failures.
+
+The classification requires the existing terminal refresh state, no remaining
+valid access token or future recovery deadline, and every eligible candidate to
+satisfy those conditions.
+A last unauthorized error alone is insufficient. Mixed pools with temporary
+refresh failures or quota cooldowns retain their existing error behavior, and a
+healthy eligible credential can still serve the request. Successful credential
+refresh or replacement clears the condition.
+
+SDK callers can use `auth.IsUpstreamAuthenticationRequired(err)`. Existing
+`errors.As(err, &authErr)` consumers still see `auth_unavailable`, HTTP 503, and
+`Retryable: false`, and the underlying diagnostic remains available through
+error unwrapping. The local scheduler still refreshes a stale selection snapshot
+before returning the error. This does not infer terminal state for a remote Home
+scheduler or an external plugin from its generic unavailable response.

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -36,8 +36,8 @@ func isAuthSelectionUnavailable(err error) bool {
 }
 
 func enrichAuthSelectionError(err error, providers []string, model string) error {
-	if err == nil {
-		return nil
+	if err == nil || coreauth.IsUpstreamAuthenticationRequired(err) {
+		return err
 	}
 
 	type modelCooldownMarker interface {

--- a/sdk/api/handlers/openai/permanent_oauth_classification_repro_test.go
+++ b/sdk/api/handlers/openai/permanent_oauth_classification_repro_test.go
@@ -1,0 +1,137 @@
+// Regression reproducer supplied in https://github.com/router-for-me/CLIProxyAPI/issues/5645.
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+const reproOAuthMessage = `token refresh failed with status 401: {"error":{"message":"Refresh credential has already been consumed; sign in again.","type":"invalid_request_error","code":"refresh_token_reused"}}`
+const reproCompletedResponse = `{"id":"resp-fixture","object":"response","status":"completed","output":[]}`
+
+type reproOAuthExecutor struct{ calls atomic.Int32 }
+
+func (*reproOAuthExecutor) Identifier() string { return "codex" }
+func (e *reproOAuthExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls.Add(1)
+	return coreexecutor.Response{Payload: []byte(reproCompletedResponse)}, nil
+}
+func (e *reproOAuthExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	e.calls.Add(1)
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":" + reproCompletedResponse + "}\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+func (*reproOAuthExecutor) Refresh(context.Context, *coreauth.Auth) (*coreauth.Auth, error) {
+	return nil, errors.New(reproOAuthMessage)
+}
+func (*reproOAuthExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("unused fixture method")
+}
+func (*reproOAuthExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("network is not used in this reproduction")
+}
+
+func TestReproPermanentOAuthFailureClassification(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%t", stream), func(t *testing.T) {
+			model := fmt.Sprintf("repro-permanent-oauth-%t", stream)
+			failedID := "failed-" + model
+			healthyID := "healthy-" + model
+			executor := &reproOAuthExecutor{}
+			manager := coreauth.NewManager(nil, nil, nil)
+			manager.RegisterExecutor(executor)
+			defer manager.StopAutoRefresh()
+
+			// This is the terminal state produced by refreshAuth when a 401
+			// refresh failure has no remaining valid access token. The upstream
+			// TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry
+			// independently verifies that transition and unscheduling behavior.
+			failed := &coreauth.Auth{
+				ID: failedID, Provider: "codex", Status: coreauth.StatusError,
+				Unavailable: true, StatusMessage: "unauthorized",
+				LastError: &coreauth.Error{Code: "unauthorized", Message: reproOAuthMessage,
+					Retryable: false, HTTPStatus: http.StatusUnauthorized},
+				Metadata: map[string]any{"access_token": "expired-fixture",
+					"expired": time.Now().Add(-time.Hour).Format(time.RFC3339)},
+			}
+			if _, err := manager.Register(context.Background(), failed); err != nil {
+				t.Fatal(err)
+			}
+			registry.GetGlobalRegistry().RegisterClient(failedID, "codex", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() {
+				registry.GetGlobalRegistry().UnregisterClient(failedID)
+				registry.GetGlobalRegistry().UnregisterClient(healthyID)
+			})
+			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+			router := gin.New()
+			router.POST("/v1/responses", NewOpenAIResponsesAPIHandler(base).Responses)
+			request := func() *httptest.ResponseRecorder {
+				body := fmt.Sprintf(`{"model":%q,"input":"fixture","stream":%t}`, model, stream)
+				req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("User-Agent", "codex_cli_rs/0.153.4")
+				recorder := httptest.NewRecorder()
+				router.ServeHTTP(recorder, req)
+				return recorder
+			}
+
+			for attempt := 1; attempt <= 3; attempt++ {
+				got := request()
+				var payload struct {
+					Error struct {
+						Code, Type, Message string
+						Retryable           *bool `json:"retryable"`
+					} `json:"error"`
+				}
+				if err := json.Unmarshal(got.Body.Bytes(), &payload); err != nil {
+					t.Fatalf("decode HTTP %d body %q: %v", got.Code, got.Body.String(), err)
+				}
+				t.Logf("attempt=%d HTTP=%d code=%q type=%q retryable=%v executor_calls=%d body=%s", attempt,
+					got.Code, payload.Error.Code, payload.Error.Type, payload.Error.Retryable, executor.calls.Load(), got.Body.String())
+				if !strings.Contains(payload.Error.Message, "refresh_token_reused") {
+					t.Errorf("terminal OAuth cause missing from response: %s", got.Body.String())
+				}
+				if got.Code != http.StatusServiceUnavailable || payload.Error.Code != coreauth.ErrorCodeUpstreamAuthenticationRequired || payload.Error.Type != "server_error" {
+					t.Errorf("unexpected terminal-auth response: HTTP=%d body=%s", got.Code, got.Body.String())
+				}
+				if got.Header().Get("Retry-After") != "" || !strings.Contains(payload.Error.Message, "proxy operator") {
+					t.Errorf("terminal failure should require operator action without an automatic retry hint: headers=%v body=%s", got.Header(), got.Body.String())
+				}
+			}
+			if executor.calls.Load() != 0 {
+				t.Errorf("terminal auth reached executor %d times", executor.calls.Load())
+			}
+
+			// A healthy candidate must make this same route succeed, proving the
+			// earlier errors are not missing model registration or a bad handler.
+			healthy := &coreauth.Auth{ID: healthyID, Provider: "codex", Status: coreauth.StatusActive}
+			if _, err := manager.Register(context.Background(), healthy); err != nil {
+				t.Fatal(err)
+			}
+			registry.GetGlobalRegistry().RegisterClient(healthyID, "codex", []*registry.ModelInfo{{ID: model}})
+			control := request()
+			if control.Code != http.StatusOK || executor.calls.Load() != 1 {
+				t.Errorf("healthy control HTTP=%d executor_calls=%d body=%s", control.Code, executor.calls.Load(), control.Body.String())
+			}
+			t.Logf("healthy control HTTP=%d executor_calls=%d", control.Code, executor.calls.Load())
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -546,6 +546,9 @@ func (m *Manager) availableAuthsForRouteModelWithPriorityMode(auths []*Auth, pro
 		lastCandidateErr := latestCandidateErrorForModel(auths, func(candidate *Auth) string {
 			return m.selectionModelForAuth(candidate, routeModel)
 		})
+		if allAuthsRequireReauthentication(auths, now) {
+			return nil, newUpstreamAuthenticationRequiredError(lastCandidateErr)
+		}
 
 		if cooldownCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
@@ -1242,7 +1245,7 @@ func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, o
 }
 
 func (m *Manager) shouldRetryAfterErrorWithAttempted(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int, defaultRequestRetry int, attempted map[string]struct{}) (time.Duration, bool) {
-	if err == nil {
+	if err == nil || IsUpstreamAuthenticationRequired(err) {
 		return 0, false
 	}
 	var homeBusy *HomeConcurrencyBusyError

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -532,6 +532,7 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 	now := time.Now()
 	total := 0
 	cooldownCount := 0
+	terminalRefreshCount := 0
 	earliest := time.Time{}
 
 	var latestModelTime time.Time
@@ -554,6 +555,7 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(predicate)
 		total += localTotal
 		cooldownCount += localCooldownCount
+		terminalRefreshCount += shard.terminalRefreshFailureCountLocked(predicate, now)
 		if !localEarliest.IsZero() && (earliest.IsZero() || localEarliest.Before(earliest)) {
 			earliest = localEarliest
 		}
@@ -583,6 +585,9 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 
 	if total == 0 {
 		return WithCause(&Error{Code: "auth_not_found", Message: "no auth available"}, lastCandidateErr)
+	}
+	if terminalRefreshCount == total {
+		return newUpstreamAuthenticationRequiredError(lastCandidateErr)
 	}
 	if cooldownCount == total && !earliest.IsZero() {
 		resetIn := earliest.Sub(now)
@@ -1239,6 +1244,9 @@ func (m *modelScheduler) unavailableErrorLocked(provider, model string, predicat
 	lastCandidateErr, _, _ := m.latestCandidateErrorWithTimeLocked(model, predicate)
 	if total == 0 {
 		return WithCause(&Error{Code: "auth_not_found", Message: "no auth available"}, lastCandidateErr)
+	}
+	if m.terminalRefreshFailureCountLocked(predicate, now) == total {
+		return newUpstreamAuthenticationRequiredError(lastCandidateErr)
 	}
 	if cooldownCount == total && !earliest.IsZero() {
 		providerForError := provider

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -527,6 +527,9 @@ func getAvailableAuthsWithPriorityMode(auths []*Auth, provider, model string, no
 
 	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
 	if len(availableByPriority) == 0 {
+		if allAuthsRequireReauthentication(auths, now) {
+			return nil, newUpstreamAuthenticationRequiredError(latestCandidateErrorForModel(auths, func(*Auth) string { return model }))
+		}
 		if cooldownCount == len(auths) && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {

--- a/sdk/cliproxy/auth/terminal_refresh_error.go
+++ b/sdk/cliproxy/auth/terminal_refresh_error.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// ErrorCodeUpstreamAuthenticationRequired tells clients that retrying without
+// operator reauthentication cannot recover the eligible upstream credentials.
+const ErrorCodeUpstreamAuthenticationRequired = "upstream_authentication_required"
+
+// Keep the auth_unavailable identity for existing selector callers, including
+// scheduler snapshot refresh, while preserving a distinct client error body.
+type upstreamAuthenticationRequiredError struct {
+	*errorWithCause
+}
+
+func newUpstreamAuthenticationRequiredError(cause error) error {
+	return &upstreamAuthenticationRequiredError{&errorWithCause{
+		base: &Error{
+			Code:       "auth_unavailable",
+			Message:    "All eligible upstream credentials require reauthentication; ask the proxy operator to sign in again",
+			HTTPStatus: http.StatusServiceUnavailable,
+		},
+		cause: cause,
+	}}
+}
+
+func (e *upstreamAuthenticationRequiredError) Error() string {
+	payload := map[string]any{"error": map[string]string{
+		"type":    "server_error",
+		"code":    ErrorCodeUpstreamAuthenticationRequired,
+		"message": e.errorWithCause.Error(),
+	}}
+	// A payload containing only strings is always JSON-serializable.
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+// IsUpstreamAuthenticationRequired reports a terminal refresh failure across
+// all eligible credentials. It does not classify a pool by its last error alone.
+func IsUpstreamAuthenticationRequired(err error) bool {
+	var required *upstreamAuthenticationRequiredError
+	return errors.As(err, &required) && required != nil
+}
+
+func hasTerminalRefreshFailure(auth *Auth, now time.Time) bool {
+	return auth != nil && !auth.Disabled && auth.Status != StatusDisabled &&
+		auth.AuthKind() == AuthKindOAuth && hasUnauthorizedAuthFailure(auth) &&
+		!auth.LastError.Retryable && auth.StatusMessage == "unauthorized" &&
+		!auth.NextRetryAfter.After(now) && !auth.Quota.NextRecoverAt.After(now) &&
+		!auth.HasValidAccessToken(now)
+}
+
+func allAuthsRequireReauthentication(auths []*Auth, now time.Time) bool {
+	if len(auths) == 0 {
+		return false
+	}
+	for _, candidate := range auths {
+		if !hasTerminalRefreshFailure(candidate, now) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *modelScheduler) terminalRefreshFailureCountLocked(predicate func(*scheduledAuth) bool, now time.Time) int {
+	count := 0
+	for _, entry := range m.entries {
+		if entry == nil || (predicate != nil && !predicate(entry)) {
+			continue
+		}
+		if hasTerminalRefreshFailure(entry.auth, now) {
+			count++
+		}
+	}
+	return count
+}

--- a/sdk/cliproxy/auth/terminal_refresh_error_test.go
+++ b/sdk/cliproxy/auth/terminal_refresh_error_test.go
@@ -1,0 +1,199 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+func terminalRefreshTestAuth(id string, now time.Time) *Auth {
+	return &Auth{
+		ID: id, Provider: "codex", Status: StatusError, Unavailable: true,
+		StatusMessage: "unauthorized",
+		LastError:     &Error{Code: "unauthorized", Message: "refresh_token_reused", HTTPStatus: http.StatusUnauthorized},
+		Metadata:      map[string]any{"access_token": "expired-fixture", "expired": now.Add(-time.Hour).Format(time.RFC3339)},
+	}
+}
+
+func TestTerminalRefreshSelectionRequiresEveryCandidate(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name     string
+		alter    func(*Auth)
+		terminal bool
+		ready    bool
+	}{
+		{name: "all terminal", terminal: true},
+		{name: "refresh scheduled", alter: func(a *Auth) { a.NextRefreshAfter = now.Add(time.Minute) }},
+		{name: "unauthorized request cooldown", alter: func(a *Auth) { a.NextRetryAfter = now.Add(30 * time.Minute) }},
+		{name: "quota recovery scheduled", alter: func(a *Auth) { a.Quota.NextRecoverAt = now.Add(time.Hour) }},
+		{name: "expired without refresh failure", alter: func(a *Auth) { a.LastError = nil }},
+		{name: "transient refresh", alter: func(a *Auth) {
+			a.LastError = &Error{HTTPStatus: http.StatusBadGateway, Message: "temporary failure", Retryable: true}
+		}},
+		{name: "retryable unauthorized", alter: func(a *Auth) { a.LastError.Retryable = true }},
+		{name: "other unavailable state", alter: func(a *Auth) { a.StatusMessage = "operator hold" }},
+		{name: "api key", alter: func(a *Auth) { a.Attributes = map[string]string{AttributeAuthKind: AuthKindAPIKey} }},
+		{name: "unexpired but held", alter: func(a *Auth) { a.Metadata["expired"] = now.Add(time.Hour).Format(time.RFC3339) }},
+		{name: "healthy", ready: true, alter: func(a *Auth) {
+			a.Metadata["expired"] = now.Add(time.Hour).Format(time.RFC3339)
+			a.Unavailable, a.Status, a.StatusMessage, a.LastError = false, StatusActive, "", nil
+		}},
+		{name: "quota cooldown", alter: func(a *Auth) {
+			a.Metadata["expired"] = now.Add(time.Hour).Format(time.RFC3339)
+			a.StatusMessage = "quota"
+			a.LastError = &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}
+			a.Quota = QuotaState{Exceeded: true, NextRecoverAt: now.Add(time.Hour)}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			first := terminalRefreshTestAuth("terminal-first", now)
+			second := terminalRefreshTestAuth("terminal-second", now)
+			if test.alter != nil {
+				test.alter(second)
+			}
+			auths := []*Auth{first, second}
+			manager := NewManager(nil, nil, nil)
+			t.Cleanup(manager.StopAutoRefresh)
+			for _, pick := range []struct {
+				name string
+				run  func() ([]*Auth, error)
+			}{
+				{"selector", func() ([]*Auth, error) { return getAvailableAuths(auths, "codex", "fixture", now) }},
+				{"manager", func() ([]*Auth, error) { return manager.availableAuthsForRouteModel(auths, "codex", "fixture", now) }},
+			} {
+				t.Run(pick.name, func(t *testing.T) {
+					available, err := pick.run()
+					if got := IsUpstreamAuthenticationRequired(err); got != test.terminal {
+						t.Fatalf("terminal = %v, want %v; error = %v", got, test.terminal, err)
+					}
+					if (len(available) > 0) != test.ready {
+						t.Fatalf("available = %v, want ready %v", available, test.ready)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTerminalRefreshSchedulerEligibility(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		for _, alternative := range []string{"terminal", "healthy", "transient", "disabled", "wrong model", "excluded by kind", "already tried", "not pinned"} {
+			t.Run(fmt.Sprintf("mixed=%t/%s", mixed, alternative), func(t *testing.T) {
+				ctx := context.Background()
+				now := time.Now()
+				model := "terminal-refresh-" + t.Name()
+				first := terminalRefreshTestAuth(model+"-first", now)
+				second := terminalRefreshTestAuth(model+"-second", now)
+				if mixed {
+					second.Provider = "claude"
+				}
+				terminal := true
+				var tried map[string]struct{}
+				opts := cliproxyexecutor.Options{}
+				secondModel := model
+				if alternative != "terminal" {
+					second.Metadata["expired"] = now.Add(time.Hour).Format(time.RFC3339)
+					second.Unavailable, second.Status, second.StatusMessage, second.LastError = false, StatusActive, "", nil
+				}
+				switch alternative {
+				case "healthy":
+					terminal = false
+				case "transient":
+					terminal = false
+					second.Unavailable, second.Status = true, StatusError
+					second.LastError = &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "temporary"}
+				case "disabled":
+					second.Disabled = true
+				case "wrong model":
+					secondModel += "-other"
+				case "excluded by kind":
+					second.Attributes = map[string]string{AttributeAuthKind: AuthKindAPIKey}
+					ctx = withRequiredAuthKind(ctx, AuthKindOAuth)
+				case "already tried":
+					tried = map[string]struct{}{second.ID: {}}
+				case "not pinned":
+					opts.Metadata = map[string]any{cliproxyexecutor.PinnedAuthMetadataKey: first.ID}
+				}
+				registerSchedulerModels(t, first.Provider, model, first.ID)
+				registerSchedulerModels(t, second.Provider, secondModel, second.ID)
+				scheduler := newAuthScheduler(&RoundRobinSelector{})
+				scheduler.rebuild([]*Auth{first, second})
+				var selected *Auth
+				var err error
+				if mixed {
+					selected, _, err = scheduler.pickMixed(ctx, []string{"codex", "claude"}, model, opts, tried)
+				} else {
+					selected, err = scheduler.pickSingle(ctx, "codex", model, opts, tried)
+				}
+				if got := IsUpstreamAuthenticationRequired(err); got != terminal {
+					t.Fatalf("terminal = %v, want %v; error = %v", got, terminal, err)
+				}
+				if alternative == "healthy" && (selected == nil || selected.ID != second.ID) {
+					t.Fatalf("selected = %v, want healthy alternative", selected)
+				}
+			})
+		}
+	}
+}
+
+func TestTerminalRefreshErrorContract(t *testing.T) {
+	cause := &Error{Code: "unauthorized", Message: "refresh_token_reused; access_token=secret-fixture"}
+	err := newUpstreamAuthenticationRequiredError(cause)
+	wrapped := fmt.Errorf("wrapped: %w", err)
+	if !IsUpstreamAuthenticationRequired(wrapped) || !errors.Is(wrapped, cause) {
+		t.Fatal("terminal classification or underlying cause lost through wrapping")
+	}
+	var selectionErr *Error
+	if !errors.As(wrapped, &selectionErr) || selectionErr.Code != "auth_unavailable" || selectionErr.Retryable || selectionErr.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("selection compatibility = %#v", selectionErr)
+	}
+	if got := gjson.Get(err.Error(), "error.code").String(); got != ErrorCodeUpstreamAuthenticationRequired {
+		t.Fatalf("client code = %q", got)
+	}
+	if strings.Contains(err.Error(), "secret-fixture") {
+		t.Fatalf("upstream secret leaked: %s", err)
+	}
+	if !shouldRetrySchedulerPick(err) {
+		t.Fatal("terminal snapshot must still allow rebuilding a stale scheduler")
+	}
+	manager := NewManager(nil, nil, nil)
+	t.Cleanup(manager.StopAutoRefresh)
+	manager.SetRetryConfig(3, time.Minute, 0)
+	if wait, retry := manager.shouldRetryAfterError(wrapped, 0, []string{"codex"}, "fixture", time.Minute); retry || wait != 0 {
+		t.Fatalf("terminal failure retried: wait=%s retry=%v", wait, retry)
+	}
+	if IsUpstreamAuthenticationRequired(WithCause(&Error{Code: "auth_unavailable"}, cause)) {
+		t.Fatal("a last unauthorized cause alone does not classify the entire pool")
+	}
+}
+
+func TestTerminalRefreshFailureAndRecoveryUseActualRefreshState(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, nil, nil)
+	t.Cleanup(manager.StopAutoRefresh)
+	manager.RegisterExecutor(unauthorizedRefreshTestExecutor{schedulerProviderTestExecutor{provider: "codex"}})
+	const model = "terminal-refresh-real-transition"
+	a := &Auth{ID: model, Provider: "codex", Metadata: map[string]any{"email": "fixture@example.test"}}
+	registerSchedulerModels(t, "codex", model, a.ID)
+	if _, errRegister := manager.Register(ctx, a); errRegister != nil {
+		t.Fatal(errRegister)
+	}
+	manager.refreshAuth(ctx, a.ID)
+	if _, _, err := manager.pickNext(ctx, "codex", model, cliproxyexecutor.Options{}, nil); !IsUpstreamAuthenticationRequired(err) {
+		t.Fatalf("after unauthorized refresh: %v", err)
+	}
+	manager.RegisterExecutor(schedulerProviderTestExecutor{provider: "codex"})
+	manager.refreshAuth(ctx, a.ID)
+	if selected, _, err := manager.pickNext(ctx, "codex", model, cliproxyexecutor.Options{}, nil); err != nil || selected == nil || selected.ID != a.ID {
+		t.Fatalf("after successful refresh: selected=%v error=%v", selected, err)
+	}
+}


### PR DESCRIPTION
Refs #5645.

When every eligible local OAuth credential is in the existing terminal unauthorized-refresh state, the Responses API currently returns only a generic 503 `internal_server_error`. The linked issue's reproducer fails in both streaming and non-streaming modes before this change.

This preserves HTTP 503 and emits `error.code: upstream_authentication_required`, with a redacted diagnostic and an instruction to contact the proxy operator. The documented client contract is to stop automatic retries for this operation until the upstream credentials are reauthenticated or replaced. This does not misidentify the client's proxy API key as invalid. Clients that retry all 5xx responses without inspecting the code still need to adopt that contract.

Classification requires **every request-eligible candidate** to have a non-retryable unauthorized state, no scheduled refresh, no valid access token, and no future auth/quota recovery deadline. A last unauthorized cause alone is insufficient. Single/mixed-provider scheduler paths and legacy selectors share the classification; temporary/mixed pools retain existing behavior. A healthy candidate or successful refresh restores service.

The typed error preserves the existing SDK `auth_unavailable` identity, underlying cause and stale-scheduler recheck, exposes `auth.IsUpstreamAuthenticationRequired`, and stops redundant manager retry rounds. HTTP enrichment preserves its structured body. No new terminal state is inferred from generic remote Home/plugin errors.

Validation:
- Adapted and credited the HTTP reproducer supplied in #5645; repeated initial stream/non-stream failures now retain the exact code, and healthy controls succeed.
- Candidate tests cover refresh backoff, request-401 cooldown, quota recovery, transient failures, API keys, retained valid tokens, healthy alternatives, mixed providers, model/kind filters, disabled/tried/pinned candidates and actual refresh failure/recovery.
- Full auth and all API-handler package tests pass. An initial full run exposed ordinary 401 cooldown misclassification; the recovery-deadline guard and two regression cases resolve it.
- Focused classification/HTTP tests pass with `-race -count=20`.
- Server build with `-buildvcs=false`, gofmt and `git diff --check` pass. VCS stamping is unavailable in this worktree environment.

No live OAuth account or paid-provider request was used. Prepared and tested with Codex assistance.