### PR TITLE
perf(xai): avoid rescanning full request body per input item

### DIFF
--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -1124,6 +1124,39 @@ func normalizeXAIToolsWithFold(body []byte, shouldFold bool) []byte {
 	return body
 }
 
+// xaiFunctionToolNameSet collects every function tool name declared in the
+// request, both from the top-level tools array and from any additional_tools
+// input items. Callers that need to test many names against an unchanging body
+// should build this set once instead of calling xaiHasFunctionToolNamed in a
+// loop, which rescans the whole payload on every probe.
+func xaiFunctionToolNameSet(body []byte) map[string]struct{} {
+	names := make(map[string]struct{})
+	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() {
+		for _, tool := range tools.Array() {
+			if tool.Get("type").String() == xaiFunctionToolType {
+				if name := tool.Get("name").String(); name != "" {
+					names[name] = struct{}{}
+				}
+			}
+		}
+	}
+	if input := gjson.GetBytes(body, "input"); input.IsArray() {
+		for _, item := range input.Array() {
+			if item.Get("type").String() != "additional_tools" {
+				continue
+			}
+			for _, tool := range item.Get("tools").Array() {
+				if tool.Get("type").String() == xaiFunctionToolType {
+					if name := tool.Get("name").String(); name != "" {
+						names[name] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	return names
+}
+
 func xaiHasFunctionToolNamed(body []byte, name string) bool {
 	if name == "" {
 		return false

--- a/internal/runtime/executor/xai_executor_response.go
+++ b/internal/runtime/executor/xai_executor_response.go
@@ -292,29 +292,37 @@ func normalizeXAIInputNamespaceToolCallsWithFold(body []byte, shouldFold bool) [
 	if !input.Exists() || !input.IsArray() {
 		return body
 	}
-	for index, item := range input.Array() {
+
+	// The declared tool set is unaffected by the rewrites below (they only touch
+	// name/arguments/namespace on function_call items), so probe it once instead
+	// of rescanning the whole payload per item.
+	toolNames := xaiFunctionToolNameSet(body)
+
+	arr := input.Array()
+	items := make([]json.RawMessage, 0, len(arr))
+	changed := false
+	for _, item := range arr {
 		if item.Get("type").String() != "function_call" {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
 		namespaceName := strings.TrimSpace(item.Get("namespace").String())
 		toolName := strings.TrimSpace(item.Get("name").String())
 		if namespaceName == "" {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
 		qualifiedName := qualifyXAINamespaceToolName(namespaceName, toolName)
 		var isFolded bool
-		if xaiHasFunctionToolNamed(body, namespaceName) {
+		if _, ok := toolNames[namespaceName]; ok {
 			isFolded = true
-		} else if xaiHasFunctionToolNamed(body, qualifiedName) {
+		} else if _, ok := toolNames[qualifiedName]; ok {
 			isFolded = false
 		} else {
 			isFolded = shouldFold
 		}
-		if isFolded {
-			namePath := fmt.Sprintf("input.%d.name", index)
-			namespacePath := fmt.Sprintf("input.%d.namespace", index)
-			argsPath := fmt.Sprintf("input.%d.arguments", index)
 
+		if isFolded {
 			dispatcherArgs := map[string]any{
 				"name": toolName,
 			}
@@ -327,41 +335,59 @@ func normalizeXAIInputNamespaceToolCallsWithFold(body []byte, shouldFold bool) [
 			}
 			encodedArgs, errMarshal := json.Marshal(dispatcherArgs)
 			if errMarshal != nil {
+				items = append(items, json.RawMessage(item.Raw))
 				continue
 			}
-
-			updated, errSet := sjson.SetBytes(body, namePath, namespaceName)
+			updated, errSet := sjson.SetBytes([]byte(item.Raw), "name", namespaceName)
 			if errSet != nil {
+				items = append(items, json.RawMessage(item.Raw))
 				continue
 			}
-			updated, errSet = sjson.SetBytes(updated, argsPath, string(encodedArgs))
+			updated, errSet = sjson.SetBytes(updated, "arguments", string(encodedArgs))
 			if errSet != nil {
+				items = append(items, json.RawMessage(item.Raw))
 				continue
 			}
-			updated, errDelete := sjson.DeleteBytes(updated, namespacePath)
+			updated, errDelete := sjson.DeleteBytes(updated, "namespace")
 			if errDelete != nil {
+				items = append(items, json.RawMessage(item.Raw))
 				continue
 			}
-			body = updated
+			items = append(items, json.RawMessage(updated))
+			changed = true
 			continue
 		}
 
 		if qualifiedName == "" {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
-		namePath := fmt.Sprintf("input.%d.name", index)
-		namespacePath := fmt.Sprintf("input.%d.namespace", index)
-		updated, errSet := sjson.SetBytes(body, namePath, qualifiedName)
+		updated, errSet := sjson.SetBytes([]byte(item.Raw), "name", qualifiedName)
 		if errSet != nil {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
-		updated, errDelete := sjson.DeleteBytes(updated, namespacePath)
+		updated, errDelete := sjson.DeleteBytes(updated, "namespace")
 		if errDelete != nil {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
-		body = updated
+		items = append(items, json.RawMessage(updated))
+		changed = true
 	}
-	return body
+	if !changed {
+		return body
+	}
+
+	rawInput, errMarshal := json.Marshal(items)
+	if errMarshal != nil {
+		return body
+	}
+	updated, errSet := sjson.SetRawBytes(body, "input", rawInput)
+	if errSet != nil {
+		return body
+	}
+	return updated
 }
 
 type xaiNamespaceRestorer struct {
@@ -703,27 +729,50 @@ func normalizeXAIInputReasoningItems(body []byte) []byte {
 		return body
 	}
 
-	updated := body
-	for i, item := range input.Array() {
+	// Strip null content/encrypted_content from reasoning items.
+	//
+	// Each edit is applied to the individual item's raw JSON and the input
+	// array is rebuilt once at the end. Probing and deleting against the whole
+	// body inside the loop costs O(N*M) in both scanning and copying, which
+	// pins a CPU core for minutes on multi-megabyte reasoning histories.
+	arr := input.Array()
+	items := make([]json.RawMessage, 0, len(arr))
+	changed := false
+	for _, item := range arr {
 		if item.Get("type").String() != "reasoning" {
+			items = append(items, json.RawMessage(item.Raw))
 			continue
 		}
-		contentPath := fmt.Sprintf("input.%d.content", i)
-		if content := gjson.GetBytes(updated, contentPath); content.Exists() && content.Type == gjson.Null {
-			updatedBody, errDel := sjson.DeleteBytes(updated, contentPath)
+		current := []byte(item.Raw)
+		if content := item.Get("content"); content.Exists() && content.Type == gjson.Null {
+			next, errDel := sjson.DeleteBytes(current, "content")
 			if errDel != nil {
 				return body
 			}
-			updated = updatedBody
+			current = next
+			changed = true
 		}
-		encryptedContentPath := fmt.Sprintf("input.%d.encrypted_content", i)
-		if encryptedContent := gjson.GetBytes(updated, encryptedContentPath); encryptedContent.Exists() && encryptedContent.Type == gjson.Null {
-			updatedBody, errDel := sjson.DeleteBytes(updated, encryptedContentPath)
+		if encryptedContent := item.Get("encrypted_content"); encryptedContent.Exists() && encryptedContent.Type == gjson.Null {
+			next, errDel := sjson.DeleteBytes(current, "encrypted_content")
 			if errDel != nil {
 				return body
 			}
-			updated = updatedBody
+			current = next
+			changed = true
 		}
+		items = append(items, json.RawMessage(current))
+	}
+	if !changed {
+		return mergeAdjacentXAIInputReasoningSummaries(body)
+	}
+
+	rawInput, errMarshal := json.Marshal(items)
+	if errMarshal != nil {
+		return body
+	}
+	updated, errSet := sjson.SetRawBytes(body, "input", rawInput)
+	if errSet != nil {
+		return body
 	}
 	return mergeAdjacentXAIInputReasoningSummaries(updated)
 }


### PR DESCRIPTION
## Problem

Two hot paths in the xAI Responses request pipeline probe and rebuild the **entire request body once per input item**, giving O(N×M) behaviour in both JSON scanning and buffer copying.

On multi-megabyte payloads — long agent conversations that retain reasoning history and many tool calls — this pins a CPU core for seconds to minutes **before the upstream request is even sent**, so it surfaces as time-to-first-token rather than upstream latency.

This was found on a 2-core host serving Codex Desktop traffic through `grok-4.6`. A CPU profile taken while the process sat at ~158% CPU:

```
gjson.squash        26.09%
runtime.memmove     24.59%
gjson.parseSquash   20.32%

prepareResponsesRequestTo                        77.40% cum
  └─ normalizeXAIInputNamespaceToolCallsWithFold    70.51% cum
       └─ xaiHasFunctionToolNamed                     40.79% cum
```

Individual requests took 16–55s, with outliers at 189s and 527s. Host CPU repeatedly hit 100%, which tripped the downstream gateway's overload protection and caused it to 503 unrelated traffic.

## Changes

**`normalizeXAIInputNamespaceToolCallsWithFold`** called `xaiHasFunctionToolNamed(body, ...)` for every `function_call` item, and each call rescans `tools` plus the whole `input` array. It also mutated the full body per item.

The declared tool set cannot change during that loop — only `name`/`arguments`/`namespace` on `function_call` items are rewritten, while the probe reads `tools[]` and `input[]` entries of type `additional_tools`. It is now collected once through a new `xaiFunctionToolNameSet` helper, and the input array is rebuilt in a single pass.

**`normalizeXAIInputReasoningItems`** probed and deleted null `content` / `encrypted_content` against the whole body per reasoning item. Edits now apply to each item's own raw JSON with one rebuild at the end, matching the existing pattern in `sanitizeXAIInputEncryptedContent`.

## Benchmarks

Payload scales with item count; run on go1.26.1.

| namespace tool calls | before | after | speedup | alloc before → after |
|---|---|---|---|---|
| 100 items | 29.3 ms | 1.2 ms | 24x | 50 MB → 1.4 MB |
| 400 items | 447.4 ms | 4.8 ms | 92x | 770 MB → 5.9 MB |
| 800 items | 1771.9 ms | 9.5 ms | **186x** | **3.0 GB → 11.6 MB** |

| reasoning items | before | after | speedup | alloc before → after |
|---|---|---|---|---|
| 200 items | 32.5 ms | 2.6 ms | 13x | 74 MB → 2.5 MB |
| 400 items | 123.6 ms | 5.2 ms | 24x | 291 MB → 4.9 MB |
| 800 items | 474.1 ms | 10.3 ms | **46x** | **1.1 GB → 11.0 MB** |

Throughput no longer degrades with payload size: it stays flat at ~51 MB/s and ~86 MB/s instead of collapsing to 0.28 MB/s and 1.87 MB/s.

## Correctness

Both functions are behaviour-preserving. Outputs were verified **byte-identical** against the previous implementations across 20 cases: empty body, malformed JSON, non-array `input`, missing namespace, non-function/non-reasoning items, empty qualified name, invalid `arguments`, fold true/false, tool name matching the namespace, tool name matching the qualified name, and bulk inputs.

`go test ./internal/runtime/executor/` passes in full, and `go vet` is clean. The throwaway equivalence/benchmark file used for this verification is not part of the commit.

## Production result

Deployed on the affected host. The dominant hot spot dropped from **70.51% to 5.12%** of CPU time, and typical request latency went from 14–18s to 4–12s. `prepareResponsesRequestTo` still accounts for roughly half of remaining CPU, but it is now spread thinly across ~20 functions in the chain that each parse and rebuild the body once — a deeper refactor (parse once, mutate, serialise once) would be needed to address that, and is out of scope here.
