### PR TITLE
fix(claude): stop SSE read at message_stop (and stream error)

### DIFF
--- a/internal/runtime/executor/claude_executor_diagnostics.go
+++ b/internal/runtime/executor/claude_executor_diagnostics.go
@@ -92,14 +92,14 @@ func claudeMessageIDFromResponse(data []byte) string {
 	return strings.TrimSpace(gjson.GetBytes(data, "id").String())
 }
 
-func observeClaudeStreamLine(line []byte, messageID *string, completed *bool) {
+func observeClaudeStreamLine(line []byte, messageID *string, completed *bool) (terminal bool) {
 	line = bytes.TrimSpace(line)
 	if !bytes.HasPrefix(line, []byte("data:")) {
-		return
+		return false
 	}
 	payload := bytes.TrimSpace(line[len("data:"):])
 	if !gjson.ValidBytes(payload) {
-		return
+		return false
 	}
 	root := gjson.ParseBytes(payload)
 	switch root.Get("type").String() {
@@ -109,7 +109,11 @@ func observeClaudeStreamLine(line []byte, messageID *string, completed *bool) {
 		}
 	case "message_stop":
 		*completed = true
+		return true
+	case "error":
+		return true
 	}
+	return false
 }
 
 func claudeMessageIDFromSSE(data []byte) string {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -412,6 +412,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			var event bytes.Buffer
 			var upstreamMessageID string
 			upstreamCompleted := false
+			streamTerminal := false
 			flushEvent := func() bool {
 				if event.Len() == 0 {
 					return true
@@ -427,7 +428,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			}
 			for scanner.Scan() {
 				line := scanner.Bytes()
-				observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
+				if observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted) {
+					streamTerminal = true
+				}
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 				streamUsage.ObserveClaudeStream(line)
 				restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
@@ -438,9 +441,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				line = e.restoreResponseModel(restoredLine, req.Model)
 				event.Write(line)
 				event.WriteByte('\n')
-				if len(bytes.TrimSpace(line)) == 0 && !flushEvent() {
+				if len(bytes.TrimSpace(line)) != 0 {
+					continue
+				}
+				if !flushEvent() {
 					emitCancellation(ctx.Err())
 					return
+				}
+				if streamTerminal {
+					break
 				}
 			}
 			if !flushEvent() {
@@ -474,7 +483,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		upstreamCompleted := false
 		for scanner.Scan() {
 			line := scanner.Bytes()
-			observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
+			terminal := observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			streamUsage.ObserveClaudeStream(line)
 			restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
@@ -505,6 +514,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 					emitCancellation(ctx.Err())
 					return
 				}
+			}
+			if terminal {
+				break
 			}
 		}
 		if emitCancellation(scanner.Err()) {

--- a/internal/runtime/executor/claude_executor_stream_terminal_test.go
+++ b/internal/runtime/executor/claude_executor_stream_terminal_test.go
@@ -1,0 +1,158 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+const claudeStreamTerminalHangTimeout = 2 * time.Second
+
+func TestClaudeExecutor_ExecuteStreamStopsAtProtocolTerminalWithoutBodyEOF(t *testing.T) {
+	completeMessage := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_hang","type":"message","role":"assistant","model":"claude-sonnet-5","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+	fatalError := strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+		``,
+		``,
+	}, "\n")
+
+	tests := []struct {
+		name           string
+		stream         string
+		sourceFormat   sdktranslator.Format
+		responseFormat sdktranslator.Format
+		wantContains   []string
+	}{
+		{
+			name:         "native Claude forward stops at message_stop",
+			stream:       completeMessage,
+			sourceFormat: sdktranslator.FormatClaude,
+			wantContains: []string{`"type":"message_stop"`, "msg_hang"},
+		},
+		{
+			name:           "openai translate stops at message_stop",
+			stream:         completeMessage,
+			sourceFormat:   sdktranslator.FormatOpenAI,
+			responseFormat: sdktranslator.FormatOpenAI,
+			wantContains:   []string{`"object":"chat.completion.chunk"`},
+		},
+		{
+			name:         "native Claude forward stops at stream error",
+			stream:       fatalError,
+			sourceFormat: sdktranslator.FormatClaude,
+			wantContains: []string{`"type":"error"`, "Overloaded"},
+		},
+		{
+			name:           "openai translate stops at stream error",
+			stream:         fatalError,
+			sourceFormat:   sdktranslator.FormatOpenAI,
+			responseFormat: sdktranslator.FormatOpenAI,
+			wantContains:   []string{"Overloaded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newClaudeHangingSSEServer(t, tt.stream)
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"api_key":  "key-123",
+				"base_url": server.URL,
+			}}
+			opts := cliproxyexecutor.Options{
+				SourceFormat: tt.sourceFormat,
+				Stream:       true,
+			}
+			if tt.responseFormat != "" {
+				opts.ResponseFormat = tt.responseFormat
+			}
+
+			result, errStream := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-sonnet-5",
+				Payload: []byte(`{"model":"claude-sonnet-5","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+			}, opts)
+			if errStream != nil {
+				t.Fatalf("ExecuteStream() error = %v", errStream)
+			}
+
+			payloads, streamErr := drainClaudeStreamChunks(t, result.Chunks, claudeStreamTerminalHangTimeout)
+			if streamErr != nil {
+				t.Fatalf("unexpected stream error after protocol terminal: %v", streamErr)
+			}
+			joined := strings.Join(payloads, "")
+			for _, want := range tt.wantContains {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("stream payloads = %q, want substring %q", joined, want)
+				}
+			}
+		})
+	}
+}
+
+func newClaudeHangingSSEServer(t *testing.T, stream string) *httptest.Server {
+	t.Helper()
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, stream)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+	return server
+}
+
+func drainClaudeStreamChunks(t *testing.T, chunks <-chan cliproxyexecutor.StreamChunk, timeout time.Duration) (payloads []string, streamErr error) {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case chunk, ok := <-chunks:
+			if !ok {
+				return payloads, streamErr
+			}
+			if chunk.Err != nil {
+				streamErr = chunk.Err
+			}
+			if len(chunk.Payload) > 0 {
+				payloads = append(payloads, string(chunk.Payload))
+			}
+		case <-deadline.C:
+			t.Fatal("stream did not finish after protocol terminal without upstream body EOF")
+		}
+	}
+}


### PR DESCRIPTION
## Why

Claude HTTP SSE is a framed protocol. `message_stop` (and a stream `error` event) is the terminal frame: the message is done, and nothing after it is part of this response.

The Claude executor still kept `scanner.Scan()` on the upstream body until EOF after that terminal frame. When the body is half-closed, idle, or otherwise never delivers EOF, the stream goroutine sits in the tail wait. Downstream then sees a hung stream or a false incomplete/EOF failure even though the protocol already finished.

## What

In `ExecuteStream`, both the native Claude forward loop and the translate-other-formats loop now stop reading once the terminal event has been flushed/emitted:

- `data.type == "message_stop"`: emit the complete SSE event (native) or translated chunks (other formats), then leave the scan loop and finish normally.
- `data.type == "error"`: emit/forward that event, then stop. Continuity is still committed only when `message_stop` was observed (`upstreamCompleted`), not on stream errors.

After the break, leftover event flush, `scanner.Err()` handling, and `commitClaudeContinuity` on a completed message still run. The body is closed without waiting for EOF.

## Tests

`TestClaudeExecutor_ExecuteStreamStopsAtProtocolTerminalWithoutBodyEOF` writes a complete terminal event, then holds the upstream body open (no EOF):

- native Claude forward after `message_stop`
- OpenAI translate path after `message_stop`
- native forward after a fatal stream `error` event
- OpenAI translate path after a fatal stream `error` event

The consumer must finish promptly with the terminal payload delivered, without requiring body EOF. Existing Claude stream tests remain green.

```
go test -timeout 180s -count=1 -run 'TestClaude' ./internal/runtime/executor/
go test -timeout 180s -count=1 ./internal/runtime/executor/
```