### PR TITLE
fix(auth): preserve plugin OAuth refresh schedule

### DIFF
--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -538,7 +538,9 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		updated.Runtime = auth.Runtime
 	}
 	updated.LastRefreshedAt = now
-	updated.NextRefreshAfter = time.Time{}
+	if !updated.NextRefreshAfter.After(now) {
+		updated.NextRefreshAfter = time.Time{}
+	}
 	updated.LastError = nil
 	updated.StatusMessage = ""
 	updated.Unavailable = false

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -38,6 +38,38 @@ func (e schedulerProviderTestExecutor) HttpRequest(ctx context.Context, auth *Au
 	return nil, nil
 }
 
+type scheduledRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+	nextRefresh time.Time
+}
+
+func (e scheduledRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	auth.NextRefreshAfter = e.nextRefresh
+	return auth, nil
+}
+
+func TestManager_RefreshAuthPreservesPluginSchedule(t *testing.T) {
+	ctx := context.Background()
+	nextRefresh := time.Now().Add(time.Hour).Truncate(time.Second)
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(scheduledRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "factory"},
+		nextRefresh:                   nextRefresh,
+	})
+	auth := &Auth{ID: "scheduled-plugin-refresh", Provider: "factory", Status: StatusActive}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	refreshed, errRefresh := manager.refreshAuthForRequest(ctx, auth.ID, "")
+	if errRefresh != nil {
+		t.Fatalf("refresh auth: %v", errRefresh)
+	}
+	if !refreshed.NextRefreshAfter.Equal(nextRefresh) {
+		t.Fatalf("NextRefreshAfter = %s, want plugin schedule %s", refreshed.NextRefreshAfter, nextRefresh)
+	}
+}
+
 type unauthorizedRefreshTestExecutor struct {
 	schedulerProviderTestExecutor
 }


### PR DESCRIPTION
Preserve a future `NextRefreshAfter` returned by a plugin after a successful credential refresh. Previously core cleared that timestamp, allowing providers that rely on plugin scheduling to fall out of the refresh heap after their first refresh.\n\nIncludes a regression test that fails when the plugin-provided schedule is discarded.\n\nVerification:\n- targeted auth refresh tests pass\n- `go test ./...` passes\n- required server build passes\n- deployed canary returned HTTP 200 for a forced Factory OAuth refresh, advanced the expiry, and retained `next_refresh_after`.