### PR TITLE
fix(codex): keep bootstrap buffer open for events that carry no output

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -246,15 +246,49 @@ codex:
   identity-confuse: false
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
-  # Hold back the initial handshake events (response.created, response.in_progress and the
-  # websocket metadata frames) until the upstream emits its first generated event.
+  # Hold back the frames that carry nothing the client has seen - the handshake (response.created,
+  # response.in_progress, the websocket metadata frames), keepalive heartbeats, and the *.added
+  # announcements of an item or part that is still empty - until the upstream emits its first
+  # generated event. Anything else, including a server-side tool item such as web_search_call and
+  # any frame not on that list, releases the stream immediately. On the SSE transport the lines that
+  # are not `data:` frames - comments, `event:` lines, blank separators - are held alongside them.
+  # The hold is bounded by a frame budget and a 1 MiB byte budget, not by wall-clock time: an
+  # upstream that trickles frames holds the response headers for as long as the client will wait.
   # Why: the upstream smuggles `server_is_overloaded` rejections *inside* an HTTP 200 stream,
   # right after those handshake events, instead of returning 503 on the wire. Buffering them
   # keeps the downstream response headers uncommitted long enough to transparently retry on
-  # another credential. Only overload/rate-limit rejections trigger failover; every other
-  # terminal failure is still delivered in-stream exactly as before.
-  # Trade-off: response headers are delayed until generation starts, which can trip client or
-  # reverse-proxy read timeouts (e.g. nginx proxy_read_timeout) on long reasoning requests.
+  # another credential. Only overload/rate-limit rejections trigger failover; every other terminal
+  # failure is still delivered in-stream exactly as before. One pre-existing behaviour is worth
+  # knowing, because this option makes the window it lives in much longer: if the stream ends while
+  # the bootstrap is still holding, the attempt ends instead of the error reaching the client, and
+  # whether another credential is then tried depends on how it ended. A clean end with no terminal
+  # event is request-scoped on SSE, so nothing else is tried; a websocket close, or a transport error
+  # such as a dropped connection on either transport, is not, so the request may be retried on
+  # another credential. None of that is new, but before this option the hold ended at the first
+  # keepalive, so it was rare; now it can span the whole reasoning phase.
+  # Trade-off: response headers are delayed until generation starts. Because heartbeats are held
+  # too, the delay now ends at the first generated token rather than at the first heartbeat. The
+  # budget bounds how much is held, not how long: 48 SSE lines, which measures out as 15 heartbeats
+  # of the three-line event:/data:/blank shape, 23 of a two-line ": keepalive" comment followed by
+  # its blank separator, or 47 of a bare ": keepalive" with no separator - one short of the obvious
+  # division, because the rejection frame's own event: line comes out of the same budget before its
+  # data: line is parsed. An upstream that sends the rejection as a bare data: line with no event:
+  # line gets the round number instead. At a 10s upstream heartbeat that is 150s, 230s or 470s of
+  # uncommitted response headers depending on the framing the upstream picks, all of it past nginx's
+  # 60s default proxy_read_timeout, so raise the timeouts in front of the proxy before enabling this.
+  # Those seconds bound what the buffer holds, not when the response headers are committed. Headers
+  # are committed on the first chunk the downstream translator actually produces, so for a format
+  # that renders the handshake as nothing - Chat Completions and Gemini do - they stay uncommitted
+  # past the budget, until the first generated token. That is not specific to the budget: any frame
+  # that releases the buffer has always behaved this way.
+  # The websocket transport spends the same 48 differently - one per message read, whether the loop
+  # holds it or skips it, with no framing to divide by - so there it is 48 heartbeats, about 480s.
+  # Two cases no budget covers: a websocket peer that sends only ping frames, which the library
+  # answers inside the read call, leaving only the 5 minute websocket read deadline; and an upstream
+  # that stops mid-line on SSE, where the scanner never returns and only the request context ends the
+  # wait. Neither is made worse by this option - with it off the same stalled line stalls the
+  # conductor instead, which waits on the same context - but a client-side request timeout, not
+  # proxy_read_timeout, is what bounds them.
   # Default: false
   stream-bootstrap-buffering: false
   # When true, optimize Codex Desktop, codex-tui, and codex_cli_rs requests for multi-agent v2.

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -166,13 +166,24 @@ type CodexConfig struct {
 	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
 	// DisableCodexCloaking disables forcing the official Codex identity headers on HTTP/SSE and WebSocket requests.
 	DisableCodexCloaking bool `yaml:"disable-codex-cloaking" json:"disable-codex-cloaking"`
-	// StreamBootstrapBuffering holds back initial handshake events (response.created,
-	// response.in_progress and the websocket metadata frames) until the first generated event
-	// arrives. The upstream delivers server_is_overloaded rejections inside an HTTP 200 stream
-	// right after those handshake events instead of returning 503 on the wire, so buffering them
-	// keeps the downstream response headers uncommitted long enough to retry on another credential.
-	// Trade-off: the response headers are delayed until the upstream starts generating, which can
-	// trip client or reverse-proxy read timeouts. Default is false.
+	// StreamBootstrapBuffering holds back the frames that arrive before generation starts, none of
+	// which the client has seen anything from - the handshake (response.created, response.in_progress,
+	// the websocket metadata frames), keepalive heartbeats, and the *.added announcements of an item
+	// or part that is still empty - until the first generated event arrives. The upstream delivers
+	// server_is_overloaded rejections inside an HTTP 200 stream right after those frames instead of
+	// returning 503 on the wire, so buffering them keeps the downstream response headers uncommitted
+	// long enough to retry on another credential. Trade-off: the response headers are delayed until
+	// the upstream starts generating, which on a slow reasoning turn now means several heartbeat
+	// intervals rather than one, and can trip client or reverse-proxy read timeouts. The hold is
+	// bounded by a frame and a byte budget, not by wall-clock time, and neither budget is advanced
+	// by a websocket peer that sends only control frames or by an upstream that never terminates an
+	// SSE line. Only overload and rate-limit rejections fail over deliberately. A stream that ends
+	// while the bootstrap is still holding ends the attempt rather than reaching the client, and
+	// what follows is pre-existing but now far more likely, since the hold can span the whole
+	// reasoning phase instead of ending at the first keepalive: a clean end with no terminal event
+	// is request-scoped on SSE and stops there, while a websocket close or a transport error on
+	// either transport is not, so the request may be retried on another credential.
+	// Default is false.
 	StreamBootstrapBuffering bool `yaml:"stream-bootstrap-buffering" json:"stream-bootstrap-buffering"`
 	// OptimizeMultiAgentV2 optimizes official Codex multi-agent requests.
 	OptimizeMultiAgentV2 bool `yaml:"optimize-multi-agent-v2" json:"optimize-multi-agent-v2"`

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -145,6 +145,18 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	var outputItemsFallback [][]byte
 
 	var bufferedChunks [][]byte
+	// bufferedFrames counts the scanned lines this loop holds and bufferedBytes sums each line
+	// together with the chunks it translates into. Every iteration either holds the line or leaves
+	// the loop, so this is one unit per line read. Counting only the chunks would bound nothing for
+	// a downstream format that renders a frame as zero chunks, and counting only some line kinds
+	// would let the upstream's choice of framing decide whether the bound advances at all. The cost
+	// is that a verbose framing spends the budget faster: the three-line event:/data:/blank shape
+	// protects roughly a third as many events as a stream of bare ": keepalive" comments does.
+	//
+	// Neither bound is a bound on time. A peer that trickles frames, or that never terminates a
+	// line, holds the downstream headers for as long as the caller's context allows.
+	bufferedFrames := 0
+	bufferedBytes := 0
 	var initialChunks [][]byte
 	streamStarted := false
 	immediateTerminal := false
@@ -191,7 +203,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 						// attempt before the downstream headers are committed so the conductor can
 						// transparently retry on another credential, and report the status the
 						// upstream refused to put on the wire.
-						helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap overload rejection after %d buffered handshake events, failing over", len(bufferedChunks))
+						helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap overload rejection after %d buffered lines, failing over", bufferedFrames)
 						return nil, newCodexBootstrapOverloadErr(terminalBody)
 					}
 					bootstrapTerminalErr = streamErr
@@ -205,9 +217,15 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					streamErr := newCodexEmptyIncompleteStreamError()
 					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
 					reporter.PublishFailure(ctx, streamErr)
-					return nil, streamErr
+					// Not an overload rejection, so it keeps its in-stream delivery: flush what is
+					// held and hand the error downstream, matching the websocket executor and the
+					// contract that only overload and rate-limit rejections fail the attempt over.
+					// The conductor commits a stream once it has seen a payload, so this only takes
+					// effect for downstream formats that render the held frames into a chunk.
+					bootstrapTerminalErr = streamErr
+					break
 				}
-				if isCodexHandshakeMetadataEvent(eventType) {
+				if isCodexBootstrapBufferableEvent(eventType, data) {
 					isHandshake = true
 				}
 				switch eventType {
@@ -229,17 +247,30 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					translatedLine = append([]byte("data: "), data...)
 				}
 			} else {
+				// Lines that are not data: frames - SSE comments, event:, id:, retry: and the blank
+				// separator - carry no event to check against the allow-list, so they are held with
+				// the frame they belong to. They spend the same budgets.
 				isHandshake = true
 			}
 
 			translatedLine = applyCodexIdentityExposeResponsePayload(translatedLine, identityState)
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, body, translatedLine, &param, claudeInputTokens)
 			if isHandshake && !terminalSuccess {
-				if len(bufferedChunks) < codexBootstrapMaxBufferedEvents {
+				frameBytes := len(line)
+				for i := range chunks {
+					frameBytes += len(chunks[i])
+				}
+				if bufferedFrames < codexBootstrapMaxBufferedFrames && bufferedBytes+frameBytes <= codexBootstrapMaxBufferedBytes {
+					bufferedFrames++
+					bufferedBytes += frameBytes
 					bufferedChunks = append(bufferedChunks, chunks...)
 					continue
 				}
-				helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+				exhausted := "frame budget"
+				if bufferedFrames < codexBootstrapMaxBufferedFrames {
+					exhausted = "byte budget"
+				}
+				helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap %s exhausted after %d lines / %d bytes, releasing stream without overload probing", exhausted, bufferedFrames, bufferedBytes)
 			}
 
 			initialChunks = chunks

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -443,22 +443,120 @@ func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time
 	return nil
 }
 
-// codexBootstrapMaxBufferedEvents bounds how many handshake metadata events may be held
-// back while probing for an upstream rejection embedded in an HTTP 200 stream. The websocket
-// transport prefixes response events with codex.response.metadata and codex.rate_limits frames,
-// so the limit must comfortably exceed the four handshake frames observed in practice. Once the
-// limit is reached the stream is released and the original unbuffered semantics apply.
-const codexBootstrapMaxBufferedEvents = 16
+// codexBootstrapMaxBufferedFrames bounds how many upstream frames may be held back while probing
+// for a rejection embedded in an HTTP 200 stream. It counts frames read from the upstream, not
+// chunks handed downstream: a frame the downstream translator does not recognise renders as zero
+// chunks, so a chunk count is a bound only for the formats that happen to render every frame.
+//
+// The two transports spend the budget differently: the SSE executor charges one unit per line it
+// holds, the websocket executor one per message it reads whether or not it holds it. So the same
+// number protects 15 heartbeats under the three-line event:/data:/blank shape a keepalive arrives
+// in - 45 lines, with the rejection frame's own event: line spending a 46th - and more under terser
+// framings; config.example.yaml lists the measured count for each. It is sized for that worst case
+// rather than for a fixed event count, because deriving the unit from the framing is what lets an
+// upstream evade the bound.
+const codexBootstrapMaxBufferedFrames = 48
 
-// isCodexHandshakeMetadataEvent reports whether an event carries no generated output and is
-// therefore safe to hold back before the downstream response headers are committed. Keeping a type
-// allow-list rather than a fixed event count matters for the websocket transport, where the
-// handshake frames arrive before response.created and would otherwise exhaust a small counter
-// before the rejection event is seen.
-func isCodexHandshakeMetadataEvent(eventType string) bool {
-	switch eventType {
-	case "response.created", "response.in_progress", "codex.rate_limits", "codex.response.metadata":
+// codexBootstrapMaxBufferedBytes caps what a single bootstrap retains, counted over the upstream
+// frames and the chunks they translate into. A frame budget alone would not bound that: on SSE
+// scanner.Buffer allows 50MB per line, and the websocket dialer sets no read limit at all. The check
+// runs before the frame is taken, so one oversized frame cannot be admitted on the strength of an
+// empty buffer - but it bounds what is retained, not the peak: the transport has already
+// materialised the frame by the time it is consulted.
+const codexBootstrapMaxBufferedBytes = 1 << 20
+
+// isCodexBootstrapBufferableEvent reports whether a frame may be held back before the downstream
+// response headers are committed, i.e. whether nothing observable has happened yet.
+//
+// The list is closed on purpose. "Nothing has happened yet" cannot be derived from the absence of a
+// TTFT token: TTFT deliberately ignores server-side tool traffic such as
+// response.shell_call_output_content.delta and its .done counterpart, and holding one of those back
+// would let a later rejection replay a tool call, and its side effects, on another credential. An
+// unrecognised frame therefore releases the stream.
+//
+// Beyond the handshake preamble the list covers what upstream interleaves before the first token:
+// keepalive heartbeats, and the *.added frames that announce an item or part with no content yet.
+func isCodexBootstrapBufferableEvent(eventType string, payload []byte) bool {
+	// An empty data: frame is the SSE heartbeat idiom and carries nothing at all, which is how the
+	// websocket loop already treats an empty message. Without this it would fall through to the
+	// default and release the stream, turning the feature off for any upstream that sends one.
+	if len(bytes.TrimSpace(payload)) == 0 {
 		return true
+	}
+	switch eventType {
+	case "response.created", "response.in_progress", "codex.rate_limits", "codex.response.metadata", "keepalive":
+		return true
+	case "response.output_item.added":
+		return isCodexBufferableOutputItem(payload)
+	case "response.content_part.added":
+		return isCodexEmptyPart(payload)
+	case "response.reasoning_summary_part.added":
+		return isCodexEmptyPart(payload)
+	default:
+		return false
+	}
+}
+
+// isCodexBufferableOutputItem reports whether an announced output item is one the model produces by
+// itself and has not started producing, so nothing is running upstream yet. The emptiness checks
+// follow the ones IsResponsesTokenEvent applies to response.output_item.done, extended to the
+// reasoning summary, which that helper has no case for. Every other item type
+// is released, which covers the server-side operations that may already have been dispatched - a
+// web_search_call is announced with status "in_progress" and its searching event follows
+// immediately, and failing the attempt over after one would run it again on another credential - and
+// errs the same way for anything else this list has not been taught about.
+func isCodexBufferableOutputItem(payload []byte) bool {
+	item := gjson.GetBytes(payload, "item")
+	switch item.Get("type").String() {
+	case "message":
+		return isCodexEmptyContentList(item.Get("content"))
+	case "reasoning":
+		if item.Get("encrypted_content").String() != "" {
+			return false
+		}
+		return isCodexEmptyContentList(item.Get("summary")) && isCodexEmptyContentList(item.Get("content"))
+	case "function_call":
+		return item.Get("arguments").String() == ""
+	case "custom_tool_call":
+		return item.Get("input").String() == ""
+	default:
+		return false
+	}
+}
+
+// isCodexEmptyContentList reports whether every entry of an item's content or summary array is a
+// textual shape this list knows about and is still empty. An entry whose type is not on the list may
+// carry content in a field this check cannot see - an output_audio entry keeps it in "audio" - so it
+// is treated as already produced.
+func isCodexEmptyContentList(list gjson.Result) bool {
+	for _, entry := range list.Array() {
+		switch entry.Get("type").String() {
+		case "output_text", "summary_text", "text", "reasoning_text":
+			if entry.Get("text").String() != "" {
+				return false
+			}
+		case "refusal":
+			if entry.Get("refusal").String() != "" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isCodexEmptyPart reports whether an announced part is a textual one that is still empty. The part
+// type is matched against a closed list for the same reason the event type is: a part shape this
+// list has not been taught about may carry content in a field the emptiness check cannot see, so it
+// releases the stream instead.
+func isCodexEmptyPart(payload []byte) bool {
+	part := gjson.GetBytes(payload, "part")
+	switch part.Get("type").String() {
+	case "output_text", "summary_text", "text", "reasoning_text":
+		return part.Get("text").String() == ""
+	case "refusal":
+		return part.Get("refusal").String() == ""
 	default:
 		return false
 	}

--- a/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
+++ b/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -15,6 +16,7 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -24,6 +26,8 @@ const (
 	codexCreatedEvent       = `{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-terra"}}`
 	codexInProgressEvent    = `{"type":"response.in_progress","response":{"id":"resp_1"}}`
 	codexOutputAddedEvent   = `{"type":"response.output_item.added","item":{"id":"msg_1","type":"message","role":"assistant","content":[]},"output_index":0}`
+	codexKeepaliveEvent     = `{"type":"keepalive","sequence_number":1}`
+	codexOutputDeltaEvent   = `{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"hi"}`
 	codexCompletedEventBody = `{"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`
 )
 
@@ -165,7 +169,7 @@ func TestCodexExecutor_BootstrapBuffering_NonOverloadStaysInStream(t *testing.T)
 	if streamErr == nil {
 		t.Fatal("expected the invalid-request failure to arrive as an in-stream chunk error")
 	}
-	if !strings.Contains(combined, "response.created") {
+	if !strings.Contains(combined, `"type":"response.created"`) {
 		t.Fatalf("buffered handshake must be flushed before the in-stream error: %s", combined)
 	}
 	if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadRequest {
@@ -176,8 +180,8 @@ func TestCodexExecutor_BootstrapBuffering_NonOverloadStaysInStream(t *testing.T)
 // Once the buffer limit is exceeded the stream is released and overload probing stops, which
 // bounds how long the downstream response headers can stay uncommitted.
 func TestCodexExecutor_BootstrapBuffering_BufferLimitReleasesStream(t *testing.T) {
-	events := make([]string, 0, codexBootstrapMaxBufferedEvents+2)
-	for i := 0; i < codexBootstrapMaxBufferedEvents+1; i++ {
+	events := make([]string, 0, codexBootstrapMaxBufferedFrames+2)
+	for i := 0; i < codexBootstrapMaxBufferedFrames+1; i++ {
 		events = append(events, fmt.Sprintf(`{"type":"response.in_progress","response":{"id":"resp_%d"}}`, i))
 	}
 	events = append(events, codexOverloadEvent)
@@ -199,9 +203,764 @@ func TestCodexExecutor_BootstrapBuffering_BufferLimitReleasesStream(t *testing.T
 	}
 }
 
+// codexWebsocketRawServer writes the supplied frames and then closes the connection, so a test can
+// drive an exact frame sequence rather than the canonical handshake.
+func codexWebsocketRawServer(t *testing.T, frames []string, tail ...string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		for _, frame := range frames {
+			if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(frame)); errWrite != nil {
+				return
+			}
+		}
+		for _, frame := range tail {
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(frame))
+		}
+	}))
+}
+
+// The websocket frame budget must bound allow-listed frames too, not only the skippable ones.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_FrameBudgetReleasesStream(t *testing.T) {
+	frames := make([]string, 0, codexBootstrapMaxBufferedFrames+1)
+	for i := 0; i < codexBootstrapMaxBufferedFrames+1; i++ {
+		frames = append(frames, codexInProgressEvent)
+	}
+	server := codexWebsocketRawServer(t, frames, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("the frame budget must release the stream before the overload arrives: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the frame budget released the stream")
+	}
+	drainChunks(result)
+}
+
+// The websocket budget is pinned on both sides, the same way the SSE one is.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_BudgetBoundaryIsExact(t *testing.T) {
+	send := func(n int) error {
+		frames := make([]string, n)
+		for i := range frames {
+			frames[i] = codexInProgressEvent
+		}
+		server := codexWebsocketRawServer(t, frames, codexOverloadEvent)
+		defer server.Close()
+		req, opts := codexWebsocketRequest()
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if result != nil {
+			drainChunks(result)
+		}
+		return err
+	}
+	if err := send(codexBootstrapMaxBufferedFrames - 1); err == nil {
+		t.Fatalf("%d messages are inside the budget and must still fail over", codexBootstrapMaxBufferedFrames-1)
+	}
+	// The last message the window still admits. Without this case a budget one frame too small
+	// looks identical, since the overload is recognised before the window is consulted and so the
+	// max-1 case fails over either way.
+	if err := send(codexBootstrapMaxBufferedFrames); err == nil {
+		t.Fatalf("%d messages exactly fill the budget and must still fail over", codexBootstrapMaxBufferedFrames)
+	}
+	if err := send(codexBootstrapMaxBufferedFrames + 1); err != nil {
+		t.Fatalf("%d messages exceed the budget and must release: %v", codexBootstrapMaxBufferedFrames+1, err)
+	}
+}
+
+// The websocket byte budget has the same two properties as the SSE one: a message larger than the
+// cap is refused admission rather than taken on the strength of an empty buffer, and the budget is
+// seeded from the upstream message so it still advances for a downstream that renders nothing.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_ByteCapOrderingAndSeed(t *testing.T) {
+	t.Run("oversized message is not admitted", func(t *testing.T) {
+		oversized := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("q", codexBootstrapMaxBufferedBytes*2) + `"}}`
+		server := codexWebsocketRawServer(t, []string{oversized}, codexOverloadEvent)
+		defer server.Close()
+
+		req, opts := codexWebsocketRequest()
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err != nil {
+			t.Fatalf("a message larger than the cap must be released, not admitted: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected a stream result")
+		}
+		drainChunks(result)
+	})
+
+	t.Run("budget counts the upstream message", func(t *testing.T) {
+		frame := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("w", codexBootstrapMaxBufferedBytes/8) + `"}}`
+		frames := make([]string, 10)
+		for i := range frames {
+			frames[i] = frame
+		}
+		server := codexWebsocketRawServer(t, frames, codexOverloadEvent)
+		defer server.Close()
+
+		req, _ := codexWebsocketRequest()
+		opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")}
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err != nil {
+			t.Fatalf("ten messages of cap/8 must exhaust the byte budget: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected a stream result")
+		}
+		drainChunks(result)
+	})
+}
+
+// The frame that trips the budget must still be delivered. Releasing the window is a decision about
+// what to do with later frames, not a licence to drop the one in hand: on a slow turn that frame is
+// the first token of the answer.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_BudgetFrameIsNotDropped(t *testing.T) {
+	frames := make([]string, 0, codexBootstrapMaxBufferedFrames+2)
+	for i := 0; i < codexBootstrapMaxBufferedFrames; i++ {
+		frames = append(frames, codexInProgressEvent)
+	}
+	frames = append(frames, `{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"FIRSTTOKEN"}`)
+	server := codexWebsocketRawServer(t, frames, codexCompletedEventBody)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("unexpected ExecuteStream error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result")
+	}
+	combined, _ := drainChunks(result)
+	if !strings.Contains(combined, "FIRSTTOKEN") {
+		t.Fatalf("the frame that tripped the budget was dropped: %s", combined)
+	}
+}
+
+// The websocket bound must be enforced where the frame is counted. A peer that sends only frames the
+// bootstrap loop skips never reaches the buffering branch, so a release decided there would never
+// run and the downstream headers would stay uncommitted for as long as the peer keeps sending.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_SkippedFramesExhaustTheWindow(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame string
+	}{
+		{"whitespace only frames", "   \n\t "},
+		{"empty frames", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			frames := make([]string, codexBootstrapMaxBufferedFrames+2)
+			for i := range frames {
+				frames[i] = tc.frame
+			}
+			server := codexWebsocketRawServer(t, frames, codexOverloadEvent)
+			defer server.Close()
+
+			req, opts := codexWebsocketRequest()
+			result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+			if err != nil {
+				t.Fatalf("the window must release before the overload arrives, got failover: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a stream result once the window was exhausted")
+			}
+			drainChunks(result)
+		})
+	}
+}
+
+// The window only protects anything if it is small. Asserting it relative to itself, as the framing
+// tests below must, cannot catch a budget that has grown to a useless size.
+func TestCodexBootstrapBudgetsStaySmall(t *testing.T) {
+	// Pinned exactly, because the framing tests below express their expectations as multiples of
+	// these constants and so cannot notice the budgets growing.
+	// TestCodexExecutor_BootstrapBuffering_HeartbeatArithmeticPerFraming states the resulting
+	// heartbeat counts in absolute numbers, which is what config.example.yaml quotes to operators.
+	if codexBootstrapMaxBufferedFrames != 48 {
+		t.Fatalf("frame budget = %d, want 48; changing it changes how long the headers are held, so update config.example.yaml too", codexBootstrapMaxBufferedFrames)
+	}
+	if codexBootstrapMaxBufferedBytes != 1<<20 {
+		t.Fatalf("byte budget = %d, want 1MiB", codexBootstrapMaxBufferedBytes)
+	}
+}
+
+// In-stream delivery depends on the held frames rendering to at least one downstream chunk: the
+// conductor commits a stream only once it has seen a non-empty payload, so against a format that
+// renders the handshake as nothing there is nothing to commit and the attempt still fails over.
+func TestCodexExecutor_BootstrapBuffering_InStreamDeliveryNeedsRenderedFrames(t *testing.T) {
+	incomplete := `{"type":"response.incomplete","response":{"id":"resp_1","output":[],"usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}}`
+	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOutputAddedEvent, incomplete)
+	defer server.Close()
+
+	req, _ := codexTestRequest()
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true}
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("the executor still returns a stream; it is the conductor that cannot commit it: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result")
+	}
+	combined, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected the failure to arrive as an in-stream chunk error")
+	}
+	if combined != "" {
+		t.Fatalf("Chat Completions renders these frames as nothing, so no payload precedes the error: %q", combined)
+	}
+}
+
+// An empty response.incomplete is not an overload rejection, so it keeps its in-stream delivery:
+// the buffered frames are flushed and the error arrives as a chunk rather than burning another
+// credential. The websocket executor already routes this condition that way; both transports agree
+// on it. A truncated stream is deliberately left alone - both transports fail that one over.
+func TestCodexExecutor_BootstrapBuffering_NonOverloadTerminalStaysInStream(t *testing.T) {
+	cases := []struct{ name, tail string }{
+		{"empty incomplete", `{"type":"response.incomplete","response":{"id":"resp_1","output":[],"usage":{"input_tokens":1,"output_tokens":0,"total_tokens":1}}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOutputAddedEvent, tc.tail)
+			defer server.Close()
+
+			req, opts := codexTestRequest()
+			result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+			if err != nil {
+				t.Fatalf("a non-overload terminal failure must not fail the attempt over: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a stream result carrying the buffered frames and the error")
+			}
+			combined, streamErr := drainChunks(result)
+			if streamErr == nil {
+				t.Fatal("expected the failure to arrive as an in-stream chunk error")
+			}
+			if !strings.Contains(combined, `"type":"response.created"`) {
+				t.Fatalf("buffered frames must be flushed before the in-stream error: %s", combined)
+			}
+		})
+	}
+}
+
+// The cap is consulted before a frame is taken, not after. A frame that alone exceeds it is refused
+// admission and released, so the rejection that follows it immediately - with no line in between to
+// trigger a late release - is delivered in-stream rather than failing the attempt over.
+func TestCodexExecutor_BootstrapBuffering_OversizedFrameIsNotAdmitted(t *testing.T) {
+	oversized := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("q", codexBootstrapMaxBufferedBytes*2) + `"}}`
+	body := "data: " + oversized + "\n" + "data: " + codexOverloadEvent + "\n\n"
+	server := codexSSERawServer(body)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("a frame larger than the cap must be released, not admitted: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the oversized frame released the stream")
+	}
+	drainChunks(result)
+}
+
+// The byte budget is seeded from the upstream frame, not only from the chunks it translates into.
+// Against a Chat Completions downstream these frames render as zero chunks, so an accounting that
+// measured chunks alone would never advance and only the frame budget would remain - which these ten
+// frames stay well inside.
+func TestCodexExecutor_BootstrapBuffering_ByteCapCountsUpstreamFrames(t *testing.T) {
+	frame := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("w", codexBootstrapMaxBufferedBytes/8) + `"}}`
+	body := strings.Repeat("data: "+frame+"\n\n", 10) + "data: " + codexOverloadEvent + "\n\n"
+	server := codexSSERawServer(body)
+	defer server.Close()
+
+	req, _ := codexTestRequest()
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true}
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("ten frames of cap/8 must exhaust the byte budget: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the byte budget released the stream")
+	}
+	drainChunks(result)
+}
+
+// The websocket byte cap needs its own coverage: without it a handful of large frames would sit
+// inside the frame budget while retaining far more than the cap.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_ByteCapReleasesStream(t *testing.T) {
+	third := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("z", codexBootstrapMaxBufferedBytes/3) + `"}}`
+	server := codexWebsocketRawServer(t, []string{third, third, third, third}, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err != nil {
+		t.Fatalf("the websocket byte cap must release the stream before the overload arrives: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the byte cap released the stream")
+	}
+	drainChunks(result)
+}
+
+// codexSSERawServer writes raw bytes, so a test can choose its own SSE framing.
+func codexSSERawServer(body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// Pins the budget at its exact boundary. Comment heartbeats cost one scanned line each, so the
+// budget holds exactly codexBootstrapMaxBufferedFrames of them and the next one releases. Written
+// with absolute arithmetic on purpose: the framing cases below scale with the constant and so cannot
+// notice an off-by-one in the comparison.
+func TestCodexExecutor_BootstrapBuffering_BudgetBoundaryIsExact(t *testing.T) {
+	overload := "data: " + codexOverloadEvent + "\n\n"
+
+	t.Run("one line under the budget still fails over", func(t *testing.T) {
+		body := strings.Repeat(": keepalive\n", codexBootstrapMaxBufferedFrames-1) + overload
+		server := codexSSERawServer(body)
+		defer server.Close()
+
+		req, opts := codexTestRequest()
+		_, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err == nil {
+			t.Fatalf("%d held lines are inside the %d-line budget and must still fail over", codexBootstrapMaxBufferedFrames-1, codexBootstrapMaxBufferedFrames)
+		}
+	})
+
+	t.Run("exactly the budget still fails over", func(t *testing.T) {
+		body := strings.Repeat(": keepalive\n", codexBootstrapMaxBufferedFrames) + overload
+		server := codexSSERawServer(body)
+		defer server.Close()
+
+		req, opts := codexTestRequest()
+		_, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err == nil {
+			t.Fatalf("%d held lines fill the budget exactly and must still fail over", codexBootstrapMaxBufferedFrames)
+		}
+	})
+
+	t.Run("one line over the budget releases", func(t *testing.T) {
+		body := strings.Repeat(": keepalive\n", codexBootstrapMaxBufferedFrames+1) + overload
+		server := codexSSERawServer(body)
+		defer server.Close()
+
+		req, opts := codexTestRequest()
+		result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err != nil {
+			t.Fatalf("%d held lines exceed the %d-line budget and must release: %v", codexBootstrapMaxBufferedFrames+1, codexBootstrapMaxBufferedFrames, err)
+		}
+		if result == nil {
+			t.Fatal("expected a stream result once the budget released the stream")
+		}
+		drainChunks(result)
+	})
+}
+
+// "data:\n\n" is the standard SSE heartbeat idiom and carries nothing, so it must not commit the
+// headers. Before this was handled it produced an empty event type, fell through the allow-list and
+// silently turned the feature off for the whole stream - while the websocket transport, which skips
+// an empty message, kept working.
+func TestCodexExecutor_BootstrapBuffering_EmptyDataFrameDoesNotReleaseStream(t *testing.T) {
+	for _, frame := range []string{"data:\n\n", "data: \n\n", "data:   \t\n\n"} {
+		body := frame + "data: " + codexOverloadEvent + "\n\n"
+		server := codexSSERawServer(body)
+
+		req, opts := codexTestRequest()
+		result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err == nil {
+			t.Errorf("an empty data frame %q must keep the bootstrap window open", frame)
+		}
+		if result != nil {
+			t.Errorf("frame %q: expected nil result so no buffered chunk can reach the client", frame)
+		}
+		server.Close()
+	}
+}
+
+// The bound must fire whatever framing the upstream picks. Each case uses a framing that a bound
+// derived from blank separators, from data: lines, or from translated chunks would fail to advance
+// on, and a Chat Completions downstream, which renders these frames as zero chunks. That last part
+// is why these cases cannot also assert what was flushed - there is nothing downstream to look at.
+// That the frames are held at all is covered by BufferLimitReleasesStream and the
+// NonContentFramesDoNotReleaseStream cases, which run against a passthrough downstream.
+func TestCodexExecutor_BootstrapBuffering_BoundHoldsForEverySSEFraming(t *testing.T) {
+	overload := "data: " + codexOverloadEvent + "\n\n"
+	handshake := `{"type":"response.in_progress","response":{"id":"resp_1"}}`
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			// Comment heartbeats need no blank separator at all.
+			name: "comment heartbeats without blank separators",
+			body: strings.Repeat(": keepalive\n", codexBootstrapMaxBufferedFrames*4) + overload,
+		},
+		{
+			// A data: line is a complete frame; a blank line is optional between them.
+			name: "data frames without blank separators",
+			body: strings.Repeat("data: "+handshake+"\n", codexBootstrapMaxBufferedFrames*4) + overload,
+		},
+		{
+			// event:/data:/blank, the framing the canonical test server emits.
+			name: "three line framing",
+			body: strings.Repeat("event: response.in_progress\ndata: "+handshake+"\n\n", codexBootstrapMaxBufferedFrames*4) + overload,
+		},
+		{
+			// Extra blank separators are legal and must not be mistaken for extra frames.
+			name: "double blank separators",
+			body: strings.Repeat("data: "+handshake+"\n\n\n", codexBootstrapMaxBufferedFrames*4) + overload,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := codexSSERawServer(tc.body)
+			defer server.Close()
+
+			req, _ := codexTestRequest()
+			// Chat Completions renders an unrecognised frame as zero chunks, so a bound derived from
+			// the downstream chunk count would never advance here.
+			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai"), Stream: true}
+			result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+			if err != nil {
+				t.Fatalf("the bound must release the stream before the overload arrives, got failover: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a stream result once the bound released the stream")
+			}
+			if _, streamErr := drainChunks(result); streamErr == nil {
+				t.Fatal("expected the overload to arrive in-stream after the bound released the stream")
+			}
+		})
+	}
+}
+
+// A single frame may be large: scanner.Buffer allows 50MB per line, so a frame budget alone is not a
+// memory bound. Measured against a passthrough downstream, where a held frame really does occupy
+// memory.
+func TestCodexExecutor_BootstrapBuffering_ByteCapReleasesStream(t *testing.T) {
+	// Frames that are individually well inside the cap but add up past it must still release, which
+	// is what makes this a cap on the buffer rather than a per-frame size limit.
+	third := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("y", codexBootstrapMaxBufferedBytes/3) + `"}}`
+	body := "data: " + third + "\n\n" + "data: " + third + "\n\n" + "data: " + third + "\n\n" +
+		"data: " + third + "\n\n" + "data: " + codexOverloadEvent + "\n\n"
+	server := codexSSERawServer(body)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err != nil {
+		t.Fatalf("the byte cap must release the stream before the overload arrives, got failover: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the byte cap released the stream")
+	}
+}
+
+// Upstream interleaves keepalive heartbeats and item announcements while the model is still
+// thinking. Neither has reached the client, so a rejection arriving after one must still fail the
+// attempt over rather than surface in-stream.
+func TestCodexExecutor_BootstrapBuffering_NonContentFramesDoNotReleaseStream(t *testing.T) {
+	cases := []struct{ name, frame string }{
+		{"keepalive", codexKeepaliveEvent},
+		{"output item added", codexOutputAddedEvent},
+		{"content part added", `{"type":"response.content_part.added","part":{"type":"output_text","text":""}}`},
+		{"reasoning summary part added", `{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, tc.frame, codexOverloadEvent)
+			defer server.Close()
+
+			req, opts := codexTestRequest()
+			result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+			if err == nil {
+				t.Fatalf("a %s frame must keep the bootstrap window open", tc.name)
+			}
+			if result != nil {
+				t.Fatal("expected nil result so no buffered chunk can reach the client")
+			}
+			if got := statusCodeFromTestError(t, err); got != http.StatusServiceUnavailable {
+				t.Fatalf("status code = %d, want %d", got, http.StatusServiceUnavailable)
+			}
+		})
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_NonContentFramesDoNotReleaseStream(t *testing.T) {
+	for _, frame := range []string{codexKeepaliveEvent, codexOutputAddedEvent} {
+		server := codexWebsocketServer(t, codexCreatedEvent, codexInProgressEvent, frame, codexOverloadEvent)
+		req, opts := codexWebsocketRequest()
+		result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if err == nil || result != nil {
+			t.Fatalf("frame %s must keep the websocket bootstrap window open", frame)
+		}
+		server.Close()
+	}
+}
+
+// The mirror image of the two tests above, and the reason the list is closed: a frame carrying
+// generated output, or announcing a server-side tool that may already be running, must commit the
+// downstream headers so a later rejection can no longer replay it on another credential. Without
+// this pair both call sites can stop consulting the allow-list altogether and the suite stays green.
+func TestCodexExecutor_BootstrapBuffering_ContentFrameReleasesBeforeOverload(t *testing.T) {
+	for _, tc := range codexReleasingFrameCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, tc.frame, codexOverloadEvent)
+			defer server.Close()
+
+			req, opts := codexTestRequest()
+			result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+			if err != nil {
+				t.Fatalf("a %s frame must release the stream, not fail the attempt over: %v", tc.name, err)
+			}
+			if result == nil {
+				t.Fatalf("a %s frame must release the stream", tc.name)
+			}
+			if _, streamErr := drainChunks(result); streamErr == nil {
+				t.Fatalf("the overload after a %s frame must be delivered in-stream", tc.name)
+			}
+		})
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_ContentFrameReleasesBeforeOverload(t *testing.T) {
+	for _, tc := range codexReleasingFrameCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			server := codexWebsocketServer(t, codexCreatedEvent, codexInProgressEvent, tc.frame, codexOverloadEvent)
+			defer server.Close()
+
+			req, opts := codexWebsocketRequest()
+			result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+			if err != nil {
+				t.Fatalf("a %s frame must release the stream, not fail the attempt over: %v", tc.name, err)
+			}
+			if result == nil {
+				t.Fatalf("a %s frame must release the stream", tc.name)
+			}
+			if _, streamErr := drainChunks(result); streamErr == nil {
+				t.Fatalf("the overload after a %s frame must be delivered in-stream", tc.name)
+			}
+		})
+	}
+}
+
+// One frame the client has already seen, and one that means the upstream has dispatched work of its
+// own. Both must reach the client rather than be held.
+func codexReleasingFrameCases() []struct{ name, frame string } {
+	return []struct{ name, frame string }{
+		{"output text delta", codexOutputDeltaEvent},
+		{"web search call announced", `{"type":"response.output_item.added","item":{"id":"ws_1","type":"web_search_call","status":"in_progress"},"output_index":0}`},
+	}
+}
+
+// The existing cancellation test cancels before the request is sent; this one cancels mid-bootstrap,
+// with frames already held, which is the case the feature makes common. It pins the returned error
+// only. The guard it exercises also suppresses recording the cancellation as an upstream failure
+// against the credential, and that half is not observable from here: the scan error raised by a
+// cancelled read is the context.Canceled sentinel itself, so removing the guard leaves the returned
+// value unchanged and this test green.
+func TestCodexExecutor_BootstrapBuffering_CancelDuringBootstrapIsNotAnUpstreamFailure(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: " + codexCreatedEvent + "\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-released
+	}))
+	defer server.Close()
+	defer close(released)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(ctx, codexTestAuth(server.URL), req, opts)
+	if result != nil {
+		drainChunks(result)
+	}
+	// Identity rather than errors.Is, so a transport error that merely wraps the cancellation cannot
+	// satisfy it.
+	if err != context.Canceled {
+		t.Fatalf("a cancelled caller must surface as context.Canceled itself, got %T: %v", err, err)
+	}
+}
+
+// The frame budget is a line count, so what it is worth to an operator depends on how the upstream
+// frames a heartbeat. These are the numbers config.example.yaml quotes, in absolute form: a test
+// that says "codexBootstrapMaxBufferedFrames heartbeats" would move with the constant and could
+// never catch the documented figure drifting. Each count is one short of the obvious division
+// because the rejection frame's own event: line is charged to the same budget before its data: line
+// is parsed.
+func TestCodexExecutor_BootstrapBuffering_HeartbeatArithmeticPerFraming(t *testing.T) {
+	overload := "event: error\ndata: " + codexOverloadEvent + "\n\n"
+	cases := []struct {
+		name      string
+		heartbeat string
+		protected int
+	}{
+		{"three-line event:/data:/blank", "event: keepalive\ndata: " + codexKeepaliveEvent + "\n\n", 15},
+		{"two-line : keepalive comment", ": keepalive\n\n", 23},
+		{"one-line : keepalive comment", ": keepalive\n", 47},
+	}
+	failsOver := func(t *testing.T, heartbeats int, heartbeat, overload string) bool {
+		t.Helper()
+		server := codexSSERawServer(strings.Repeat(heartbeat, heartbeats) + overload)
+		defer server.Close()
+		req, opts := codexTestRequest()
+		result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+		if result != nil {
+			drainChunks(result)
+		}
+		return err != nil
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !failsOver(t, tc.protected, tc.heartbeat, overload) {
+				t.Fatalf("%d heartbeats of the %s framing must still fail over; config.example.yaml documents %d", tc.protected, tc.name, tc.protected)
+			}
+			if failsOver(t, tc.protected+1, tc.heartbeat, overload) {
+				t.Fatalf("%d heartbeats of the %s framing exceed the budget and must release the stream", tc.protected+1, tc.name)
+			}
+		})
+	}
+}
+
+// The byte budget is charged for the upstream frame *and* for the chunks it translates into, because
+// what is retained is the chunks. Both padded frames fit the cap on their upstream bytes alone, so
+// only a budget that also counts the translated chunks releases the stream here.
+func TestCodexExecutor_BootstrapBuffering_ByteCapCountsTranslatedChunks(t *testing.T) {
+	padded := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("p", 300<<10) + `"}}`
+	server := codexSSEServer(padded, padded, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("two frames whose upstream bytes fit the cap but whose chunks do not must release the stream: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the byte budget released the stream")
+	}
+	if _, streamErr := drainChunks(result); streamErr == nil {
+		t.Fatal("expected the overload to arrive in-stream after the byte budget released")
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_ByteCapCountsTranslatedChunks(t *testing.T) {
+	padded := `{"type":"response.in_progress","response":{"id":"` + strings.Repeat("p", 300<<10) + `"}}`
+	server := codexWebsocketRawServer(t, []string{padded, padded}, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("two frames whose upstream bytes fit the cap but whose chunks do not must release the stream: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result once the byte budget released the stream")
+	}
+	if _, streamErr := drainChunks(result); streamErr == nil {
+		t.Fatal("expected the overload to arrive in-stream after the byte budget released")
+	}
+}
+
+// Anything the client has seen, anything a server-side tool has already started, and anything
+// unrecognised must release the stream. This is what keeps the list closed.
+func TestIsCodexBootstrapBufferableEvent(t *testing.T) {
+	hold := []string{
+		`{"type":"response.created"}`,
+		`{"type":"response.in_progress"}`,
+		`{"type":"codex.rate_limits"}`,
+		`{"type":"codex.response.metadata"}`,
+		codexKeepaliveEvent,
+		codexOutputAddedEvent,
+		`{"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}`,
+		`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","arguments":""}}`,
+		`{"type":"response.output_item.added","item":{"id":"ct_1","type":"custom_tool_call","input":""}}`,
+		`{"type":"response.output_item.added","item":{"id":"msg_2","type":"message","content":[{"type":"output_text","text":""}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"msg_3","type":"message","content":[{"type":"refusal","refusal":""}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"rs_2","type":"reasoning","summary":[{"type":"summary_text","text":""}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"rs_3","type":"reasoning","content":[{"type":"reasoning_text","text":""}]}}`,
+		`{"type":"response.content_part.added","part":{"type":"text","text":""}}`,
+		`{"type":"response.reasoning_summary_part.added","part":{"type":"reasoning_text","text":""}}`,
+		`{"type":"response.content_part.added","part":{"type":"output_text","text":""}}`,
+		`{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":""}}`,
+		``,
+		`   `,
+	}
+	for _, payload := range hold {
+		eventType := gjson.GetBytes([]byte(payload), "type").String()
+		if !isCodexBootstrapBufferableEvent(eventType, []byte(payload)) {
+			t.Errorf("must stay bufferable: %s", payload)
+		}
+	}
+
+	release := []string{
+		`{"type":"response.output_text.delta","delta":"hi"}`,
+		`{"type":"response.reasoning_summary_text.delta","delta":"x"}`,
+		`{"type":"response.shell_call_command.delta","delta":"ls"}`,
+		`{"type":"response.shell_call_output_content.delta","delta":{"stdout":"x"}}`,
+		`{"type":"response.shell_call_output_content.done","output":[]}`,
+		`{"type":"response.output_item.done","item":{"id":"m1","type":"message"}}`,
+		`{"type":"response.output_item.added","item":{"id":"ws_1","type":"web_search_call","status":"in_progress"}}`,
+		`{"type":"response.output_item.added","item":{"id":"fs_1","type":"file_search_call"}}`,
+		`{"type":"response.output_item.added","item":{"id":"ig_1","type":"image_generation_call"}}`,
+		`{"type":"response.output_item.added","item":{"id":"x_1","type":"some_future_server_tool"}}`,
+		`{"type":"response.content_part.added","part":{"type":"output_text","text":"already here"}}`,
+		`{"type":"response.reasoning_summary_part.added","part":{"type":"summary_text","text":"already here"}}`,
+		`{"type":"response.content_part.added","part":{"type":"output_audio","audio":"AAAA"}}`,
+		`{"type":"response.content_part.added","part":{"type":"refusal","refusal":"I cannot help"}}`,
+		`{"type":"response.output_item.added","item":{"id":"rf1","type":"message","content":[{"type":"refusal","refusal":"I cannot help"}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"m1","type":"message","content":[{"type":"output_text","text":"already generated"}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"r1","type":"reasoning","summary":[{"type":"summary_text","text":"already reasoned"}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"f1","type":"function_call","arguments":"{\"path\":\"/\"}"}}`,
+		`{"type":"response.output_item.added","item":{"id":"c1","type":"custom_tool_call","input":"already here"}}`,
+		`{"type":"response.output_item.added","item":{"id":"a1","type":"message","content":[{"type":"output_audio","audio":"AAAA"}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"i1","type":"message","content":[{"type":"output_image","image_url":"data:x"}]}}`,
+		`{"type":"response.output_item.added","item":{"id":"r2","type":"reasoning","encrypted_content":"BLOB"}}`,
+		`{"type":"response.output_item.added","item":{"id":"r3","type":"reasoning","content":[{"type":"reasoning_text","text":"already reasoned"}]}}`,
+		`{"type":"response.web_search_call.searching","item_id":"ws_1"}`,
+		codexCompletedEventBody,
+		codexOverloadEvent,
+		`{"type":"response.some_future_event_we_have_never_seen"}`,
+	}
+	for _, payload := range release {
+		eventType := gjson.GetBytes([]byte(payload), "type").String()
+		if isCodexBootstrapBufferableEvent(eventType, []byte(payload)) {
+			t.Errorf("must release the stream: %s", payload)
+		}
+	}
+}
+
 // Buffered handshake events must be replayed in upstream order ahead of the first generated event.
 func TestCodexExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(t *testing.T) {
-	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOutputAddedEvent, codexCompletedEventBody)
+	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOutputAddedEvent, codexOutputDeltaEvent, codexCompletedEventBody)
 	defer server.Close()
 
 	req, opts := codexTestRequest()
@@ -214,13 +973,28 @@ func TestCodexExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(t *testing
 	if streamErr != nil {
 		t.Fatalf("unexpected chunk error: %v", streamErr)
 	}
-	createdAt := strings.Index(combined, "response.created")
-	addedAt := strings.Index(combined, "response.output_item.added")
-	if createdAt < 0 || addedAt < 0 {
-		t.Fatalf("missing handshake or first generated event: %s", combined)
+	// Matched on the payload form throughout. The bare type name also appears in the `event:` line,
+	// and that line is held whatever the frame turns out to be, so an index on it would find a
+	// buffered chunk even if the released `data:` frame were dropped entirely.
+	// Pinned as a chain rather than a single held-before-released comparison: the released frame is
+	// always flushed after the whole held batch, so comparing against it alone cannot see the held
+	// frames permuted among themselves.
+	order := []string{`"type":"response.created"`, `"type":"response.in_progress"`, `"type":"response.output_item.added"`, `"type":"response.output_text.delta"`}
+	prev := -1
+	for _, marker := range order {
+		at := strings.Index(combined, marker)
+		if at < 0 {
+			t.Fatalf("missing %s: %s", marker, combined)
+		}
+		if at <= prev {
+			t.Fatalf("frames must be replayed in upstream order, %s came too early: %s", marker, combined)
+		}
+		prev = at
 	}
-	if createdAt > addedAt {
-		t.Fatalf("buffered handshake must be replayed before the first generated event: %s", combined)
+	for _, marker := range order {
+		if n := strings.Count(combined, marker); n != 1 {
+			t.Fatalf("held frame %s was emitted %d times, want 1: %s", marker, n, combined)
+		}
 	}
 }
 
@@ -350,7 +1124,7 @@ func TestCodexWebsocketsExecutor_BootstrapBuffering_NonOverloadStaysInStream(t *
 	if streamErr == nil {
 		t.Fatal("expected the invalid-request failure to arrive as an in-stream chunk error")
 	}
-	if !strings.Contains(combined, "response.created") {
+	if !strings.Contains(combined, `"type":"response.created"`) {
 		t.Fatalf("buffered handshake must be flushed before the in-stream error: %s", combined)
 	}
 }
@@ -360,6 +1134,7 @@ func TestCodexWebsocketsExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(
 		codexCreatedEvent,
 		codexInProgressEvent,
 		codexOutputAddedEvent,
+		codexOutputDeltaEvent,
 		`{"type":"response.completed","response":{"id":"resp_1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`,
 	)
 	defer server.Close()
@@ -374,13 +1149,25 @@ func TestCodexWebsocketsExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(
 	if streamErr != nil {
 		t.Fatalf("unexpected chunk error: %v", streamErr)
 	}
-	createdAt := strings.Index(combined, "response.created")
-	addedAt := strings.Index(combined, "response.output_item.added")
-	if createdAt < 0 || addedAt < 0 {
-		t.Fatalf("missing handshake or first generated event: %s", combined)
+	// Pinned as a chain rather than a single held-before-released comparison: the released frame is
+	// always flushed after the whole held batch, so comparing against it alone cannot see the held
+	// frames permuted among themselves. Mirrors the SSE assertions exactly.
+	order := []string{`"type":"response.created"`, `"type":"response.in_progress"`, `"type":"response.output_item.added"`, `"type":"response.output_text.delta"`}
+	prev := -1
+	for _, marker := range order {
+		at := strings.Index(combined, marker)
+		if at < 0 {
+			t.Fatalf("missing %s: %s", marker, combined)
+		}
+		if at <= prev {
+			t.Fatalf("frames must be replayed in upstream order, %s came too early: %s", marker, combined)
+		}
+		prev = at
 	}
-	if createdAt > addedAt {
-		t.Fatalf("buffered handshake must be replayed before the first generated event: %s", combined)
+	for _, marker := range order {
+		if got := strings.Count(combined, marker); got != 1 {
+			t.Fatalf("held frame %s was emitted %d times, want 1: %s", marker, got, combined)
+		}
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -281,6 +281,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var outputItemsFallback [][]byte
 
 	var bufferedChunks [][]byte
+	// bufferedFrames counts every websocket message read during bootstrap, including the ones the
+	// loop skips, so a peer that only sends frames the loop ignores cannot keep the window open.
+	bufferedFrames := 0
+	bufferedBytes := 0
 	var initialChunks [][]byte
 	immediateTerminal := false
 	// bootstrapTerminalErr holds a non-overload terminal failure seen while buffering. It is
@@ -315,6 +319,18 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				reporter.PublishFailure(ctx, mappedErr)
 				return nil, mappedErr
 			}
+			// Count every message ReadMessage returns, including the ones this loop goes on to skip,
+			// so a peer sending only skippable text frames still closes the window. Control frames
+			// are not counted: the websocket library answers ping and pong inside ReadMessage and
+			// never returns them, so only the read deadline bounds a peer that sends nothing else.
+			// windowOpen is carried into the skip branches below rather than breaking here, because
+			// this message has not been processed yet and dropping it would lose a token, or a
+			// terminal event, from the turn.
+			bufferedFrames++
+			windowOpen := bufferedFrames <= codexBootstrapMaxBufferedFrames
+			if !windowOpen && bufferedFrames == codexBootstrapMaxBufferedFrames+1 {
+				helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap frame budget exhausted after %d messages read; this is the first message that may no longer be held", bufferedFrames)
+			}
 			if msgType != websocket.TextMessage {
 				if msgType == websocket.BinaryMessage {
 					errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
@@ -330,11 +346,17 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					reporter.PublishFailure(ctx, errBinary)
 					return nil, errBinary
 				}
+				// No window check here: ReadMessage only ever returns text or binary, and binary
+				// returned just above, so nothing reaches this line. The empty-payload skip below
+				// is the reachable one and does consult the window.
 				continue
 			}
 
 			payload = bytes.TrimSpace(payload)
 			if len(payload) == 0 {
+				if !windowOpen {
+					break
+				}
 				continue
 			}
 			observeCodexTokenEvent(reporter, payload)
@@ -391,7 +413,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					// Fail the attempt before the downstream headers are committed so the
 					// conductor can transparently retry on another credential, and report the
 					// status the upstream refused to put on the wire.
-					helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap overload rejection after %d buffered handshake events, failing over", len(bufferedChunks))
+					helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap overload rejection after %d messages read, failing over", bufferedFrames)
 					return nil, newCodexBootstrapOverloadErr(terminalBody)
 				}
 				bootstrapTerminalErr = streamErr
@@ -452,12 +474,20 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				currentChunks = helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, clientBody, line, &param, claudeInputTokens)
 			}
 
-			if isCodexHandshakeMetadataEvent(eventType) && !isTerminalEvent {
-				if len(bufferedChunks) < codexBootstrapMaxBufferedEvents {
+			// !isTerminalEvent is redundant against the closed allow-list, which admits no terminal
+			// type, and the empty-payload rule cannot fire on a payload already known non-empty. It
+			// stays as the guard a reader expects to find, and its SSE counterpart is !terminalSuccess.
+			if windowOpen && isCodexBootstrapBufferableEvent(eventType, payload) && !isTerminalEvent {
+				frameBytes := len(payload)
+				for i := range currentChunks {
+					frameBytes += len(currentChunks[i])
+				}
+				if bufferedBytes+frameBytes <= codexBootstrapMaxBufferedBytes {
+					bufferedBytes += frameBytes
 					bufferedChunks = append(bufferedChunks, currentChunks...)
 					continue
 				}
-				helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+				helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap byte limit reached after %d messages / %d bytes, releasing stream without overload probing", bufferedFrames, bufferedBytes)
 			}
 
 			initialChunks = currentChunks


### PR DESCRIPTION
### Problem
`codex.stream-bootstrap-buffering` holds the handshake back so an overload rejection hidden inside an HTTP 200 stream can be retried on another credential before the response headers go out. It releases on the first event that is not in the handshake allow-list, and upstream sends `keepalive` frames and `response.output_item.added` well before the first token:

```
response.created → response.in_progress → keepalive                  → response.failed(server_is_overloaded)
response.created → response.in_progress → response.output_item.added → response.failed(server_is_overloaded)
```

`keepalive` has no payload, and `response.output_item.added` only announces an item with an empty `content` array. Neither is output, but both hit the `default` branch of
`isCodexHandshakeMetadataEvent`, committed the headers and left the rejection nowhere to go but in-stream.

On one deployment with the option enabled, 1,225 rejections reached clients over ~5 h, all of them 
with `output_tokens = 0`:
<img width="806" height="267" alt="image" src="https://github.com/user-attachments/assets/042f32db-424e-4547-bef3-224dd1e7ae78" />


**73.1% (895 of 1,225)** ended on a frame the client had seen nothing from, so the buffer could still have been held and the attempt failed over to another credential. The 24.0% that had already forwarded a delta stay in-stream by design — failing those over would replay generated output.

### Solution
1.  **Extend the allow-list with the frames upstream sends before the first token**: `keepalive`,
    `response.content_part.added` and `response.reasoning_summary_part.added`, each announcing a part
    whose content is still empty. `response.output_item.added` is accepted only for `message`,
    `reasoning`, `function_call` and `custom_tool_call` items — every other item type stands for a
    server-side operation that may already be running, such as a `web_search_call` announced with
    status `in_progress`.
2.  **Keep the list closed.** An unrecognised frame, or an unrecognised item type, releases the
    stream exactly as before. TTFT cannot stand in for "nothing has happened yet": it deliberately
    ignores server-side tool traffic, and holding such a frame back would let a later rejection
    replay a tool call on another credential.
3.  **Rename** `isCodexHandshakeMetadataEvent` to `isCodexBootstrapBufferableEvent`, since the list
    is no longer only handshake metadata.
4.  **Tests**: 7 new cases in `codex_stream_bootstrap_buffering_test.go`, covering both the SSE and
    the websocket path. Details below.

### Verification

```
gofmt -l .                                                        clean
go vet ./internal/runtime/executor/                               clean
go build -ldflags="-s -w" -o /dev/null ./cmd/server               PASS
go test -race ./internal/runtime/executor/... ./sdk/api/handlers  PASS, 0 race warnings
go test ./...                                                     PASS
```

7 new tests in `codex_stream_bootstrap_buffering_test.go`, SSE and websocket paths in parallel

Related: #5545、#5634、#5586