### PR TITLE
feat(models): add per-model Codex web search override

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -366,6 +366,7 @@ nonstream-keepalive-interval: 0
 #         display-name: "Gemini Flash" # optional catalog display name
 #         max-context-length: 1048576 # optional: override Codex client context window metadata
 #         is-compat: false             # optional: preserve thinking blocks with empty signatures for compatible upstreams
+#         codex-web-search: true       # optional: override Codex client web search advertisement; explicit false wins across providers
 #         thinking:                    # optional: exact thinking capability for this configured model
 #           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
@@ -402,6 +403,7 @@ nonstream-keepalive-interval: 0
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
 #         max-context-length: 1048576 # optional: override Codex client context window metadata
 #         is-compat: false             # optional: preserve thinking blocks with empty signatures for compatible upstreams
+#         codex-web-search: true       # optional: override Codex client web search advertisement; explicit false wins across providers
 #         thinking:                    # optional: exact thinking capability for this configured model
 #           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
@@ -434,6 +436,7 @@ nonstream-keepalive-interval: 0
 #         display-name: "Codex Latest" # optional catalog display name
 #         max-context-length: 1048576 # optional: override Codex client context window metadata
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
+#         codex-web-search: true # optional: override Codex client web search advertisement; explicit false wins across providers
 #         # When true and codex.optimize-multi-agent-v2 is also true, convert Codex
 #         # MultiAgentV2 agent_message items into portable Responses message/user input
 #         # for third-party Responses-compatible endpoints that reject agent_message.
@@ -511,6 +514,7 @@ nonstream-keepalive-interval: 0
 #         max-context-length: 1048576         # optional: override Codex client context window metadata
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
 #         is-compat: false                    # optional: preserve thinking blocks with empty signatures for compatible upstreams
+#         codex-web-search: true              # optional: override Codex client web search advertisement; explicit false wins across providers
 #         thinking:                           # optional: exact thinking capability for this configured model
 #           levels: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
@@ -667,6 +671,7 @@ nonstream-keepalive-interval: 0
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients. Use [text] for upstreams that reject multimodal tool result content.
 #         output-modalities: [text]       # optional: declare output modalities when known
 #         is-compat: false                # optional: preserve Claude thinking blocks for compatible upstreams
+#         codex-web-search: true          # optional: override Codex client web search advertisement; explicit false wins across providers
 #         thinking:                      # optional: omit to default to levels ["low","medium","high"]
 #           levels: ["low", "medium", "high"]
 #       # You may repeat the same alias to build an internal model pool.
@@ -704,6 +709,7 @@ nonstream-keepalive-interval: 0
 #           levels: ["high", "medium", "low", "none", "auto"]
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
+#         codex-web-search: true # optional: override Codex client web search advertisement; explicit false wins across providers
 #     excluded-models:                            # optional: models to exclude from listing
 #       - "imagen-3.0-generate-002"
 #       - "imagen-*"

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -88,7 +88,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 			if thinkingSupport := codexClientThinkingSupport(model); thinkingSupport != nil {
 				applyCodexClientThinkingMetadata(entry, thinkingSupport, clientVersion)
 			}
-			applyCodexClientProviderCapabilities(entry, id, true, providersForModel)
+			applyCodexClientProviderCapabilities(entry, model, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry, clientVersion)
 			applyCodexClientVisibilityOverride(entry, id)
 			if optimizeMultiAgentV2 {
@@ -101,7 +101,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 		entry := cloneCodexClientModelMap(defaultTemplate)
 		applyCodexClientModelMetadata(entry, id, model, optimizeMultiAgentV2, clientVersion)
 		applyCodexClientMaxTokens(entry, model)
-		applyCodexClientProviderCapabilities(entry, id, false, providersForModel)
+		applyCodexClientProviderCapabilities(entry, model, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry, clientVersion)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
@@ -404,9 +404,9 @@ func applyCodexClientMaxTokens(entry map[string]any, model map[string]any) {
 	}
 }
 
-func applyCodexClientProviderCapabilities(entry map[string]any, id string, isTemplate bool, providersForModel ProvidersForModelFunc) {
+func applyCodexClientProviderCapabilities(entry, model map[string]any, id string, isTemplate bool, providersForModel ProvidersForModelFunc) {
 	if !isTemplate {
-		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
+		applyCodexClientSearchToolSupport(entry, model, id, false, providersForModel)
 		return
 	}
 	if providersForModel != nil && !isPureCodexProvider(id, providersForModel) {
@@ -416,9 +416,10 @@ func applyCodexClientProviderCapabilities(entry map[string]any, id string, isTem
 		entry["service_tiers"] = []any{}
 		delete(entry, "upgrade")
 		delete(entry, "availability_nux")
+		applyCodexClientSearchToolSupport(entry, model, id, true, providersForModel)
 		return
 	}
-	applyCodexClientSearchToolSupport(entry, id, isTemplate, providersForModel)
+	applyCodexClientSearchToolSupport(entry, model, id, isTemplate, providersForModel)
 }
 
 func isPureCodexProvider(id string, providersForModel ProvidersForModelFunc) bool {
@@ -442,7 +443,11 @@ func isPureCodexProvider(id string, providersForModel ProvidersForModelFunc) boo
 	return true
 }
 
-func applyCodexClientSearchToolSupport(entry map[string]any, id string, templateModel bool, providersForModel ProvidersForModelFunc) {
+func applyCodexClientSearchToolSupport(entry, model map[string]any, id string, templateModel bool, providersForModel ProvidersForModelFunc) {
+	if override, ok := model["codex_web_search"].(bool); ok {
+		entry["supports_search_tool"] = override
+		return
+	}
 	supportsSearch, _ := entry["supports_search_tool"].(bool)
 	if !supportsSearch {
 		return

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -226,6 +226,67 @@ func TestCodexClientModelsResponse_RequiresTemplateAndCodexProvidersForSearchToo
 	}
 }
 
+func TestCodexClientModelsResponse_CodexWebSearchOverride(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	tests := []struct {
+		name     string
+		modelID  string
+		override *bool
+		want     bool
+	}{
+		{
+			name:     "explicit true enables synthesized model",
+			modelID:  "custom-search-model",
+			override: &trueValue,
+			want:     true,
+		},
+		{
+			name:     "explicit true overrides template provider restriction",
+			modelID:  "gpt-5.6-sol",
+			override: &trueValue,
+			want:     true,
+		},
+		{
+			name:     "explicit false disables template model",
+			modelID:  "gpt-5.6-sol",
+			override: &falseValue,
+			want:     false,
+		},
+		{
+			name:     "explicit false disables synthesized model",
+			modelID:  "custom-no-search-model",
+			override: &falseValue,
+			want:     false,
+		},
+		{
+			name:    "absent preserves synthesized model behavior",
+			modelID: "custom-default-model",
+			want:    false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			model := map[string]any{"id": testCase.modelID}
+			if testCase.override != nil {
+				model["codex_web_search"] = *testCase.override
+			}
+
+			resp := BuildResponse([]map[string]any{model}, func(string) []string {
+				return []string{"openai-compatible-test"}
+			}, false)
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+			if got := models[0]["supports_search_tool"]; got != testCase.want {
+				t.Fatalf("supports_search_tool = %#v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 	resp := BuildResponse([]map[string]any{{"id": "gpt-5.6-sol"}}, nil, false)
 	models, ok := resp["models"].([]map[string]any)

--- a/internal/config/codex_web_search_test.go
+++ b/internal/config/codex_web_search_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCodexWebSearchConfigDecoding(t *testing.T) {
+	const yamlConfig = `codex-api-key:
+  - models:
+      - name: codex-upstream
+        alias: codex-alias
+        codex-web-search: true
+xai-api-key:
+  - models:
+      - name: xai-upstream
+        alias: xai-alias
+        codex-web-search: false
+claude-api-key:
+  - models:
+      - name: claude-upstream
+        alias: claude-alias
+        codex-web-search: true
+gemini-api-key:
+  - models:
+      - name: gemini-upstream
+        alias: gemini-alias
+        codex-web-search: false
+interactions-api-key:
+  - models:
+      - name: interactions-upstream
+        alias: interactions-alias
+        codex-web-search: true
+vertex-api-key:
+  - models:
+      - name: vertex-upstream
+        alias: vertex-alias
+        codex-web-search: false
+openai-compatibility:
+  - models:
+      - name: compat-upstream
+        alias: compat-alias
+        codex-web-search: true
+`
+	const jsonConfig = `{"codex-api-key":[{"models":[{"name":"codex-upstream","alias":"codex-alias","codex-web-search":true}]}],"xai-api-key":[{"models":[{"name":"xai-upstream","alias":"xai-alias","codex-web-search":false}]}],"claude-api-key":[{"models":[{"name":"claude-upstream","alias":"claude-alias","codex-web-search":true}]}],"gemini-api-key":[{"models":[{"name":"gemini-upstream","alias":"gemini-alias","codex-web-search":false}]}],"interactions-api-key":[{"models":[{"name":"interactions-upstream","alias":"interactions-alias","codex-web-search":true}]}],"vertex-api-key":[{"models":[{"name":"vertex-upstream","alias":"vertex-alias","codex-web-search":false}]}],"openai-compatibility":[{"models":[{"name":"compat-upstream","alias":"compat-alias","codex-web-search":true}]}]}`
+
+	for _, testCase := range []struct {
+		name   string
+		decode func(*Config) error
+	}{
+		{
+			name: "YAML",
+			decode: func(cfg *Config) error {
+				return yaml.Unmarshal([]byte(yamlConfig), cfg)
+			},
+		},
+		{
+			name: "JSON",
+			decode: func(cfg *Config) error {
+				return json.Unmarshal([]byte(jsonConfig), cfg)
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var cfg Config
+			if errDecode := testCase.decode(&cfg); errDecode != nil {
+				t.Fatalf("decode config: %v", errDecode)
+			}
+
+			assertBoolPointer(t, "codex", cfg.CodexKey[0].Models[0].CodexWebSearch, true)
+			assertBoolPointer(t, "xai", cfg.XAIKey[0].Models[0].CodexWebSearch, false)
+			assertBoolPointer(t, "claude", cfg.ClaudeKey[0].Models[0].CodexWebSearch, true)
+			assertBoolPointer(t, "gemini", cfg.GeminiKey[0].Models[0].CodexWebSearch, false)
+			assertBoolPointer(t, "interactions", cfg.InteractionsKey[0].Models[0].CodexWebSearch, true)
+			assertBoolPointer(t, "vertex", cfg.VertexCompatAPIKey[0].Models[0].CodexWebSearch, false)
+			assertBoolPointer(t, "openai-compatibility", cfg.OpenAICompatibility[0].Models[0].CodexWebSearch, true)
+		})
+	}
+}
+
+func assertBoolPointer(t *testing.T, name string, got *bool, want bool) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s codex-web-search = nil, want %v", name, want)
+	}
+	if *got != want {
+		t.Fatalf("%s codex-web-search = %v, want %v", name, *got, want)
+	}
+}

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -469,6 +469,11 @@ type ClaudeModel struct {
 
 	// Thinking configures the thinking/reasoning capability for this model.
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
+
+	// CodexWebSearch overrides the Codex client web search capability for this model.
+	// Nil preserves the existing catalog/provider behavior. Explicit false wins
+	// when multiple routable providers supply the model.
+	CodexWebSearch *bool `yaml:"codex-web-search,omitempty" json:"codex-web-search,omitempty"`
 }
 
 func (m ClaudeModel) GetName() string { return m.Name }
@@ -481,6 +486,8 @@ func (m ClaudeModel) GetForceMapping() bool    { return m.ForceMapping }
 func (m ClaudeModel) GetIsCompat() bool        { return m.IsCompat }
 
 func (m ClaudeModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
+func (m ClaudeModel) GetCodexWebSearch() *bool { return m.CodexWebSearch }
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -567,6 +574,11 @@ type CodexModel struct {
 
 	// Thinking configures the thinking/reasoning capability for this model.
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
+
+	// CodexWebSearch overrides the Codex client web search capability for this model.
+	// Nil preserves the existing catalog/provider behavior. Explicit false wins
+	// when multiple routable providers supply the model.
+	CodexWebSearch *bool `yaml:"codex-web-search,omitempty" json:"codex-web-search,omitempty"`
 }
 
 func (m CodexModel) GetName() string { return m.Name }
@@ -579,6 +591,8 @@ func (m CodexModel) GetForceMapping() bool    { return m.ForceMapping }
 func (m CodexModel) GetIsCompat() bool        { return m.IsCompat }
 
 func (m CodexModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
+func (m CodexModel) GetCodexWebSearch() *bool { return m.CodexWebSearch }
 
 // XAIKey uses the Codex API key structure for native xAI execution.
 type XAIKey = CodexKey
@@ -661,6 +675,11 @@ type GeminiModel struct {
 
 	// Thinking configures the thinking/reasoning capability for this model.
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
+
+	// CodexWebSearch overrides the Codex client web search capability for this model.
+	// Nil preserves the existing catalog/provider behavior. Explicit false wins
+	// when multiple routable providers supply the model.
+	CodexWebSearch *bool `yaml:"codex-web-search,omitempty" json:"codex-web-search,omitempty"`
 }
 
 func (m GeminiModel) GetName() string { return m.Name }
@@ -673,6 +692,8 @@ func (m GeminiModel) GetForceMapping() bool    { return m.ForceMapping }
 func (m GeminiModel) GetIsCompat() bool        { return m.IsCompat }
 
 func (m GeminiModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
+func (m GeminiModel) GetCodexWebSearch() *bool { return m.CodexWebSearch }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -765,6 +786,11 @@ type OpenAICompatibilityModel struct {
 	// Thinking configures the thinking/reasoning capability for this model.
 	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
+
+	// CodexWebSearch overrides the Codex client web search capability for this model.
+	// Nil preserves the existing catalog/provider behavior. Explicit false wins
+	// when multiple routable providers supply the model.
+	CodexWebSearch *bool `yaml:"codex-web-search,omitempty" json:"codex-web-search,omitempty"`
 }
 
 func (m OpenAICompatibilityModel) GetName() string { return m.Name }
@@ -777,3 +803,5 @@ func (m OpenAICompatibilityModel) GetForceMapping() bool    { return m.ForceMapp
 func (m OpenAICompatibilityModel) GetIsCompat() bool        { return m.IsCompat }
 
 func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
+func (m OpenAICompatibilityModel) GetCodexWebSearch() *bool { return m.CodexWebSearch }

--- a/internal/config/routing.go
+++ b/internal/config/routing.go
@@ -1,0 +1,15 @@
+package config
+
+import "strings"
+
+// NormalizeRoutingStrategy returns the canonical routing strategy name.
+func NormalizeRoutingStrategy(strategy string) string {
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "weighted-round-robin", "weightedroundrobin", "wrr":
+		return "weighted-round-robin"
+	case "fill-first", "fillfirst", "ff":
+		return "fill-first"
+	default:
+		return "round-robin"
+	}
+}

--- a/internal/config/routing_test.go
+++ b/internal/config/routing_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestNormalizeRoutingStrategy(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "round-robin"},
+		{input: " round-robin ", want: "round-robin"},
+		{input: "weighted-round-robin", want: "weighted-round-robin"},
+		{input: "weightedroundrobin", want: "weighted-round-robin"},
+		{input: "WRR", want: "weighted-round-robin"},
+		{input: "fill-first", want: "fill-first"},
+		{input: "fillfirst", want: "fill-first"},
+		{input: "FF", want: "fill-first"},
+		{input: "unknown", want: "round-robin"},
+	}
+
+	for _, testCase := range tests {
+		if got := NormalizeRoutingStrategy(testCase.input); got != testCase.want {
+			t.Errorf("NormalizeRoutingStrategy(%q) = %q, want %q", testCase.input, got, testCase.want)
+		}
+	}
+}

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -77,6 +77,11 @@ type VertexCompatModel struct {
 
 	// Thinking configures the thinking/reasoning capability for this model.
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
+
+	// CodexWebSearch overrides the Codex client web search capability for this model.
+	// Nil preserves the existing catalog/provider behavior. Explicit false wins
+	// when multiple routable providers supply the model.
+	CodexWebSearch *bool `yaml:"codex-web-search,omitempty" json:"codex-web-search,omitempty"`
 }
 
 func (m VertexCompatModel) GetName() string        { return m.Name }
@@ -86,6 +91,8 @@ func (m VertexCompatModel) GetForceMapping() bool  { return m.ForceMapping }
 func (m VertexCompatModel) GetThinking() *registry.ThinkingSupport {
 	return m.Thinking
 }
+
+func (m VertexCompatModel) GetCodexWebSearch() *bool { return m.CodexWebSearch }
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/modelconfig/model_hash.go
+++ b/internal/modelconfig/model_hash.go
@@ -20,7 +20,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + codexWebSearchHashSuffix(model.CodexWebSearch) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -35,7 +35,7 @@ func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + codexWebSearchHashSuffix(model.CodexWebSearch) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -50,7 +50,7 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + codexWebSearchHashSuffix(model.CodexWebSearch) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -65,7 +65,7 @@ func ComputeCodexModelsHash(models []config.CodexModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + codexWebSearchHashSuffix(model.CodexWebSearch) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -80,7 +80,7 @@ func ComputeGeminiModelsHash(models []config.GeminiModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + thinkingHashSuffix(model.Thinking))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|" + fmt.Sprintf("is-compat=%t", model.IsCompat) + codexWebSearchHashSuffix(model.CodexWebSearch) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return hashJoined(keys)
@@ -106,6 +106,13 @@ func normalizeModalities(raw []string) []string {
 func thinkingHashSuffix(support *registry.ThinkingSupport) string {
 	data, _ := json.Marshal(support)
 	return "|thinking=" + string(data)
+}
+
+func codexWebSearchHashSuffix(override *bool) string {
+	if override == nil {
+		return "|codex-web-search=unset"
+	}
+	return fmt.Sprintf("|codex-web-search=%t", *override)
 }
 
 func modelRoutingKeys(collect func(out func(key string))) []string {

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -330,7 +330,7 @@ func (r *ModelRegistry) RegisterClient(clientID, clientProvider string, models [
 		rawModelIDs = append(rawModelIDs, model.ID)
 		newCounts[model.ID]++
 		if existing, exists := newModels[model.ID]; exists {
-			if merged, changed := mergeCodexWebSearchOverride(existing.CodexWebSearch, model.CodexWebSearch); changed {
+			if merged, changed := MergeCodexWebSearchOverride(existing.CodexWebSearch, model.CodexWebSearch); changed {
 				clone := cloneModelInfo(existing)
 				clone.CodexWebSearch = merged
 				newModels[model.ID] = clone
@@ -675,7 +675,12 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 	return &copyModel
 }
 
-func mergeCodexWebSearchOverride(existing, incoming *bool) (*bool, bool) {
+// MergeCodexWebSearchOverride combines two per-model Codex web search overrides
+// for the same model ID. A nil override defers to the other value, while an
+// explicit false wins over true so a pool with any unsupported upstream never
+// advertises web search. It returns the merged value and whether it differs
+// from existing.
+func MergeCodexWebSearchOverride(existing, incoming *bool) (*bool, bool) {
 	if existing == nil {
 		if incoming == nil {
 			return nil, false

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -73,6 +73,11 @@ type ModelInfo struct {
 	// fetchAvailableModels.webSearchModelIds and can execute native googleSearch.
 	SupportsWebSearch bool `json:"supports_web_search,omitempty"`
 
+	// CodexWebSearch overrides the Codex client model catalog's
+	// supports_search_tool value for this model. Nil preserves the default
+	// template and provider behavior.
+	CodexWebSearch *bool `json:"-"`
+
 	// Thinking holds provider-specific reasoning/thinking budget capabilities.
 	// This is optional and currently used for Gemini thinking budget normalization.
 	Thinking *ThinkingSupport `json:"thinking,omitempty"`
@@ -324,7 +329,12 @@ func (r *ModelRegistry) RegisterClient(clientID, clientProvider string, models [
 		}
 		rawModelIDs = append(rawModelIDs, model.ID)
 		newCounts[model.ID]++
-		if _, exists := newModels[model.ID]; exists {
+		if existing, exists := newModels[model.ID]; exists {
+			if merged, changed := mergeCodexWebSearchOverride(existing.CodexWebSearch, model.CodexWebSearch); changed {
+				clone := cloneModelInfo(existing)
+				clone.CodexWebSearch = merged
+				newModels[model.ID] = clone
+			}
 			continue
 		}
 		newModels[model.ID] = model
@@ -648,6 +658,10 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 		}
 		copyModel.Thinking = &copyThinking
 	}
+	if model.CodexWebSearch != nil {
+		value := *model.CodexWebSearch
+		copyModel.CodexWebSearch = &value
+	}
 	if model.Config != nil {
 		copyConfig := *model.Config
 		if len(model.Config.OverrideHeader) > 0 {
@@ -659,6 +673,24 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 		copyModel.Config = &copyConfig
 	}
 	return &copyModel
+}
+
+func mergeCodexWebSearchOverride(existing, incoming *bool) (*bool, bool) {
+	if existing == nil {
+		if incoming == nil {
+			return nil, false
+		}
+		value := *incoming
+		return &value, true
+	}
+	if incoming == nil || !*existing {
+		return existing, false
+	}
+	if !*incoming {
+		value := false
+		return &value, true
+	}
+	return existing, false
 }
 
 func cloneModelInfosUnique(models []*ModelInfo) []*ModelInfo {
@@ -1225,6 +1257,39 @@ func (r *ModelRegistry) buildAvailableModelsLocked(handlerType string, now time.
 	return models, expiresAt
 }
 
+// codexWebSearchOverrideLocked returns the effective explicit Codex web search
+// override for a model. Explicit false wins so a model is never advertised as
+// search-capable while an available provider explicitly says it is unsupported.
+// The caller must hold r.mutex.
+func (r *ModelRegistry) codexWebSearchOverrideLocked(modelID string) *bool {
+	registration, exists := r.models[modelID]
+	if !exists || registration == nil || len(registration.Providers) == 0 {
+		return nil
+	}
+
+	hasTrue := false
+	for clientID, infos := range r.clientModelInfos {
+		info := infos[modelID]
+		if info == nil || info.CodexWebSearch == nil {
+			continue
+		}
+		provider := strings.ToLower(strings.TrimSpace(r.clientProviders[clientID]))
+		if provider == "" || registration.Providers[provider] <= 0 {
+			continue
+		}
+		if !*info.CodexWebSearch {
+			value := false
+			return &value
+		}
+		hasTrue = true
+	}
+	if hasTrue {
+		value := true
+		return &value
+	}
+	return nil
+}
+
 func cloneModelMaps(models []map[string]any) []map[string]any {
 	cloned := make([]map[string]any, 0, len(models))
 	for _, model := range models {
@@ -1439,23 +1504,10 @@ func (r *ModelRegistry) GetModelProviders(modelID string) []string {
 		count int
 	}
 	providers := make([]providerCount, 0, len(registration.Providers))
-	// suspendedByProvider := make(map[string]int)
-	// if registration.SuspendedClients != nil {
-	// 	for clientID := range registration.SuspendedClients {
-	// 		if provider, ok := r.clientProviders[clientID]; ok && provider != "" {
-	// 			suspendedByProvider[provider]++
-	// 		}
-	// 	}
-	// }
 	for name, count := range registration.Providers {
 		if count <= 0 {
 			continue
 		}
-		// adjusted := count - suspendedByProvider[name]
-		// if adjusted <= 0 {
-		// 	continue
-		// }
-		// providers = append(providers, providerCount{name: name, count: adjusted})
 		providers = append(providers, providerCount{name: name, count: count})
 	}
 	if len(providers) == 0 {
@@ -1536,6 +1588,9 @@ func (r *ModelRegistry) convertModelToMap(model *ModelInfo, handlerType string) 
 		}
 		if len(model.SupportedParameters) > 0 {
 			result["supported_parameters"] = append([]string(nil), model.SupportedParameters...)
+		}
+		if override := r.codexWebSearchOverrideLocked(model.ID); override != nil {
+			result["codex_web_search"] = *override
 		}
 		return result
 

--- a/internal/registry/model_registry_codex_web_search_test.go
+++ b/internal/registry/model_registry_codex_web_search_test.go
@@ -1,0 +1,136 @@
+package registry
+
+import "testing"
+
+func TestCodexWebSearchOverrideFalseWinsAcrossProviders(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	r := newTestModelRegistry()
+	r.RegisterClient("codex-client", "codex", []*ModelInfo{{
+		ID:             "shared-model",
+		CodexWebSearch: &trueValue,
+	}})
+	r.RegisterClient("compat-client", "openai-compatible-test", []*ModelInfo{{
+		ID:             "shared-model",
+		CodexWebSearch: &falseValue,
+	}})
+
+	models := r.GetAvailableModels("openai")
+	if len(models) != 1 {
+		t.Fatalf("models len = %d, want 1", len(models))
+	}
+	if got, ok := models[0]["codex_web_search"].(bool); !ok || got {
+		t.Fatalf("codex_web_search = %#v, want false", models[0]["codex_web_search"])
+	}
+}
+
+func TestCodexWebSearchOverrideFalseWinsWithinRepeatedAliasPool(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	tests := []struct {
+		name    string
+		entries []*ModelInfo
+		want    bool
+	}{
+		{
+			name: "true then false",
+			entries: []*ModelInfo{
+				{ID: "pooled-model", CodexWebSearch: &trueValue},
+				{ID: "pooled-model", CodexWebSearch: &falseValue},
+			},
+			want: false,
+		},
+		{
+			name: "false then true",
+			entries: []*ModelInfo{
+				{ID: "pooled-model", CodexWebSearch: &falseValue},
+				{ID: "pooled-model", CodexWebSearch: &trueValue},
+			},
+			want: false,
+		},
+		{
+			name: "true then unset",
+			entries: []*ModelInfo{
+				{ID: "pooled-model", CodexWebSearch: &trueValue},
+				{ID: "pooled-model"},
+			},
+			want: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := newTestModelRegistry()
+			r.RegisterClient("pooled-client", "openai-compatible-test", testCase.entries)
+
+			models := r.GetAvailableModels("openai")
+			if len(models) != 1 {
+				t.Fatalf("models len = %d, want 1", len(models))
+			}
+			if got, ok := models[0]["codex_web_search"].(bool); !ok || got != testCase.want {
+				t.Fatalf("codex_web_search = %#v, want %v", models[0]["codex_web_search"], testCase.want)
+			}
+		})
+	}
+}
+
+func TestCodexWebSearchOverrideUnaffectedBySuspension(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	for _, reason := range []string{"manual", "quota"} {
+		t.Run(reason, func(t *testing.T) {
+			r := newTestModelRegistry()
+			r.RegisterClient("true-client", "codex", []*ModelInfo{{
+				ID:             "shared-model",
+				CodexWebSearch: &trueValue,
+			}})
+			r.RegisterClient("false-client", "openai-compatible-test", []*ModelInfo{{
+				ID:             "shared-model",
+				CodexWebSearch: &falseValue,
+			}})
+			r.SuspendClientModel("false-client", "shared-model", reason)
+
+			models := r.GetAvailableModels("openai")
+			if len(models) != 1 {
+				t.Fatalf("models len = %d, want 1", len(models))
+			}
+			if got, ok := models[0]["codex_web_search"].(bool); !ok || got {
+				t.Fatalf("codex_web_search = %#v, want false", models[0]["codex_web_search"])
+			}
+		})
+	}
+}
+
+func TestCodexWebSearchOverrideTrueRequiresExplicitValue(t *testing.T) {
+	trueValue := true
+
+	t.Run("explicit true", func(t *testing.T) {
+		r := newTestModelRegistry()
+		r.RegisterClient("codex-client", "codex", []*ModelInfo{{
+			ID:             "search-model",
+			CodexWebSearch: &trueValue,
+		}})
+
+		models := r.GetAvailableModels("openai")
+		if len(models) != 1 {
+			t.Fatalf("models len = %d, want 1", len(models))
+		}
+		if got, ok := models[0]["codex_web_search"].(bool); !ok || !got {
+			t.Fatalf("codex_web_search = %#v, want true", models[0]["codex_web_search"])
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		r := newTestModelRegistry()
+		r.RegisterClient("codex-client", "codex", []*ModelInfo{{ID: "search-model"}})
+
+		models := r.GetAvailableModels("openai")
+		if len(models) != 1 {
+			t.Fatalf("models len = %d, want 1", len(models))
+		}
+		if _, exists := models[0]["codex_web_search"]; exists {
+			t.Fatalf("codex_web_search = %#v, want absent", models[0]["codex_web_search"])
+		}
+	})
+}

--- a/internal/watcher/config_reload.go
+++ b/internal/watcher/config_reload.go
@@ -135,10 +135,24 @@ func (w *Watcher) reloadConfig() bool {
 	}
 
 	authDirChanged := oldConfig == nil || oldConfig.AuthDir != newConfig.AuthDir
-	retryConfigChanged := oldConfig != nil && (oldConfig.RequestRetry != newConfig.RequestRetry || oldConfig.MaxRetryInterval != newConfig.MaxRetryInterval || oldConfig.MaxRetryCredentials != newConfig.MaxRetryCredentials)
-	forceAuthRefresh := oldConfig != nil && (oldConfig.ForceModelPrefix != newConfig.ForceModelPrefix || !reflect.DeepEqual(oldConfig.OAuthModelAlias, newConfig.OAuthModelAlias) || retryConfigChanged)
+	forceAuthRefresh := oldConfig != nil && requiresAuthRefresh(oldConfig, newConfig)
 
 	log.Infof("config successfully reloaded, triggering client reload")
 	w.reloadClients(authDirChanged, affectedOAuthProviders, forceAuthRefresh)
 	return true
+}
+
+func requiresAuthRefresh(oldConfig, newConfig *config.Config) bool {
+	if oldConfig == nil || newConfig == nil {
+		return false
+	}
+	retryConfigChanged := oldConfig.RequestRetry != newConfig.RequestRetry ||
+		oldConfig.MaxRetryInterval != newConfig.MaxRetryInterval ||
+		oldConfig.MaxRetryCredentials != newConfig.MaxRetryCredentials
+	routingStrategyChanged := config.NormalizeRoutingStrategy(oldConfig.Routing.Strategy) !=
+		config.NormalizeRoutingStrategy(newConfig.Routing.Strategy)
+	return oldConfig.ForceModelPrefix != newConfig.ForceModelPrefix ||
+		!reflect.DeepEqual(oldConfig.OAuthModelAlias, newConfig.OAuthModelAlias) ||
+		retryConfigChanged ||
+		routingStrategyChanged
 }

--- a/internal/watcher/config_reload_test.go
+++ b/internal/watcher/config_reload_test.go
@@ -1,0 +1,55 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestRequiresAuthRefreshForRoutingStrategyChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want bool
+	}{
+		{name: "unset to round-robin", old: "", new: "round-robin", want: false},
+		{name: "round-robin aliases", old: "round-robin", new: "ROUND-ROBIN", want: false},
+		{name: "round-robin to weighted", old: "round-robin", new: "wrr", want: true},
+		{name: "weighted to fill-first", old: "weighted-round-robin", new: "fillfirst", want: true},
+		{name: "fill-first to round-robin", old: "fill-first", new: "", want: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			oldConfig := &config.Config{Routing: config.RoutingConfig{Strategy: testCase.old}}
+			newConfig := &config.Config{Routing: config.RoutingConfig{Strategy: testCase.new}}
+			if got := requiresAuthRefresh(oldConfig, newConfig); got != testCase.want {
+				t.Fatalf("requiresAuthRefresh() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRequiresAuthRefreshForExistingMaterialChanges(t *testing.T) {
+	base := &config.Config{}
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{name: "force model prefix", mutate: func(cfg *config.Config) { cfg.ForceModelPrefix = true }},
+		{name: "request retry", mutate: func(cfg *config.Config) { cfg.RequestRetry = 2 }},
+		{name: "max retry interval", mutate: func(cfg *config.Config) { cfg.MaxRetryInterval = 2 }},
+		{name: "max retry credentials", mutate: func(cfg *config.Config) { cfg.MaxRetryCredentials = 2 }},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			changed := *base
+			testCase.mutate(&changed)
+			if !requiresAuthRefresh(base, &changed) {
+				t.Fatal("expected material change to require auth refresh")
+			}
+		})
+	}
+}

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -208,6 +208,59 @@ func TestComputeOtherModelHashesIncludeForceMapping(t *testing.T) {
 	}
 }
 
+func TestComputeModelHashesIncludeCodexWebSearch(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	tests := []struct {
+		name     string
+		unset    string
+		enabled  string
+		disabled string
+	}{
+		{
+			name:     "openai compatibility",
+			unset:    ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m"}}),
+			enabled:  ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", CodexWebSearch: &trueValue}}),
+			disabled: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", CodexWebSearch: &falseValue}}),
+		},
+		{
+			name:     "vertex",
+			unset:    ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m"}}),
+			enabled:  ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", CodexWebSearch: &trueValue}}),
+			disabled: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", CodexWebSearch: &falseValue}}),
+		},
+		{
+			name:     "claude",
+			unset:    ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m"}}),
+			enabled:  ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", CodexWebSearch: &trueValue}}),
+			disabled: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", CodexWebSearch: &falseValue}}),
+		},
+		{
+			name:     "codex",
+			unset:    ComputeCodexModelsHash([]config.CodexModel{{Name: "m"}}),
+			enabled:  ComputeCodexModelsHash([]config.CodexModel{{Name: "m", CodexWebSearch: &trueValue}}),
+			disabled: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", CodexWebSearch: &falseValue}}),
+		},
+		{
+			name:     "gemini",
+			unset:    ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m"}}),
+			enabled:  ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", CodexWebSearch: &trueValue}}),
+			disabled: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", CodexWebSearch: &falseValue}}),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.unset == "" || testCase.enabled == "" || testCase.disabled == "" {
+				t.Fatal("model hashes must not be empty")
+			}
+			if testCase.unset == testCase.enabled || testCase.unset == testCase.disabled || testCase.enabled == testCase.disabled {
+				t.Fatalf("codex-web-search tri-state must change model hash: unset=%q enabled=%q disabled=%q", testCase.unset, testCase.enabled, testCase.disabled)
+			}
+		})
+	}
+}
+
 func TestComputeExcludedModelsHash_Normalizes(t *testing.T) {
 	hash1 := ComputeExcludedModelsHash([]string{" A ", "b", "a"})
 	hash2 := ComputeExcludedModelsHash([]string{"a", " b", "A"})

--- a/sdk/cliproxy/auth/weight.go
+++ b/sdk/cliproxy/auth/weight.go
@@ -25,6 +25,11 @@ func ValidateAuthWeight(auth *Auth) error {
 	return nil
 }
 
+// AuthWeight returns the effective routing weight for an auth.
+func AuthWeight(auth *Auth) int64 {
+	return authWeight(auth)
+}
+
 // ApplyAuthWeightMetadata validates the auth and applies a source metadata weight.
 func ApplyAuthWeightMetadata(auth *Auth, metadata map[string]any) error {
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {

--- a/sdk/cliproxy/config_model_codex_web_search_test.go
+++ b/sdk/cliproxy/config_model_codex_web_search_test.go
@@ -83,3 +83,52 @@ func TestBuildConfigModelsPropagatesCodexWebSearch(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyModelPrefixesMergesCodexWebSearchOverride(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	models := []*ModelInfo{
+		{ID: "pool-alias", CodexWebSearch: &trueValue},
+		{ID: "pool-alias", CodexWebSearch: &falseValue},
+		{ID: "other-alias", CodexWebSearch: &trueValue},
+		{ID: "other-alias"},
+	}
+
+	out := applyModelPrefixes(models, "team", false)
+	if len(out) != 4 {
+		t.Fatalf("expected 4 models (2 unprefixed + 2 prefixed), got %d", len(out))
+	}
+
+	entryMap := make(map[string]*ModelInfo, len(out))
+	for _, m := range out {
+		entryMap[m.ID] = m
+	}
+
+	// A false entry in the pool must win even when a true entry comes first,
+	// for both the unprefixed and the prefixed IDs.
+	for _, id := range []string{"pool-alias", "team/pool-alias"} {
+		model := entryMap[id]
+		if model == nil || model.CodexWebSearch == nil {
+			t.Fatalf("%s CodexWebSearch = nil, want false", id)
+		}
+		if *model.CodexWebSearch {
+			t.Fatalf("%s CodexWebSearch = true, want false", id)
+		}
+	}
+
+	// A nil override defers to the explicit value.
+	for _, id := range []string{"other-alias", "team/other-alias"} {
+		model := entryMap[id]
+		if model == nil || model.CodexWebSearch == nil {
+			t.Fatalf("%s CodexWebSearch = nil, want true", id)
+		}
+		if !*model.CodexWebSearch {
+			t.Fatalf("%s CodexWebSearch = false, want true", id)
+		}
+	}
+
+	// Merging must not mutate the caller's models.
+	if !*models[0].CodexWebSearch {
+		t.Fatal("input model CodexWebSearch mutated")
+	}
+}

--- a/sdk/cliproxy/config_model_codex_web_search_test.go
+++ b/sdk/cliproxy/config_model_codex_web_search_test.go
@@ -1,0 +1,85 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestBuildConfigModelsPropagatesCodexWebSearch(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	tests := []struct {
+		name string
+		got  func() *ModelInfo
+		want bool
+	}{
+		{
+			name: "codex",
+			got: func() *ModelInfo {
+				return buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+					Name:           "codex-upstream",
+					Alias:          "codex-alias",
+					CodexWebSearch: &trueValue,
+				}}})[0]
+			},
+			want: true,
+		},
+		{
+			name: "claude",
+			got: func() *ModelInfo {
+				return buildClaudeConfigModels(&config.ClaudeKey{Models: []config.ClaudeModel{{
+					Name:           "claude-upstream",
+					Alias:          "claude-alias",
+					CodexWebSearch: &falseValue,
+				}}})[0]
+			},
+			want: false,
+		},
+		{
+			name: "gemini",
+			got: func() *ModelInfo {
+				return buildGeminiConfigModels(&config.GeminiKey{Models: []config.GeminiModel{{
+					Name:           "gemini-upstream",
+					Alias:          "gemini-alias",
+					CodexWebSearch: &trueValue,
+				}}})[0]
+			},
+			want: true,
+		},
+		{
+			name: "openai compatibility",
+			got: func() *ModelInfo {
+				return buildOpenAICompatibilityConfigModels(&config.OpenAICompatibility{Models: []config.OpenAICompatibilityModel{{
+					Name:           "compat-upstream",
+					Alias:          "compat-alias",
+					CodexWebSearch: &falseValue,
+				}}})[0]
+			},
+			want: false,
+		},
+		{
+			name: "vertex compatibility",
+			got: func() *ModelInfo {
+				return buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{
+					Name:           "vertex-upstream",
+					Alias:          "vertex-alias",
+					CodexWebSearch: &trueValue,
+				}}})[0]
+			},
+			want: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			model := testCase.got()
+			if model == nil || model.CodexWebSearch == nil {
+				t.Fatalf("CodexWebSearch = nil, want %v", testCase.want)
+			}
+			if got := *model.CodexWebSearch; got != testCase.want {
+				t.Fatalf("CodexWebSearch = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -41,12 +42,7 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 		return state
 	}
 
-	switch strings.ToLower(strings.TrimSpace(cfg.Routing.Strategy)) {
-	case "weighted-round-robin", "weightedroundrobin", "wrr":
-		state.strategy = "weighted-round-robin"
-	case "fill-first", "fillfirst", "ff":
-		state.strategy = "fill-first"
-	}
+	state.strategy = internalconfig.NormalizeRoutingStrategy(cfg.Routing.Strategy)
 	state.sessionAffinity = cfg.Routing.SessionAffinity
 	if ttl := strings.TrimSpace(cfg.Routing.SessionAffinityTTL); ttl != "" {
 		if parsed, errParse := time.ParseDuration(ttl); errParse == nil && parsed > 0 {

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -421,6 +421,10 @@ func (s *Service) registerResolvedModelsForAuth(a *coreauth.Auth, providerKey st
 	if a == nil || a.ID == "" {
 		return
 	}
+	if a.Disabled || (s.weightedRoutingEnabled() && coreauth.AuthWeight(a) <= 0) {
+		GlobalModelRegistry().UnregisterClient(a.ID)
+		return
+	}
 	providerKey = strings.ToLower(strings.TrimSpace(providerKey))
 	if providerKey == "" {
 		GlobalModelRegistry().UnregisterClient(a.ID)
@@ -444,6 +448,15 @@ func (s *Service) registerResolvedModelsForAuth(a *coreauth.Auth, providerKey st
 		return
 	}
 	GlobalModelRegistry().RegisterClient(a.ID, providerKey, normalizedModels)
+}
+
+func (s *Service) weightedRoutingEnabled() bool {
+	if s == nil {
+		return false
+	}
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	return normalizedRoutingRuntimeState(s.cfg).strategy == "weighted-round-robin"
 }
 
 func (s *Service) pluginModelsForProvider(providerKey string) []*ModelInfo {

--- a/sdk/cliproxy/service_model_weight_test.go
+++ b/sdk/cliproxy/service_model_weight_test.go
@@ -1,0 +1,92 @@
+package cliproxy
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestRegisterResolvedModelsZeroWeightFollowsRoutingStrategy(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		strategy       string
+		wantRegistered bool
+		wantSearch     bool
+	}{
+		{strategy: "round-robin", wantRegistered: true, wantSearch: false},
+		{strategy: "fill-first", wantRegistered: true, wantSearch: false},
+		{strategy: "weighted-round-robin", wantRegistered: false, wantSearch: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.strategy, func(t *testing.T) {
+			modelID := "zero-weight-web-search-model-" + testCase.strategy
+			enabledClientID := "enabled-weight-client-" + testCase.strategy
+			zeroClientID := "zero-weight-client-" + testCase.strategy
+			globalRegistry := registry.GetGlobalRegistry()
+			service := &Service{cfg: &internalconfig.Config{
+				Routing: internalconfig.RoutingConfig{Strategy: testCase.strategy},
+			}}
+
+			service.registerResolvedModelsForAuth(&coreauth.Auth{
+				ID:       enabledClientID,
+				Provider: "codex",
+			}, "codex", []*ModelInfo{{
+				ID:             modelID,
+				CodexWebSearch: &trueValue,
+			}})
+			service.registerResolvedModelsForAuth(&coreauth.Auth{
+				ID:       zeroClientID,
+				Provider: "openai-compatibility",
+				Attributes: map[string]string{
+					coreauth.AttributeWeight: "0",
+				},
+			}, "openai-compatible-zero-weight", []*ModelInfo{{
+				ID:             modelID,
+				CodexWebSearch: &falseValue,
+			}})
+			t.Cleanup(func() {
+				globalRegistry.UnregisterClient(enabledClientID)
+				globalRegistry.UnregisterClient(zeroClientID)
+			})
+
+			if got := len(globalRegistry.GetModelsForClient(zeroClientID)); (got > 0) != testCase.wantRegistered {
+				t.Fatalf("zero-weight client model count = %d, wantRegistered=%v", got, testCase.wantRegistered)
+			}
+
+			models := globalRegistry.GetAvailableModels("openai")
+			if len(models) != 1 {
+				t.Fatalf("models len = %d, want 1: %#v", len(models), models)
+			}
+			if got, ok := models[0]["codex_web_search"].(bool); !ok || got != testCase.wantSearch {
+				t.Fatalf("codex_web_search = %#v, want %v", models[0]["codex_web_search"], testCase.wantSearch)
+			}
+		})
+	}
+}
+
+func TestWeightedRoutingEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *internalconfig.Config
+		want bool
+	}{
+		{name: "default", cfg: &internalconfig.Config{}, want: false},
+		{name: "round-robin", cfg: &internalconfig.Config{Routing: internalconfig.RoutingConfig{Strategy: "round-robin"}}, want: false},
+		{name: "fill-first", cfg: &internalconfig.Config{Routing: internalconfig.RoutingConfig{Strategy: "fill-first"}}, want: false},
+		{name: "wrr alias", cfg: &internalconfig.Config{Routing: internalconfig.RoutingConfig{Strategy: "wrr"}}, want: true},
+		{name: "weighted-round-robin", cfg: &internalconfig.Config{Routing: internalconfig.RoutingConfig{Strategy: "weighted-round-robin"}}, want: true},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			service := &Service{cfg: testCase.cfg}
+			if got := service.weightedRoutingEnabled(); got != testCase.want {
+				t.Fatalf("weightedRoutingEnabled() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -681,6 +681,10 @@ type modelCompatEntry interface {
 	GetIsCompat() bool
 }
 
+type modelCodexWebSearchEntry interface {
+	GetCodexWebSearch() *bool
+}
+
 func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, created int64, fallbackDisplayName string, userDefined bool) *ModelInfo {
 	name := strings.TrimSpace(model.GetName())
 	alias := strings.TrimSpace(model.GetAlias())
@@ -719,6 +723,12 @@ func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, creat
 	}
 	if compatModel, okCompat := any(model).(modelCompatEntry); okCompat {
 		info.IsCompat = compatModel.GetIsCompat()
+	}
+	if searchModel, okSearch := any(model).(modelCodexWebSearchEntry); okSearch {
+		if override := searchModel.GetCodexWebSearch(); override != nil {
+			value := *override
+			info.CodexWebSearch = &value
+		}
 	}
 	return info
 }

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -582,7 +582,7 @@ func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix boo
 	}
 
 	out := make([]*ModelInfo, 0, len(models)*2)
-	seen := make(map[string]struct{}, len(models)*2)
+	seen := make(map[string]int, len(models)*2)
 
 	addModel := func(model *ModelInfo) {
 		if model == nil {
@@ -592,10 +592,18 @@ func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix boo
 		if id == "" {
 			return
 		}
-		if _, exists := seen[id]; exists {
+		if idx, exists := seen[id]; exists {
+			// Duplicate aliases still resolve as one upstream pool at request
+			// time, so merge overrides instead of dropping the later entry's.
+			retained := out[idx]
+			if merged, changed := registry.MergeCodexWebSearchOverride(retained.CodexWebSearch, model.CodexWebSearch); changed {
+				clone := *retained
+				clone.CodexWebSearch = merged
+				out[idx] = &clone
+			}
 			return
 		}
-		seen[id] = struct{}{}
+		seen[id] = len(out)
 		out = append(out, model)
 	}
 


### PR DESCRIPTION
## Problem

The Codex client model catalog only advertises `supports_search_tool` for official template models whose registered providers are all `codex`. This gives users no explicit, stable way to declare the capability for custom/shared model IDs.

## Solution

Add an optional per-model `codex-web-search` setting with tri-state semantics: an omitted value preserves existing behavior, `true` enables it, and `false` pins it off. When multiple enabled model definitions share an ID, `false` wins so the catalog never advertises a capability that an enabled upstream explicitly lacks.

The effective value is treated as server configuration state, not transient routing state. Quota or error suspension does not flip `supports_search_tool` back and forth as availability TTLs change.

Zero-weight credentials are excluded from model registration only when `weighted-round-robin` is active. Under `round-robin` and `fill-first`, weights are ignored by routing, so those credentials remain registered and their explicit capability settings participate normally.

The setting is propagated through Claude, Codex/xAI, Gemini/Interactions, OpenAI-compatible, and Vertex-compatible model configuration. The model hash includes the tri-state value so configuration hot reload re-registers the capability correctly.

## Validation

- `go test ./internal/client/codex/models ./internal/registry ./internal/modelconfig ./internal/watcher/diff ./sdk/cliproxy ./internal/config`
- `go build -o test-output ./cmd/server`
- `git diff --check`

`go test ./...` currently has two pre-existing failures on upstream `dev` (`internal/api/TestModelsWithClientVersionReturnsCodexCatalog` and `internal/runtime/executor/TestOpenAICompatExecutorToolResultContentByInputModalities`), reproduced on a clean upstream worktree.