### PR TITLE
fix(signature): preserve Gemini 3 server-side tool thought signatures (#5652)

### DIFF
--- a/internal/signature/gemini_sanitize.go
+++ b/internal/signature/gemini_sanitize.go
@@ -25,9 +25,11 @@ func GeminiReplaySignatureOrBypass(rawSignature string, blockKind SignatureBlock
 
 // SanitizeGeminiRequestThoughtSignatures applies Gemini replay policy to a
 // Gemini-shaped request. Existing provider signatures stay on their original
-// model parts. Only a missing or incompatible first functionCall gets the bypass
-// sentinel; unsigned sibling calls remain unsigned, matching native Gemini
-// parallel-call history. functionResponse parts never carry signatures.
+// model parts. Server-side tool blocks (toolCall and toolResponse) are echoed back
+// untouched per the Gemini API contract. Only a missing or incompatible first
+// functionCall gets the bypass sentinel; unsigned sibling calls remain unsigned,
+// matching native Gemini parallel-call history. functionResponse parts never carry
+// signatures.
 func SanitizeGeminiRequestThoughtSignatures(payload []byte, contentsPath string) []byte {
 	contentsPath = strings.TrimSpace(contentsPath)
 	if contentsPath == "" {
@@ -70,6 +72,10 @@ func SanitizeGeminiRequestThoughtSignatures(payload []byte, contentsPath string)
 				return true
 			}
 			if !isModelTurn {
+				partItems = append(partItems, partJSON)
+				return true
+			}
+			if part.Get("toolCall").Exists() || part.Get("tool_call").Exists() || part.Get("toolResponse").Exists() || part.Get("tool_response").Exists() {
 				partItems = append(partItems, partJSON)
 				return true
 			}
@@ -161,6 +167,9 @@ func geminiContentsThoughtSignaturesNeedSanitize(contents gjson.Result) bool {
 				return !needsSanitize
 			}
 			if !isModelTurn {
+				return true
+			}
+			if part.Get("toolCall").Exists() || part.Get("tool_call").Exists() || part.Get("toolResponse").Exists() || part.Get("tool_response").Exists() {
 				return true
 			}
 			hasFunctionCall := part.Get("functionCall").Exists()

--- a/internal/signature/gemini_sanitize_test.go
+++ b/internal/signature/gemini_sanitize_test.go
@@ -261,3 +261,91 @@ func TestSanitizeGeminiRequestThoughtSignaturesRemovesFunctionResponseSignature(
 		t.Fatalf("functionResponse nested thoughtSignature should be removed. Output: %s", string(out))
 	}
 }
+
+func TestSanitizeGeminiRequestThoughtSignatures_PreservesToolCallAndResponseSignatures(t *testing.T) {
+	const liveCapturedToolCallSig = "ErUDCrIDCAISrQMBEU0yD9ECvDhSY1DQJNUGafArdfd2mDfO8VQq7XjLx/91zESuo0QPSdkRFWkLeVIocSQmQULonYMOJcs6XDLV2LTRC9myb3MCCP9CUoWbEeqhAvXKTScyS3nwBDDVJYuDDbY3YvR4V86T/DnU3qufpaVZ3wQOiJVyBVZ515dYTN+XGq7SuUc3RpfAqVU06jgxaCM0WKV4Df5mGMJWb25e/aFG2Jc7upSqpf3n6aElj+4c/eWr4GdKd0TUIElXBZ0HEN/vNcWzD3F0S4MeVbk1LDakL6HG6oyaSS2gocxYNYxqm9mdMHaXYa4mIYqWqmqBEnbgcHp8H4fgqBxc3Cx8C3otV8IarO5OALaVDA3NaXB1zjLet1587kEpkCNr9OvrYOES2nCl/i4EgbPK01nlXo+Wwm5jsZU5nEG4/Z0bErzqC5TKwOsqpJ7afL2sPWI0IGrXhXL+QCumWCS5iUtwybSkL7CYSk9GC+iY+ev6FAmC4V5JEc4OaWOc9+m/29LniN/iPTSxtUQSZT94pUa3/irIIdH7ReAS3cpeM6OTvumR1PwNxXx3XM1mEGc="
+	sigModel := testGemini3ThoughtSignature([]byte{0x01, 0x0c, 0x39})
+
+	input := []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]},{"role":"model","parts":[{"toolCall":{"toolType":"GOOGLE_SEARCH_WEB","id":"1"},"thoughtSignature":"` + liveCapturedToolCallSig + `"},{"toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","id":"1"},"thoughtSignature":"` + liveCapturedToolCallSig + `"},{"functionCall":{"name":"f","args":{}},"thoughtSignature":"` + sigModel + `"}]}]}`)
+
+	out := SanitizeGeminiRequestThoughtSignatures(input, "contents")
+
+	if got := gjson.GetBytes(out, "contents.1.parts.0.thoughtSignature").String(); got != liveCapturedToolCallSig {
+		t.Fatalf("toolCall thoughtSignature = %q, want %q. Output: %s", got, liveCapturedToolCallSig, string(out))
+	}
+	if got := gjson.GetBytes(out, "contents.1.parts.1.thoughtSignature").String(); got != liveCapturedToolCallSig {
+		t.Fatalf("toolResponse thoughtSignature = %q, want %q. Output: %s", got, liveCapturedToolCallSig, string(out))
+	}
+	if got := gjson.GetBytes(out, "contents.1.parts.2.thoughtSignature").String(); got != sigModel {
+		t.Fatalf("functionCall thoughtSignature = %q, want %q. Output: %s", got, sigModel, string(out))
+	}
+}
+
+func TestSanitizeGeminiRequestThoughtSignatures_SkipsToolCallAndToolResponseParts(t *testing.T) {
+	// Server-side tool blocks (toolCall and toolResponse) carry their own signatures/envelopes
+	// that must be echoed back to the API untouched.
+	const arbitrarySig = "arbitrary_opaque_tool_sig_value"
+	input := []byte(`{"contents":[{"role":"model","parts":[
+		{"toolCall":{"toolType":"GOOGLE_SEARCH_WEB","args":{}},"thoughtSignature":"` + arbitrarySig + `"},
+		{"toolResponse":{"toolType":"GOOGLE_SEARCH_WEB","response":{}},"thoughtSignature":"` + arbitrarySig + `"}
+	]}]}`)
+
+	out := SanitizeGeminiRequestThoughtSignatures(input, "contents")
+
+	if got := gjson.GetBytes(out, "contents.0.parts.0.thoughtSignature").String(); got != arbitrarySig {
+		t.Fatalf("toolCall thoughtSignature = %q, want preserved %q", got, arbitrarySig)
+	}
+	if got := gjson.GetBytes(out, "contents.0.parts.1.thoughtSignature").String(); got != arbitrarySig {
+		t.Fatalf("toolResponse thoughtSignature = %q, want preserved %q", got, arbitrarySig)
+	}
+}
+
+func TestSanitizeGeminiRequestThoughtSignatures_SkipsSnakeCaseToolCallAndResponseParts(t *testing.T) {
+	// Defensively ensure snake_case tool_call and tool_response variants are also skipped
+	const arbitrarySig = "arbitrary_snake_tool_sig"
+	input := []byte(`{"contents":[{"role":"model","parts":[
+		{"tool_call":{"tool_type":"GOOGLE_SEARCH_WEB","args":{}},"thought_signature":"` + arbitrarySig + `"},
+		{"tool_response":{"tool_type":"GOOGLE_SEARCH_WEB","response":{}},"thought_signature":"` + arbitrarySig + `"}
+	]}]}`)
+
+	out := SanitizeGeminiRequestThoughtSignatures(input, "contents")
+
+	if got := gjson.GetBytes(out, "contents.0.parts.0.thought_signature").String(); got != arbitrarySig {
+		t.Fatalf("tool_call thought_signature = %q, want preserved %q", got, arbitrarySig)
+	}
+	if got := gjson.GetBytes(out, "contents.0.parts.1.thought_signature").String(); got != arbitrarySig {
+		t.Fatalf("tool_response thought_signature = %q, want preserved %q", got, arbitrarySig)
+	}
+}
+
+func TestSanitizeGeminiRequestThoughtSignatures_DropsForeignSignatureOnTextPart(t *testing.T) {
+	// An arbitrary unknown or foreign signature on a model text part must be dropped
+	// to prevent upstream Gemini 400 "Corrupted thought signature" errors.
+	const foreignSig = "claude_or_invalid_signature"
+	input := []byte(`{"contents":[{"role":"model","parts":[{"text":"answer","thoughtSignature":"` + foreignSig + `"}]}]}`)
+
+	out := SanitizeGeminiRequestThoughtSignatures(input, "contents")
+
+	if gjson.GetBytes(out, "contents.0.parts.0.thoughtSignature").Exists() {
+		t.Fatalf("expected foreign signature on text part to be dropped, got %s", string(out))
+	}
+}
+
+func TestSanitizeGeminiRequestThoughtSignatures_MixedToolCallAndUnsignedFunctionCall(t *testing.T) {
+	// In a mixed turn with toolCall and unsigned functionCall, the toolCall signature
+	// must be preserved, and the first functionCall must receive the bypass sentinel.
+	const toolSig = "ErUDCrIDCAISrQMBEU0yD9ECvDhSY1DQJNUGafArdfd2mDfO8VQq7XjLx/91zESuo0QPSdkRFWkLeVIocSQmQULonYMOJcs6XDLV2LTRC9myb3MCCP9CUoWbEeqhAvXKTScyS3nwBDDVJYuDDbY3YvR4V86T/DnU3qufpaVZ3wQOiJVyBVZ515dYTN+XGq7SuUc3RpfAqVU06jgxaCM0WKV4Df5mGMJWb25e/aFG2Jc7upSqpf3n6aElj+4c/eWr4GdKd0TUIElXBZ0HEN/vNcWzD3F0S4MeVbk1LDakL6HG6oyaSS2gocxYNYxqm9mdMHaXYa4mIYqWqmqBEnbgcHp8H4fgqBxc3Cx8C3otV8IarO5OALaVDA3NaXB1zjLet1587kEpkCNr9OvrYOES2nCl/i4EgbPK01nlXo+Wwm5jsZU5nEG4/Z0bErzqC5TKwOsqpJ7afL2sPWI0IGrXhXL+QCumWCS5iUtwybSkL7CYSk9GC+iY+ev6FAmC4V5JEc4OaWOc9+m/29LniN/iPTSxtUQSZT94pUa3/irIIdH7ReAS3cpeM6OTvumR1PwNxXx3XM1mEGc="
+	input := []byte(`{"contents":[{"role":"model","parts":[
+		{"toolCall":{"toolType":"GOOGLE_SEARCH_WEB","id":"1"},"thoughtSignature":"` + toolSig + `"},
+		{"functionCall":{"name":"my_func","args":{}}}
+	]}]}`)
+
+	out := SanitizeGeminiRequestThoughtSignatures(input, "contents")
+
+	if got := gjson.GetBytes(out, "contents.0.parts.0.thoughtSignature").String(); got != toolSig {
+		t.Fatalf("toolCall signature = %q, want preserved %q", got, toolSig)
+	}
+	if got := gjson.GetBytes(out, "contents.0.parts.1.thoughtSignature").String(); got != GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("functionCall signature = %q, want bypass %q. Output: %s", got, GeminiSkipThoughtSignatureValidator, string(out))
+	}
+}

--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -37,12 +37,13 @@
 //     traceable to a prior Gemini model response in the same conversation.
 //   - Opaque-shape tier: for real Gemini signatures, require a non-empty string,
 //     bounded length, successful standard base64 decoding, and a known protobuf
-//     envelope when the caller needs provider compatibility. The only known
+//     envelope when the caller needs provider compatibility. The known
 //     envelope is the Gemini 3.x field-2 -> field-1 payload, whose body holds
-//     either versioned opaque state or a provider UUID. Gemini 2.5 emitted a
-//     repeated field-1 form; those models are out of scope and their signatures
-//     are no longer a known envelope. Bare base64 UUID payloads are classified
-//     separately and should be replaced with the bypass sentinel rather than
+//     versioned opaque Tink state, a provider UUID, or a nested protobuf structure
+//     wrapping Tink ciphertext for server-side tool invocations (toolCall/toolResponse).
+//     Gemini 2.5 emitted a repeated field-1 form; those models are out of scope and
+//     their signatures are no longer a known envelope. Bare base64 UUID payloads are
+//     classified separately and should be replaced with the bypass sentinel rather than
 //     replayed.
 //   - Replay tier: real validation means preserving the exact model part that
 //     came from Gemini, including its thoughtSignature, id/name/function args,
@@ -472,7 +473,7 @@ type geminiEnvelopeInfo struct {
 
 func inspectGeminiField2Envelope(decoded []byte) (geminiEnvelopeInfo, bool) {
 	value, ok := consumeGeminiField2Field1Value(decoded)
-	if !ok || (!isLikelyGeminiOpaquePayload(value) && !isASCIIUUIDBytes(value)) {
+	if !ok || (!isLikelyGeminiOpaquePayload(value) && !isASCIIUUIDBytes(value) && !isLikelyGeminiToolInvocationPayload(value)) {
 		return geminiEnvelopeInfo{}, false
 	}
 	return geminiEnvelopeInfo{
@@ -527,6 +528,59 @@ func isLikelyGeminiOpaquePayload(value []byte) bool {
 	// rate against a caller that reproduces the protobuf envelope but not the key
 	// material; provenance or target scoping, not more byte checks, closes that gap.
 	return len(value) > 0 && value[0] == 0x01
+}
+
+func isLikelyGeminiToolInvocationPayload(value []byte) bool {
+	// In Gemini 3 Tool Combination / Context Circulation, server-side tool blocks
+	// (toolCall and toolResponse) wrap the Tink ciphertext in a protobuf message
+	// containing a length-delimited bytes field whose content is a valid Tink payload
+	// starting with 0x01 (commonly preceded by a status/type varint field).
+	// Validate that value is a valid protobuf structure containing at least one
+	// length-delimited bytes field whose content is a valid Gemini Tink payload.
+	if len(value) == 0 {
+		return false
+	}
+	offset := 0
+	hasTinkField := false
+	for offset < len(value) {
+		_, typ, n := protowire.ConsumeTag(value[offset:])
+		if n < 0 {
+			return false
+		}
+		offset += n
+		switch typ {
+		case protowire.VarintType:
+			_, n = protowire.ConsumeVarint(value[offset:])
+			if n < 0 {
+				return false
+			}
+			offset += n
+		case protowire.BytesType:
+			bytesVal, n := protowire.ConsumeBytes(value[offset:])
+			if n < 0 {
+				return false
+			}
+			offset += n
+			if isLikelyGeminiOpaquePayload(bytesVal) {
+				hasTinkField = true
+			}
+		case protowire.Fixed32Type:
+			_, n = protowire.ConsumeFixed32(value[offset:])
+			if n < 0 {
+				return false
+			}
+			offset += n
+		case protowire.Fixed64Type:
+			_, n = protowire.ConsumeFixed64(value[offset:])
+			if n < 0 {
+				return false
+			}
+			offset += n
+		default:
+			return false
+		}
+	}
+	return hasTinkField && offset == len(value)
 }
 
 func isASCIIUUIDBytes(decoded []byte) bool {

--- a/internal/signature/gemini_validation_test.go
+++ b/internal/signature/gemini_validation_test.go
@@ -104,6 +104,69 @@ func TestInspectGeminiThoughtSignature_AcceptsCapturedGemini31FlashLiteEnvelope(
 	}
 }
 
+func TestInspectGeminiThoughtSignature_AcceptsServerSideToolProtobufEnvelope(t *testing.T) {
+	// Real live capture from Gemini 3.8 Flash toolCall (googleSearch)
+	const liveCapturedToolCallSig = "ErUDCrIDCAISrQMBEU0yD9ECvDhSY1DQJNUGafArdfd2mDfO8VQq7XjLx/91zESuo0QPSdkRFWkLeVIocSQmQULonYMOJcs6XDLV2LTRC9myb3MCCP9CUoWbEeqhAvXKTScyS3nwBDDVJYuDDbY3YvR4V86T/DnU3qufpaVZ3wQOiJVyBVZ515dYTN+XGq7SuUc3RpfAqVU06jgxaCM0WKV4Df5mGMJWb25e/aFG2Jc7upSqpf3n6aElj+4c/eWr4GdKd0TUIElXBZ0HEN/vNcWzD3F0S4MeVbk1LDakL6HG6oyaSS2gocxYNYxqm9mdMHaXYa4mIYqWqmqBEnbgcHp8H4fgqBxc3Cx8C3otV8IarO5OALaVDA3NaXB1zjLet1587kEpkCNr9OvrYOES2nCl/i4EgbPK01nlXo+Wwm5jsZU5nEG4/Z0bErzqC5TKwOsqpJ7afL2sPWI0IGrXhXL+QCumWCS5iUtwybSkL7CYSk9GC+iY+ev6FAmC4V5JEc4OaWOc9+m/29LniN/iPTSxtUQSZT94pUa3/irIIdH7ReAS3cpeM6OTvumR1PwNxXx3XM1mEGc="
+
+	info, err := InspectGeminiThoughtSignature(liveCapturedToolCallSig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true})
+	if err != nil {
+		t.Fatalf("captured Gemini 3.8 Flash server-side toolCall envelope should be known: %v", err)
+	}
+	if info.Envelope != GeminiThoughtSignatureEnvelopeProtobufField2 {
+		t.Fatalf("Envelope = %q, want %q", info.Envelope, GeminiThoughtSignatureEnvelopeProtobufField2)
+	}
+	if !info.KnownEnvelope {
+		t.Fatal("KnownEnvelope should be true for server-side toolCall envelope")
+	}
+	if provider := DetectSignatureProviderForBlock(liveCapturedToolCallSig, SignatureBlockKindGeminiModelPart); provider != SignatureProviderGemini {
+		t.Fatalf("DetectSignatureProviderForBlock = %q, want %q", provider, SignatureProviderGemini)
+	}
+}
+
+func TestInspectGeminiThoughtSignature_RejectsMalformedToolInvocationPayload(t *testing.T) {
+	// 1. Truncated protobuf
+	truncated := testGemini3ThoughtSignature([]byte{0x08, 0x02, 0x12, 0x10, 0x01}) // declares 16 bytes, only gives 1
+	if info, err := InspectGeminiThoughtSignature(truncated, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil && info.KnownEnvelope {
+		t.Fatal("truncated inner protobuf payload should not be a known envelope")
+	}
+
+	// 2. Valid protobuf without Tink 0x01 prefix in any bytes field
+	noTink := testGemini3ThoughtSignature([]byte{0x08, 0x02, 0x12, 0x04, 0x99, 0x98, 0x97, 0x96})
+	if info, err := InspectGeminiThoughtSignature(noTink, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil && info.KnownEnvelope {
+		t.Fatal("protobuf payload without Tink 0x01 prefix should not be a known envelope")
+	}
+
+	// 3. Protobuf with pure varint, no bytes field
+	pureVarint := testGemini3ThoughtSignature([]byte{0x08, 0x02, 0x10, 0x05})
+	if info, err := InspectGeminiThoughtSignature(pureVarint, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil && info.KnownEnvelope {
+		t.Fatal("protobuf payload without length-delimited bytes field should not be a known envelope")
+	}
+}
+
+func TestValidateGeminiFunctionCallPairing_AcceptsServerSideToolBlocks(t *testing.T) {
+	input := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"toolCall": {"id": "search_1", "toolType": "GOOGLE_SEARCH_WEB"}},
+					{"toolResponse": {"id": "search_1", "response": {}}},
+					{"functionCall": {"id": "call_1", "name": "do_something", "args": {}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"id": "call_1", "name": "do_something", "response": {"result": "ok"}}}
+				]
+			}
+		]
+	}`)
+	if err := ValidateGeminiFunctionCallPairing(input); err != nil {
+		t.Fatalf("pairing validator should accept server-side tool blocks alongside functionCall: %v", err)
+	}
+}
+
 func TestInspectGeminiThoughtSignature_AcceptsGemini3WrappedUUIDEnvelope(t *testing.T) {
 	const providerUUID = "e24830a7-5cd6-42fe-998b-ee539e72b9c3"
 	sig := testGemini3ThoughtSignature([]byte(providerUUID))


### PR DESCRIPTION
## Problem
Fixes #5652.

When a Gemini 3 request carries both a server-side tool (e.g. `googleSearch` / `GOOGLE_SEARCH_WEB`) and a custom client tool (`functionCall`), replaying that model turn fails upstream with:
```text
400 contents[1].parts[0]: Tool call part is missing thought_signature
```

### Root Cause
1. **Validation**: Server-side tool parts (`toolCall` / `toolResponse`) in Gemini 3 wrap the Tink AEAD ciphertext inside an inner Protobuf envelope (Field 1 varint `0x08` + Field 2 bytes `0x12` containing `0x01...`). `isLikelyGeminiOpaquePayload` only checked `payload[0] == 0x01`, which failed on the outer tag `0x08`, classifying the legitimate signature as an unknown envelope.
2. **Sanitization**: In `SanitizeGeminiRequestThoughtSignatures`, unrecognized signatures on non-functionCall parts fell through to `SignatureActionDropSignature`, dropping the `thoughtSignature` on `toolCall` and `toolResponse`.
3. **API Contract**: Unlike client-side `functionCall` where Google whitelists `"skip_thought_signature_validator"` for synthetic/migrated history, Google strictly validates server-side tools against genuine Tink ciphertexts and rejects `"skip_thought_signature_validator"` on `toolCall` with `400 Request contains an invalid argument`. Per Google's v1beta Discovery document contract (`Part.toolCall`: *"The client is expected to echo this message back to the API"*), server-side tool blocks must be echoed back verbatim.

## Solution
1. **Recognition (`internal/signature/gemini_validation.go`)**:
   - Implemented `isLikelyGeminiToolInvocationPayload` to parse inner Protobuf tags, verify wire format validity, and detect nested Tink ciphertexts starting with `0x01`.
   - Wired into `inspectGeminiField2Envelope` so server-side tool signatures are correctly classified as `SignatureProviderGemini`.
2. **Sanitization (`internal/signature/gemini_sanitize.go`)**:
   - Added early short-circuit skip in `SanitizeGeminiRequestThoughtSignatures` and `geminiContentsThoughtSignaturesNeedSanitize` for `toolCall`, `tool_call`, `toolResponse`, and `tool_response` parts.
   - Preserved existing sanitization rules: first `functionCall` gets the bypass sentinel when missing/incompatible, sibling calls remain unsigned, and unrecognized foreign signatures on normal `text` parts are dropped to prevent upstream `400 Corrupted thought signature` errors.
3. **Tests**:
   - `gemini_validation_test.go`: Added test for live-captured Gemini 3.8 Flash Google Search `toolCall` envelope; added negative tests rejecting malformed/truncated payloads; added `ValidateGeminiFunctionCallPairing` test accepting server-side tool blocks alongside function calls.
   - `gemini_sanitize_test.go`: Added tests verifying preservation of `toolCall` and `toolResponse` signatures (both camelCase and snake_case), mixed turn behavior (`toolCall` preserved + unsigned `functionCall` gets bypass sentinel), and foreign signature stripping on `text` parts.

## Verification
- Unit tests: `go test -race ./internal/signature/... ./internal/translator/gemini/...` (PASS)
- Build verification: `go build -ldflags="-s -w" -o /dev/null ./cmd/server` (clean)
- End-to-end: Replayed real Turn 2 request with `toolCall` (Google Search) + `toolResponse` + `functionCall` through CLIProxyAPI to Google AI Studio, successfully returning HTTP 200 OK.