### PR TITLE
fix(registry): isolate empty model header overrides

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -643,7 +643,7 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 	}
 	if model.Config != nil {
 		copyConfig := *model.Config
-		if len(model.Config.OverrideHeader) > 0 {
+		if model.Config.OverrideHeader != nil {
 			copyConfig.OverrideHeader = make(map[string]string, len(model.Config.OverrideHeader))
 			for key, value := range model.Config.OverrideHeader {
 				copyConfig.OverrideHeader[key] = value

--- a/internal/registry/model_registry_safety_test.go
+++ b/internal/registry/model_registry_safety_test.go
@@ -1,9 +1,64 @@
 package registry
 
 import (
+	"maps"
 	"testing"
 	"time"
 )
+
+func TestModelRegistryHeaderOverridesAreIsolated(t *testing.T) {
+	for _, initial := range []struct {
+		name    string
+		headers map[string]string
+	}{
+		{name: "nil"},
+		{name: "empty", headers: map[string]string{}},
+		{name: "populated", headers: map[string]string{"user-agent": "original"}},
+	} {
+		for _, source := range []struct {
+			name string
+			get  func(*ModelRegistry, *ModelInfo) *ModelInfo
+		}{
+			{"registration input", func(_ *ModelRegistry, input *ModelInfo) *ModelInfo { return input }},
+			{"global lookup", func(r *ModelRegistry, _ *ModelInfo) *ModelInfo { return r.GetModelInfo("m1", "") }},
+			{"provider lookup", func(r *ModelRegistry, _ *ModelInfo) *ModelInfo { return r.GetModelInfo("m1", "openai") }},
+			{"available models", func(r *ModelRegistry, _ *ModelInfo) *ModelInfo { return r.GetAvailableModelInfos()[0] }},
+			{"provider models", func(r *ModelRegistry, _ *ModelInfo) *ModelInfo { return r.GetAvailableModelsByProvider("openai")[0] }},
+			{"client models", func(r *ModelRegistry, _ *ModelInfo) *ModelInfo { return r.GetModelsForClient("client-1")[0] }},
+		} {
+			t.Run(initial.name+"/"+source.name, func(t *testing.T) {
+				r := newTestModelRegistry()
+				input := &ModelInfo{ID: "m1", Config: &ModelConfig{OverrideHeader: maps.Clone(initial.headers)}}
+				r.RegisterClient("client-1", "openai", []*ModelInfo{input})
+
+				snapshot := source.get(r, input)
+				if snapshot == nil || snapshot.Config == nil {
+					t.Fatal("expected model with config")
+				}
+				if (snapshot.Config.OverrideHeader == nil) != (initial.headers == nil) {
+					t.Fatal("snapshot changed nil versus allocated header map")
+				}
+				if snapshot.Config.OverrideHeader == nil {
+					snapshot.Config.OverrideHeader = make(map[string]string)
+				}
+				snapshot.Config.OverrideHeader["user-agent"] = "local override"
+
+				for _, info := range []*ModelInfo{
+					r.GetModelInfo("m1", ""),
+					r.GetModelInfo("m1", "openai"),
+					r.GetModelsForClient("client-1")[0],
+				} {
+					if info == nil || info.Config == nil {
+						t.Fatal("expected registered model with config")
+					}
+					if !maps.Equal(info.Config.OverrideHeader, initial.headers) {
+						t.Fatalf("registered headers = %#v, want %#v after local mutation", info.Config.OverrideHeader, initial.headers)
+					}
+				}
+			})
+		}
+	}
+}
 
 func TestGetModelInfoReturnsClone(t *testing.T) {
 	r := newTestModelRegistry()


### PR DESCRIPTION
`cloneModelInfo` copied header overrides only when the map had entries. An allocated empty `config.override_header` map was therefore still shared with the registration input and returned model snapshots. Adding the first header to a caller-owned snapshot silently changed the registry's configuration for other callers.

Copy every non-nil override map, preserving nil maps. The regression exercises the public registration input, global/provider lookups, and available/client model lists with nil, empty, and populated configurations.

Validation:
- Before the fix, all six empty-map cases fail because the local header mutation reaches the registry; the nil and populated controls pass.
- After the fix, all 18 cases pass, along with `go test -race ./internal/registry -count=1`.
- Server build with `-buildvcs=false` and `git diff --check` pass.
