### PR TITLE
feat(signature): validate Claude CAQS reasoning signatures

### DIFF
--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -163,6 +163,9 @@ func TestStripInvalidClaudeThinkingBlocks_KeepsClaudeSignaturePrefixes(t *testin
 
 const observedFable5Sample = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
 
+const observedFable51CAQSSample = "CAQSwyAKEAgRGAI4AUIIdGhpbmtpbmcSDFt2zxT+tnYKOGXVWBoMBoVUWi2LD4EMTL6gIjCANUNtuYZhGTmRFOcayglOsTTLug6XvH4RjT7VqyDRQ1vioEo6QPEo0A9y7WwSFTMq4B8XkscTE8yH4vRwM4byMhSSlAdSRCPOsKjbS/+4yM0MKF6rSlYZKodJ+xaSACMCRp5xHFRZ97nE9Jdaoi2ucQUY0CFT8TmLEspjAvBi73P7JwVx9bzdUTQkGeHP9CMuRad6mSvduMpl+YXDLEbcTcKbcteGAet04cD/LnkIUMQuA69LayQ/RacFDEBhSfMXzfF3Z8OBCqPTNJRg+iQ7oRB0KTM1ZDCqnTU5fsDPL+/pDw2U6IrEB2/60g2gEJefIJdKUUidDKWLgVks9eo/Mlzj5A0mncUwFazcMyxPaYSyqVkEh87jCkhY+lSL4vy6xtpt3EkGD69s/hy/pABGCOB4sSG9Go3j5NvthhyJ8Hesz+7B2cHmSeaS0fOhzkepMQiG7MwoGfJRHFGHmL0OIU2Ow8FAc7iOcgAu3P4DkD6NDdBM/PCJMHEpfxeVldfCYXiL3n4/CULfnbU403ZI/KKkFNgztkHZzOFyFwBn40gxZ65cK/eHpLY2Ezv79/FAiz6MYHx/WFgTz1NjWng/RMxESU9WaD601UYtU+ixGnk3OqrRM8CBY6H3+uYWVuLHsWYJJM2EnXfl8Nocq3TJSAED2zVGfaPilSBAdI75SNKj2OX5VOCdNxrpUqbDMgpZnudMHhvHQmsdjN1RebcAhVy0EDmue1w/SqcXkrox32kjRQoSfIRbhPfKOjzrX6IFLe7Wb3/PTIu13irnEqMgU8K09J9BtmFMLeD6hlnIabN8uGyztXRC2oHN/8dn/TWmOXnpH1s/DdCfUKT1x+ZL8ekgRFprVZA2+BqXmwK4wijw72FN/Y9MnOU3DpMVoNda8XgGyfLJykMh0c0fTOUgTf0wMeg66cPPTeEEHaigy3RYu/tAcNcGXjXT5z1QyshJ61I7baaqsMXOa083dvor/M5oIitsx4wbli0qRh7VI4O0o3BuuhaEKKsTxfrD2YgC4zippmzk6sMu/gHs86l56D/o0Uyd2pjhWc8vUmPxo/g182c4ZF/03lec3KmRKux3QCFwG/7eQF201wQ21J3tv1/06SVCv3Djb8TCn+Zg2dutkWH6tn+hKA3ZzQeoCznWcQ3U0nAsn82kaYnKLHAJ5lg/1AlPdnesqhp8OaAD4b07BUiY9MYGEF1cpGYvrGbMU4ayu6I2BozEi9FC0HtSU9yx0MI6ZETRDr/w6sp14BHPVR3RkZ706+WmrWBjOpwgZQG+6Fz8s0JlQa9P2h7OgYMo6LZQXaKjtXM6/C8663b0iIN+KSxqCE9JGd6jSIeiySmvHDSXAzrAMQF0N+lQpNHRW5R4H1/9sGjwtETQjSSpP8kZw37v6zmB1j3zKeobn4IDGALQVuQL93BKWTlBuNs1GGE4i6rtSPJJM8HspxO8MJJL9JdreCnCiWuIaEDiEdw/VmYCATpzagaomCxYJGL0QzjJzgH6MwlcuH+XKzM7+sbDOQqj0S47jvqGwGxDmglAiNEXQVTJEe2Td2UCWNTMEOlW0Q59w5w8Tb8c4otIHHzIqcntHVKzD5MxR8Ol1k1TPREA2aDpX9TCHvjG46GYwfzGVL7cptq7QTLeS9Ye2gcTzDCro9j7RvJVj3ZORo87+alkSg3wJaHQEGW2Cd7HBK/N1SF9HvpwzmSgwKx+6+uPq0/0ilvFVOarqMqi6a6IrLEey7jFO9HhpdJLIEiOcbfd+l8hXd1ylGBKR+puzpW5AL2EIQdCN67IU2FCrod2t7tjDumVm0Noua/l728lausvZNDwy6nHwyJ8PXZeFwDh2kvuLhpOWOIgzubuJTnZV5RM59pFa6VJncCT8WpxDJKo90wApoGuunfLm+Oi/NnWS3dQAQHXnnzWh+Q5+0wF3oKAY/JXpm8BF/GJFp7IxUcFUfItNw+jXTfF49JzVzC5YWE+OufFVU3v4jvdASvdMym4BzvKT+x/ZT0wClD8vdIJ97vYvPDRxi3b/suOr1WKTh3OORZEEvhG8Sje4KGYezS2m3CpapuGDlVqQJUAXhCZo92YGSqw28Wzz4BPz0hHhFjJyUrsO8A0GxjXzLt/GDW3mxNiDn/3NkltJW98KzZOyOAAHOYPDhyGmoLXFOfRbCMl58FZhT2aQHqc4Qdh3pI1tyZbEAn/ScoiVl7zo1wCZRudIAxioLs36wCka94Of3Z3AHB6c5ZdPwhOlT7pfxhDVOpl9k8qSV3lAZkloDcsFPYp9Jvw3S7hXII3/wD+NEVFoAWYbVg5XRpeNAjklhIKXQ7Q9N7WA7BkjD1+KA7wGUTg6oCw1Y2wg5vZua2dq12HQ9vuwrIgtyQiM2pdcTIuW5jOpO1RI+Fkl6eAp1FRcoTxP8Up92OzUsQ/g4E7x4Tf0fs7YttsMID2IkpbZSoOUC9ZplyHwv0lYdbYVaLjgESvsUX2n0KxyquHFxb91RM+0ic5Hz31ABnSt3V3Z1iy/0C8QDrFjgGfhXWh2XblAyl/htf5awVHkcmVUoUnGQdXGiuK0hKLqaivvlDxRXN5W1IaiK0mxyTtUdkVH491LST7077B9CCLyuM4RQSd7oUYxwSGHhyjz+cuYyjA46fExAjLSNyzr4Fn8DYy0rtCrzGCzDvv37iZRQ63b5cWWooFtpGve5dm34sY6qFpbbx6mCCeufjJ2AOmYBNu6q+Pr9GFkrJWiKtVRSbOfOfp9l4t/2hkeHeI7piq+qkLcJIOUld4V+Ov0zhX7+qE04jkshnrEnYWob4Aowv7c5Lz7/kx0g2i7CHu8NVT/dotU+UP20QbFkwMyAnWsehU9zUQc4Q/qodIIFJP7IPFK4db3XtJdLjZ2Zcib11Rwq1vwu2sqEsRlVGGoGw96pFeB17W0hiuWsFfOf+FKVHkFgzFOeLTjs14l9EEzVd7wSIiThvJTrYt0Sdd1ZNjCEtmHHRDtfRX0JxazjPacGCrnh6UOKWDCzQoVn5FdkjhebOkj38qbn0ocQkoq0AoliX2ZZZeIna1mdcaSBVDpDtbhpYVsTAoqXVMLjZQVotYUdUWJAOC+5zXRIRylBTmr26wMJErFv+khKj0LhRg2jDPCYf44XLT0quJ2TM2kL4UUaI0N7xMmz87mQCk1mgge6mx0hOvCVT2oIt11iLXCfe+bA4rITTRMkm2ElagQCwXxuTYobZC8bDEiacWA8Nwul2BOLaEGu9GDx02Wzc4h+rglTwLqry/eoCo92abjfEbeTHlZbAKQQRPfTOELcgMxm9VsqQJgjA6tloEfeLxxoZW+bbvBLcbODZik44mfZIjgAJBod+Ow3xHtwtH4yDPWDjQkqP0KDjxqYTjTJnZVKJX2l2oIYPlUtfr1c6eA1jis1KSo60z8LLIO3nx/ryhdt5SGJPMONZMBNKeu895Ksp41zhTL4PlQtFXK0zW/V6j+a1LO+Xrk96rEQ1oXIqta7ameAT+2wk7jfDxtZncfWIZAKhHV/sYqVAI/NO9ch6VEKb71vHLGu0W0Cp4H/jhe4FB8e50Q2znydKpLGV6vypldo3S1kJbxuwYy+mgslw3sIgGsfKm649DXxOFdZWhwU5fjLor7FJiC9SLZf81qEfV7HgcJl36MZRqU7x1Fs2Kr6n5pwxeAT8lcJI6AsTAeziAyrlzldijmwNBnlafwifi2dI7az79YTMmblqBO622yO21BaSG/SgPIrGT0gd3j90o3P2F9eUrncOhvhOgD6fdlBJsdVGp8C1JR9luNDKTviJQb1AQWIplArFdRbgUk8mPW/voa7Pyb1B7lCK+S7PX9i8w1s2Q5B7rjiLZUyUsROCL/to6I/3TUIMiS/XtMoXl+aJihbTzr/GYKOZ4zy60mTXmRagjJCbQf2qavrx/nDNrwGfVKR9OTtH20YpZ7HmneQpDhijpA8lu7QZNupMMdQpnra4SStwJownqjGkDDa2LFFWhGFz4oJ/yyHE3WkkKxTTkfg2vZ45D1OV/gTgWn+l9ZLqxrj92mcnalj+bzB/mAHFOqCqgW5cdxyNtVRHva53/UbzURwbhd837Xlyxl/i9f8k/oSS50m3wziustYoV5BfERFwk7pLfCkxqLxqIXoTwozCmokyiIMEK7NS9W1RM2SFqOrDPT5sCt6de1EZ8hNeTVihwSmljepOlmpQhopxEsaj+pEMcocvhVSAqzabagwvEI8BNlLkK8TdytRBgA0EXdsE9tFIxsH9uEWfzCTDlePUyMYMTtIY/c/2B1oByua4Y2EDs9lzPWwq47ck6KnxJhgFdLQ/yFQAoBXuuy27GBIQO9LlJqpS2JNNUR9etILS8qPfJAmYnVuf/Cgx1vuJAfn3Q9RsDbwYKTIf3XvYwjZkPfBWlbnm/f6KpIfIMQIu9KywQQmA66hY2gauU53739BicCQhOFNi3mM3EACK57GO9d186MWBcOjClYGW/JXuDAO8MzRyDE5XD9g4l5yX6qyeiPLM7jTXwRZo0SQVnN28q+8iU46tO1FoHDkdcT0r0lemF7/SX64dUbrKsYE5pLWWYpTWgUeJL1HuVewMTjJ3oybL7pMezb0CjR6uXTJQ1b2raUX4sMW0aPjsxI94xwu08kdTIoYsvsOBEVABSz01HlCEhwn6yV9h/Y+XRKAVcUzLnem8tNVE6ZrY55VXYK/G6M3boRP+miUeA2d17QbO5OLAoU6ghk3uE+DHnkL7QdSFhtv/7+uxJwY6TBXrpCoPxnTuxMlIzpmiPoafyf34Ois9AgLMBeqD50q7vzpRUmIQQjG792zjtvMZdF3mqVgUoIlcCpLGqMIskaawTznHVpB0A9kZoLoCCAoRGJP2ka81q9xHTuBqp1NomVX5h4Dl8ISoo+ZzesBUQVXice1f9w6ziTbTabF/EynrvKVvE/6B0qvQx6yzO8+HFKUOo9h7LtYQnNmXNnxxFQ0Ga+j0OPGD5TQjlY0RO9Vq0Jl3kHM849iYdt5+Dc0ZZJBJSEAXwMpfiKPPQ13I2K71WbUVkeARXA+7rKysafQ2T5tHbbNA7uigRq0Yp8PVKR8hGRaEqUczOX9FpgdNNy7OKDFqSjeDi6SwGvz3DAN9XLQWw/GszjBIGm6bf5uFx1fEX2C9Ka1aeJbMiGewuymR3bEYr7HlPQyYHtoC9rrF22Y5cwO3dRKqeGm7zIdn7pPaYfZ5Pjz9NBBYwP+zkZEwO1XMQExpBSmyOuUume2lPin55WWr7LN3lTVWN2GIr7yfQsHerW5mXiWrJH1XFB4aViQ9HQaOzhDI4kBJj53WmhzbCoYsWmJf4P15s3c8egsfsrbGru7DTzYghUKTe6iIH5bCdQmtRqZoR2902AqW6Z63JQcnR1tX4Ew6si7cAFI/Y9uytmBjQcUBCbNDdKQQag1C2PuOAfd/ST7KWmaT4Atu33Opeh3ewtBC3RrriuKLNj5o4aQRpu8PQtelRsBmQCtwLcOeSyNLcxXZXiRgB"
+const observedFable51CAQSNarrationSample = "CAQS1wcKEQgRGAI4AUIJbmFycmF0aW9uEgx5LrAwGWmNqIuLoPoaDCz9ejHfn6/z4XQk9SIwhyZlO5uaOp3VmdX3F7fs7KEDyPDqwVnN7xaSmeJOV5Arz+KM6Jxjf9GCXPbFBh9UKvMGF85qvThSqk2AZdjBT+OH4tN1F9puuxtUcp9vlwta78FgdgwUxd6/h0gD2r+5lEUJ9XfwxBvSi3X6fBGoHh+GV/3b0bQKutA7FgmvO7x6s5oAYg4EKs7CSkIOnkwo3g1ahX43xHjkaMsQeoziouORPGM6kCWq9E2TpwhEse3ouQ6PzvbTkj2W/vOhy2RVDXf5qvS/zt4w488A17nI5z8upoVvO0rmY5KQhaZRuAOmjMUqnFyNAZzikwNo9O8ukArtXkSWkGjbIbJ4rd1cX0zdYzmTE8Nos/LroXsqB2Dk7GxZn2TP6uqtoLL/6aowhC+yYOYPeSobtERH9AUuAgBEZk0vGHR+viVeJf6cCm2dFQtv0hEYgPlgcSwoDiKrMq7fOEiBkpM8QD114FR39f0C8cJemOScabiaToHE75grwQx1NVoBjYRHNb/sftU3tnSiiqhsCTxxZVYtB5p4WLhLH21KeI7Fjs1DQhXv9MwfByAHJXusYsQ4SPwAUYnxn+NN/XzN/0OeCxz+CtUo1QD9q4LU/tWM58EcA/y1sAUE9p+6ILvXYQ9bitNf8RQFzp9hNCFWKgiuRtKTGKGI2PEaWOUp7Lmo8LM1DeFyKU4RiylXXKEdhS53WoK+gY0/iwJPBMoFZv+EAWZCGxOfYjgv51XVTl2tHLCwevmuSQqzdZSdKtuyoheaDaAblRJNwK/8CngwAZk8ef+CCdM5lCFkZ4dKVrmbSDBGi5PZDkY185oRVqVWO1VyiqjQ4AfwMp3vYE+vDlI+ylm72KU4TqScVgSm/SUGVsER7Wg5Kuqgb7fOvPhPVX6/C4v7sfUwejjax0T7JFXqlUGqxP8yGUck2PA9XPeZXFpuQVmhuWgWp4lWAWCQggvMnhQILFojjxnIwvA8v16n3FpK8ZODxQ2hlg6NJBai5S3OdSxGIR30io4g24rfSkXinMoaofM6VSUeUs0io05byPmuGocGoC6ivpnU+rOuIR5ShNHiIuPQl1PMfuPxzOPPMu4GyuFO659GTqtyokntivgIGtS1XC/2CX/sp42A3gflhPR7oZmtnAOFUm3mQT94SU9dGUTT06eXyx4g+4VaiW6keFOAJ6dfa6PMd0MUJc0z/nXmpzEFr3gZJo8FUrpTyw/HTTq5RVbvPnxAz5ZAcVMJy10t0hwS0Qyf5xgB"
+
 const observedContextID = "d9743975-4bb0-4936-9e28-d5b0d21bdc48"
 
 // claudeCAISParts builds Claude CAIS signatures field by field so tests can
@@ -293,6 +296,103 @@ func TestClaudeCAISSignature_ObservedFable5Sample(t *testing.T) {
 	}
 	if info.FirstByte != 0x08 {
 		t.Fatalf("FirstByte = 0x%02x, want 0x08", info.FirstByte)
+	}
+}
+
+func TestClaudeCAQSSignature_ObservedFable51Sample(t *testing.T) {
+	if !IsValidClaudeCAISSignature(observedFable51CAQSSample) {
+		t.Fatal("IsValidClaudeCAISSignature(observedFable51CAQSSample) = false, want true")
+	}
+
+	info, err := InspectClaudeCAISSignature(observedFable51CAQSSample)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+
+	if info.EnvelopeVersion != 4 {
+		t.Fatalf("EnvelopeVersion = %d, want 4", info.EnvelopeVersion)
+	}
+	if info.ChannelID != 17 {
+		t.Fatalf("ChannelID = %d, want 17", info.ChannelID)
+	}
+	if info.BlockKind != "thinking" {
+		t.Fatalf("BlockKind = %q, want %q", info.BlockKind, "thinking")
+	}
+	if info.FirstByte != 0x08 {
+		t.Fatalf("FirstByte = 0x%02x, want 0x08", info.FirstByte)
+	}
+	if info.SignatureLen != 4064 {
+		t.Fatalf("SignatureLen = %d, want 4064", info.SignatureLen)
+	}
+
+	if got := DetectSignatureProvider(observedFable51CAQSSample); got != SignatureProviderClaude {
+		t.Fatalf("DetectSignatureProvider(observedFable51CAQSSample) = %v, want %v", got, SignatureProviderClaude)
+	}
+}
+
+func TestClaudeCAISSignature_ObservedFable51CAQSNarrationSample(t *testing.T) {
+	if !IsValidClaudeCAISSignature(observedFable51CAQSNarrationSample) {
+		t.Fatal("IsValidClaudeCAISSignature(observedFable51CAQSNarrationSample) = false, want true")
+	}
+
+	info, err := InspectClaudeCAISSignature(observedFable51CAQSNarrationSample)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+
+	if info.EnvelopeVersion != 4 {
+		t.Fatalf("EnvelopeVersion = %d, want 4", info.EnvelopeVersion)
+	}
+	if info.ChannelID != 17 {
+		t.Fatalf("ChannelID = %d, want 17", info.ChannelID)
+	}
+	if info.BlockKind != "narration" {
+		t.Fatalf("BlockKind = %q, want %q", info.BlockKind, "narration")
+	}
+	if info.FirstByte != 0x08 {
+		t.Fatalf("FirstByte = 0x%02x, want 0x08", info.FirstByte)
+	}
+	if info.SignatureLen != 883 {
+		t.Fatalf("SignatureLen = %d, want 883", info.SignatureLen)
+	}
+
+	if got := DetectSignatureProvider(observedFable51CAQSNarrationSample); got != SignatureProviderClaude {
+		t.Fatalf("DetectSignatureProvider(observedFable51CAQSNarrationSample) = %v, want %v", got, SignatureProviderClaude)
+	}
+}
+
+func TestClaudeCAQSSignature_RejectsMalformedPayloads(t *testing.T) {
+	cases := []struct {
+		name      string
+		signature string
+	}{
+		{"invalid block kind", func() string {
+			decoded, err := base64.StdEncoding.DecodeString(observedFable51CAQSSample)
+			if err != nil {
+				t.Fatalf("decode sample: %v", err)
+			}
+			mutated := strings.Replace(string(decoded), "thinking", "unknown!", 1)
+			return base64.StdEncoding.EncodeToString([]byte(mutated))
+		}()},
+		{"unrecognized block kind", func() string {
+			decoded, err := base64.StdEncoding.DecodeString(observedFable51CAQSSample)
+			if err != nil {
+				t.Fatalf("decode sample: %v", err)
+			}
+			mutated := strings.Replace(string(decoded), "thinking", "redacted", 1)
+			return base64.StdEncoding.EncodeToString([]byte(mutated))
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsValidClaudeCAISSignature(tc.signature) {
+				t.Fatalf("IsValidClaudeCAISSignature(%s) = true, want false", tc.name)
+			}
+			if _, err := InspectClaudeCAISSignature(tc.signature); err == nil {
+				t.Fatalf("InspectClaudeCAISSignature(%s) succeeded, want error", tc.name)
+			}
+		})
 	}
 }
 

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -81,10 +81,12 @@
 // bytes. The payload is an opaque upstream-issued blob and rejecting it drops
 // the whole thinking block, so only the fields that actually identify the format
 // are required: the 0x08 marker, the nested container/channel block, the
-// signature bytes, and the "claude-" model text. Observed-but-incidental values
-// such as channel_id 16 or the "thinking" block kind are recorded for debugging
-// and checked only for wire type, so an upstream field bump cannot silently
-// erase conversation history.
+// signature bytes, and (for EnvelopeVersion < 4) the "claude-" model text. Observed-but-incidental values
+// such as channel_id 16/17 are recorded for debugging.
+//
+// In EnvelopeVersion >= 4 (CAQS, e.g. claude-fable-5-1 / claude-fable-5-1-max),
+// signature bytes are located in Container Field 5 (Field 2.5), plaintext model_text
+// is omitted, and block kind supports both "thinking" and "narration".
 //
 // # Which provider emits which envelope
 //
@@ -637,6 +639,7 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 	info := &ClaudeCAISSignatureInfo{FirstByte: decoded[0]}
 
 	var container []byte
+	var containerSignatureBytes []byte
 	err = walkClaudeProtobufFields(decoded, func(num protowire.Number, typ protowire.Type, raw []byte) error {
 		switch num {
 		case 1:
@@ -667,14 +670,20 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 
 	var channelBlock []byte
 	err = walkClaudeProtobufFields(container, func(num protowire.Number, typ protowire.Type, raw []byte) error {
-		if num != 1 {
-			return nil
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
+			if errField != nil {
+				return errField
+			}
+			channelBlock = value
+		case 5:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 5 signature bytes")
+			if errField != nil {
+				return errField
+			}
+			containerSignatureBytes = value
 		}
-		value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
-		if errField != nil {
-			return errField
-		}
-		channelBlock = value
 		return nil
 	})
 	if err != nil {
@@ -743,13 +752,19 @@ func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, 
 	if err != nil {
 		return nil, err
 	}
+	if !haveSignatureBytes && info.EnvelopeVersion >= 4 && len(containerSignatureBytes) > 0 {
+		info.SignatureLen = len(containerSignatureBytes)
+		haveSignatureBytes = true
+	}
 	switch {
 	case !haveChannelID:
 		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 1 channel_id")
 	case !haveSignatureBytes:
-		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 5 signature bytes")
-	case !haveModelText:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing signature bytes")
+	case !haveModelText && info.EnvelopeVersion < 4:
 		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 6 model_text")
+	case info.EnvelopeVersion >= 4 && info.BlockKind != "thinking" && info.BlockKind != "narration":
+		return nil, fmt.Errorf("invalid Claude CAQS signature: expected block kind \"thinking\" or \"narration\", got %q", info.BlockKind)
 	}
 
 	return info, nil

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -190,7 +190,7 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 	// Probes run from the strongest marker to the weakest:
 	//   1. GPT carries the literal "gAAAA" prefix, which pins both the version
 	//      byte and the high timestamp bytes.
-	//   2. Claude CAIS carries marker 0x08 plus a literal "claude-" model text.
+	//   2. Claude CAIS/CAQS carries marker 0x08 with nested container/channel structure.
 	//   3. Claude single/double-layer carries marker 0x12 plus the same literal.
 	//   4. Gemini validates wire shape only and has no literal to anchor on, so
 	//      it is the weakest judge and goes last.
@@ -392,7 +392,14 @@ func claudeCompatibleSignatureReason(targetProvider SignatureProvider, rawSignat
 	if err != nil {
 		return genericReason
 	}
-	reason := "valid Claude CAIS signature with embedded model " + info.ModelText + " is compatible with any Claude target"
+	var reason string
+	if info.ModelText != "" {
+		reason = "valid Claude CAIS signature with embedded model " + info.ModelText + " is compatible with any Claude target"
+	} else if info.EnvelopeVersion >= 4 {
+		reason = "valid Claude CAQS signature is compatible with any Claude target"
+	} else {
+		reason = "valid Claude CAIS signature is compatible with any Claude target"
+	}
 	if trimmedModel := strings.TrimSpace(targetModel); trimmedModel != "" {
 		reason += ", including target model " + trimmedModel
 	}


### PR DESCRIPTION
## Summary
Support Claude Envelope v4 reasoning signatures (encoded base64 prefix `CAQS`, `EnvelopeVersion == 4`, `ChannelID == 17`), observed on models such as `claude-fable-5-1` and `claude-fable-5-1-max`:

- **Container Field 5 Signature Extraction**: In Envelope v4, signature bytes (800B–4,000B+) were moved out of `Channel.Field 5` and into `Container.Field 5` (`Field 2.5`). Added a version-gated fallback (`EnvelopeVersion >= 4`) to extract signature bytes from `Container.Field 5` when absent in the channel block.
- **Omit Plaintext `model_text` Requirement**: For `EnvelopeVersion >= 4`, omitted the mandatory check for `model_text` (`Channel.Field 6`), which Anthropic has removed in this generation.
- **Dual BlockKind Support**: Allow both `"thinking"` and `"narration"` block kinds under `EnvelopeVersion >= 4`, matching live Anthropic wire emissions.
- **Traceability & Diagnostics**: Updated `claudeCompatibleSignatureReason` in `provider_compatibility.go` to provide clear reason strings without empty model name formatting when `model_text` is omitted.
- **Testing**: Added observed sample fixtures and unit tests in `internal/signature/claude_test.go` covering positive validation of `thinking` and `narration` CAQS signatures, as well as negative tests for malformed/unrecognized block kinds.

## Verification
- `go test -v ./internal/signature/...` passes cleanly.
- `go build -ldflags="-s -w" -o /dev/null ./cmd/server` builds successfully.