### PR TITLE
feat(precompact): server-side pre-compaction of oversized requests

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -328,7 +328,9 @@ nonstream-keepalive-interval: 0
 # Server-side pre-compaction: when a request's estimated input tokens exceed
 # window * threshold (minus max_tokens), older turns are summarized by an
 # auxiliary model and the shortened request is forwarded upstream. The system
-# prompt, tools, and the last keep-recent-turns turns are kept byte-identical.
+# prompt, tools, and the recent turns (bounded by keep-recent-turns and
+# keep-recent-tokens) are kept byte-identical. A middle block too large for the
+# auxiliary model's window is summarized in a rolling pass, chunk by chunk.
 # Applies to Claude Messages and OpenAI chat formats; Gemini is out of scope.
 # Summaries are cached per session (X-Claude-Code-Session-Id, else derived) so
 # a later turn in the same session does not re-summarize already-covered turns.
@@ -336,7 +338,8 @@ nonstream-keepalive-interval: 0
 #   enabled: true
 #   aux-model: bedrock/claude-haiku-4-5-20251001 # model used for the summarization call
 #   threshold: 0.85            # fraction of the model's context window usable before compacting
-#   keep-recent-turns: 6       # most recent user turns kept verbatim (prompt-cache prefix safe)
+#   keep-recent-turns: 6       # at most this many recent user turns kept verbatim (prompt-cache prefix safe)
+#   keep-recent-tokens: 40000  # stop keeping turns once the kept tail exceeds this; at least one full turn is always kept
 #   cache-ttl: 2h              # how long a per-session summary is reused
 #   cache-max-sessions: 2000   # LRU cap on cached sessions
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -336,7 +336,7 @@ nonstream-keepalive-interval: 0
 # a later turn in the same session does not re-summarize already-covered turns.
 # pre-compact:
 #   enabled: true
-#   aux-model: bedrock/claude-haiku-4-5-20251001 # model used for the summarization call
+#   aux-model: claude-haiku-4-5-20251001       # model used for the summarization call
 #   threshold: 0.85            # fraction of the model's context window usable before compacting
 #   keep-recent-turns: 6       # at most this many recent user turns kept verbatim (prompt-cache prefix safe)
 #   keep-recent-tokens: 40000  # stop keeping turns once the kept tail exceeds this; at least one full turn is always kept

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -325,6 +325,21 @@ nonstream-keepalive-interval: 0
 #   keepalive-seconds: 15   # Default: 0 (disabled). <= 0 disables keep-alives.
 #   bootstrap-retries: 1    # Default: 0 (disabled). Retries before first byte is sent.
 
+# Server-side pre-compaction: when a request's estimated input tokens exceed
+# window * threshold (minus max_tokens), older turns are summarized by an
+# auxiliary model and the shortened request is forwarded upstream. The system
+# prompt, tools, and the last keep-recent-turns turns are kept byte-identical.
+# Applies to Claude Messages and OpenAI chat formats; Gemini is out of scope.
+# Summaries are cached per session (X-Claude-Code-Session-Id, else derived) so
+# a later turn in the same session does not re-summarize already-covered turns.
+# pre-compact:
+#   enabled: true
+#   aux-model: bedrock/claude-haiku-4-5-20251001 # model used for the summarization call
+#   threshold: 0.85            # fraction of the model's context window usable before compacting
+#   keep-recent-turns: 6       # most recent user turns kept verbatim (prompt-cache prefix safe)
+#   cache-ttl: 2h              # how long a per-session summary is reused
+#   cache-max-sessions: 2000   # LRU cap on cached sessions
+
 # Signature cache validation for thinking blocks (Antigravity/Claude).
 # When true (default), cached signatures are preferred and validated.
 # When false, client signatures are used directly after normalization (bypass mode for testing).

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -89,6 +89,10 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
+	cfg.PreCompact = cfg.PreCompact.WithDefaults()
+	if errValidate := cfg.PreCompact.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
 		return nil, errValidate
 	}

--- a/internal/config/precompact_config.go
+++ b/internal/config/precompact_config.go
@@ -10,6 +10,7 @@ const (
 	DefaultPreCompactAuxModel        = "bedrock/claude-haiku-4-5-20251001"
 	DefaultPreCompactThreshold       = 0.85
 	DefaultPreCompactKeepRecentTurns = 6
+	DefaultPreCompactKeepRecentTokens = 40000
 	DefaultPreCompactCacheTTL        = "2h"
 	DefaultPreCompactCacheMaxSess    = 2000
 )
@@ -26,6 +27,9 @@ type PreCompactConfig struct {
 	Threshold float64 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
 	// KeepRecentTurns is the number of trailing user turns kept byte-identical.
 	KeepRecentTurns int `yaml:"keep-recent-turns,omitempty" json:"keep-recent-turns,omitempty"`
+	// KeepRecentTokens stops keeping further turns once the kept tail exceeds
+	// this many tokens. At least one full turn is always kept.
+	KeepRecentTokens int `yaml:"keep-recent-tokens,omitempty" json:"keep-recent-tokens,omitempty"`
 	// CacheTTL is how long a per-session summary stays reusable (duration string).
 	CacheTTL string `yaml:"cache-ttl,omitempty" json:"cache-ttl,omitempty"`
 	// CacheMaxSessions bounds the number of cached sessions.
@@ -43,6 +47,9 @@ func (c PreCompactConfig) WithDefaults() PreCompactConfig {
 	}
 	if c.KeepRecentTurns <= 0 {
 		c.KeepRecentTurns = DefaultPreCompactKeepRecentTurns
+	}
+	if c.KeepRecentTokens <= 0 {
+		c.KeepRecentTokens = DefaultPreCompactKeepRecentTokens
 	}
 	if strings.TrimSpace(c.CacheTTL) == "" {
 		c.CacheTTL = DefaultPreCompactCacheTTL
@@ -63,6 +70,9 @@ func (c PreCompactConfig) Validate() error {
 	}
 	if c.KeepRecentTurns < 1 {
 		return fmt.Errorf("pre-compact.keep-recent-turns must be >= 1, got %d", c.KeepRecentTurns)
+	}
+	if c.KeepRecentTokens < 1 {
+		return fmt.Errorf("pre-compact.keep-recent-tokens must be >= 1, got %d", c.KeepRecentTokens)
 	}
 	if _, err := time.ParseDuration(c.CacheTTL); err != nil {
 		return fmt.Errorf("pre-compact.cache-ttl: %w", err)

--- a/internal/config/precompact_config.go
+++ b/internal/config/precompact_config.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	DefaultPreCompactAuxModel        = "bedrock/claude-haiku-4-5-20251001"
-	DefaultPreCompactThreshold       = 0.85
-	DefaultPreCompactKeepRecentTurns = 6
+	DefaultPreCompactAuxModel         = "claude-haiku-4-5-20251001"
+	DefaultPreCompactThreshold        = 0.85
+	DefaultPreCompactKeepRecentTurns  = 6
 	DefaultPreCompactKeepRecentTokens = 40000
-	DefaultPreCompactCacheTTL        = "2h"
-	DefaultPreCompactCacheMaxSess    = 2000
+	DefaultPreCompactCacheTTL         = "2h"
+	DefaultPreCompactCacheMaxSess     = 2000
 )
 
 // PreCompactConfig controls server-side pre-compaction: when a request does not

--- a/internal/config/precompact_config.go
+++ b/internal/config/precompact_config.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultPreCompactAuxModel        = "bedrock/claude-haiku-4-5-20251001"
+	DefaultPreCompactThreshold       = 0.85
+	DefaultPreCompactKeepRecentTurns = 6
+	DefaultPreCompactCacheTTL        = "2h"
+	DefaultPreCompactCacheMaxSess    = 2000
+)
+
+// PreCompactConfig controls server-side pre-compaction: when a request does not
+// fit the selected upstream model's context window, older turns are summarized
+// with an auxiliary model before the request is forwarded.
+type PreCompactConfig struct {
+	// Enabled turns the feature on. Default false.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// AuxModel is the model used to write the summary.
+	AuxModel string `yaml:"aux-model,omitempty" json:"aux-model,omitempty"`
+	// Threshold is the fraction of the context window that triggers compaction (0 < t <= 1).
+	Threshold float64 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+	// KeepRecentTurns is the number of trailing user turns kept byte-identical.
+	KeepRecentTurns int `yaml:"keep-recent-turns,omitempty" json:"keep-recent-turns,omitempty"`
+	// CacheTTL is how long a per-session summary stays reusable (duration string).
+	CacheTTL string `yaml:"cache-ttl,omitempty" json:"cache-ttl,omitempty"`
+	// CacheMaxSessions bounds the number of cached sessions.
+	CacheMaxSessions int `yaml:"cache-max-sessions,omitempty" json:"cache-max-sessions,omitempty"`
+}
+
+// WithDefaults fills absent values with defaults.
+func (c PreCompactConfig) WithDefaults() PreCompactConfig {
+	if strings.TrimSpace(c.AuxModel) == "" {
+		c.AuxModel = DefaultPreCompactAuxModel
+	}
+	c.AuxModel = strings.TrimSpace(c.AuxModel)
+	if c.Threshold <= 0 {
+		c.Threshold = DefaultPreCompactThreshold
+	}
+	if c.KeepRecentTurns <= 0 {
+		c.KeepRecentTurns = DefaultPreCompactKeepRecentTurns
+	}
+	if strings.TrimSpace(c.CacheTTL) == "" {
+		c.CacheTTL = DefaultPreCompactCacheTTL
+	}
+	if c.CacheMaxSessions <= 0 {
+		c.CacheMaxSessions = DefaultPreCompactCacheMaxSess
+	}
+	return c
+}
+
+// Validate reports configuration errors.
+func (c PreCompactConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Threshold <= 0 || c.Threshold > 1 {
+		return fmt.Errorf("pre-compact.threshold must be in (0, 1], got %v", c.Threshold)
+	}
+	if c.KeepRecentTurns < 1 {
+		return fmt.Errorf("pre-compact.keep-recent-turns must be >= 1, got %d", c.KeepRecentTurns)
+	}
+	if _, err := time.ParseDuration(c.CacheTTL); err != nil {
+		return fmt.Errorf("pre-compact.cache-ttl: %w", err)
+	}
+	return nil
+}
+
+// CacheTTLDuration returns the parsed TTL or the default on error.
+func (c PreCompactConfig) CacheTTLDuration() time.Duration {
+	d, err := time.ParseDuration(c.CacheTTL)
+	if err != nil || d <= 0 {
+		d, _ = time.ParseDuration(DefaultPreCompactCacheTTL)
+	}
+	return d
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -47,6 +47,8 @@ type SDKConfig struct {
 
 	// CodexOrphanDelegationCompatibility mirrors the provider-wide runtime setting for API handlers.
 	CodexOrphanDelegationCompatibility bool `yaml:"-" json:"-"`
+	// PreCompact configures server-side pre-compaction of oversized requests.
+	PreCompact PreCompactConfig `yaml:"pre-compact" json:"pre-compact"`
 
 	// ClaudeCode configures Claude Code compatibility behavior.
 	ClaudeCode ClaudeCodeConfig `yaml:"claude-code" json:"claude-code"`

--- a/internal/precompact/aux.go
+++ b/internal/precompact/aux.go
@@ -1,0 +1,18 @@
+package precompact
+
+import "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+
+// AuxPromptShare is the fraction of the auxiliary model's window that one
+// transcript chunk may use; the rest is headroom for the instruction, the
+// previous summary and the summary output.
+const AuxPromptShare = 0.7
+
+// AuxBudget returns how many transcript tokens fit in one aux call for model,
+// using the same registry lookup as ModelWindow (default 200k).
+func AuxBudget(reg *registry.ModelRegistry, model string) int {
+	budget := int(float64(ModelWindow(reg, model)) * AuxPromptShare)
+	if budget < 1 {
+		budget = 1
+	}
+	return budget
+}

--- a/internal/precompact/cache.go
+++ b/internal/precompact/cache.go
@@ -1,0 +1,59 @@
+package precompact
+
+import (
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+)
+
+// Entry is a cached summary for one session.
+type Entry struct {
+	// Covered is how many middle messages the summary covers.
+	Covered int
+	// PrefixHash hashes those covered messages.
+	PrefixHash string
+	Summary    string
+	ExpiresAt  time.Time
+}
+
+// Cache is a bounded, TTL-aware per-session summary cache.
+type Cache struct {
+	mu  sync.Mutex
+	lru *cache.BoundedLRU[string, *Entry]
+	ttl time.Duration
+}
+
+// NewCache builds a cache holding at most maxSessions entries alive for ttl.
+func NewCache(maxSessions int, ttl time.Duration) *Cache {
+	if ttl <= 0 {
+		ttl = 2 * time.Hour
+	}
+	return &Cache{lru: cache.NewBoundedLRU[string, *Entry](maxSessions, nil), ttl: ttl}
+}
+
+// Get returns a live entry for session.
+func (c *Cache) Get(session string) (Entry, bool) {
+	if c == nil || session == "" {
+		return Entry{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.lru.Get(session)
+	if !ok || e == nil || time.Now().After(e.ExpiresAt) {
+		return Entry{}, false
+	}
+	return *e, true
+}
+
+// Put stores or replaces the entry for session.
+func (c *Cache) Put(session string, e Entry) {
+	if c == nil || session == "" {
+		return
+	}
+	e.ExpiresAt = time.Now().Add(c.ttl)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	slot := c.lru.GetOrAdd(session, func() *Entry { return &Entry{} })
+	*slot = e
+}

--- a/internal/precompact/cache_test.go
+++ b/internal/precompact/cache_test.go
@@ -1,0 +1,38 @@
+package precompact
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheGetPutRoundTrip(t *testing.T) {
+	c := NewCache(10, time.Hour)
+	if _, ok := c.Get("sess-1"); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+	c.Put("sess-1", Entry{Covered: 4, PrefixHash: "abc", Summary: "sum"})
+	e, ok := c.Get("sess-1")
+	if !ok {
+		t.Fatal("expected hit after Put")
+	}
+	if e.Covered != 4 || e.PrefixHash != "abc" || e.Summary != "sum" {
+		t.Fatalf("unexpected entry: %+v", e)
+	}
+}
+
+func TestCacheExpires(t *testing.T) {
+	c := NewCache(10, time.Millisecond)
+	c.Put("sess-1", Entry{Covered: 1, PrefixHash: "x", Summary: "y"})
+	time.Sleep(5 * time.Millisecond)
+	if _, ok := c.Get("sess-1"); ok {
+		t.Fatal("expected entry to expire")
+	}
+}
+
+func TestCacheEmptySessionIsNoop(t *testing.T) {
+	c := NewCache(10, time.Hour)
+	c.Put("", Entry{Summary: "should not store"})
+	if _, ok := c.Get(""); ok {
+		t.Fatal("empty session key must never be stored")
+	}
+}

--- a/internal/precompact/count.go
+++ b/internal/precompact/count.go
@@ -1,0 +1,31 @@
+package precompact
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// Count estimates input tokens for body in the given client format.
+func Count(format sdktranslator.Format, model string, body []byte) (int, error) {
+	switch format {
+	case sdktranslator.FormatClaude:
+		n, err := helps.CountClaudeInputTokens(body)
+		return int(n), err
+	case sdktranslator.FormatOpenAI:
+		enc, err := helps.TokenizerForModel(model)
+		if err != nil {
+			return 0, err
+		}
+		n, err := helps.CountOpenAIChatTokens(enc, body)
+		return int(n), err
+	default:
+		return 0, fmt.Errorf("precompact: unsupported format %q", format)
+	}
+}
+
+// Supported reports whether the client format can be compacted.
+func Supported(format sdktranslator.Format) bool {
+	return format == sdktranslator.FormatClaude || format == sdktranslator.FormatOpenAI
+}

--- a/internal/precompact/count_test.go
+++ b/internal/precompact/count_test.go
@@ -1,0 +1,37 @@
+package precompact
+
+import (
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestSupported(t *testing.T) {
+	if !Supported(sdktranslator.FormatClaude) {
+		t.Fatal("claude should be supported")
+	}
+	if !Supported(sdktranslator.FormatOpenAI) {
+		t.Fatal("openai should be supported")
+	}
+	if Supported(sdktranslator.FormatGemini) {
+		t.Fatal("gemini must be out of scope")
+	}
+}
+
+func TestCountClaude(t *testing.T) {
+	body := []byte(`{"model":"claude-3","messages":[{"role":"user","content":"hello world"}]}`)
+	n, err := Count(sdktranslator.FormatClaude, "claude-3", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n <= 0 {
+		t.Fatalf("expected positive token count, got %d", n)
+	}
+}
+
+func TestCountUnsupportedFormat(t *testing.T) {
+	_, err := Count(sdktranslator.FormatGemini, "gemini-pro", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+}

--- a/internal/precompact/interceptor.go
+++ b/internal/precompact/interceptor.go
@@ -1,0 +1,141 @@
+package precompact
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+// CompactedHeader is set on the downstream response when compaction happened.
+const CompactedHeader = "X-Cliproxy-Compacted"
+
+// internalSourceValue mirrors handlers.modelExecutionInternalSource; requests
+// carrying it are auxiliary calls and are never compacted.
+const internalSourceValue = "plugin_host_model_callback"
+
+// Interceptor applies pre-compaction to selected-auth requests.
+type Interceptor struct {
+	reg        *registry.ModelRegistry
+	summarizer Summarizer
+	cache      *Cache
+}
+
+// New builds an interceptor. The cache is sized from cfg once; every other
+// setting is read per call from the config passed to Apply so hot reload applies.
+func New(cfg config.PreCompactConfig, reg *registry.ModelRegistry, s Summarizer) *Interceptor {
+	c := cfg.WithDefaults()
+	return &Interceptor{
+		reg:        reg,
+		summarizer: s,
+		cache:      NewCache(c.CacheMaxSessions, c.CacheTTLDuration()),
+	}
+}
+
+// Result reports what Apply did.
+type Result struct {
+	Compacted  bool
+	FromTokens int
+	ToTokens   int
+	CacheHit   bool
+	AuxMillis  int64
+}
+
+// Apply returns a replacement body when the request exceeds the model budget.
+// Any failure returns nil (forward the original) and is logged; it never blocks.
+func (i *Interceptor) Apply(ctx context.Context, cfgIn config.PreCompactConfig, req cliproxyexecutor.RequestAfterAuthInterceptRequest) ([]byte, Result) {
+	var res Result
+	if i == nil {
+		return nil, res
+	}
+	cfg := cfgIn.WithDefaults()
+	if !cfg.Enabled || !Supported(req.SourceFormat) || len(req.Body) == 0 {
+		return nil, res
+	}
+	if src, _ := req.Metadata["source"].(string); src == internalSourceValue {
+		return nil, res
+	}
+	count, err := Count(req.SourceFormat, req.Model, req.Body)
+	if err != nil {
+		log.WithError(err).Debug("precompact: token count failed, forwarding original")
+		return nil, res
+	}
+	window := ModelWindow(i.reg, req.Model)
+	budget := Budget(window, cfg.Threshold, req.Body)
+	res.FromTokens = count
+	if count <= budget {
+		return nil, res
+	}
+	sp, ok := SplitMessages(req.SourceFormat, req.Body, cfg.KeepRecentTurns)
+	if !ok {
+		log.Warnf("precompact: %d tokens > budget %d for %s but fewer than %d turns to keep; forwarding original", count, budget, req.Model, cfg.KeepRecentTurns)
+		return nil, res
+	}
+	session := sessionKey(ctx, req)
+	previous := ""
+	newPart := sp.Middle
+	if entry, hit := i.cache.Get(session); hit && entry.Covered <= len(sp.Middle) && HashMessages(sp.Middle[:entry.Covered]) == entry.PrefixHash {
+		previous = entry.Summary
+		newPart = sp.Middle[entry.Covered:]
+		res.CacheHit = true
+	}
+	summary := previous
+	if len(newPart) > 0 || summary == "" {
+		if i.summarizer == nil {
+			return nil, res
+		}
+		start := time.Now()
+		out, errSum := i.summarizer.Summarize(ctx, cfg.AuxModel, previous, Transcript(newPart))
+		res.AuxMillis = time.Since(start).Milliseconds()
+		if errSum != nil || strings.TrimSpace(out) == "" {
+			log.WithError(errSum).Warnf("precompact: summary failed for session=%s model=%s; forwarding original", session, req.Model)
+			return nil, res
+		}
+		summary = out
+		i.cache.Put(session, Entry{Covered: len(sp.Middle), PrefixHash: HashMessages(sp.Middle), Summary: summary})
+	}
+	body, errBuild := Rebuild(req.SourceFormat, req.Body, sp, summary)
+	if errBuild != nil {
+		log.WithError(errBuild).Warn("precompact: rebuild failed; forwarding original")
+		return nil, res
+	}
+	to, _ := Count(req.SourceFormat, req.Model, body)
+	res.ToTokens = to
+	res.Compacted = true
+	log.Infof("precompact: session=%s model=%s from_tokens=%d to_tokens=%d budget=%d window=%d aux_ms=%d cache_hit=%t middle_msgs=%d",
+		session, req.Model, res.FromTokens, res.ToTokens, budget, window, res.AuxMillis, res.CacheHit, len(sp.Middle))
+	setResponseHeader(ctx, res)
+	return body, res
+}
+
+func sessionKey(ctx context.Context, req cliproxyexecutor.RequestAfterAuthInterceptRequest) string {
+	if id := helps.ExtractClaudeCodeSessionID(ctx, req.Body, req.Headers); id != "" {
+		return id
+	}
+	if id := helps.DerivedSessionID(req.Metadata); id != "" {
+		return id
+	}
+	return ""
+}
+
+func setResponseHeader(ctx context.Context, res Result) {
+	if ctx == nil {
+		return
+	}
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Writer != nil && !ginCtx.Writer.Written() {
+		ginCtx.Writer.Header().Set(CompactedHeader, headerValue(res))
+	}
+}
+
+func headerValue(res Result) string {
+	return itoa(res.FromTokens) + "->" + itoa(res.ToTokens)
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/internal/precompact/interceptor.go
+++ b/internal/precompact/interceptor.go
@@ -2,6 +2,7 @@ package precompact
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +47,10 @@ type Result struct {
 	ToTokens   int
 	CacheHit   bool
 	AuxMillis  int64
+	AuxCalls   int
 }
+
+var errEmptySummary = errors.New("aux call returned an empty summary")
 
 // Apply returns a replacement body when the request exceeds the model budget.
 // Any failure returns nil (forward the original) and is logged; it never blocks.
@@ -73,9 +77,10 @@ func (i *Interceptor) Apply(ctx context.Context, cfgIn config.PreCompactConfig, 
 	if count <= budget {
 		return nil, res
 	}
-	sp, ok := SplitMessages(req.SourceFormat, req.Body, cfg.KeepRecentTurns)
+	tokens := ScaledEstimator(count, len(req.Body))
+	sp, ok := SplitMessagesBudget(req.SourceFormat, req.Body, cfg.KeepRecentTurns, cfg.KeepRecentTokens, tokens)
 	if !ok {
-		log.Warnf("precompact: %d tokens > budget %d for %s but fewer than %d turns to keep; forwarding original", count, budget, req.Model, cfg.KeepRecentTurns)
+		log.Warnf("precompact: %d tokens > budget %d for %s but no complete turn left to summarize after keeping the recent tail (keep-recent-turns=%d keep-recent-tokens=%d); forwarding original", count, budget, req.Model, cfg.KeepRecentTurns, cfg.KeepRecentTokens)
 		return nil, res
 	}
 	session := sessionKey(ctx, req)
@@ -91,14 +96,30 @@ func (i *Interceptor) Apply(ctx context.Context, cfgIn config.PreCompactConfig, 
 		if i.summarizer == nil {
 			return nil, res
 		}
+		// The aux model has its own window: chunk the new part so every aux
+		// prompt (instruction + previous summary + transcript) fits, and roll
+		// the summary forward chunk by chunk.
+		auxBudget := AuxBudget(i.reg, cfg.AuxModel)
+		chunks := ChunkTurns(req.SourceFormat, newPart, auxBudget, tokens)
 		start := time.Now()
-		out, errSum := i.summarizer.Summarize(ctx, cfg.AuxModel, previous, Transcript(newPart))
+		var errSum error
+		for idx, chunk := range chunks {
+			var out string
+			out, errSum = i.summarizer.Summarize(ctx, cfg.AuxModel, summary, Transcript(chunk))
+			if errSum != nil || strings.TrimSpace(out) == "" {
+				if errSum == nil {
+					errSum = errEmptySummary
+				}
+				log.WithError(errSum).Warnf("precompact: summary failed for session=%s model=%s aux=%s chunk=%d/%d; forwarding original", session, req.Model, cfg.AuxModel, idx+1, len(chunks))
+				break
+			}
+			summary = out
+		}
 		res.AuxMillis = time.Since(start).Milliseconds()
-		if errSum != nil || strings.TrimSpace(out) == "" {
-			log.WithError(errSum).Warnf("precompact: summary failed for session=%s model=%s; forwarding original", session, req.Model)
+		res.AuxCalls = len(chunks)
+		if errSum != nil {
 			return nil, res
 		}
-		summary = out
 		i.cache.Put(session, Entry{Covered: len(sp.Middle), PrefixHash: HashMessages(sp.Middle), Summary: summary})
 	}
 	body, errBuild := Rebuild(req.SourceFormat, req.Body, sp, summary)
@@ -109,8 +130,8 @@ func (i *Interceptor) Apply(ctx context.Context, cfgIn config.PreCompactConfig, 
 	to, _ := Count(req.SourceFormat, req.Model, body)
 	res.ToTokens = to
 	res.Compacted = true
-	log.Infof("precompact: session=%s model=%s from_tokens=%d to_tokens=%d budget=%d window=%d aux_ms=%d cache_hit=%t middle_msgs=%d",
-		session, req.Model, res.FromTokens, res.ToTokens, budget, window, res.AuxMillis, res.CacheHit, len(sp.Middle))
+	log.Infof("precompact: session=%s model=%s from_tokens=%d to_tokens=%d budget=%d window=%d aux_ms=%d aux_calls=%d cache_hit=%t middle_msgs=%d recent_msgs=%d",
+		session, req.Model, res.FromTokens, res.ToTokens, budget, window, res.AuxMillis, res.AuxCalls, res.CacheHit, len(sp.Middle), len(sp.Recent))
 	setResponseHeader(ctx, res)
 	return body, res
 }

--- a/internal/precompact/interceptor_test.go
+++ b/internal/precompact/interceptor_test.go
@@ -1,0 +1,189 @@
+package precompact
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type fakeSummarizer struct {
+	calls int
+	out   string
+	err   error
+}
+
+func (f *fakeSummarizer) Summarize(ctx context.Context, model, previous, transcript string) (string, error) {
+	f.calls++
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.out, nil
+}
+
+func bigClaudeBody(turns int) []byte {
+	msgs := make([]map[string]any, 0, turns*2)
+	filler := make([]byte, 20000)
+	for i := range filler {
+		filler[i] = 'x'
+	}
+	for i := 0; i < turns; i++ {
+		msgs = append(msgs, map[string]any{"role": "user", "content": string(filler)})
+		msgs = append(msgs, map[string]any{"role": "assistant", "content": string(filler)})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"model":    "claude-test",
+		"system":   "you are helpful",
+		"messages": msgs,
+	})
+	return body
+}
+
+func testCfg() config.PreCompactConfig {
+	return config.PreCompactConfig{
+		Enabled:          true,
+		AuxModel:         "aux-model",
+		Threshold:        0.85,
+		KeepRecentTurns:  2,
+		CacheTTL:         "2h",
+		CacheMaxSessions: 100,
+	}
+}
+
+func TestApplyNoopUnderBudget(t *testing.T) {
+	sum := &fakeSummarizer{out: "summary"}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	body := bigClaudeBody(1)
+	body, _ = json.Marshal(map[string]any{"model": "claude-test", "system": "s", "messages": []map[string]any{{"role": "user", "content": "hi"}}})
+	out, res := it.Apply(context.Background(), testCfg(), cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+	})
+	if out != nil {
+		t.Fatalf("expected no replacement body under budget, got %d bytes", len(out))
+	}
+	if res.Compacted {
+		t.Fatal("did not expect Compacted=true under budget")
+	}
+	if sum.calls != 0 {
+		t.Fatal("summarizer must not be called when under budget")
+	}
+}
+
+func TestApplyCompactsOverBudgetAndCachesSummary(t *testing.T) {
+	sum := &fakeSummarizer{out: "a dense summary"}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	body := bigClaudeBody(60) // large enough to exceed a 200k*0.85 budget with 4000-byte fillers
+	req := cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Headers:      map[string][]string{"X-Claude-Code-Session-Id": {"sess-abc"}},
+		Body:         body,
+	}
+	out, res := it.Apply(context.Background(), testCfg(), req)
+	if out == nil {
+		t.Fatal("expected a compacted body over budget")
+	}
+	if !res.Compacted {
+		t.Fatal("expected Compacted=true")
+	}
+	if sum.calls != 1 {
+		t.Fatalf("expected exactly one aux call, got %d", sum.calls)
+	}
+	if res.CacheHit {
+		t.Fatal("first call must not be a cache hit")
+	}
+
+	// Second call with an identical body and the same session should reuse the cached summary
+	// and not add new middle content, so the summarizer should not be invoked again.
+	out2, res2 := it.Apply(context.Background(), testCfg(), req)
+	if out2 == nil {
+		t.Fatal("expected a compacted body on second call too")
+	}
+	if !res2.CacheHit {
+		t.Fatal("expected cache hit on identical follow-up request")
+	}
+	if sum.calls != 1 {
+		t.Fatalf("expected summarizer not to be called again on cache hit, calls=%d", sum.calls)
+	}
+}
+
+func TestApplyForwardsOriginalOnSummarizeError(t *testing.T) {
+	sum := &fakeSummarizer{err: errTest{}}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	body := bigClaudeBody(60)
+	out, res := it.Apply(context.Background(), testCfg(), cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+	})
+	if out != nil {
+		t.Fatal("expected nil (forward original) when the aux call fails")
+	}
+	if res.Compacted {
+		t.Fatal("must not report Compacted=true on failure")
+	}
+}
+
+func TestApplySkipsInternalSourceRequests(t *testing.T) {
+	sum := &fakeSummarizer{out: "summary"}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	body := bigClaudeBody(60)
+	out, _ := it.Apply(context.Background(), testCfg(), cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+		Metadata:     map[string]any{"source": "plugin_host_model_callback"},
+	})
+	if out != nil {
+		t.Fatal("aux/internal requests must never be compacted")
+	}
+	if sum.calls != 0 {
+		t.Fatal("summarizer must not run for internal-source requests")
+	}
+}
+
+func TestApplyDisabledIsNoop(t *testing.T) {
+	sum := &fakeSummarizer{out: "summary"}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	cfg := testCfg()
+	cfg.Enabled = false
+	body := bigClaudeBody(60)
+	out, _ := it.Apply(context.Background(), cfg, cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+	})
+	if out != nil {
+		t.Fatal("disabled config must be a no-op")
+	}
+	if sum.calls != 0 {
+		t.Fatal("summarizer must not run when disabled")
+	}
+}
+
+func TestApplyGeminiOutOfScope(t *testing.T) {
+	sum := &fakeSummarizer{out: "summary"}
+	it := New(testCfg(), registry.GetGlobalRegistry(), sum)
+	body := bigClaudeBody(60)
+	out, _ := it.Apply(context.Background(), testCfg(), cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatGemini,
+		Model:        "gemini-pro",
+		Body:         body,
+	})
+	if out != nil {
+		t.Fatal("gemini format is out of scope and must never be compacted")
+	}
+	if sum.calls != 0 {
+		t.Fatal("summarizer must not run for gemini requests")
+	}
+}
+
+type errTest struct{}
+
+func (errTest) Error() string { return "aux call failed" }

--- a/internal/precompact/interceptor_test.go
+++ b/internal/precompact/interceptor_test.go
@@ -92,8 +92,10 @@ func TestApplyCompactsOverBudgetAndCachesSummary(t *testing.T) {
 	if !res.Compacted {
 		t.Fatal("expected Compacted=true")
 	}
-	if sum.calls != 1 {
-		t.Fatalf("expected exactly one aux call, got %d", sum.calls)
+	// The middle block (~300k tokens) exceeds the aux model's 140k budget, so
+	// the summary is rolled over several chunks.
+	if sum.calls < 1 || sum.calls != res.AuxCalls {
+		t.Fatalf("expected aux calls to match AuxCalls=%d, got %d", res.AuxCalls, sum.calls)
 	}
 	if res.CacheHit {
 		t.Fatal("first call must not be a cache hit")
@@ -108,8 +110,8 @@ func TestApplyCompactsOverBudgetAndCachesSummary(t *testing.T) {
 	if !res2.CacheHit {
 		t.Fatal("expected cache hit on identical follow-up request")
 	}
-	if sum.calls != 1 {
-		t.Fatalf("expected summarizer not to be called again on cache hit, calls=%d", sum.calls)
+	if sum.calls != res.AuxCalls {
+		t.Fatalf("expected summarizer not to be called again on cache hit, calls=%d first=%d", sum.calls, res.AuxCalls)
 	}
 }
 

--- a/internal/precompact/limit.go
+++ b/internal/precompact/limit.go
@@ -1,0 +1,46 @@
+// Package precompact shrinks requests that do not fit the selected upstream
+// model's context window by summarizing older turns with an auxiliary model.
+package precompact
+
+import (
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/tidwall/gjson"
+)
+
+// ModelWindow returns the context window for model, falling back to the
+// Claude default when the registry has no explicit value.
+func ModelWindow(reg *registry.ModelRegistry, model string) int {
+	if reg != nil {
+		if info := reg.GetModelInfo(model, ""); info != nil {
+			switch {
+			case info.MaxContextLength > 0:
+				return info.MaxContextLength
+			case info.ContextLength > 0:
+				return info.ContextLength
+			case info.InputTokenLimit > 0:
+				return info.InputTokenLimit
+			}
+		}
+	}
+	return registry.DefaultClaudeMaxInputTokens
+}
+
+// Budget is the input-token budget for a request: window * threshold minus the
+// requested max_tokens (so the reply fits too).
+func Budget(window int, threshold float64, body []byte) int {
+	if threshold <= 0 || threshold > 1 {
+		threshold = 0.85
+	}
+	budget := int(float64(window) * threshold)
+	maxTokens := int(gjson.GetBytes(body, "max_tokens").Int())
+	if maxTokens <= 0 {
+		maxTokens = int(gjson.GetBytes(body, "max_completion_tokens").Int())
+	}
+	if maxTokens > 0 && maxTokens < window {
+		budget -= maxTokens
+	}
+	if budget < 1 {
+		budget = 1
+	}
+	return budget
+}

--- a/internal/precompact/limit_test.go
+++ b/internal/precompact/limit_test.go
@@ -1,0 +1,33 @@
+package precompact
+
+import "testing"
+
+func TestBudget(t *testing.T) {
+	cases := []struct {
+		name      string
+		window    int
+		threshold float64
+		body      string
+		want      int
+	}{
+		{"basic", 200000, 0.85, `{}`, 170000},
+		{"with max_tokens", 200000, 0.85, `{"max_tokens":8000}`, 162000},
+		{"invalid threshold falls back to 0.85", 200000, 0, `{}`, 170000},
+		{"max_completion_tokens honored", 100000, 0.85, `{"max_completion_tokens":5000}`, 80000},
+		{"never below one", 10, 0.85, `{"max_tokens":9}`, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Budget(c.window, c.threshold, []byte(c.body))
+			if got != c.want {
+				t.Fatalf("Budget(%d,%v,%s) = %d, want %d", c.window, c.threshold, c.body, got, c.want)
+			}
+		})
+	}
+}
+
+func TestModelWindowDefaultsWithoutRegistry(t *testing.T) {
+	if got := ModelWindow(nil, "some-model"); got != 200000 {
+		t.Fatalf("ModelWindow(nil,..) = %d, want 200000", got)
+	}
+}

--- a/internal/precompact/rolling_test.go
+++ b/internal/precompact/rolling_test.go
@@ -1,0 +1,255 @@
+package precompact
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+// chainSummarizer records every call and returns a summary that names the
+// call index and echoes the previous summary, so chaining is observable.
+type chainSummarizer struct {
+	calls       []string
+	previous    []string
+	transcripts []string
+}
+
+func (c *chainSummarizer) Summarize(ctx context.Context, model, previous, transcript string) (string, error) {
+	n := len(c.calls) + 1
+	c.previous = append(c.previous, previous)
+	c.transcripts = append(c.transcripts, transcript)
+	out := fmt.Sprintf("SUMMARY-%d(prev=%q)", n, previous)
+	c.calls = append(c.calls, out)
+	return out, nil
+}
+
+// toolTurns builds n Claude turns where every turn is user -> assistant
+// tool_use -> user tool_result -> assistant text, with a filler of fillerBytes.
+func toolTurns(n int, fillerBytes int) []map[string]any {
+	filler := strings.Repeat("lorem ipsum ", fillerBytes/12)
+	msgs := make([]map[string]any, 0, n*4)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("toolu_%d", i)
+		msgs = append(msgs,
+			map[string]any{"role": "user", "content": fmt.Sprintf("turn %d %s", i, filler)},
+			map[string]any{"role": "assistant", "content": []map[string]any{{"type": "tool_use", "id": id, "name": "bash", "input": map[string]any{"cmd": "ls"}}}},
+			map[string]any{"role": "user", "content": []map[string]any{{"type": "tool_result", "tool_use_id": id, "content": filler}}},
+			map[string]any{"role": "assistant", "content": fmt.Sprintf("done %d", i)},
+		)
+	}
+	return msgs
+}
+
+func claudeBody(msgs []map[string]any) []byte {
+	body, _ := json.Marshal(map[string]any{"model": "claude-test", "system": "s", "messages": msgs})
+	return body
+}
+
+// assertNoOrphans checks that within msgs every tool_use id has its
+// tool_result and vice versa.
+func assertNoOrphans(t *testing.T, msgs []string) {
+	t.Helper()
+	uses := map[string]bool{}
+	results := map[string]bool{}
+	for _, raw := range msgs {
+		for _, b := range gjson.Get(raw, "content").Array() {
+			switch b.Get("type").String() {
+			case "tool_use":
+				uses[b.Get("id").String()] = true
+			case "tool_result":
+				results[b.Get("tool_use_id").String()] = true
+			}
+		}
+	}
+	for id := range uses {
+		if !results[id] {
+			t.Fatalf("tool_use %s has no tool_result in the same block", id)
+		}
+	}
+	for id := range results {
+		if !uses[id] {
+			t.Fatalf("tool_result %s has no tool_use in the same block", id)
+		}
+	}
+}
+
+// (a) A middle block of about 3x the aux budget yields 3 chained aux calls.
+func TestRollingSummaryChunksMiddleForAuxWindow(t *testing.T) {
+	tokens := func(raw string) int { return len(raw) / 4 }
+	msgs := make([]string, 0)
+	for _, m := range toolTurns(9, 4000) {
+		raw, _ := json.Marshal(m)
+		msgs = append(msgs, string(raw))
+	}
+	total := 0
+	for _, m := range msgs {
+		total += tokens(m)
+	}
+	auxBudget := total/3 + 1 // each chunk holds roughly three turns
+	chunks := ChunkTurns(sdktranslator.FormatClaude, msgs, auxBudget, tokens)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+	n := 0
+	for _, c := range chunks {
+		assertNoOrphans(t, c)
+		n += len(c)
+	}
+	if n != len(msgs) {
+		t.Fatalf("chunks lost messages: %d != %d", n, len(msgs))
+	}
+
+	// Drive the same chunks through the interceptor path with a fake executor.
+	sum := &chainSummarizer{}
+	summary := ""
+	for _, c := range chunks {
+		out, err := sum.Summarize(context.Background(), "aux", summary, Transcript(c))
+		if err != nil {
+			t.Fatal(err)
+		}
+		summary = out
+	}
+	if len(sum.calls) != 3 {
+		t.Fatalf("expected 3 aux calls, got %d", len(sum.calls))
+	}
+	if !strings.HasPrefix(summary, "SUMMARY-3") {
+		t.Fatalf("final summary must come from the last call, got %q", summary)
+	}
+	if sum.previous[1] != sum.calls[0] || sum.previous[2] != sum.calls[1] {
+		t.Fatal("each chunk must receive the previous chunk's summary as context")
+	}
+	if !strings.Contains(sum.transcripts[0], "turn 0") || !strings.Contains(sum.transcripts[2], "turn 8") {
+		t.Fatal("chunks must be in conversation order")
+	}
+}
+
+// (a, end to end) Apply performs the rolling summary itself.
+func TestApplyRollsSummaryAcrossChunks(t *testing.T) {
+	sum := &chainSummarizer{}
+	cfg := testCfg()
+	cfg.KeepRecentTurns = 1
+	cfg.KeepRecentTokens = 1 << 30
+	it := New(cfg, registry.GetGlobalRegistry(), sum)
+	// 200k window * 0.7 = 140k aux budget; 24 middle turns of ~40k tokens need >3 chunks.
+	body := claudeBody(toolTurns(25, 80000))
+	out, res := it.Apply(context.Background(), cfg, cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+		Headers:      map[string][]string{"X-Claude-Code-Session-Id": {"roll"}},
+	})
+	if out == nil || !res.Compacted {
+		t.Fatal("expected compaction")
+	}
+	if len(sum.calls) < 3 {
+		t.Fatalf("expected at least 3 aux calls for a middle block ~3x the aux budget, got %d", len(sum.calls))
+	}
+	if res.AuxCalls != len(sum.calls) {
+		t.Fatalf("AuxCalls=%d but summarizer saw %d", res.AuxCalls, len(sum.calls))
+	}
+	last := sum.calls[len(sum.calls)-1]
+	if !bytes.Contains(out, []byte(fmt.Sprintf("SUMMARY-%d", len(sum.calls)))) {
+		t.Fatalf("compacted body must carry the last call's output %q", last)
+	}
+	for i := 1; i < len(sum.previous); i++ {
+		if sum.previous[i] != sum.calls[i-1] {
+			t.Fatalf("call %d did not receive summary of call %d", i+1, i)
+		}
+	}
+	kept := gjson.GetBytes(out, "messages").Array()
+	raws := make([]string, 0, len(kept))
+	for _, k := range kept {
+		raws = append(raws, k.Raw)
+	}
+	assertNoOrphans(t, raws)
+	if !strings.Contains(kept[len(kept)-1].Raw, "done 24") {
+		t.Fatal("last turn must be kept verbatim")
+	}
+}
+
+// (b) 4 turns of ~50k tokens with keep-turns 6 and keep-tokens 40k: keep 1.
+func TestSplitBudgetKeepsOneTurnWhenTokensExceeded(t *testing.T) {
+	tokens := func(raw string) int { return len(raw) / 4 }
+	body := claudeBody(toolTurns(4, 160000)) // ~80k tokens per turn (two 160k-byte fillers), well over 170k budget in total
+	sp, ok := SplitMessagesBudget(sdktranslator.FormatClaude, body, 6, 40000, tokens)
+	if !ok {
+		t.Fatal("expected a split")
+	}
+	if len(sp.Recent) != 4 {
+		t.Fatalf("expected exactly one full turn (4 messages) kept, got %d", len(sp.Recent))
+	}
+	if len(sp.Middle) != 12 {
+		t.Fatalf("expected 3 turns (12 messages) in the middle, got %d", len(sp.Middle))
+	}
+	assertNoOrphans(t, sp.Recent)
+	assertNoOrphans(t, sp.Middle)
+	if !strings.Contains(sp.Recent[0], "turn 3") {
+		t.Fatal("kept turn must be the last one")
+	}
+
+	// Same body through Apply compacts (previously: "fewer than 6 turns to keep").
+	sum := &chainSummarizer{}
+	cfg := testCfg()
+	cfg.KeepRecentTurns = 6
+	cfg.KeepRecentTokens = 40000
+	it := New(cfg, registry.GetGlobalRegistry(), sum)
+	out, res := it.Apply(context.Background(), cfg, cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+	})
+	if out == nil || !res.Compacted {
+		t.Fatal("expected compaction with one turn kept and three summarized")
+	}
+	if got := len(gjson.GetBytes(out, "messages").Array()); got != 6 {
+		t.Fatalf("expected summary pair + 4 kept messages = 6, got %d", got)
+	}
+}
+
+// With a single turn there is nothing to summarize.
+func TestSplitBudgetNoSplitWithOneTurn(t *testing.T) {
+	tokens := func(raw string) int { return len(raw) / 4 }
+	body := claudeBody(toolTurns(1, 100000))
+	if _, ok := SplitMessagesBudget(sdktranslator.FormatClaude, body, 6, 40000, tokens); ok {
+		t.Fatal("one turn must not be split")
+	}
+}
+
+// (c) A body under budget is forwarded byte-identical (nil replacement).
+func TestApplyUnderBudgetIsByteIdentical(t *testing.T) {
+	sum := &chainSummarizer{}
+	cfg := testCfg()
+	it := New(cfg, registry.GetGlobalRegistry(), sum)
+	body := claudeBody(toolTurns(3, 2000))
+	orig := append([]byte(nil), body...)
+	out, res := it.Apply(context.Background(), cfg, cliproxyexecutor.RequestAfterAuthInterceptRequest{
+		SourceFormat: sdktranslator.FormatClaude,
+		Model:        "claude-test",
+		Body:         body,
+	})
+	if out != nil || res.Compacted || len(sum.calls) != 0 {
+		t.Fatal("under budget must not compact")
+	}
+	if !bytes.Equal(body, orig) {
+		t.Fatal("request body must be untouched")
+	}
+}
+
+func TestConfigKeepRecentTokensDefault(t *testing.T) {
+	c := config.PreCompactConfig{Enabled: true}.WithDefaults()
+	if c.KeepRecentTokens != config.DefaultPreCompactKeepRecentTokens {
+		t.Fatalf("default keep-recent-tokens = %d", c.KeepRecentTokens)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/precompact/split.go
+++ b/internal/precompact/split.go
@@ -1,0 +1,197 @@
+package precompact
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Split describes a request body divided into a byte-identical head (system
+// prompt, tools, leading system messages), a middle block to summarize, and a
+// byte-identical tail of recent turns.
+type Split struct {
+	// Prefix holds raw JSON of leading OpenAI system messages (empty for Claude).
+	Prefix []string
+	// Middle holds raw JSON of the messages to summarize.
+	Middle []string
+	// Recent holds raw JSON of the messages kept verbatim.
+	Recent []string
+}
+
+// isUserTurn reports whether a raw message starts a real user turn: role user
+// and not a tool-result carrier. Cutting only at such messages never separates
+// a tool_use from its tool_result.
+func isUserTurn(format sdktranslator.Format, msg gjson.Result) bool {
+	role := msg.Get("role").String()
+	if role != "user" {
+		return false
+	}
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		return true
+	}
+	if !content.IsArray() {
+		return true
+	}
+	for _, block := range content.Array() {
+		if block.Get("type").String() == "tool_result" {
+			return false
+		}
+	}
+	_ = format
+	return true
+}
+
+// SplitMessages splits body.messages so the last keepTurns user turns stay
+// verbatim. ok is false when there is nothing to summarize.
+func SplitMessages(format sdktranslator.Format, body []byte, keepTurns int) (Split, bool) {
+	var out Split
+	msgs := gjson.GetBytes(body, "messages")
+	if !msgs.IsArray() {
+		return out, false
+	}
+	raw := make([]string, 0, len(msgs.Array()))
+	for _, m := range msgs.Array() {
+		raw = append(raw, m.Raw)
+	}
+	start := 0
+	if format == sdktranslator.FormatOpenAI {
+		for start < len(raw) {
+			role := gjson.Get(raw[start], "role").String()
+			if role != "system" && role != "developer" {
+				break
+			}
+			start++
+		}
+	}
+	// Find the cut: the keepTurns-th user turn counted from the end.
+	cut := -1
+	seen := 0
+	for i := len(raw) - 1; i >= start; i-- {
+		if isUserTurn(format, gjson.Parse(raw[i])) {
+			seen++
+			if seen == keepTurns {
+				cut = i
+				break
+			}
+		}
+	}
+	if cut <= start {
+		return out, false
+	}
+	out.Prefix = raw[:start]
+	out.Middle = raw[start:cut]
+	out.Recent = raw[cut:]
+	return out, true
+}
+
+// Rebuild writes a compacted messages array back into body. Everything outside
+// "messages" stays byte-identical.
+func Rebuild(format sdktranslator.Format, body []byte, sp Split, summary string) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString("[")
+	first := true
+	add := func(raw string) {
+		if !first {
+			b.WriteString(",")
+		}
+		first = false
+		b.WriteString(raw)
+	}
+	for _, p := range sp.Prefix {
+		add(p)
+	}
+	userMsg, _ := sjson.Set(`{"role":"user"}`, "content", summaryText(summary))
+	ackMsg, _ := sjson.Set(`{"role":"assistant"}`, "content", "Understood. I will continue from that summary.")
+	if format == sdktranslator.FormatClaude {
+		userMsg, _ = sjson.SetRaw(`{"role":"user"}`, "content", textBlocks(summaryText(summary)))
+		ackMsg, _ = sjson.SetRaw(`{"role":"assistant"}`, "content", textBlocks("Understood. I will continue from that summary."))
+	}
+	add(userMsg)
+	add(ackMsg)
+	for _, r := range sp.Recent {
+		add(r)
+	}
+	b.WriteString("]")
+	return sjson.SetRawBytes(body, "messages", []byte(b.String()))
+}
+
+func textBlocks(text string) string {
+	block, _ := sjson.Set(`{"type":"text"}`, "text", text)
+	return "[" + block + "]"
+}
+
+func summaryText(summary string) string {
+	return "[Conversation compacted by the proxy because it exceeded the model's context window. Summary of the earlier conversation follows.]\n\n" + summary
+}
+
+// Transcript renders middle messages as plain text for the summarizer.
+// Thinking blocks are dropped; tool calls and results are kept in short form.
+func Transcript(msgs []string) string {
+	var b strings.Builder
+	for _, raw := range msgs {
+		m := gjson.Parse(raw)
+		role := m.Get("role").String()
+		content := m.Get("content")
+		b.WriteString(strings.ToUpper(role))
+		b.WriteString(": ")
+		if content.Type == gjson.String {
+			b.WriteString(content.String())
+		} else if content.IsArray() {
+			for _, block := range content.Array() {
+				switch block.Get("type").String() {
+				case "thinking", "redacted_thinking":
+					continue
+				case "text":
+					b.WriteString(block.Get("text").String())
+				case "tool_use":
+					b.WriteString("[tool_use ")
+					b.WriteString(block.Get("name").String())
+					b.WriteString(" ")
+					b.WriteString(clip(block.Get("input").Raw, 2000))
+					b.WriteString("]")
+				case "tool_result":
+					b.WriteString("[tool_result ")
+					b.WriteString(clip(block.Get("content").String(), 2000))
+					b.WriteString("]")
+				default:
+					b.WriteString(clip(block.Raw, 500))
+				}
+				b.WriteString("\n")
+			}
+		}
+		// OpenAI tool calls.
+		if calls := m.Get("tool_calls"); calls.IsArray() {
+			for _, c := range calls.Array() {
+				b.WriteString("[tool_call ")
+				b.WriteString(c.Get("function.name").String())
+				b.WriteString(" ")
+				b.WriteString(clip(c.Get("function.arguments").String(), 2000))
+				b.WriteString("]\n")
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// HashMessages returns a stable hash of raw messages, used for cache prefix matching.
+func HashMessages(msgs []string) string {
+	h := sha256.New()
+	for _, m := range msgs {
+		h.Write([]byte(m))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/precompact/split.go
+++ b/internal/precompact/split.go
@@ -47,8 +47,20 @@ func isUserTurn(format sdktranslator.Format, msg gjson.Result) bool {
 }
 
 // SplitMessages splits body.messages so the last keepTurns user turns stay
-// verbatim. ok is false when there is nothing to summarize.
+// verbatim. ok is false when there is nothing to summarize. It applies no
+// token limit; see SplitMessagesBudget.
 func SplitMessages(format sdktranslator.Format, body []byte, keepTurns int) (Split, bool) {
+	return SplitMessagesBudget(format, body, keepTurns, 0, nil)
+}
+
+// SplitMessagesBudget splits body.messages keeping the most recent turns
+// verbatim until both limits are reached: at most keepTurns user turns, and
+// stop earlier once the kept tail exceeds keepTokens (0 = no token limit).
+// At least one full turn (the last user turn and everything after it, so a
+// tool_use is never separated from its tool_result) is always kept.
+// tokens estimates the token count of one raw message; nil disables the
+// token limit. ok is false when nothing would be left to summarize.
+func SplitMessagesBudget(format sdktranslator.Format, body []byte, keepTurns, keepTokens int, tokens func(raw string) int) (Split, bool) {
 	var out Split
 	msgs := gjson.GetBytes(body, "messages")
 	if !msgs.IsArray() {
@@ -68,16 +80,29 @@ func SplitMessages(format sdktranslator.Format, body []byte, keepTurns int) (Spl
 			start++
 		}
 	}
-	// Find the cut: the keepTurns-th user turn counted from the end.
+	if keepTurns < 1 {
+		keepTurns = 1
+	}
+	limitTokens := keepTokens > 0 && tokens != nil
+	// Walk back over user-turn boundaries. The first boundary is always kept;
+	// each further one only while both limits still hold.
 	cut := -1
 	seen := 0
+	kept := 0
 	for i := len(raw) - 1; i >= start; i-- {
-		if isUserTurn(format, gjson.Parse(raw[i])) {
-			seen++
-			if seen == keepTurns {
-				cut = i
-				break
-			}
+		if limitTokens {
+			kept += tokens(raw[i])
+		}
+		if !isUserTurn(format, gjson.Parse(raw[i])) {
+			continue
+		}
+		if seen > 0 && limitTokens && kept > keepTokens {
+			break
+		}
+		seen++
+		cut = i
+		if seen >= keepTurns {
+			break
 		}
 	}
 	if cut <= start {
@@ -87,6 +112,58 @@ func SplitMessages(format sdktranslator.Format, body []byte, keepTurns int) (Spl
 	out.Middle = raw[start:cut]
 	out.Recent = raw[cut:]
 	return out, true
+}
+
+// ChunkTurns groups msgs into consecutive chunks that each fit within budget
+// tokens, cutting only at user-turn boundaries so a tool_use always stays in
+// the same chunk as its tool_result. A single turn larger than budget forms
+// its own chunk. budget <= 0 or a nil counter returns one chunk.
+func ChunkTurns(format sdktranslator.Format, msgs []string, budget int, tokens func(raw string) int) [][]string {
+	if len(msgs) == 0 {
+		return nil
+	}
+	if budget <= 0 || tokens == nil {
+		return [][]string{msgs}
+	}
+	var chunks [][]string
+	chunkStart, chunkTokens := 0, 0
+	turnStart, turnTokens := 0, 0
+	flushTurn := func(end int) {
+		if turnStart > chunkStart && chunkTokens+turnTokens > budget {
+			chunks = append(chunks, msgs[chunkStart:turnStart])
+			chunkStart = turnStart
+			chunkTokens = 0
+		}
+		chunkTokens += turnTokens
+		turnStart = end
+		turnTokens = 0
+	}
+	for i, raw := range msgs {
+		if i > 0 && isUserTurn(format, gjson.Parse(raw)) {
+			flushTurn(i)
+		}
+		turnTokens += tokens(raw)
+	}
+	flushTurn(len(msgs))
+	chunks = append(chunks, msgs[chunkStart:])
+	return chunks
+}
+
+// ScaledEstimator returns a per-message token estimator calibrated on the
+// real count of the whole body: each message gets its byte share of total.
+// It never re-tokenizes, so splitting and chunking stay cheap.
+func ScaledEstimator(totalTokens, totalBytes int) func(raw string) int {
+	ratio := 0.25
+	if totalTokens > 0 && totalBytes > 0 {
+		ratio = float64(totalTokens) / float64(totalBytes)
+	}
+	return func(raw string) int {
+		n := int(float64(len(raw)) * ratio)
+		if n < 1 {
+			n = 1
+		}
+		return n
+	}
 }
 
 // Rebuild writes a compacted messages array back into body. Everything outside

--- a/internal/precompact/split_test.go
+++ b/internal/precompact/split_test.go
@@ -1,0 +1,141 @@
+package precompact
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func claudeBodyWithTurns(n int) []byte {
+	msgs := make([]map[string]any, 0, n*2)
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, map[string]any{"role": "user", "content": "question " + itoaTest(i)})
+		msgs = append(msgs, map[string]any{"role": "assistant", "content": "answer " + itoaTest(i)})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-3",
+		"system":     "you are helpful",
+		"tools":      []any{map[string]any{"name": "bash"}},
+		"max_tokens": 1024,
+		"messages":   msgs,
+	})
+	return body
+}
+
+func itoaTest(i int) string {
+	return string(rune('0' + i%10))
+}
+
+func TestSplitMessagesKeepsRecentTurnsVerbatim(t *testing.T) {
+	body := claudeBodyWithTurns(10)
+	sp, ok := SplitMessages(sdktranslator.FormatClaude, body, 3)
+	if !ok {
+		t.Fatal("expected a split")
+	}
+	if len(sp.Recent) == 0 {
+		t.Fatal("expected recent messages")
+	}
+	// The last 3 user turns means the last 6 messages (user+assistant pairs), possibly plus a
+	// trailing assistant-less turn. Verify recent block is a byte-identical suffix of the raw messages.
+	msgs := gjson.GetBytes(body, "messages").Array()
+	tail := msgs[len(msgs)-len(sp.Recent):]
+	for i, m := range tail {
+		if m.Raw != sp.Recent[i] {
+			t.Fatalf("recent[%d] not byte-identical:\n got: %s\nwant: %s", i, sp.Recent[i], m.Raw)
+		}
+	}
+}
+
+func TestSplitMessagesNoSplitWhenTooFewTurns(t *testing.T) {
+	body := claudeBodyWithTurns(2)
+	_, ok := SplitMessages(sdktranslator.FormatClaude, body, 6)
+	if ok {
+		t.Fatal("expected no split when fewer turns exist than keepTurns")
+	}
+}
+
+func TestSplitMessagesNeverOrphansToolUse(t *testing.T) {
+	// A user turn carrying a tool_result must not be treated as a fresh turn boundary,
+	// so the cut never lands between a tool_use and its tool_result.
+	msgs := []map[string]any{
+		{"role": "user", "content": "do a thing"},
+		{"role": "assistant", "content": []map[string]any{{"type": "tool_use", "id": "t1", "name": "bash", "input": map[string]any{}}}},
+		{"role": "user", "content": []map[string]any{{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}}},
+		{"role": "assistant", "content": "done"},
+		{"role": "user", "content": "next question"},
+		{"role": "assistant", "content": "next answer"},
+	}
+	body, _ := json.Marshal(map[string]any{"system": "s", "messages": msgs})
+	sp, ok := SplitMessages(sdktranslator.FormatClaude, body, 1)
+	if !ok {
+		t.Fatal("expected a split")
+	}
+	// The tool_result-carrying "user" message must stay paired with its tool_use in the same
+	// partition (either both in Middle or both in Recent), never split across the cut.
+	allMsgs := gjson.ParseBytes(body).Get("messages").Array()
+	toolUseIdx, toolResultIdx := -1, -1
+	for i, m := range allMsgs {
+		for _, block := range m.Get("content").Array() {
+			if block.Get("type").String() == "tool_use" {
+				toolUseIdx = i
+			}
+			if block.Get("type").String() == "tool_result" {
+				toolResultIdx = i
+			}
+		}
+	}
+	if toolUseIdx < 0 || toolResultIdx < 0 {
+		t.Fatal("fixture missing tool_use/tool_result")
+	}
+	inRecent := func(idx int) bool { return idx >= len(allMsgs)-len(sp.Recent) }
+	if inRecent(toolUseIdx) != inRecent(toolResultIdx) {
+		t.Fatalf("tool_use (idx %d) and tool_result (idx %d) landed on opposite sides of the cut", toolUseIdx, toolResultIdx)
+	}
+}
+
+func TestRebuildPreservesEverythingOutsideMessages(t *testing.T) {
+	body := claudeBodyWithTurns(10)
+	sp, ok := SplitMessages(sdktranslator.FormatClaude, body, 3)
+	if !ok {
+		t.Fatal("expected a split")
+	}
+	out, err := Rebuild(sdktranslator.FormatClaude, body, sp, "a short summary")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, field := range []string{"model", "system", "tools", "max_tokens"} {
+		if gjson.GetBytes(out, field).Raw != gjson.GetBytes(body, field).Raw {
+			t.Fatalf("field %q changed by Rebuild", field)
+		}
+	}
+	msgs := gjson.GetBytes(out, "messages").Array()
+	if len(msgs) < len(sp.Recent)+2 {
+		t.Fatalf("expected summary turn plus recent turns, got %d messages", len(msgs))
+	}
+}
+
+func TestTranscriptDropsThinkingBlocks(t *testing.T) {
+	msg := `{"role":"assistant","content":[{"type":"thinking","thinking":"secret reasoning"},{"type":"text","text":"visible answer"}]}`
+	out := Transcript([]string{msg})
+	if contains(out, "secret reasoning") {
+		t.Fatal("thinking content leaked into transcript")
+	}
+	if !contains(out, "visible answer") {
+		t.Fatal("visible text missing from transcript")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/precompact/summarize.go
+++ b/internal/precompact/summarize.go
@@ -1,0 +1,35 @@
+package precompact
+
+import (
+	"context"
+	"strings"
+)
+
+// Summarizer produces a compact summary of a transcript. Implementations call
+// the auxiliary model; previous is a prior summary to extend (may be empty).
+type Summarizer interface {
+	Summarize(ctx context.Context, model, previous, transcript string) (string, error)
+}
+
+// SummaryInstruction is the fixed prompt used for the auxiliary call.
+const SummaryInstruction = `You are compacting a long coding-assistant conversation so it fits a smaller context window. Write a dense summary that lets the assistant continue seamlessly. Preserve, in this order:
+1. The user's goal and any constraints they stated.
+2. Files touched (absolute paths) and what changed in each.
+3. Commands run and their results, including errors verbatim where short.
+4. Decisions made and why.
+5. Open items and the immediate next step.
+Use plain prose and short lists. Do not invent details. Do not address the user. Output only the summary.`
+
+// BuildPrompt joins a previous summary and a new transcript into one user message.
+func BuildPrompt(previous, transcript string) string {
+	var b strings.Builder
+	if strings.TrimSpace(previous) != "" {
+		b.WriteString("Previous summary (extend it, do not drop facts):\n\n")
+		b.WriteString(previous)
+		b.WriteString("\n\n---\n\nNew conversation since then:\n\n")
+	} else {
+		b.WriteString("Conversation:\n\n")
+	}
+	b.WriteString(transcript)
+	return b.String()
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -55,6 +55,15 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.DisableClaudeCloakMode != newCfg.DisableClaudeCloakMode {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}
+	if oldCfg.PreCompact != newCfg.PreCompact {
+		changes = append(changes, fmt.Sprintf("pre-compact: enabled %t -> %t, aux-model %s -> %s, threshold %v -> %v, keep-recent-turns %d -> %d, cache-ttl %s -> %s, cache-max-sessions %d -> %d",
+			oldCfg.PreCompact.Enabled, newCfg.PreCompact.Enabled,
+			oldCfg.PreCompact.AuxModel, newCfg.PreCompact.AuxModel,
+			oldCfg.PreCompact.Threshold, newCfg.PreCompact.Threshold,
+			oldCfg.PreCompact.KeepRecentTurns, newCfg.PreCompact.KeepRecentTurns,
+			oldCfg.PreCompact.CacheTTL, newCfg.PreCompact.CacheTTL,
+			oldCfg.PreCompact.CacheMaxSessions, newCfg.PreCompact.CacheMaxSessions))
+	}
 	if oldCfg.ClaudeCode.DisableCloakingModelList != newCfg.ClaudeCode.DisableCloakingModelList {
 		changes = append(changes, fmt.Sprintf("claude-code.disable-cloaking-model-list: %t -> %t", oldCfg.ClaudeCode.DisableCloakingModelList, newCfg.ClaudeCode.DisableCloakingModelList))
 	}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -56,11 +56,12 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}
 	if oldCfg.PreCompact != newCfg.PreCompact {
-		changes = append(changes, fmt.Sprintf("pre-compact: enabled %t -> %t, aux-model %s -> %s, threshold %v -> %v, keep-recent-turns %d -> %d, cache-ttl %s -> %s, cache-max-sessions %d -> %d",
+		changes = append(changes, fmt.Sprintf("pre-compact: enabled %t -> %t, aux-model %s -> %s, threshold %v -> %v, keep-recent-turns %d -> %d, keep-recent-tokens %d -> %d, cache-ttl %s -> %s, cache-max-sessions %d -> %d",
 			oldCfg.PreCompact.Enabled, newCfg.PreCompact.Enabled,
 			oldCfg.PreCompact.AuxModel, newCfg.PreCompact.AuxModel,
 			oldCfg.PreCompact.Threshold, newCfg.PreCompact.Threshold,
 			oldCfg.PreCompact.KeepRecentTurns, newCfg.PreCompact.KeepRecentTurns,
+			oldCfg.PreCompact.KeepRecentTokens, newCfg.PreCompact.KeepRecentTokens,
 			oldCfg.PreCompact.CacheTTL, newCfg.PreCompact.CacheTTL,
 			oldCfg.PreCompact.CacheMaxSessions, newCfg.PreCompact.CacheMaxSessions))
 	}

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -290,7 +290,7 @@ func (h *BaseAPIHandler) pluginExecutorRequest(ctx context.Context, entryProtoco
 }
 
 func (h *BaseAPIHandler) applyRequestInterceptorsAfterPluginExecutorRoute(ctx context.Context, host PluginExecutorHost, executorPluginID, entryProtocol, originalRequestedModel, requestID string, req coreexecutor.Request, opts coreexecutor.Options, skipPluginID string) (coreexecutor.Request, coreexecutor.Options, *interfaces.ErrorMessage) {
-	if !requestInterceptorsEnabled(h.interceptorHost()) {
+	if !requestInterceptorsEnabled(h.interceptorHost()) && !h.precompactEnabled() {
 		return req, opts, nil
 	}
 	toFormat := sdktranslator.FromString(entryProtocol)

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -492,7 +492,7 @@ func (h *BaseAPIHandler) applyRequestInterceptorsBeforeAuth(ctx context.Context,
 }
 
 func (h *BaseAPIHandler) requestAfterAuthInterceptor(capture *requestAfterAuthCapture, requestID, skipPluginID string) coreexecutor.RequestAfterAuthInterceptor {
-	if !requestInterceptorsEnabled(h.interceptorHost()) {
+	if !requestInterceptorsEnabled(h.interceptorHost()) && !h.precompactEnabled() {
 		return nil
 	}
 	return func(ctx context.Context, req coreexecutor.RequestAfterAuthInterceptRequest) coreexecutor.RequestAfterAuthInterceptResponse {
@@ -546,9 +546,14 @@ func (h *BaseAPIHandler) webSocketResponseObserver(requestID, skipPluginID strin
 }
 
 func (h *BaseAPIHandler) applyRequestInterceptorsAfterAuth(ctx context.Context, req coreexecutor.RequestAfterAuthInterceptRequest, requestID, skipPluginID string) coreexecutor.RequestAfterAuthInterceptResponse {
+	// Pre-compaction runs first so plugins see the body that will be sent upstream.
+	compacted := h.applyPreCompact(ctx, req)
+	if len(compacted) > 0 {
+		req.Body = compacted
+	}
 	host := h.interceptorHost()
 	if !requestInterceptorsEnabled(host) {
-		return coreexecutor.RequestAfterAuthInterceptResponse{}
+		return coreexecutor.RequestAfterAuthInterceptResponse{Body: compacted}
 	}
 	resp := interceptRequestAfterAuth(ctx, host, pluginapi.RequestInterceptRequest{
 		RequestID:      requestID,
@@ -562,9 +567,13 @@ func (h *BaseAPIHandler) applyRequestInterceptorsAfterAuth(ctx context.Context, 
 		Body:           cloneBytes(req.Body),
 		Metadata:       req.Metadata,
 	}, skipPluginID)
+	outBody := resp.Body
+	if len(outBody) == 0 {
+		outBody = compacted
+	}
 	return coreexecutor.RequestAfterAuthInterceptResponse{
 		Headers:         resp.Headers,
-		Body:            resp.Body,
+		Body:            outBody,
 		ClearHeaders:    resp.ClearHeaders,
 		Terminate:       resp.Terminate,
 		StatusCode:      normalizedTerminationStatus(resp.StatusCode),

--- a/sdk/api/handlers/precompact.go
+++ b/sdk/api/handlers/precompact.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/precompact"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var (
+	precompactMu       sync.Mutex
+	precompactByHandle = map[*BaseAPIHandler]*precompact.Interceptor{}
+)
+
+// precompactConfig returns the live pre-compact config (zero value = disabled).
+func (h *BaseAPIHandler) precompactConfig() config.PreCompactConfig {
+	if h == nil || h.Cfg == nil {
+		return config.PreCompactConfig{}
+	}
+	return h.Cfg.PreCompact
+}
+
+func (h *BaseAPIHandler) precompactEnabled() bool {
+	return h.precompactConfig().Enabled
+}
+
+// precompactInterceptor lazily builds one interceptor per handler so the
+// per-session summary cache survives across requests and config reloads.
+func (h *BaseAPIHandler) precompactInterceptor() *precompact.Interceptor {
+	if h == nil {
+		return nil
+	}
+	precompactMu.Lock()
+	defer precompactMu.Unlock()
+	if it, ok := precompactByHandle[h]; ok {
+		return it
+	}
+	it := precompact.New(h.precompactConfig(), registry.GetGlobalRegistry(), &auxSummarizer{h: h})
+	precompactByHandle[h] = it
+	return it
+}
+
+// applyPreCompact replaces req.Body when the request exceeds the selected
+// model's budget. It never returns an error: on any failure the original body
+// is forwarded and the failure is logged inside the precompact package.
+func (h *BaseAPIHandler) applyPreCompact(ctx context.Context, req coreexecutor.RequestAfterAuthInterceptRequest) []byte {
+	cfg := h.precompactConfig()
+	if !cfg.Enabled {
+		return nil
+	}
+	body, _ := h.precompactInterceptor().Apply(ctx, cfg, req)
+	return body
+}
+
+// auxSummarizer runs the summary call through the handler's own execution
+// path (InternalSource is set by ExecuteModel, so pre-compaction skips it).
+type auxSummarizer struct {
+	h *BaseAPIHandler
+}
+
+func (s *auxSummarizer) Summarize(ctx context.Context, model, previous, transcript string) (string, error) {
+	if s == nil || s.h == nil {
+		return "", fmt.Errorf("precompact: no handler")
+	}
+	body := []byte(`{"max_tokens":4096,"messages":[]}`)
+	body, _ = sjson.SetBytes(body, "model", model)
+	body, _ = sjson.SetBytes(body, "system", precompact.SummaryInstruction)
+	msg, _ := sjson.Set(`{"role":"user"}`, "content", precompact.BuildPrompt(previous, transcript))
+	body, _ = sjson.SetRawBytes(body, "messages.-1", []byte(msg))
+
+	resp, errMsg := s.h.ExecuteModel(ctx, ModelExecutionRequest{
+		EntryProtocol: "claude",
+		Model:         model,
+		Body:          body,
+	})
+	if errMsg != nil {
+		if errMsg.Error != nil {
+			return "", fmt.Errorf("aux call status %d: %w", errMsg.StatusCode, errMsg.Error)
+		}
+		return "", fmt.Errorf("aux call status %d", errMsg.StatusCode)
+	}
+	var b strings.Builder
+	for _, block := range gjson.GetBytes(resp.Body, "content").Array() {
+		if block.Get("type").String() == "text" {
+			b.WriteString(block.Get("text").String())
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "" {
+		return "", fmt.Errorf("aux call returned no text")
+	}
+	return out, nil
+}


### PR DESCRIPTION
## What

Split out of #5701 so pre-compaction can be reviewed without the routing commits. Applies cleanly on `dev`; it does not depend on #5718.

- `internal/precompact/`: when a request does not fit the selected model's context window, older turns are summarised with an auxiliary model and the shortened request is forwarded. System prompt, tools and the recent turns (bounded by `keep-recent-turns` / `keep-recent-tokens`) stay byte-identical so the prompt-cache prefix survives. A middle block too large for the aux model is summarised in a rolling pass, chunk by chunk. Summaries are cached per session.
- `internal/config/precompact_config.go`, `config_load.go`, `sdk_config.go`, `watcher/diff/config_diff.go`: new `pre-compact` block, hot-reloadable.
- `sdk/api/handlers/precompact.go`, `handlers_interceptors.go`: interceptor wiring for Claude Messages and OpenAI chat. Gemini is out of scope.
- Default aux model is the native `claude-haiku-4-5-20251001` (the earlier `bedrock/...` default is not a route upstream knows).

Off by default (`pre-compact.enabled: false`). Example config documented in `config.example.yaml`.

## Why

Long agent sessions eventually exceed the upstream window and fail hard. Compacting server-side keeps them running without the client having to know.

No changes to `internal/translator/**` or AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)