### PR TITLE
fix(translator): surface audioTranscription parts in gemini-to-openai responses

### DIFF
--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
@@ -168,6 +168,12 @@ func ConvertGeminiResponseToOpenAI(_ context.Context, _ string, originalRequestR
 					if !inlineDataResult.Exists() {
 						inlineDataResult = partResult.Get("inline_data")
 					}
+					// Speech-to-text models (gemini-3.5-transcribe) deliver the
+					// transcript in an audioTranscription part instead of text.
+					audioTranscriptionResult := partResult.Get("audioTranscription")
+					if audioTranscriptionResult.Exists() && !partTextResult.Exists() {
+						partTextResult = audioTranscriptionResult.Get("text")
+					}
 					thoughtSignatureResult := partResult.Get("thoughtSignature")
 					if !thoughtSignatureResult.Exists() {
 						thoughtSignatureResult = partResult.Get("thought_signature")
@@ -367,6 +373,12 @@ func ConvertGeminiResponseToOpenAINonStream(_ context.Context, _ string, origina
 					inlineDataResult := partResult.Get("inlineData")
 					if !inlineDataResult.Exists() {
 						inlineDataResult = partResult.Get("inline_data")
+					}
+					// Speech-to-text models (gemini-3.5-transcribe) deliver the
+					// transcript in an audioTranscription part instead of text.
+					audioTranscriptionResult := partResult.Get("audioTranscription")
+					if audioTranscriptionResult.Exists() && !partTextResult.Exists() {
+						partTextResult = audioTranscriptionResult.Get("text")
 					}
 
 					if partTextResult.Exists() {

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_response_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_response_test.go
@@ -77,3 +77,32 @@ func TestConvertGeminiResponseToOpenAINonStream_EmptyTextProducesEmptyString(t *
 		t.Fatalf("expected reasoning_content to be empty string \"\", got %v (type %v)", reasoning.Value(), reasoning.Type)
 	}
 }
+
+// Gemini 3.5 Transcribe returns its transcript in an audioTranscription part instead
+// of the regular text part. Without handling it, the transcript is silently dropped
+// and the OpenAI client sees an empty assistant message.
+func TestConvertGeminiResponseToOpenAINonStream_AudioTranscriptionPartProducesContent(t *testing.T) {
+	response := []byte(`{"candidates":[{"content":{"parts":[{"text":""},{"audioTranscription":{"text":"Hello world"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":185,"totalTokenCount":185}}`)
+	result := ConvertGeminiResponseToOpenAINonStream(context.Background(), "model", nil, nil, response, nil)
+
+	content := gjson.GetBytes(result, "choices.0.message.content")
+	if !content.Exists() || content.String() != "Hello world" {
+		t.Fatalf("expected content to carry the transcript, got %v. Output: %s", content.Raw, result)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAI_AudioTranscriptionPartStreamsContent(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	chunk := []byte(`{"candidates":[{"content":{"parts":[{"text":""},{"audioTranscription":{"text":"Testing one two three."}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":185,"candidatesTokenCount":8,"totalTokenCount":193}}`)
+	result := ConvertGeminiResponseToOpenAI(ctx, "model", nil, nil, chunk, &param)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	content := gjson.GetBytes(result[0], "choices.0.delta.content")
+	if !content.Exists() || content.String() != "Testing one two three." {
+		t.Fatalf("expected delta.content to carry the transcript, got %v. Output: %s", content.Raw, result[0])
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #5722.

`gemini-3.5-transcribe` returns its transcript in an `audioTranscription` part instead of the regular `text` part. The Gemini → OpenAI chat-completions response converters only handled `text`/`functionCall`/`inlineData` parts, so the transcript was silently dropped: OpenAI-compatible clients received an empty assistant message (`content: ""`, `completion_tokens: 0`) with HTTP 200 — easy to miss because nothing errors.

The empty `text: ""` part that ships alongside the transcript made the converter emit the empty content field, so the drop happened without any warning.

## Solution

Both converters (streaming and non-stream) fall back to `audioTranscription.text` when a part carries no plain `text`:

```go
// Speech-to-text models (gemini-3.5-transcribe) deliver the
// transcript in an audioTranscription part instead of text.
audioTranscriptionResult := partResult.Get("audioTranscription")
if audioTranscriptionResult.Exists() && !partTextResult.Exists() {
    partTextResult = audioTranscriptionResult.Get("text")
}
```

A part that has both `text` and `audioTranscription` keeps using `text`, matching the existing precedence between other part kinds. The transcript therefore lands in the normal `choices[0].delta.content` / `choices[0].message.content` field — no new response fields, no client changes.

## Scope

- `internal/translator/gemini/openai/chat-completions/gemini_openai_response.go`: two mirrored guard blocks (streaming + non-stream part loops).
- No request-side changes: `input_audio` → `inlineData` conversion already works.

## Verification

- Live upstream API (`v1beta`, same `glEndpoint` the aistudio executor uses): bare, `maxOutputTokens`-only, and SSE-streaming `generateContent` calls all return the transcript in `audioTranscription.text` (verbatim match against the source audio).
- New unit tests cover both converter paths with the exact upstream response shape (empty text part + audioTranscription part), asserting the transcript reaches `message.content` / `delta.content`.
- `go build ./...`, `gofmt`, and the full translator test suite are clean; the only failing test in `go test ./...` (`TestPionMediaRelayBridgesAudioAndDataChannel`, codex live module) fails identically on upstream/dev without this change.

## Notes

- Orthogonal to #5278 (interactions-channel registration): this PR fixes response conversion on the `generateContent` surface used by `gemini-api-key` and the aistudio websocket channel, where the request already succeeds today but returns an empty message.
- A companion models.json PR (router-for-me/models#55) adds `gemini-3.1-flash-lite-image` to the aistudio catalog; transcribe itself will follow the catalogs once this conversion path is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)