### PR TITLE
fix(auth): isolate last-error snapshots from manager state

### DIFF
--- a/sdk/cliproxy/auth/auth_error_snapshot_test.go
+++ b/sdk/cliproxy/auth/auth_error_snapshot_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestManagerAuthErrorSnapshotsDoNotChangeRetryEligibility(t *testing.T) {
+	for _, boundary := range []string{"registration input", "registration result", "GetByID", "List"} {
+		t.Run(boundary, func(t *testing.T) {
+			want := Error{Code: "unauthorized", Message: "credential rejected", HTTPStatus: http.StatusUnauthorized}
+			initial := want
+			auth := &Auth{ID: t.Name(), Provider: "codex", Status: StatusError, Unavailable: true, LastError: &initial, NextRetryAfter: time.Now().Add(time.Hour)}
+			manager := NewManager(nil, nil, nil)
+			registered, err := manager.Register(t.Context(), auth)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, retry := manager.closestCooldownWait([]string{"codex"}, "", 0, authSelectionEligibility{}, "", 1); retry {
+				t.Fatal("401 control unexpectedly permits a credential retry round")
+			}
+			var snapshot *Auth
+			switch boundary {
+			case "registration input":
+				snapshot = auth
+			case "registration result":
+				snapshot = registered
+			case "GetByID":
+				snapshot, _ = manager.GetByID(auth.ID)
+			case "List":
+				snapshot = manager.List()[0]
+			}
+			if snapshot == nil || snapshot.LastError == nil {
+				t.Fatal("missing error snapshot")
+			}
+			// A caller may annotate its own diagnostic without updating the credential.
+			*snapshot.LastError = Error{Code: "display-only", Message: "temporary error", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
+			fresh, ok := manager.GetByID(auth.ID)
+			if !ok || fresh.LastError == nil || *fresh.LastError != want {
+				t.Errorf("caller mutation changed the manager error: %+v, want %+v", fresh.LastError, want)
+			}
+			if wait, retry := manager.closestCooldownWait([]string{"codex"}, "", 0, authSelectionEligibility{}, "", 1); retry {
+				t.Errorf("caller mutation enabled a credential retry round with wait %v", wait)
+			}
+		})
+	}
+}
+
+func TestAuthCloneKeepsAbsentLastErrorNil(t *testing.T) {
+	if cloned := (&Auth{ID: "healthy"}).Clone(); cloned.LastError != nil {
+		t.Fatalf("healthy clone acquired an error: %+v", cloned.LastError)
+	}
+}

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -284,13 +284,14 @@ func (a *Auth) RecentRequestsSnapshot(now time.Time) []RecentRequestBucket {
 	return out
 }
 
-// Clone shallow copies the Auth structure, duplicating maps to avoid accidental mutation.
+// Clone shallow copies Auth, duplicating maps and error details to avoid accidental mutation.
 func (a *Auth) Clone() *Auth {
 	if a == nil {
 		return nil
 	}
 	copyAuth := *a
 	copyAuth.Quota = a.Quota.Clone()
+	copyAuth.LastError = cloneError(a.LastError)
 	if len(a.Attributes) > 0 {
 		copyAuth.Attributes = make(map[string]string, len(a.Attributes))
 		for key, value := range a.Attributes {


### PR DESCRIPTION
`Auth.Clone` duplicates model-level errors, but its top-level `LastError` still aliases the original pointer. This lets a caller mutate live manager state through the object passed to `Register`, the object returned from `Register`, `GetByID`, or `List`, without calling `Update`.

The regression registers a cooling credential with a 401 error, then changes only the caller-owned snapshot's error to 503. Before this patch, all four boundaries change the manager's recorded error and incorrectly make `closestCooldownWait` consider the credential eligible for a retry round. The test does not wait for that cooldown or call a provider.

Reuse the existing nil-safe `cloneError` helper when cloning `Auth`. Preserve all error fields and keep absent errors nil. This is independent of the empty-map isolation in #5592; no map allocation, cooldown policy, or provider behavior is changed.

Validation on `dev` at `60e5b8bd432e5a87d2a97a786b9d08ee4bac6e4d`:
- Four deterministic manager-boundary cases fail before the fix and pass afterward; the nil-error control passes in both.
- Complete auth package: `go test -race ./sdk/cliproxy/auth -count=1` passes.
- Server build: `go build -buildvcs=false -o test-output ./cmd/server` passes.
- `gofmt` and `git diff --check` pass.

Prepared and verified with Codex assistance.