### PR TITLE
fix(usage): honor in-band reasoning effort updates

### DIFF
--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -581,6 +581,22 @@ func ExtractReasoningEffort(body []byte, provider, model string) string {
 // setting as a canonical reasoning_effort label for usage logging.
 func ExtractTranslatedReasoningEffort(body []byte, provider string) string {
 	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "codex" || provider == "openai-response" {
+		// Usage follows in-band updates without rewriting the cached prompt's baseline effort.
+		effort := ""
+		gjson.GetBytes(body, `input.#(type=="configuration_update")#.reasoning.effort`).ForEach(func(_, value gjson.Result) bool {
+			if value.Type == gjson.String {
+				if level := strings.ToLower(strings.TrimSpace(value.Str)); level != "" {
+					effort = level
+				}
+			}
+			return true
+		})
+		if effort != "" {
+			return effort
+		}
+	}
+
 	config := extractThinkingConfig(body, provider)
 	if !hasThinkingConfig(config) {
 		switch provider {

--- a/internal/thinking/effort_test.go
+++ b/internal/thinking/effort_test.go
@@ -1,0 +1,83 @@
+package thinking
+
+import "testing"
+
+func TestExtractTranslatedReasoningEffortConfigurationUpdate(t *testing.T) {
+	const original = `{"model":"gpt-6-astra","reasoning":{"effort":"xhigh"},"input":[{"role":"user","content":"Earlier turn"},{"type":"configuration_update","reasoning":{"effort":"low"}},{"role":"user","content":"Reply OK"}]}`
+	body := []byte(original)
+	if got := ExtractTranslatedReasoningEffort(body, "codex"); got != "low" {
+		t.Fatalf("reasoning effort = %q, want low", got)
+	}
+	if got := ExtractReasoningEffort(body, "codex", "gpt-6-astra"); got != "xhigh" {
+		t.Fatalf("request baseline effort = %q, want xhigh", got)
+	}
+	if string(body) != original {
+		t.Fatal("usage extraction changed the request payload")
+	}
+}
+
+func TestExtractTranslatedReasoningEffortUpdatePrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		body     string
+		want     string
+	}{
+		{
+			name: "responses format", provider: "openai-response",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"configuration_update","reasoning":{"effort":"low"}}]}`,
+			want: "low",
+		},
+		{
+			name: "latest update wins", provider: "codex",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"configuration_update","reasoning":{"effort":"low"}},{"role":"user","content":"Earlier turn"},{"type":"configuration_update","reasoning":{"effort":"medium"}},{"role":"user","content":"Reply OK"}]}`,
+			want: "medium",
+		},
+		{
+			name: "summary-only update preserves effort", provider: "codex",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"configuration_update","reasoning":{"effort":"low"}},{"role":"user","content":"Earlier turn"},{"type":"configuration_update","reasoning":{"summary":"auto"}}]}`,
+			want: "low",
+		},
+		{
+			name: "invalid effort fields preserve prior update", provider: "codex",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"configuration_update","reasoning":{"effort":"low"}},{"type":"configuration_update","reasoning":{"effort":null}},{"type":"configuration_update","reasoning":{"effort":12}},{"type":"configuration_update","reasoning":{"effort":" "}}]}`,
+			want: "low",
+		},
+		{
+			name: "none is an explicit update", provider: "codex",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"configuration_update","reasoning":{"effort":"none"}}]}`,
+			want: "none",
+		},
+		{
+			name: "other input items cannot override effort", provider: "codex",
+			body: `{"reasoning":{"effort":"xhigh"},"input":[{"type":"message","role":"user","reasoning":{"effort":"low"},"content":"Reply OK"}]}`,
+			want: "xhigh",
+		},
+		{
+			name: "text input retains baseline", provider: "openai-response",
+			body: `{"reasoning":{"effort":"high"},"input":"Reply OK"}`,
+			want: "high",
+		},
+		{
+			name: "update without explicit baseline", provider: "codex",
+			body: `{"input":[{"type":"configuration_update","reasoning":{"effort":"low"}}]}`,
+			want: "low",
+		},
+		{
+			name: "chat format retains its own effort", provider: "openai",
+			body: `{"reasoning_effort":"high","input":[{"type":"configuration_update","reasoning":{"effort":"low"}}]}`,
+			want: "high",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			if got := ExtractTranslatedReasoningEffort(body, tt.provider); got != tt.want {
+				t.Fatalf("reasoning effort = %q, want %q", got, tt.want)
+			}
+			if string(body) != tt.body {
+				t.Fatal("usage extraction changed the request payload")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes router-for-me/CLIProxyAPI#5714

GPT-6 Astra clients such as OMP preserve the initial request-level
reasoning.effort for prompt caching and send subsequent effort changes
as configuration_update input items. Usage reporting currently reads
only the initial value, so a conversation switched from xhigh to low
continues to be reported as xhigh.

## Changes

- For codex and openai-response translated payloads, report the last
  nonblank string configuration_update.reasoning.effort in input order.
- Preserve the existing provider/top-level fallback when no applicable
  update exists.
- Keep request bytes and the request-level cache baseline unchanged.
- Add regression coverage for update precedence, missing or unusable
  effort values, explicit none, provider isolation, and payload preservation.

The change is confined to usage extraction. Shared thinking configuration
and request rewriting retain their existing behavior.

## Validation

- [x] Reproduced the original failure: reported xhigh, expected low.
- [x] Confirmed the same regression test passes after the fix.
- [x] Passed focused checks:
  go test ./internal/thinking ./internal/runtime/executor/helps ./test \
    -run 'Test(ExtractTranslatedReasoningEffort|UsageReporter|Thinking)' \
    -count=1
- [x] Ran a standalone UsageReporter → usage.Plugin smoke scenario:
  published xhigh, low, and medium while preserving request bytes
  and the top-level xhigh baseline.
- [x] Built ./cmd/server and verified the compiled executable's --help.
- [x] Completed Standards and Spec reviews with no findings.

Validation used Go 1.26.8 on Linux/WSL2.
