### PR TITLE
feat(routing): CLI subscription fallback chains and fallback header fixes

### DIFF
--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -61,6 +61,22 @@ func newClaudeHeaderTestRequest(t *testing.T, incoming http.Header) *http.Reques
 	return req.WithContext(context.WithValue(req.Context(), "gin", ginCtx))
 }
 
+// pinnedDeviceFingerprintOSArch reports the OS and arch that the pinned device
+// profile applies to unconfirmed clients, derived through the same exported
+// helper the production path uses so the value tracks any config override.
+//
+// Asserting helps.MapStainlessOS() here instead would only hold on a macOS
+// host: for unconfirmed clients ApplyClaudeLegacyDeviceHeaders deliberately
+// writes profile.OS (default "MacOS") rather than the host OS, so that a
+// third-party client cannot leak its own platform into the Claude Code
+// fingerprint. On any non-darwin machine that assertion fails spuriously.
+func pinnedDeviceFingerprintOSArch(t *testing.T, cfg *config.Config) (string, string) {
+	t.Helper()
+	probe := httptest.NewRequest(http.MethodPost, "https://example.com/v1/messages", nil)
+	helps.ApplyClaudeDefaultDeviceProfileHeaders(probe, cfg)
+	return probe.Header.Get("X-Stainless-Os"), probe.Header.Get("X-Stainless-Arch")
+}
+
 func assertClaudeFingerprint(t *testing.T, headers http.Header, userAgent, pkgVersion, runtimeVersion, osName, arch string) {
 	t.Helper()
 
@@ -617,7 +633,8 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Arch":            []string{"x64"},
 	})
 	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, nil, cfg, nil, false)
-	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	wantOS, wantArch := pinnedDeviceFingerprintOSArch(t, cfg)
+	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", wantOS, wantArch)
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent":                  []string{"claude-cli/2.1.61 (external, cli)"},
@@ -659,7 +676,8 @@ func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForCla
 	})
 	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, nil, cfg, nil, true)
 
-	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.70.0", "v22.0.0", "MacOS", "arm64")
+	wantOS, wantArch := pinnedDeviceFingerprintOSArch(t, cfg)
+	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.70.0", "v22.0.0", wantOS, wantArch)
 }
 
 func TestApplyClaudeHeaders_LegacyThirdPartyUsesStableConfiguredOSArch(t *testing.T) {
@@ -816,7 +834,8 @@ func TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint(t *testi
 		t.Fatalf("Execute() error = %v", errExecute)
 	}
 
-	assertClaudeFingerprint(t, seenHeaders, "claude-cli/2.1.258 (external, cli)", "0.112.1", "v26.3.0", "MacOS", "arm64")
+	wantOS, wantArch := pinnedDeviceFingerprintOSArch(t, &config.Config{})
+	assertClaudeFingerprint(t, seenHeaders, "claude-cli/2.1.258 (external, cli)", "0.112.1", "v26.3.0", wantOS, wantArch)
 	if got := seenHeaders.Get("X-App"); got != "cli" {
 		t.Fatalf("X-App = %q, want cli", got)
 	}

--- a/sdk/api/handlers/cli_sub_fallback.go
+++ b/sdk/api/handlers/cli_sub_fallback.go
@@ -156,12 +156,8 @@ func fallbackEligible(err error) bool {
 	if isAuthSelectionUnavailable(err) {
 		return true
 	}
-	switch statusFromError(err) {
-	case http.StatusPaymentRequired, http.StatusTooManyRequests, http.StatusServiceUnavailable:
-		return true
-	default:
-		return false
-	}
+	status := statusFromError(err)
+	return status == http.StatusPaymentRequired || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
 var fallbackResponseModelPaths = []string{"model", "modelVersion", "response.model", "response.modelVersion", "message.model", "usage.model"}

--- a/sdk/api/handlers/cli_sub_fallback.go
+++ b/sdk/api/handlers/cli_sub_fallback.go
@@ -1,0 +1,364 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	cliSubscriptionsOwner  = "cli-subscriptions"
+	cliProxyUpstreamHeader = "x-cliproxy-upstream"
+)
+
+var cliSubEffortSuffix = regexp.MustCompile(`(?i)(?:-(?:thinking|non-reasoning|reasoning))?(?:-(?:xhigh|extra-high|high|medium|low|minimal|none|max|pro|agent))?(?:-fast)?$`)
+
+var cliSubVendorRenames = []struct{ from, to string }{
+	{"claude-4.5-opus", "claude-opus-4-5"},
+	{"claude-4.6-opus", "claude-opus-4-6"},
+	{"claude-4.5-sonnet", "claude-sonnet-4-5"},
+	{"claude-4.6-sonnet", "claude-sonnet-4-6"},
+	{"claude-4-sonnet", "claude-sonnet-4"},
+}
+
+var cliSubEffortRank = []string{"max", "xhigh", "extra-high", "high", "medium", "low", "minimal", "none"}
+
+type cliSubFallbackTarget struct {
+	Model        string
+	Providers    []string
+	PrimaryOwner string
+}
+
+var (
+	cliSubContextSuffix   = regexp.MustCompile(`\[\d+m\]$`)
+	cliSubPreviewSuffix   = regexp.MustCompile(`-preview.*$`)
+	cliSubDateSuffix      = regexp.MustCompile(`-\d{8}$`)
+	cliSubGPTVersion      = regexp.MustCompile(`^gpt-(\d)-(\d)`)
+	cliSubThinkingPrimary = regexp.MustCompile(`^claude-(opus|sonnet)-[45]`)
+)
+
+func normalizeCLISubModelID(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	model = strings.TrimPrefix(model, "custom/")
+	model = cliSubContextSuffix.ReplaceAllString(model, "")
+	model = strings.TrimPrefix(model, "cursor-")
+	model = strings.TrimPrefix(model, "droid-")
+	for range 2 {
+		model = cliSubEffortSuffix.ReplaceAllString(model, "")
+	}
+	for _, rename := range cliSubVendorRenames {
+		model = strings.ReplaceAll(model, rename.from, rename.to)
+	}
+	if strings.HasPrefix(model, "opus-") || strings.HasPrefix(model, "sonnet-") || strings.HasPrefix(model, "haiku-") {
+		model = "claude-" + model
+	}
+	model = cliSubPreviewSuffix.ReplaceAllString(model, "")
+	model = cliSubDateSuffix.ReplaceAllString(model, "")
+	model = strings.ReplaceAll(model, ".", "-")
+	model = cliSubGPTVersion.ReplaceAllString(model, `gpt-$1.$2`)
+	return model
+}
+
+func cliSubEffortTier(model string) int {
+	lower := strings.ToLower(model)
+	fastTrimmed := strings.TrimSuffix(lower, "-fast")
+	for i, name := range cliSubEffortRank {
+		if strings.HasSuffix(fastTrimmed, "-"+name) {
+			return i
+		}
+	}
+	return len(cliSubEffortRank)
+}
+
+func cliSubCandidateScore(model string, wantThinking bool) [4]int {
+	lower := strings.ToLower(model)
+	thinking := strings.Contains(lower, "-thinking") || strings.Contains(lower, "-reasoning")
+	thinkingPenalty := 1
+	if thinking == wantThinking {
+		thinkingPenalty = 0
+	}
+	tier := cliSubEffortTier(lower)
+	fast := 0
+	if strings.HasSuffix(lower, "-fast") {
+		fast = 1
+	}
+	return [4]int{thinkingPenalty, tier, fast, len(lower)}
+}
+
+func lessCLISubCandidate(a, b string, wantThinking bool) bool {
+	sa, sb := cliSubCandidateScore(a, wantThinking), cliSubCandidateScore(b, wantThinking)
+	for i := range sa {
+		if sa[i] != sb[i] {
+			return sa[i] < sb[i]
+		}
+	}
+	return a < b
+}
+
+func buildCLISubFallbackChain(reg *registry.ModelRegistry, requestedModel string) []cliSubFallbackTarget {
+	if reg == nil || strings.TrimSpace(requestedModel) == "" {
+		return nil
+	}
+	requestedInfo := reg.GetModelInfo(requestedModel, "")
+	if requestedInfo == nil || strings.EqualFold(strings.TrimSpace(requestedInfo.OwnedBy), cliSubscriptionsOwner) {
+		return nil
+	}
+	primaryOwner := strings.ToLower(strings.TrimSpace(requestedInfo.OwnedBy))
+	key := normalizeCLISubModelID(requestedModel)
+	if key == "" {
+		return nil
+	}
+	wantThinking := strings.Contains(strings.ToLower(requestedModel), "thinking") || cliSubThinkingPrimary.MatchString(strings.ToLower(requestedModel))
+	groups := map[string][]string{"cursor": nil, "droid": nil, "other": nil}
+	for _, info := range reg.GetAvailableModelInfos() {
+		if info == nil || !strings.EqualFold(strings.TrimSpace(info.OwnedBy), cliSubscriptionsOwner) || normalizeCLISubModelID(info.ID) != key {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(strings.ToLower(info.ID), "cursor-"):
+			groups["cursor"] = append(groups["cursor"], info.ID)
+		case strings.HasPrefix(strings.ToLower(info.ID), "droid-"):
+			groups["droid"] = append(groups["droid"], info.ID)
+		default:
+			groups["other"] = append(groups["other"], info.ID)
+		}
+	}
+	chain := make([]cliSubFallbackTarget, 0, 3)
+	for _, group := range []string{"cursor", "droid", "other"} {
+		models := groups[group]
+		if len(models) == 0 {
+			continue
+		}
+		sort.Slice(models, func(i, j int) bool { return lessCLISubCandidate(models[i], models[j], wantThinking) })
+		model := models[0]
+		providers := reg.GetModelProviders(model)
+		if len(providers) == 0 {
+			continue
+		}
+		chain = append(chain, cliSubFallbackTarget{Model: model, Providers: providers, PrimaryOwner: primaryOwner})
+	}
+	return chain
+}
+
+func fallbackEligible(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isAuthSelectionUnavailable(err) {
+		return true
+	}
+	switch statusFromError(err) {
+	case http.StatusPaymentRequired, http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+var fallbackResponseModelPaths = []string{"model", "modelVersion", "response.model", "response.modelVersion", "message.model", "usage.model"}
+
+func rewriteFallbackJSONModel(data []byte, targetModel string) ([]byte, string) {
+	if len(data) == 0 || strings.TrimSpace(targetModel) == "" || !gjson.ValidBytes(data) {
+		return data, ""
+	}
+	upstream := ""
+	for _, path := range fallbackResponseModelPaths {
+		value := gjson.GetBytes(data, path)
+		if !value.Exists() {
+			continue
+		}
+		if upstream == "" && value.Type == gjson.String && !strings.EqualFold(value.String(), targetModel) {
+			upstream = value.String()
+		}
+		data, _ = sjson.SetBytes(data, path, targetModel)
+	}
+	return data, upstream
+}
+
+func rewriteFallbackResponseModel(data []byte, targetModel string) ([]byte, string) {
+	return rewriteFallbackJSONModel(data, targetModel)
+}
+
+func rewriteFallbackStreamFrame(frame []byte, targetModel string) ([]byte, string) {
+	if len(frame) == 0 {
+		return frame, ""
+	}
+	lines := bytes.Split(frame, []byte("\n"))
+	upstream := ""
+	for i, line := range lines {
+		prefix := []byte(nil)
+		jsonData := line
+		if bytes.HasPrefix(line, []byte("data: ")) {
+			prefix, jsonData = []byte("data: "), line[len("data: "):]
+		} else if bytes.HasPrefix(line, []byte("data:")) {
+			prefix, jsonData = []byte("data:"), line[len("data:"):]
+		}
+		rewritten, found := rewriteFallbackJSONModel(jsonData, targetModel)
+		if found != "" && upstream == "" {
+			upstream = found
+		}
+		if prefix != nil {
+			lines[i] = append(append([]byte{}, prefix...), rewritten...)
+		} else {
+			lines[i] = rewritten
+		}
+	}
+	return bytes.Join(lines, []byte("\n")), upstream
+}
+
+func withFallbackModel(req coreexecutor.Request, opts coreexecutor.Options, requestedModel, fallbackModel string) (coreexecutor.Request, coreexecutor.Options) {
+	req.Model = fallbackModel
+	if len(req.Payload) > 0 && gjson.ValidBytes(req.Payload) && gjson.GetBytes(req.Payload, "model").Exists() {
+		req.Payload, _ = sjson.SetBytes(req.Payload, "model", fallbackModel)
+	}
+	opts.Metadata = cloneAnyMap(opts.Metadata)
+	opts.Metadata[coreexecutor.RequestedModelMetadataKey] = requestedModel
+	return req, opts
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	out := make(map[string]any, len(src)+1)
+	for key, value := range src {
+		out[key] = value
+	}
+	return out
+}
+
+func preserveCLIProxyUpstreamHeader(downstream, raw http.Header) http.Header {
+	value := strings.TrimSpace(raw.Get(cliProxyUpstreamHeader))
+	if value == "" {
+		return downstream
+	}
+	if downstream == nil {
+		downstream = make(http.Header)
+	}
+	downstream.Set(cliProxyUpstreamHeader, value)
+	return downstream
+}
+
+func (h *BaseAPIHandler) executeCLISubFallback(ctx context.Context, requestedModel string, req coreexecutor.Request, opts coreexecutor.Options, initialErr error) (coreexecutor.Response, error) {
+	if h == nil || h.AuthManager == nil || !fallbackEligible(initialErr) {
+		return coreexecutor.Response{}, initialErr
+	}
+	for _, target := range buildCLISubFallbackChain(registry.GetGlobalRegistry(), requestedModel) {
+		fallbackReq, fallbackOpts := withFallbackModel(req, opts, requestedModel, target.Model)
+		resp, errExec := h.AuthManager.Execute(ctx, target.Providers, fallbackReq, fallbackOpts)
+		if errExec != nil {
+			if fallbackEligible(errExec) {
+				continue
+			}
+			return coreexecutor.Response{}, errExec
+		}
+		var upstream string
+		resp.Payload, upstream = rewriteFallbackResponseModel(resp.Payload, requestedModel)
+		if upstream == "" {
+			upstream = target.Model
+		}
+		if resp.Headers == nil {
+			resp.Headers = make(http.Header)
+		}
+		resp.Headers.Set(cliProxyUpstreamHeader, upstream)
+		log.WithFields(log.Fields{"model": requestedModel, "upstream": upstream}).Info("CLI-sub fallback served request")
+		return resp, nil
+	}
+	return coreexecutor.Response{}, initialErr
+}
+
+func readCLISubFallbackStreamBootstrap(ctx context.Context, chunks <-chan coreexecutor.StreamChunk) ([]coreexecutor.StreamChunk, bool, error) {
+	buffered := make([]coreexecutor.StreamChunk, 0, 1)
+	for {
+		var (
+			chunk coreexecutor.StreamChunk
+			ok    bool
+		)
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				return nil, false, ctx.Err()
+			case chunk, ok = <-chunks:
+			}
+		} else {
+			chunk, ok = <-chunks
+		}
+		if !ok {
+			return buffered, true, nil
+		}
+		if chunk.Err != nil {
+			return nil, false, chunk.Err
+		}
+		buffered = append(buffered, chunk)
+		if len(chunk.Payload) > 0 {
+			return buffered, false, nil
+		}
+	}
+}
+
+func (h *BaseAPIHandler) executeCLISubFallbackStream(ctx context.Context, requestedModel string, req coreexecutor.Request, opts coreexecutor.Options, initialErr error) (*coreexecutor.StreamResult, error) {
+	if h == nil || h.AuthManager == nil || !fallbackEligible(initialErr) {
+		return nil, initialErr
+	}
+	for _, target := range buildCLISubFallbackChain(registry.GetGlobalRegistry(), requestedModel) {
+		fallbackReq, fallbackOpts := withFallbackModel(req, opts, requestedModel, target.Model)
+		result, errExec := h.AuthManager.ExecuteStream(ctx, target.Providers, fallbackReq, fallbackOpts)
+		if errExec != nil {
+			if fallbackEligible(errExec) {
+				continue
+			}
+			return nil, errExec
+		}
+		if result == nil || result.Chunks == nil {
+			continue
+		}
+		headers := result.Headers.Clone()
+		if headers == nil {
+			headers = make(http.Header)
+		}
+		buffered, closed, errBootstrap := readCLISubFallbackStreamBootstrap(ctx, result.Chunks)
+		if errBootstrap != nil {
+			if fallbackEligible(errBootstrap) {
+				continue
+			}
+			return nil, errBootstrap
+		}
+		upstream := target.Model
+		for i := range buffered {
+			if len(buffered[i].Payload) == 0 {
+				continue
+			}
+			var found string
+			buffered[i].Payload, found = rewriteFallbackStreamFrame(buffered[i].Payload, requestedModel)
+			if found != "" {
+				upstream = found
+			}
+		}
+		headers.Set(cliProxyUpstreamHeader, upstream)
+		out := make(chan coreexecutor.StreamChunk)
+		go func(chunks <-chan coreexecutor.StreamChunk, initial []coreexecutor.StreamChunk, streamClosed bool) {
+			defer close(out)
+			for _, chunk := range initial {
+				out <- chunk
+			}
+			if streamClosed {
+				return
+			}
+			for chunk := range chunks {
+				if len(chunk.Payload) > 0 {
+					chunk.Payload, _ = rewriteFallbackStreamFrame(chunk.Payload, requestedModel)
+				}
+				out <- chunk
+			}
+		}(result.Chunks, buffered, closed)
+		log.WithFields(log.Fields{"model": requestedModel, "upstream": upstream}).Info("CLI-sub fallback served streaming request")
+		return &coreexecutor.StreamResult{Headers: headers, Chunks: out}, nil
+	}
+	return nil, initialErr
+}

--- a/sdk/api/handlers/cli_sub_fallback_integration_test.go
+++ b/sdk/api/handlers/cli_sub_fallback_integration_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type cliSubFallbackExecutor struct {
+	provider string
+}
+
+func (e cliSubFallbackExecutor) Identifier() string { return e.provider }
+func (e cliSubFallbackExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{Payload: []byte(`{"id":"chatcmpl-test","model":"cursor/gpt-9-test-high","usage":{"model":"cursor/gpt-9-test-high"}}`)}, nil
+}
+func (e cliSubFallbackExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	chunks := make(chan coreexecutor.StreamChunk, 1)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"id\":\"chunk-test\",\"model\":\"cursor/gpt-9-test-high\"}\n\n")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+func (e cliSubFallbackExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+func (e cliSubFallbackExecutor) CountTokens(_ context.Context, _ *coreauth.Auth, _ coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+func (e cliSubFallbackExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func setupCLISubFallbackHandler(t *testing.T) *BaseAPIHandler {
+	t.Helper()
+	reg := registry.GetGlobalRegistry()
+	primaryID := "test-cli-sub-route-primary"
+	cursorID := "test-cli-sub-route-cursor"
+	t.Cleanup(func() {
+		reg.UnregisterClient(primaryID)
+		reg.UnregisterClient(cursorID)
+	})
+	reg.RegisterClient(primaryID, "openai", []*registry.ModelInfo{{ID: "gpt-9-test", OwnedBy: "openai"}})
+	reg.RegisterClient(cursorID, "cursor", []*registry.ModelInfo{{ID: "cursor-gpt-9-test-high", OwnedBy: cliSubscriptionsOwner}})
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(cliSubFallbackExecutor{provider: "openai"})
+	manager.RegisterExecutor(cliSubFallbackExecutor{provider: "cursor"})
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:             primaryID,
+		Provider:       "openai",
+		Status:         coreauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("register primary auth: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{ID: cursorID, Provider: "cursor", Status: coreauth.StatusActive}); err != nil {
+		t.Fatalf("register cursor auth: %v", err)
+	}
+	return NewBaseAPIHandlers(nil, manager)
+}
+
+func TestExecuteWithAuthManagerFallsBackAndPreservesWireModel(t *testing.T) {
+	handler := setupCLISubFallbackHandler(t)
+	body, headers, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", "gpt-9-test", []byte(`{"model":"gpt-9-test","messages":[{"role":"user","content":"hi"}]}`), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %v", errMsg.Error)
+	}
+	if got := headers.Get(cliProxyUpstreamHeader); got != "cursor/gpt-9-test-high" {
+		t.Fatalf("upstream header = %q, want cursor/gpt-9-test-high", got)
+	}
+	want := `{"id":"chatcmpl-test","model":"gpt-9-test","usage":{"model":"gpt-9-test"}}`
+	if string(body) != want {
+		t.Fatalf("body = %s, want %s", body, want)
+	}
+}
+
+func TestExecuteStreamWithAuthManagerFallsBackAndPreservesWireModel(t *testing.T) {
+	handler := setupCLISubFallbackHandler(t)
+	data, headers, errs := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", "gpt-9-test", []byte(`{"model":"gpt-9-test","stream":true,"messages":[{"role":"user","content":"hi"}]}`), "")
+	if got := headers.Get(cliProxyUpstreamHeader); got != "cursor/gpt-9-test-high" {
+		t.Fatalf("upstream header = %q, want cursor/gpt-9-test-high", got)
+	}
+	var body []byte
+	for chunk := range data {
+		body = append(body, chunk...)
+	}
+	for errMsg := range errs {
+		if errMsg != nil {
+			t.Fatalf("stream error = %v", errMsg.Error)
+		}
+	}
+	want := "data: {\"id\":\"chunk-test\",\"model\":\"gpt-9-test\"}\n\n"
+	if string(body) != want {
+		t.Fatalf("stream body = %q, want %q", body, want)
+	}
+}

--- a/sdk/api/handlers/cli_sub_fallback_test.go
+++ b/sdk/api/handlers/cli_sub_fallback_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestCLISubFallbackChainUsesLiveCatalogOwnership(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	primaryClient := "test-cli-sub-primary"
+	cursorClient := "test-cli-sub-cursor"
+	droidClient := "test-cli-sub-droid"
+	defer reg.UnregisterClient(primaryClient)
+	defer reg.UnregisterClient(cursorClient)
+	defer reg.UnregisterClient(droidClient)
+
+	reg.RegisterClient(primaryClient, "openai", []*registry.ModelInfo{{ID: "gpt-9-test", OwnedBy: "openai"}})
+	reg.RegisterClient(cursorClient, "cursor", []*registry.ModelInfo{{ID: "cursor-gpt-9-test-high", OwnedBy: cliSubscriptionsOwner}})
+	reg.RegisterClient(droidClient, "droid", []*registry.ModelInfo{{ID: "droid-gpt-9-test", OwnedBy: cliSubscriptionsOwner}})
+
+	chain := buildCLISubFallbackChain(reg, "gpt-9-test")
+	if len(chain) != 2 {
+		t.Fatalf("fallback chain length = %d, want 2: %#v", len(chain), chain)
+	}
+	if chain[0].Model != "cursor-gpt-9-test-high" || chain[1].Model != "droid-gpt-9-test" {
+		t.Fatalf("fallback order = %#v, want cursor then droid", chain)
+	}
+
+	reg.RegisterClient(primaryClient, "gemini", []*registry.ModelInfo{{ID: "gpt-9-test", OwnedBy: "gemini"}})
+	chain = buildCLISubFallbackChain(reg, "gpt-9-test")
+	if len(chain) != 2 {
+		t.Fatalf("fallback chain after ownership change length = %d, want 2", len(chain))
+	}
+	if chain[0].PrimaryOwner != "gemini" {
+		t.Fatalf("primary owner = %q, want live catalog owner gemini", chain[0].PrimaryOwner)
+	}
+}
+
+func TestCLISubFallbackChainSupportsDroidOnlyAndGenericVendors(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clients := []string{"test-cli-sub-minimax-primary", "test-cli-sub-minimax-droid", "test-cli-sub-minimax-other"}
+	defer func() {
+		for _, client := range clients {
+			reg.UnregisterClient(client)
+		}
+	}()
+
+	reg.RegisterClient(clients[0], "opencode-go", []*registry.ModelInfo{{ID: "custom/minimax-m9-test", OwnedBy: "opencode-go"}})
+	reg.RegisterClient(clients[1], "droid", []*registry.ModelInfo{{ID: "droid-minimax-m9-test", OwnedBy: cliSubscriptionsOwner}})
+	reg.RegisterClient(clients[2], "future-cli", []*registry.ModelInfo{{ID: "minimax-m9-test", OwnedBy: cliSubscriptionsOwner}})
+
+	chain := buildCLISubFallbackChain(reg, "custom/minimax-m9-test")
+	if len(chain) != 2 {
+		t.Fatalf("fallback chain length = %d, want 2: %#v", len(chain), chain)
+	}
+	if chain[0].Model != "droid-minimax-m9-test" || chain[1].Model != "minimax-m9-test" {
+		t.Fatalf("fallback order = %#v, want droid then generic provider", chain)
+	}
+}
+
+func TestRewriteFallbackResponseModelPreservesClientID(t *testing.T) {
+	payload := []byte(`{"id":"chatcmpl-1","model":"cursor/gpt-9-test-high","usage":{"model":"cursor/gpt-9-test-high"}}`)
+	got, upstream := rewriteFallbackResponseModel(payload, "gpt-9-test")
+	want := `{"id":"chatcmpl-1","model":"gpt-9-test","usage":{"model":"gpt-9-test"}}`
+	if string(got) != want {
+		t.Fatalf("rewritten response = %s, want %s", got, want)
+	}
+	if upstream != "cursor/gpt-9-test-high" {
+		t.Fatalf("upstream = %q, want cursor/gpt-9-test-high", upstream)
+	}
+}
+
+func TestRewriteFallbackStreamFramePreservesClientID(t *testing.T) {
+	frame := []byte("data: {\"id\":\"chunk-1\",\"model\":\"droid/minimax-m9-test\"}\n\n")
+	got, upstream := rewriteFallbackStreamFrame(frame, "minimax-m9-test")
+	want := "data: {\"id\":\"chunk-1\",\"model\":\"minimax-m9-test\"}\n\n"
+	if string(got) != want {
+		t.Fatalf("rewritten frame = %q, want %q", got, want)
+	}
+	if upstream != "droid/minimax-m9-test" {
+		t.Fatalf("upstream = %q, want droid/minimax-m9-test", upstream)
+	}
+}

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -96,15 +96,19 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	resp, err := h.AuthManager.Execute(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
-		errMsg := executionErrorMessage(err)
-		lifecycle.completeError(ctx, errMsg)
-		return nil, nil, errMsg
+		resp, err = h.executeCLISubFallback(ctx, originalRequestedModel, req, opts, err)
+		if err != nil {
+			err = enrichAuthSelectionError(err, providers, normalizedModel)
+			errMsg := executionErrorMessage(err)
+			lifecycle.completeError(ctx, errMsg)
+			return nil, nil, errMsg
+		}
 	}
 	executedReq, executedOpts := afterAuthCapture.apply(req, opts)
 	ctx = enrichContextWithSessionHierarchy(ctx, executedOpts.Headers, executedReq.Payload, executedOpts.Metadata)
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
+	responseHeaders = preserveCLIProxyUpstreamHeader(responseHeaders, rawResponseHeaders)
 	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), responseProtocol, normalizedModel, originalRequestedModel, executedOpts, rawResponseHeaders, responseHeaders, executedOpts.OriginalRequest, executedReq.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
 	lifecycle.complete(pluginapi.RequestCompletionSucceeded, http.StatusOK, nil)
 	return body, responseHeaders, nil

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -108,8 +108,8 @@ func (h *BaseAPIHandler) executeWithAuthManagerFormats(ctx context.Context, entr
 	ctx = enrichContextWithSessionHierarchy(ctx, executedOpts.Headers, executedReq.Payload, executedOpts.Metadata)
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
-	responseHeaders = preserveCLIProxyUpstreamHeader(responseHeaders, rawResponseHeaders)
 	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), responseProtocol, normalizedModel, originalRequestedModel, executedOpts, rawResponseHeaders, responseHeaders, executedOpts.OriginalRequest, executedReq.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
+	responseHeaders = preserveCLIProxyUpstreamHeader(responseHeaders, rawResponseHeaders)
 	lifecycle.complete(pluginapi.RequestCompletionSucceeded, http.StatusOK, nil)
 	return body, responseHeaders, nil
 }

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -444,6 +445,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	transformStreamPayload := func(payload []byte, chunkIndex *int, historyChunks [][]byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		applyStreamHeaderInit()
 		payload = cloneBytes(payload)
+		if strings.TrimSpace(baseStreamHeaders.Get(cliProxyUpstreamHeader)) != "" {
+			payload, _ = rewriteFallbackStreamFrame(payload, originalRequestedModel)
+		}
 		if streamInterceptorsActive {
 			chunkReq := pluginapi.StreamChunkInterceptRequest{
 				RequestID:       lifecycle.requestID(),

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -597,7 +597,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 
 	upstreamHeaders := downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled)
-	upstreamHeaders = preserveCLIProxyUpstreamHeader(upstreamHeaders, rawStreamHeaders)
+	upstreamHeaders = preserveCLIProxyUpstreamHeader(upstreamHeaders, baseStreamHeaders)
 	if upstreamHeaders == nil && (passthroughHeadersEnabled || streamInterceptorsActive) {
 		upstreamHeaders = make(http.Header)
 	}

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -360,13 +360,16 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	ctx = enrichContextWithSessionHierarchy(ctx, opts.Headers, req.Payload, opts.Metadata)
 	streamResult, err := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 	if err != nil {
-		err = enrichAuthSelectionError(err, providers, normalizedModel)
-		errMsg := executionErrorMessage(err)
-		lifecycle.completeError(ctx, errMsg)
-		errChan := make(chan *interfaces.ErrorMessage, 1)
-		errChan <- errMsg
-		close(errChan)
-		return nil, nil, errChan
+		streamResult, err = h.executeCLISubFallbackStream(ctx, originalRequestedModel, req, opts, err)
+		if err != nil {
+			err = enrichAuthSelectionError(err, providers, normalizedModel)
+			errMsg := executionErrorMessage(err)
+			lifecycle.completeError(ctx, errMsg)
+			errChan := make(chan *interfaces.ErrorMessage, 1)
+			errChan <- errMsg
+			close(errChan)
+			return nil, nil, errChan
+		}
 	}
 	if streamResult == nil {
 		errMsg := &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("auth manager returned nil stream")}
@@ -594,6 +597,7 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	}
 
 	upstreamHeaders := downstreamHeadersAfterInterceptors(baseStreamHeaders, rawStreamHeaders, passthroughHeadersEnabled)
+	upstreamHeaders = preserveCLIProxyUpstreamHeader(upstreamHeaders, rawStreamHeaders)
 	if upstreamHeaders == nil && (passthroughHeadersEnabled || streamInterceptorsActive) {
 		upstreamHeaders = make(http.Header)
 	}

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -479,6 +479,7 @@ func (h *OpenAIAPIHandler) handleStreamingResponse(c *gin.Context, rawJSON []byt
 		c.Header("Cache-Control", "no-cache")
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
+		handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	}
 
 	// Peek at the first chunk to determine success or failure before setting headers
@@ -596,6 +597,7 @@ func (h *OpenAIAPIHandler) handleCompletionsStreamingResponse(c *gin.Context, ra
 		c.Header("Cache-Control", "no-cache")
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
+		handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	}
 
 	// Peek at the first chunk

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"sort"
 	"strings"
@@ -2139,7 +2140,21 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 		cooldown = quotaBackoffBase
 	}
 	if cooldown >= quotaBackoffMax {
-		return quotaBackoffMax, prevLevel
+		return withCooldownJitter(quotaBackoffMax), prevLevel
 	}
-	return cooldown, prevLevel + 1
+	return withCooldownJitter(cooldown), prevLevel + 1
+}
+
+// withCooldownJitter spreads recovery across credentials that hit the same quota
+// ceiling at the same moment. Without it every credential in the pool recovers in
+// lockstep, retries together, and re-trips the upstream limit.
+func withCooldownJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	delta := int64(d) / 5 // +/-20%
+	if delta <= 0 {
+		return d
+	}
+	return time.Duration(int64(d) - delta + rand.Int63n(2*delta+1))
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -875,6 +875,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 										if otherState.Quota.Exceeded && otherState.Quota.NextRecoverAt.After(otherQuotaNext) {
 											otherQuotaNext = otherState.Quota.NextRecoverAt
 										}
+										// Cap credential-scoped cooldowns at the same maximum as per-model
+										// quota. Without this, stale multi-day cooldowns persist because the
+										// propagation keeps whichever NextRecoverAt is later, so the value
+										// can only grow — never shrink, even after the underlying quota
+										// window has reset.
+										if capDeadline := now.Add(quotaBackoffMax); otherQuotaNext.After(capDeadline) {
+											otherQuotaNext = capDeadline
+										}
 										otherRetryAfter := otherQuotaNext
 										// Propagation only extends a sibling's still-live
 										// per-model deadline; it never shortens one.

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -122,9 +122,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
 	firstRecover := auth.Quota.NextRecoverAt
-	if !firstRecover.Equal(now.Add(time.Second)) {
-		t.Fatalf("expected first window to close at %v, got %v", now.Add(time.Second), firstRecover)
-	}
+	assertWithinJitter(t, "first window", firstRecover, now, time.Second)
 
 	// In-window failure keeps the current window and level.
 	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
@@ -140,9 +138,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
-	if !auth.Quota.NextRecoverAt.Equal(now.Add(4 * time.Second)) {
-		t.Fatalf("expected second window to close at %v, got %v", now.Add(4*time.Second), auth.Quota.NextRecoverAt)
-	}
+	assertWithinJitter(t, "second window", auth.Quota.NextRecoverAt, now.Add(2*time.Second), 2*time.Second)
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
@@ -306,5 +302,18 @@ func TestJitteredCooldownWaitBounds(t *testing.T) {
 	}
 	if got := jitteredCooldownWait(3, 0); got != 3 {
 		t.Fatalf("expected sub-4ns wait to stay unchanged, got %v", got)
+	}
+}
+
+// assertWithinJitter checks that got falls inside the +/-20% jitter band that
+// nextQuotaCooldown applies around a nominal backoff duration. Jitter exists so a
+// pool of credentials that exhaust quota together do not all retry in lockstep.
+func assertWithinJitter(t *testing.T, label string, got, base time.Time, nominal time.Duration) {
+	t.Helper()
+	delta := nominal / 5
+	earliest := base.Add(nominal - delta)
+	latest := base.Add(nominal + delta)
+	if got.Before(earliest) || got.After(latest) {
+		t.Fatalf("%s: expected within [%v, %v], got %v", label, earliest, latest, got)
 	}
 }


### PR DESCRIPTION
## What

Split out of #5701 so the routing work can be reviewed on its own.

- `feat(routing)`: CLI subscription fallback chains (`sdk/api/handlers/cli_sub_fallback.go`) — when a CLI-subscription credential is exhausted or errors, the request continues down a configured chain instead of failing.
- `fix(routing)`: continue the fallback after upstream 5xx, preserve the upstream header on both non-streaming and streaming paths, rewrite every fallback stream frame.
- `fix(openai)`: write fallback headers before the stream starts.
- `fix(auth)`: match quota backoff to the provider window, desynchronise the pool, cap `credential_quota` cooldown at `quotaBackoffMax`.
- `test(executor)`: host-independent Claude fingerprint assertions.

## Why

A single exhausted subscription seat should not fail the request when other seats or providers can serve it, and the client should still see which upstream actually answered.

No changes to `internal/translator/**` or AGENTS.md.

Precompact is in a separate PR (feat/precompact-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)