### PR TITLE
feat: add Trae CLI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ PackyCode provides special discounts for our software users: register using <a h
 - OpenAI Codex support (GPT models) via OAuth login
 - Claude Code support via OAuth login
 - Grok Build support via OAuth login
+- Trae CLI support by importing an existing local Trae login
 - Streaming, non-streaming, and WebSocket responses where supported
 - Function calling/tools support
 - Multimodal input support (text and images)
@@ -125,6 +126,18 @@ PackyCode provides special discounts for our software users: register using <a h
 ## Getting Started
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
+
+### Trae CLI
+
+Import the account already logged in by your local `traecli`, then start the proxy normally:
+
+```bash
+traecli login status
+./CLIProxyAPI --trae-login
+./CLIProxyAPI --config config.yaml
+```
+
+The import stores only references to Trae CLI's local state and its model catalog; it does not copy the access token into CLIProxyAPI's auth file. By default it discovers `traecli` on `PATH` and reads `~/.trae/cli/auth.json`. Custom installations can use `TRAECLI_PATH`, `TRAE_HOME`, `TRAE_AUTH_PATH`, and `TRAE_MODELS_PATH`; `TRAE_API_BASE_URL` overrides the upstream endpoint.
 
 ## Management API
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -105,6 +105,7 @@ PackyCode 为本软件用户提供了特别优惠：使用<a href="https://www.p
 - 新增 OpenAI Codex（GPT 系列）支持（OAuth 登录）
 - 新增 Claude Code 支持（OAuth 登录）
 - 新增 Grok Build 支持（OAuth 登录）
+- 支持导入本机 Trae CLI 的现有登录状态
 - 支持流式、非流式响应，以及受支持场景下的 WebSocket 响应
 - 函数调用/工具支持
 - 多模态输入（文本、图片）
@@ -121,6 +122,18 @@ PackyCode 为本软件用户提供了特别优惠：使用<a href="https://www.p
 ## 新手入门
 
 CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-for.me/cn/)
+
+### Trae CLI
+
+导入本机 `traecli` 已登录的账号，然后正常启动代理：
+
+```bash
+traecli login status
+./CLIProxyAPI --trae-login
+./CLIProxyAPI --config config.yaml
+```
+
+导入过程只保存 Trae CLI 本地状态文件的引用和模型目录，不会把 access token 复制进 CLIProxyAPI 的认证文件。默认从 `PATH` 查找 `traecli` 并读取 `~/.trae/cli/auth.json`；自定义安装可设置 `TRAECLI_PATH`、`TRAE_HOME`、`TRAE_AUTH_PATH` 和 `TRAE_MODELS_PATH`，也可用 `TRAE_API_BASE_URL` 覆盖上游地址。
 
 ## 管理 API 文档
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -80,6 +80,7 @@ func main() {
 	var oauthCallbackPort int
 	var antigravityLogin bool
 	var kimiLogin bool
+	var traeLogin bool
 	var xaiLogin bool
 	var vertexImport string
 	var vertexImportPrefix string
@@ -99,6 +100,7 @@ func main() {
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
 	flag.BoolVar(&kimiLogin, "kimi-login", false, "Login to Kimi using OAuth")
+	flag.BoolVar(&traeLogin, "trae-login", false, "Import authentication from the local Trae CLI")
 	flag.BoolVar(&xaiLogin, "xai-login", false, "Login to xAI using OAuth")
 	flag.StringVar(&configPath, "config", DefaultConfigPath, "Configure File Path")
 	flag.StringVar(&vertexImport, "vertex-import", "", "Import Vertex service account key JSON file")
@@ -588,7 +590,7 @@ func main() {
 		CallbackPort: oauthCallbackPort,
 	}
 
-	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || xaiLogin
+	commandMode := vertexImport != "" || antigravityLogin || codexLogin || codexDeviceLogin || claudeLogin || kimiLogin || traeLogin || xaiLogin
 	cloudConfigMissing := isCloudDeploy && !configFileExists
 	homeMode := configLoadedFromHome || (cfg != nil && cfg.Home.Enabled)
 	exampleAPIKeySafeMode := shouldEnableExampleAPIKeySafeMode(cfg, commandMode, tuiMode, standalone, cloudConfigMissing, homeMode)
@@ -660,6 +662,8 @@ func main() {
 		cmd.DoClaudeLogin(cfg, options)
 	} else if kimiLogin {
 		cmd.DoKimiLogin(cfg, options)
+	} else if traeLogin {
+		cmd.DoTraeLogin(cfg, options)
 	} else if xaiLogin {
 		cmd.DoXAILogin(cfg, options)
 	} else {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -710,7 +710,7 @@ nonstream-keepalive-interval: 0
 
 # Global OAuth model name aliases (per channel)
 # These aliases rename model IDs for both model listing and request routing.
-# Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, xai.
+# Supported channels: vertex, aistudio, antigravity, claude, codex, kimi, trae, xai.
 # NOTE: Aliases do not apply to gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, or vertex-api-key.
 # NOTE: Because aliases affect the merged /v1 model list and merged request routing, overlapping
 # client-visible names can become ambiguous across providers. For strict backend pinning, use

--- a/internal/auth/trae/trae.go
+++ b/internal/auth/trae/trae.go
@@ -1,0 +1,441 @@
+// Package trae provides helpers for reusing a local Trae CLI login.
+package trae
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+const (
+	Provider             = "trae"
+	DefaultCNBaseURL     = "https://copilot-cn.bytedance.net"
+	DefaultGlobalBaseURL = "https://copilot.byteintl.net"
+	DefaultSGBaseURL     = "https://copilot-sg.byteintl.net"
+	RawChatPath          = "/api/ide/v2/llm_raw_chat"
+	AppID                = "6eefa01c-1036-4c7e-9ca5-d891f63bfcd8"
+)
+
+// Installation contains the local Trae CLI executable and state paths.
+type Installation struct {
+	CLIPath    string
+	Home       string
+	AuthPath   string
+	ModelsPath string
+}
+
+// Credentials is the non-persisted credential view loaded from Trae CLI state.
+type Credentials struct {
+	AccessToken    string
+	UserID         string
+	ExpiresAt      string
+	Region         string
+	LoginMethod    string
+	CredentialKind string
+	LastRefresh    string
+}
+
+// Model is the model catalog shape printed by `traecli models --json`.
+type Model struct {
+	Name               string   `json:"name"`
+	ConfigName         string   `json:"config_name,omitempty"`
+	BackendModel       string   `json:"backend_model,omitempty"`
+	Provider           string   `json:"provider,omitempty"`
+	Description        string   `json:"description,omitempty"`
+	ContextWindow      int      `json:"context_window,omitempty"`
+	SupportedMIMETypes []string `json:"supported_mime_types,omitempty"`
+	Meta               struct {
+		Trae struct {
+			ContextWindow    int  `json:"contextWindow,omitempty"`
+			MaxContextWindow int  `json:"maxContextWindow,omitempty"`
+			SupportsMaxMode  bool `json:"supportsMaxMode,omitempty"`
+		} `json:"trae,omitempty"`
+	} `json:"_meta,omitempty"`
+}
+
+type authFile struct {
+	AuthMode    string `json:"auth_mode"`
+	LastRefresh string `json:"last_refresh"`
+	Trae        struct {
+		AccessToken    string `json:"access_token"`
+		UserID         string `json:"user_id"`
+		ExpiresAt      string `json:"expires_at"`
+		Region         string `json:"region"`
+		LoginMethod    string `json:"login_method"`
+		CredentialKind string `json:"credential_kind"`
+	} `json:"trae"`
+}
+
+type cachedModelsFile struct {
+	ClientVersion string `json:"client_version"`
+	Models        []struct {
+		Slug            string   `json:"slug"`
+		ConfigName      string   `json:"config_name"`
+		PromptModelID   string   `json:"prompt_model_id"`
+		Description     string   `json:"description"`
+		ContextWindow   int      `json:"context_window"`
+		InputModalities []string `json:"input_modalities"`
+	} `json:"models"`
+}
+
+// ResolveInstallation finds the installed Trae CLI and its local state files.
+func ResolveInstallation() (Installation, error) {
+	cliPath := strings.TrimSpace(os.Getenv("TRAECLI_PATH"))
+	if cliPath == "" {
+		var errLookPath error
+		cliPath, errLookPath = exec.LookPath("traecli")
+		if errLookPath != nil {
+			cliPath, errLookPath = exec.LookPath("traex")
+		}
+		if errLookPath != nil {
+			return Installation{}, fmt.Errorf("trae: local traecli executable not found: %w", errLookPath)
+		}
+	}
+	cliPath, errAbs := filepath.Abs(cliPath)
+	if errAbs != nil {
+		return Installation{}, fmt.Errorf("trae: resolve CLI path: %w", errAbs)
+	}
+
+	home := firstNonEmptyEnv("TRAE_HOME", "TRAECLI_HOME")
+	if home == "" {
+		userHome, errHome := os.UserHomeDir()
+		if errHome != nil {
+			return Installation{}, fmt.Errorf("trae: resolve user home: %w", errHome)
+		}
+		home = filepath.Join(userHome, ".trae")
+	}
+	home, errAbs = filepath.Abs(home)
+	if errAbs != nil {
+		return Installation{}, fmt.Errorf("trae: resolve state home: %w", errAbs)
+	}
+	authPath := strings.TrimSpace(os.Getenv("TRAE_AUTH_PATH"))
+	if authPath == "" {
+		authPath = filepath.Join(home, "cli", "auth.json")
+	}
+	modelsPath := strings.TrimSpace(os.Getenv("TRAE_MODELS_PATH"))
+	if modelsPath == "" {
+		modelsPath = filepath.Join(home, "cli", "models_cache.json")
+	}
+	return Installation{CLIPath: cliPath, Home: home, AuthPath: authPath, ModelsPath: modelsPath}, nil
+}
+
+// LoadCredentials reads the current access token from Trae CLI state.
+func LoadCredentials(path string) (Credentials, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return Credentials{}, errors.New("trae: credential path is empty")
+	}
+	raw, errRead := os.ReadFile(path)
+	if errRead != nil {
+		return Credentials{}, fmt.Errorf("trae: read credentials: %w", errRead)
+	}
+	var stored authFile
+	if errUnmarshal := json.Unmarshal(raw, &stored); errUnmarshal != nil {
+		return Credentials{}, fmt.Errorf("trae: parse credentials: %w", errUnmarshal)
+	}
+	if !strings.EqualFold(strings.TrimSpace(stored.AuthMode), Provider) {
+		return Credentials{}, fmt.Errorf("trae: local CLI is logged in with %q instead of Trae", stored.AuthMode)
+	}
+	if strings.TrimSpace(stored.Trae.AccessToken) == "" {
+		return Credentials{}, errors.New("trae: local CLI credential has no access token")
+	}
+	return Credentials{
+		AccessToken:    strings.TrimSpace(stored.Trae.AccessToken),
+		UserID:         strings.TrimSpace(stored.Trae.UserID),
+		ExpiresAt:      strings.TrimSpace(stored.Trae.ExpiresAt),
+		Region:         strings.ToUpper(strings.TrimSpace(stored.Trae.Region)),
+		LoginMethod:    strings.TrimSpace(stored.Trae.LoginMethod),
+		CredentialKind: strings.TrimSpace(stored.Trae.CredentialKind),
+		LastRefresh:    strings.TrimSpace(stored.LastRefresh),
+	}, nil
+}
+
+// FetchModels asks the installed CLI for its live, account-filtered model catalog.
+func FetchModels(ctx context.Context, cliPath string) ([]Model, string, error) {
+	cliPath = strings.TrimSpace(cliPath)
+	if cliPath == "" {
+		return nil, "", errors.New("trae: CLI path is empty")
+	}
+	command := exec.CommandContext(ctx, cliPath, "models", "--json")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if errRun := command.Run(); errRun != nil {
+		return nil, "", fmt.Errorf("trae: list models: %w: %s", errRun, strings.TrimSpace(stderr.String()))
+	}
+	var models []Model
+	if errUnmarshal := json.Unmarshal(stdout.Bytes(), &models); errUnmarshal != nil {
+		return nil, "", fmt.Errorf("trae: parse model catalog: %w", errUnmarshal)
+	}
+	models = normalizeModels(models)
+	if len(models) == 0 {
+		return nil, "", errors.New("trae: local CLI returned an empty model catalog")
+	}
+	return models, cliVersion(ctx, cliPath), nil
+}
+
+// LoadCachedModels reads Trae CLI's cached model catalog as an offline fallback.
+func LoadCachedModels(path string) ([]Model, string, error) {
+	raw, errRead := os.ReadFile(strings.TrimSpace(path))
+	if errRead != nil {
+		return nil, "", fmt.Errorf("trae: read model cache: %w", errRead)
+	}
+	var cached cachedModelsFile
+	if errUnmarshal := json.Unmarshal(raw, &cached); errUnmarshal != nil {
+		return nil, "", fmt.Errorf("trae: parse model cache: %w", errUnmarshal)
+	}
+	models := make([]Model, 0, len(cached.Models))
+	for _, item := range cached.Models {
+		backend := firstNonEmpty(item.PromptModelID, item.ConfigName, item.Slug)
+		if backend != "" && !strings.HasSuffix(strings.ToLower(backend), "__dev") {
+			backend += "__dev"
+		}
+		model := Model{
+			Name:          item.Slug,
+			ConfigName:    firstNonEmpty(item.ConfigName, item.Slug),
+			BackendModel:  backend,
+			Provider:      Provider,
+			Description:   item.Description,
+			ContextWindow: item.ContextWindow,
+		}
+		for _, modality := range item.InputModalities {
+			if strings.EqualFold(modality, "image") {
+				model.SupportedMIMETypes = append(model.SupportedMIMETypes, "image/*")
+			}
+		}
+		models = append(models, model)
+	}
+	models = normalizeModels(models)
+	if len(models) == 0 {
+		return nil, cached.ClientVersion, errors.New("trae: cached model catalog is empty")
+	}
+	return models, cached.ClientVersion, nil
+}
+
+// ModelsFromMetadata decodes the catalog stored in a CLIProxyAPI auth record.
+func ModelsFromMetadata(metadata map[string]any) []Model {
+	if metadata == nil {
+		return nil
+	}
+	rawModels, ok := metadata["models"]
+	if !ok {
+		return nil
+	}
+	raw, errMarshal := json.Marshal(rawModels)
+	if errMarshal != nil {
+		return nil
+	}
+	var models []Model
+	if json.Unmarshal(raw, &models) != nil {
+		return nil
+	}
+	return normalizeModels(models)
+}
+
+// ModelFor resolves a public, config, or backend model identifier.
+func ModelFor(metadata map[string]any, requested string) (Model, bool) {
+	requested = strings.TrimSpace(requested)
+	for _, model := range ModelsFromMetadata(metadata) {
+		for _, candidate := range []string{model.Name, model.ConfigName, model.BackendModel} {
+			if strings.EqualFold(requested, strings.TrimSpace(candidate)) {
+				return model, true
+			}
+		}
+	}
+	return Model{}, false
+}
+
+// RegistryModels converts imported Trae models into CLIProxyAPI model metadata.
+func RegistryModels(metadata map[string]any) []*registry.ModelInfo {
+	models := ModelsFromMetadata(metadata)
+	if len(models) == 0 {
+		modelsPath := metadataString(metadata, "trae_models_path")
+		cached, _, errCached := LoadCachedModels(modelsPath)
+		if errCached == nil {
+			models = cached
+		}
+	}
+	out := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		inputModalities := []string{"TEXT"}
+		for _, mimeType := range model.SupportedMIMETypes {
+			if strings.HasPrefix(strings.ToLower(mimeType), "image/") || strings.EqualFold(mimeType, "image/*") {
+				inputModalities = append(inputModalities, "IMAGE")
+				break
+			}
+		}
+		levels := []string{"low", "medium", "high"}
+		if model.Meta.Trae.SupportsMaxMode {
+			levels = append(levels, "max")
+		}
+		out = append(out, &registry.ModelInfo{
+			ID:                         model.Name,
+			Object:                     "model",
+			OwnedBy:                    Provider,
+			Type:                       "openai",
+			DisplayName:                model.Name,
+			Name:                       model.Name,
+			Version:                    model.BackendModel,
+			Description:                model.Description,
+			InputTokenLimit:            model.ContextWindow,
+			ContextLength:              model.ContextWindow,
+			MaxContextLength:           model.ContextWindow,
+			MaxCompletionTokens:        64_000,
+			SupportedInputModalities:   inputModalities,
+			SupportedOutputModalities:  []string{"TEXT"},
+			SupportedGenerationMethods: []string{"generateContent", "streamGenerateContent"},
+			Thinking:                   &registry.ThinkingSupport{Levels: levels},
+		})
+	}
+	return out
+}
+
+// AccessToken reloads the token from Trae CLI state, falling back to an explicitly stored token.
+func AccessToken(metadata map[string]any) (string, error) {
+	path := metadataString(metadata, "trae_auth_path")
+	if path != "" {
+		credentials, errLoad := LoadCredentials(path)
+		if errLoad == nil {
+			return credentials.AccessToken, nil
+		}
+		if metadataString(metadata, "access_token") == "" {
+			return "", errLoad
+		}
+	}
+	if token := metadataString(metadata, "access_token"); token != "" {
+		return token, nil
+	}
+	return "", errors.New("trae: no local access token is available")
+}
+
+// BaseURLs returns endpoint candidates in the same regional order as Trae CLI.
+func BaseURLs(metadata map[string]any) []string {
+	if override := strings.TrimSpace(os.Getenv("TRAE_API_BASE_URL")); override != "" {
+		return []string{strings.TrimSuffix(override, "/")}
+	}
+	urls := metadataStrings(metadata, "base_urls")
+	if baseURL := metadataString(metadata, "base_url"); baseURL != "" {
+		urls = append([]string{baseURL}, urls...)
+	}
+	if len(urls) == 0 {
+		if strings.EqualFold(metadataString(metadata, "region"), "CN") {
+			urls = []string{DefaultCNBaseURL, DefaultSGBaseURL, DefaultGlobalBaseURL}
+		} else {
+			urls = []string{DefaultGlobalBaseURL, DefaultSGBaseURL, DefaultCNBaseURL}
+		}
+	}
+	seen := make(map[string]struct{}, len(urls))
+	out := make([]string, 0, len(urls))
+	for _, rawURL := range urls {
+		rawURL = strings.TrimSuffix(strings.TrimSpace(rawURL), "/")
+		if rawURL == "" {
+			continue
+		}
+		key := strings.ToLower(rawURL)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, rawURL)
+	}
+	return out
+}
+
+func normalizeModels(models []Model) []Model {
+	out := make([]Model, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		model.Name = strings.TrimSpace(model.Name)
+		if model.Name == "" || (!strings.EqualFold(model.Provider, Provider) && strings.TrimSpace(model.Provider) != "") {
+			continue
+		}
+		model.Provider = Provider
+		model.ConfigName = firstNonEmpty(model.ConfigName, model.Name)
+		model.BackendModel = firstNonEmpty(model.BackendModel, model.ConfigName, model.Name)
+		if !strings.HasSuffix(strings.ToLower(model.BackendModel), "__dev") {
+			model.BackendModel += "__dev"
+		}
+		if model.ContextWindow <= 0 {
+			model.ContextWindow = model.Meta.Trae.ContextWindow
+		}
+		key := strings.ToLower(model.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, model)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name) })
+	return out
+}
+
+func cliVersion(ctx context.Context, cliPath string) string {
+	command := exec.CommandContext(ctx, cliPath, "--version")
+	output, errRun := command.Output()
+	if errRun != nil {
+		return ""
+	}
+	fields := strings.Fields(string(output))
+	for _, field := range fields {
+		if field != "" && field[0] >= '0' && field[0] <= '9' {
+			return strings.TrimSpace(strings.SplitN(field, "(", 2)[0])
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func metadataStrings(metadata map[string]any, key string) []string {
+	if metadata == nil {
+		return nil
+	}
+	switch values := metadata[key].(type) {
+	case []string:
+		return append([]string(nil), values...)
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if text, ok := value.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/auth/trae/trae.go
+++ b/internal/auth/trae/trae.go
@@ -274,7 +274,7 @@ func RegistryModels(metadata map[string]any) []*registry.ModelInfo {
 				break
 			}
 		}
-		levels := []string{"low", "medium", "high"}
+		levels := []string{"low", "medium", "high", "xhigh"}
 		if model.Meta.Trae.SupportsMaxMode {
 			levels = append(levels, "max")
 		}

--- a/internal/auth/trae/trae_test.go
+++ b/internal/auth/trae/trae_test.go
@@ -1,0 +1,77 @@
+package trae
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCredentials(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "auth.json")
+	raw := []byte(`{"auth_mode":"trae","last_refresh":"2026-09-08T06:13:21Z","trae":{"access_token":"secret-token","user_id":"user@example.com","expires_at":"2026-09-22T06:13:21Z","region":"cn","login_method":"device","credential_kind":"cloud_cli_jwt"}}`)
+	if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	credentials, errLoad := LoadCredentials(path)
+	if errLoad != nil {
+		t.Fatalf("LoadCredentials() error = %v", errLoad)
+	}
+	if credentials.AccessToken != "secret-token" || credentials.UserID != "user@example.com" || credentials.Region != "CN" {
+		t.Fatalf("LoadCredentials() = %+v", credentials)
+	}
+}
+
+func TestLoadCredentialsRejectsDifferentAuthMode(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if errWrite := os.WriteFile(path, []byte(`{"auth_mode":"chatgpt","trae":{"access_token":"secret-token"}}`), 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	if _, errLoad := LoadCredentials(path); errLoad == nil {
+		t.Fatal("LoadCredentials() error = nil, want auth mode error")
+	}
+}
+
+func TestModelsFromMetadataAndRegistryModels(t *testing.T) {
+	t.Parallel()
+	models := []Model{{
+		Name:               "GPT-5.6-Sol",
+		ConfigName:         "gpt-5.6-sol",
+		BackendModel:       "gpt-5.6-sol__dev",
+		Provider:           Provider,
+		ContextWindow:      272000,
+		SupportedMIMETypes: []string{"image/*"},
+	}}
+	metadata := map[string]any{"models": models}
+	resolved, ok := ModelFor(metadata, "gpt-5.6-sol")
+	if !ok || resolved.Name != "GPT-5.6-Sol" || resolved.BackendModel != "gpt-5.6-sol__dev" {
+		t.Fatalf("ModelFor() = (%+v, %t)", resolved, ok)
+	}
+	registryModels := RegistryModels(metadata)
+	if len(registryModels) != 1 {
+		t.Fatalf("RegistryModels() len = %d, want 1", len(registryModels))
+	}
+	if registryModels[0].ID != "GPT-5.6-Sol" || registryModels[0].ContextLength != 272000 {
+		t.Fatalf("RegistryModels()[0] = %+v", registryModels[0])
+	}
+	if len(registryModels[0].SupportedInputModalities) != 2 || registryModels[0].SupportedInputModalities[1] != "IMAGE" {
+		t.Fatalf("SupportedInputModalities = %v", registryModels[0].SupportedInputModalities)
+	}
+}
+
+func TestLoadCachedModels(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "models_cache.json")
+	raw := []byte(`{"client_version":"0.204.1","models":[{"slug":"GPT-5.6-Sol","config_name":"gpt-5.6-sol","prompt_model_id":"gpt-5.6-sol","context_window":272000,"input_modalities":["text","image"]}]}`)
+	if errWrite := os.WriteFile(path, raw, 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	models, version, errLoad := LoadCachedModels(path)
+	if errLoad != nil {
+		t.Fatalf("LoadCachedModels() error = %v", errLoad)
+	}
+	if version != "0.204.1" || len(models) != 1 || models[0].BackendModel != "gpt-5.6-sol__dev" {
+		t.Fatalf("LoadCachedModels() = (%+v, %q)", models, version)
+	}
+}

--- a/internal/auth/trae/trae_test.go
+++ b/internal/auth/trae/trae_test.go
@@ -58,6 +58,10 @@ func TestModelsFromMetadataAndRegistryModels(t *testing.T) {
 	if len(registryModels[0].SupportedInputModalities) != 2 || registryModels[0].SupportedInputModalities[1] != "IMAGE" {
 		t.Fatalf("SupportedInputModalities = %v", registryModels[0].SupportedInputModalities)
 	}
+	levels := registryModels[0].Thinking.Levels
+	if len(levels) != 4 || levels[3] != "xhigh" {
+		t.Fatalf("Thinking levels = %v, want xhigh capability", levels)
+	}
 }
 
 func TestLoadCachedModels(t *testing.T) {

--- a/internal/cmd/auth_manager.go
+++ b/internal/cmd/auth_manager.go
@@ -6,7 +6,7 @@ import (
 
 // newAuthManager creates a new authentication manager instance with all supported
 // authenticators and a file-based token store. It initializes authenticators for
-// Codex, Claude, Antigravity, Kimi, and xAI providers.
+// Codex, Claude, Antigravity, Kimi, Trae, and xAI providers.
 //
 // Returns:
 //   - *sdkAuth.Manager: A configured authentication manager instance
@@ -17,6 +17,7 @@ func newAuthManager() *sdkAuth.Manager {
 		sdkAuth.NewClaudeAuthenticator(),
 		sdkAuth.NewAntigravityAuthenticator(),
 		sdkAuth.NewKimiAuthenticator(),
+		sdkAuth.NewTraeAuthenticator(),
 		sdkAuth.NewXAIAuthenticator(),
 	)
 	return manager

--- a/internal/cmd/trae_login.go
+++ b/internal/cmd/trae_login.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// DoTraeLogin imports the existing local Trae CLI session and model catalog.
+func DoTraeLogin(cfg *config.Config, options *LoginOptions) {
+	manager := newAuthManager()
+	record, savedPath, errLogin := manager.Login(context.Background(), "trae", cfg, nil)
+	if errLogin != nil {
+		log.Errorf("Trae CLI authentication import failed: %v", errLogin)
+		return
+	}
+	if savedPath != "" {
+		fmt.Printf("Authentication reference saved to %s\n", savedPath)
+	}
+	if record != nil && record.Label != "" {
+		fmt.Printf("Imported Trae CLI login for %s\n", record.Label)
+	}
+	fmt.Println("Trae CLI authentication import successful!")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,7 +157,7 @@ type Config struct {
 
 	// OAuthModelAlias defines global model name aliases for OAuth/file-backed auth channels.
 	// These aliases affect both model listing and model routing for supported channels:
-	// vertex, aistudio, antigravity, claude, codex, kimi, xai.
+	// vertex, aistudio, antigravity, claude, codex, kimi, trae, xai.
 	//
 	// NOTE: This does not apply to existing per-credential model alias features under:
 	// gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, and vertex-api-key.

--- a/internal/runtime/executor/helps/trae_events.go
+++ b/internal/runtime/executor/helps/trae_events.go
@@ -1,4 +1,4 @@
-package executor
+package helps
 
 import (
 	"bufio"
@@ -9,9 +9,12 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
-type traeSSEEvent struct {
+// TraeSSEEvent is one event from Trae's raw-chat SSE stream.
+type TraeSSEEvent struct {
 	Name string
 	Data []byte
 }
@@ -65,7 +68,8 @@ type traeStreamToolState struct {
 	Name string
 }
 
-type traeStreamState struct {
+// TraeStreamState converts Trae output events into OpenAI-compatible stream chunks.
+type TraeStreamState struct {
 	ID           string
 	Model        string
 	Created      int64
@@ -75,16 +79,18 @@ type traeStreamState struct {
 	Tools        map[int]traeStreamToolState
 }
 
-func newTraeStreamState(model string) *traeStreamState {
-	return &traeStreamState{
-		ID:      "chatcmpl-" + strings.ReplaceAll(newTraeUUID(), "-", ""),
+// NewTraeStreamState creates a converter for one Trae stream.
+func NewTraeStreamState(model string) *TraeStreamState {
+	return &TraeStreamState{
+		ID:      "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
 		Model:   model,
 		Created: time.Now().Unix(),
 		Tools:   make(map[int]traeStreamToolState),
 	}
 }
 
-func scanTraeSSE(reader io.Reader, consume func(traeSSEEvent) error) error {
+// ScanTraeSSE scans a Trae raw-chat response and emits complete SSE events.
+func ScanTraeSSE(reader io.Reader, consume func(TraeSSEEvent) error) error {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 	name := ""
@@ -93,7 +99,7 @@ func scanTraeSSE(reader io.Reader, consume func(traeSSEEvent) error) error {
 		if name == "" && len(data) == 0 {
 			return nil
 		}
-		event := traeSSEEvent{Name: name, Data: bytes.Clone(data)}
+		event := TraeSSEEvent{Name: name, Data: bytes.Clone(data)}
 		name = ""
 		data = data[:0]
 		return consume(event)
@@ -122,7 +128,7 @@ func scanTraeSSE(reader io.Reader, consume func(traeSSEEvent) error) error {
 	return emit()
 }
 
-func (state *traeStreamState) convert(event traeSSEEvent) ([]byte, *traeTokenUsage, error) {
+func (state *TraeStreamState) convert(event TraeSSEEvent) ([]byte, *traeTokenUsage, error) {
 	switch event.Name {
 	case "metadata":
 		var metadata traeMetadataEvent
@@ -154,7 +160,7 @@ func (state *traeStreamState) convert(event traeSSEEvent) ([]byte, *traeTokenUsa
 			name := strings.TrimSpace(toolCall.FunctionCall.Name)
 			id := strings.TrimSpace(toolCall.ID)
 			callType := strings.TrimSpace(toolCall.Type)
-			arguments := toolCall.FunctionCall.Arguments
+			arguments := traeToolCallArguments(toolCall)
 			if arguments == "" && id != "" && name != "" && previous.ID == id && previous.Name == name {
 				continue
 			}
@@ -239,7 +245,18 @@ func (state *traeStreamState) convert(event traeSSEEvent) ([]byte, *traeTokenUsa
 	}
 }
 
-func (state *traeStreamState) chatChunk(delta map[string]any, finishReason *string, usage map[string]any) []byte {
+// Convert converts one Trae event into an OpenAI-compatible SSE data line.
+func (state *TraeStreamState) Convert(event TraeSSEEvent) ([]byte, error) {
+	line, _, errConvert := state.convert(event)
+	return line, errConvert
+}
+
+// IsFinished reports whether the Trae stream emitted a done event.
+func (state *TraeStreamState) IsFinished() bool {
+	return state != nil && state.Finished
+}
+
+func (state *TraeStreamState) chatChunk(delta map[string]any, finishReason *string, usage map[string]any) []byte {
 	choices := make([]any, 0, 1)
 	if delta != nil || finishReason != nil {
 		choice := map[string]any{"index": 0, "delta": delta, "finish_reason": nil}
@@ -262,7 +279,8 @@ func (state *traeStreamState) chatChunk(delta map[string]any, finishReason *stri
 	return append([]byte("data: "), raw...)
 }
 
-type traeResponseAccumulator struct {
+// TraeResponseAccumulator builds an OpenAI-compatible non-stream response from Trae events.
+type TraeResponseAccumulator struct {
 	ID                string
 	Model             string
 	Created           int64
@@ -283,16 +301,17 @@ type traeAccumulatedToolCall struct {
 	Arguments strings.Builder
 }
 
-func newTraeResponseAccumulator(model string) *traeResponseAccumulator {
-	return &traeResponseAccumulator{
-		ID:      "chatcmpl-" + strings.ReplaceAll(newTraeUUID(), "-", ""),
+// NewTraeResponseAccumulator creates an accumulator for one Trae response.
+func NewTraeResponseAccumulator(model string) *TraeResponseAccumulator {
+	return &TraeResponseAccumulator{
+		ID:      "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
 		Model:   model,
 		Created: time.Now().Unix(),
 		Tools:   make(map[int]*traeAccumulatedToolCall),
 	}
 }
 
-func (accumulator *traeResponseAccumulator) consume(event traeSSEEvent) error {
+func (accumulator *TraeResponseAccumulator) consume(event TraeSSEEvent) error {
 	switch event.Name {
 	case "metadata":
 		var metadata traeMetadataEvent
@@ -327,7 +346,7 @@ func (accumulator *traeResponseAccumulator) consume(event traeSSEEvent) error {
 			if toolCall.FunctionCall.Name != "" {
 				current.Name = toolCall.FunctionCall.Name
 			}
-			current.Arguments.WriteString(toolCall.FunctionCall.Arguments)
+			current.Arguments.WriteString(traeToolCallArguments(toolCall))
 		}
 	case "token_usage":
 		var usage traeTokenUsage
@@ -357,7 +376,17 @@ func (accumulator *traeResponseAccumulator) consume(event traeSSEEvent) error {
 	return nil
 }
 
-func (accumulator *traeResponseAccumulator) responseJSON() []byte {
+// Consume adds one Trae event to the response accumulator.
+func (accumulator *TraeResponseAccumulator) Consume(event TraeSSEEvent) error {
+	return accumulator.consume(event)
+}
+
+// IsFinished reports whether the accumulated response emitted a done event.
+func (accumulator *TraeResponseAccumulator) IsFinished() bool {
+	return accumulator != nil && accumulator.Finished
+}
+
+func (accumulator *TraeResponseAccumulator) responseJSON() []byte {
 	message := map[string]any{"role": "assistant", "content": accumulator.Content.String()}
 	if accumulator.Reasoning.Len() > 0 {
 		message["reasoning_content"] = accumulator.Reasoning.String()
@@ -414,6 +443,11 @@ func (accumulator *traeResponseAccumulator) responseJSON() []byte {
 	return raw
 }
 
+// ResponseJSON returns the accumulated OpenAI-compatible chat completion.
+func (accumulator *TraeResponseAccumulator) ResponseJSON() []byte {
+	return accumulator.responseJSON()
+}
+
 func openAIUsage(usage traeTokenUsage) map[string]any {
 	promptTokens := usage.PromptTokens
 	completionTokens := usage.CompletionTokens
@@ -427,19 +461,53 @@ func openAIUsage(usage traeTokenUsage) map[string]any {
 	if totalTokens == 0 && usage.TotalTokensTotal > 0 {
 		totalTokens = usage.TotalTokensTotal
 	}
+	cacheCreationInputTokens := usage.CacheCreationInputTokens
+	if cacheCreationInputTokens == 0 && usage.CacheCreationInputTokensTotal > 0 {
+		cacheCreationInputTokens = usage.CacheCreationInputTokensTotal
+	}
+	cacheReadInputTokens := usage.CacheReadInputTokens
+	if cacheReadInputTokens == 0 && usage.CacheReadInputTokensTotal > 0 {
+		cacheReadInputTokens = usage.CacheReadInputTokensTotal
+	}
+	reasoningTokens := usage.ReasoningTokens
+	if reasoningTokens == 0 && usage.ReasoningTokensTotal > 0 {
+		reasoningTokens = usage.ReasoningTokensTotal
+	}
 	return map[string]any{
 		"prompt_tokens":     promptTokens,
 		"completion_tokens": completionTokens,
 		"total_tokens":      totalTokens,
 		"prompt_tokens_details": map[string]any{
-			"cached_tokens": usage.CacheReadInputTokens,
+			"cached_tokens": cacheReadInputTokens,
 		},
 		"completion_tokens_details": map[string]any{
-			"reasoning_tokens": usage.ReasoningTokens,
+			"reasoning_tokens": reasoningTokens,
 		},
-		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
-		"cache_read_input_tokens":     usage.CacheReadInputTokens,
+		"cache_creation_input_tokens": cacheCreationInputTokens,
+		"cache_read_input_tokens":     cacheReadInputTokens,
 	}
+}
+
+func traeToolCallArguments(toolCall traeToolCall) string {
+	if toolCall.FunctionCall.Arguments != "" {
+		return toolCall.FunctionCall.Arguments
+	}
+	partial := bytes.TrimSpace(toolCall.FunctionCall.PartialArguments)
+	if len(partial) == 0 || bytes.Equal(partial, []byte("null")) {
+		return ""
+	}
+	var fragment string
+	if json.Unmarshal(partial, &fragment) == nil {
+		return fragment
+	}
+	var fragments []string
+	if json.Unmarshal(partial, &fragments) == nil {
+		return strings.Join(fragments, "")
+	}
+	if json.Valid(partial) {
+		return string(partial)
+	}
+	return ""
 }
 
 func anyString(value any) string {

--- a/internal/runtime/executor/trae_events.go
+++ b/internal/runtime/executor/trae_events.go
@@ -1,0 +1,454 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+type traeSSEEvent struct {
+	Name string
+	Data []byte
+}
+
+type traeMetadataEvent struct {
+	Model     string `json:"model"`
+	SessionID string `json:"session_id"`
+}
+
+type traeOutputEvent struct {
+	Response          string          `json:"response"`
+	ReasoningContent  string          `json:"reasoning_content"`
+	ToolCalls         []traeToolCall  `json:"tool_calls"`
+	MultimodalContent json.RawMessage `json:"multimodal_contents"`
+}
+
+type traeToolCall struct {
+	Index        int    `json:"index"`
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	FunctionCall struct {
+		Name             string          `json:"name"`
+		Arguments        string          `json:"arguments"`
+		PartialArguments json.RawMessage `json:"partial_arguments"`
+		Namespace        string          `json:"namespace"`
+	} `json:"function_call"`
+}
+
+type traeTokenUsage struct {
+	PromptTokens                  int64 `json:"prompt_tokens"`
+	CompletionTokens              int64 `json:"completion_tokens"`
+	TotalTokens                   int64 `json:"total_tokens"`
+	CacheCreationInputTokens      int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens          int64 `json:"cache_read_input_tokens"`
+	ReasoningTokens               int64 `json:"reasoning_tokens"`
+	PromptTokensTotal             int64 `json:"prompt_tokens_total"`
+	CompletionTokensTotal         int64 `json:"completion_tokens_total"`
+	TotalTokensTotal              int64 `json:"total_tokens_total"`
+	CacheCreationInputTokensTotal int64 `json:"cache_creation_input_tokens_total"`
+	CacheReadInputTokensTotal     int64 `json:"cache_read_input_tokens_total"`
+	ReasoningTokensTotal          int64 `json:"reasoning_tokens_total"`
+}
+
+type traeDoneEvent struct {
+	FinishReason string `json:"finish_reason"`
+}
+
+type traeStreamToolState struct {
+	ID   string
+	Type string
+	Name string
+}
+
+type traeStreamState struct {
+	ID           string
+	Model        string
+	Created      int64
+	EmittedRole  bool
+	Finished     bool
+	FinishReason string
+	Tools        map[int]traeStreamToolState
+}
+
+func newTraeStreamState(model string) *traeStreamState {
+	return &traeStreamState{
+		ID:      "chatcmpl-" + strings.ReplaceAll(newTraeUUID(), "-", ""),
+		Model:   model,
+		Created: time.Now().Unix(),
+		Tools:   make(map[int]traeStreamToolState),
+	}
+}
+
+func scanTraeSSE(reader io.Reader, consume func(traeSSEEvent) error) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	name := ""
+	data := make([]byte, 0, 4096)
+	emit := func() error {
+		if name == "" && len(data) == 0 {
+			return nil
+		}
+		event := traeSSEEvent{Name: name, Data: bytes.Clone(data)}
+		name = ""
+		data = data[:0]
+		return consume(event)
+	}
+	for scanner.Scan() {
+		line := bytes.TrimSuffix(scanner.Bytes(), []byte{'\r'})
+		if len(line) == 0 {
+			if errEmit := emit(); errEmit != nil {
+				return errEmit
+			}
+			continue
+		}
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			name = strings.TrimSpace(string(bytes.TrimPrefix(line, []byte("event:"))))
+		case bytes.HasPrefix(line, []byte("data:")):
+			if len(data) > 0 {
+				data = append(data, '\n')
+			}
+			data = append(data, bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))...)
+		}
+	}
+	if errScan := scanner.Err(); errScan != nil {
+		return errScan
+	}
+	return emit()
+}
+
+func (state *traeStreamState) convert(event traeSSEEvent) ([]byte, *traeTokenUsage, error) {
+	switch event.Name {
+	case "metadata":
+		var metadata traeMetadataEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &metadata); errUnmarshal != nil {
+			return nil, nil, fmt.Errorf("trae executor: parse metadata event: %w", errUnmarshal)
+		}
+		if metadata.SessionID != "" {
+			state.ID = "chatcmpl-" + strings.ReplaceAll(metadata.SessionID, "-", "")
+		}
+		return nil, nil, nil
+	case "output":
+		var output traeOutputEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &output); errUnmarshal != nil {
+			return nil, nil, fmt.Errorf("trae executor: parse output event: %w", errUnmarshal)
+		}
+		delta := make(map[string]any)
+		meaningful := false
+		if output.Response != "" {
+			delta["content"] = output.Response
+			meaningful = true
+		}
+		if output.ReasoningContent != "" {
+			delta["reasoning_content"] = output.ReasoningContent
+			meaningful = true
+		}
+		toolCalls := make([]map[string]any, 0, len(output.ToolCalls))
+		for _, toolCall := range output.ToolCalls {
+			previous := state.Tools[toolCall.Index]
+			name := strings.TrimSpace(toolCall.FunctionCall.Name)
+			id := strings.TrimSpace(toolCall.ID)
+			callType := strings.TrimSpace(toolCall.Type)
+			arguments := toolCall.FunctionCall.Arguments
+			if arguments == "" && id != "" && name != "" && previous.ID == id && previous.Name == name {
+				continue
+			}
+			converted := map[string]any{"index": toolCall.Index}
+			if id != "" {
+				converted["id"] = id
+			}
+			if callType != "" {
+				converted["type"] = callType
+			}
+			function := make(map[string]any)
+			if name != "" {
+				function["name"] = name
+			}
+			if arguments != "" {
+				function["arguments"] = arguments
+			}
+			if len(function) > 0 {
+				converted["function"] = function
+			}
+			if len(converted) == 1 {
+				continue
+			}
+			toolCalls = append(toolCalls, converted)
+			if id != "" {
+				previous.ID = id
+			}
+			if callType != "" {
+				previous.Type = callType
+			}
+			if name != "" {
+				previous.Name = name
+			}
+			state.Tools[toolCall.Index] = previous
+		}
+		if len(toolCalls) > 0 {
+			delta["tool_calls"] = toolCalls
+			meaningful = true
+		}
+		if len(output.MultimodalContent) > 0 && string(output.MultimodalContent) != "null" {
+			var multimodal any
+			if json.Unmarshal(output.MultimodalContent, &multimodal) == nil {
+				delta["multimodal_contents"] = multimodal
+				meaningful = true
+			}
+		}
+		if !meaningful {
+			return nil, nil, nil
+		}
+		if !state.EmittedRole {
+			delta["role"] = "assistant"
+			state.EmittedRole = true
+		}
+		return state.chatChunk(delta, nil, nil), nil, nil
+	case "token_usage":
+		var usage traeTokenUsage
+		if errUnmarshal := json.Unmarshal(event.Data, &usage); errUnmarshal != nil {
+			return nil, nil, fmt.Errorf("trae executor: parse token usage event: %w", errUnmarshal)
+		}
+		return state.chatChunk(nil, nil, openAIUsage(usage)), &usage, nil
+	case "done":
+		var done traeDoneEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &done); errUnmarshal != nil {
+			return nil, nil, fmt.Errorf("trae executor: parse done event: %w", errUnmarshal)
+		}
+		if done.FinishReason == "" {
+			done.FinishReason = "stop"
+		}
+		state.Finished = true
+		state.FinishReason = done.FinishReason
+		return state.chatChunk(map[string]any{}, &done.FinishReason, nil), nil, nil
+	case "error":
+		var payload map[string]any
+		_ = json.Unmarshal(event.Data, &payload)
+		message := strings.TrimSpace(anyString(payload["message"]))
+		if message == "" {
+			message = strings.TrimSpace(string(event.Data))
+		}
+		return nil, nil, fmt.Errorf("trae upstream error: %s", message)
+	default:
+		return nil, nil, nil
+	}
+}
+
+func (state *traeStreamState) chatChunk(delta map[string]any, finishReason *string, usage map[string]any) []byte {
+	choices := make([]any, 0, 1)
+	if delta != nil || finishReason != nil {
+		choice := map[string]any{"index": 0, "delta": delta, "finish_reason": nil}
+		if finishReason != nil {
+			choice["finish_reason"] = *finishReason
+		}
+		choices = append(choices, choice)
+	}
+	payload := map[string]any{
+		"id":      state.ID,
+		"object":  "chat.completion.chunk",
+		"created": state.Created,
+		"model":   state.Model,
+		"choices": choices,
+	}
+	if usage != nil {
+		payload["usage"] = usage
+	}
+	raw, _ := json.Marshal(payload)
+	return append([]byte("data: "), raw...)
+}
+
+type traeResponseAccumulator struct {
+	ID                string
+	Model             string
+	Created           int64
+	Content           strings.Builder
+	Reasoning         strings.Builder
+	Tools             map[int]*traeAccumulatedToolCall
+	MultimodalContent json.RawMessage
+	Usage             *traeTokenUsage
+	FinishReason      string
+	Finished          bool
+}
+
+type traeAccumulatedToolCall struct {
+	Index     int
+	ID        string
+	Type      string
+	Name      string
+	Arguments strings.Builder
+}
+
+func newTraeResponseAccumulator(model string) *traeResponseAccumulator {
+	return &traeResponseAccumulator{
+		ID:      "chatcmpl-" + strings.ReplaceAll(newTraeUUID(), "-", ""),
+		Model:   model,
+		Created: time.Now().Unix(),
+		Tools:   make(map[int]*traeAccumulatedToolCall),
+	}
+}
+
+func (accumulator *traeResponseAccumulator) consume(event traeSSEEvent) error {
+	switch event.Name {
+	case "metadata":
+		var metadata traeMetadataEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &metadata); errUnmarshal != nil {
+			return fmt.Errorf("trae executor: parse metadata event: %w", errUnmarshal)
+		}
+		if metadata.SessionID != "" {
+			accumulator.ID = "chatcmpl-" + strings.ReplaceAll(metadata.SessionID, "-", "")
+		}
+	case "output":
+		var output traeOutputEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &output); errUnmarshal != nil {
+			return fmt.Errorf("trae executor: parse output event: %w", errUnmarshal)
+		}
+		accumulator.Content.WriteString(output.Response)
+		accumulator.Reasoning.WriteString(output.ReasoningContent)
+		if len(output.MultimodalContent) > 0 && string(output.MultimodalContent) != "null" {
+			accumulator.MultimodalContent = bytes.Clone(output.MultimodalContent)
+		}
+		for _, toolCall := range output.ToolCalls {
+			current := accumulator.Tools[toolCall.Index]
+			if current == nil {
+				current = &traeAccumulatedToolCall{Index: toolCall.Index}
+				accumulator.Tools[toolCall.Index] = current
+			}
+			if toolCall.ID != "" {
+				current.ID = toolCall.ID
+			}
+			if toolCall.Type != "" {
+				current.Type = toolCall.Type
+			}
+			if toolCall.FunctionCall.Name != "" {
+				current.Name = toolCall.FunctionCall.Name
+			}
+			current.Arguments.WriteString(toolCall.FunctionCall.Arguments)
+		}
+	case "token_usage":
+		var usage traeTokenUsage
+		if errUnmarshal := json.Unmarshal(event.Data, &usage); errUnmarshal != nil {
+			return fmt.Errorf("trae executor: parse token usage event: %w", errUnmarshal)
+		}
+		accumulator.Usage = &usage
+	case "done":
+		var done traeDoneEvent
+		if errUnmarshal := json.Unmarshal(event.Data, &done); errUnmarshal != nil {
+			return fmt.Errorf("trae executor: parse done event: %w", errUnmarshal)
+		}
+		accumulator.FinishReason = done.FinishReason
+		if accumulator.FinishReason == "" {
+			accumulator.FinishReason = "stop"
+		}
+		accumulator.Finished = true
+	case "error":
+		var payload map[string]any
+		_ = json.Unmarshal(event.Data, &payload)
+		message := strings.TrimSpace(anyString(payload["message"]))
+		if message == "" {
+			message = strings.TrimSpace(string(event.Data))
+		}
+		return fmt.Errorf("trae upstream error: %s", message)
+	}
+	return nil
+}
+
+func (accumulator *traeResponseAccumulator) responseJSON() []byte {
+	message := map[string]any{"role": "assistant", "content": accumulator.Content.String()}
+	if accumulator.Reasoning.Len() > 0 {
+		message["reasoning_content"] = accumulator.Reasoning.String()
+	}
+	if len(accumulator.MultimodalContent) > 0 {
+		var multimodal any
+		if json.Unmarshal(accumulator.MultimodalContent, &multimodal) == nil {
+			message["multimodal_contents"] = multimodal
+		}
+	}
+	indexes := make([]int, 0, len(accumulator.Tools))
+	for index := range accumulator.Tools {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	if len(indexes) > 0 {
+		toolCalls := make([]map[string]any, 0, len(indexes))
+		for _, index := range indexes {
+			toolCall := accumulator.Tools[index]
+			callType := toolCall.Type
+			if callType == "" {
+				callType = "function"
+			}
+			toolCalls = append(toolCalls, map[string]any{
+				"id":   toolCall.ID,
+				"type": callType,
+				"function": map[string]any{
+					"name":      toolCall.Name,
+					"arguments": toolCall.Arguments.String(),
+				},
+			})
+		}
+		message["tool_calls"] = toolCalls
+	}
+	finishReason := accumulator.FinishReason
+	if finishReason == "" {
+		finishReason = "stop"
+	}
+	payload := map[string]any{
+		"id":      accumulator.ID,
+		"object":  "chat.completion",
+		"created": accumulator.Created,
+		"model":   accumulator.Model,
+		"choices": []any{map[string]any{
+			"index":         0,
+			"message":       message,
+			"finish_reason": finishReason,
+		}},
+	}
+	if accumulator.Usage != nil {
+		payload["usage"] = openAIUsage(*accumulator.Usage)
+	}
+	raw, _ := json.Marshal(payload)
+	return raw
+}
+
+func openAIUsage(usage traeTokenUsage) map[string]any {
+	promptTokens := usage.PromptTokens
+	completionTokens := usage.CompletionTokens
+	totalTokens := usage.TotalTokens
+	if promptTokens == 0 && usage.PromptTokensTotal > 0 {
+		promptTokens = usage.PromptTokensTotal
+	}
+	if completionTokens == 0 && usage.CompletionTokensTotal > 0 {
+		completionTokens = usage.CompletionTokensTotal
+	}
+	if totalTokens == 0 && usage.TotalTokensTotal > 0 {
+		totalTokens = usage.TotalTokensTotal
+	}
+	return map[string]any{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      totalTokens,
+		"prompt_tokens_details": map[string]any{
+			"cached_tokens": usage.CacheReadInputTokens,
+		},
+		"completion_tokens_details": map[string]any{
+			"reasoning_tokens": usage.ReasoningTokens,
+		},
+		"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+		"cache_read_input_tokens":     usage.CacheReadInputTokens,
+	}
+}
+
+func anyString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return ""
+	}
+}

--- a/internal/runtime/executor/trae_executor.go
+++ b/internal/runtime/executor/trae_executor.go
@@ -95,21 +95,21 @@ func (e *TraeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 		}
 	}()
 
-	accumulator := newTraeResponseAccumulator(req.Model)
-	errScan := scanTraeSSE(httpResp.Body, func(event traeSSEEvent) error {
+	accumulator := helps.NewTraeResponseAccumulator(req.Model)
+	errScan := helps.ScanTraeSSE(httpResp.Body, func(event helps.TraeSSEEvent) error {
 		helpRaw := append([]byte("event: "+event.Name+"\ndata: "), event.Data...)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, helpRaw)
-		return accumulator.consume(event)
+		return accumulator.Consume(event)
 	})
 	if errScan != nil {
 		helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 		return resp, errScan
 	}
-	if !accumulator.Finished {
+	if !accumulator.IsFinished() {
 		return resp, fmt.Errorf("trae executor: raw chat stream closed before done event")
 	}
 
-	openAIResponse := accumulator.responseJSON()
+	openAIResponse := accumulator.ResponseJSON()
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(openAIResponse))
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	var param any
@@ -139,7 +139,7 @@ func (e *TraeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	}
 
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
-	streamState := newTraeStreamState(req.Model)
+	streamState := helps.NewTraeStreamState(req.Model)
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -168,10 +168,10 @@ func (e *TraeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 			return true
 		}
-		errStream := scanTraeSSE(httpResp.Body, func(event traeSSEEvent) error {
+		errStream := helps.ScanTraeSSE(httpResp.Body, func(event helps.TraeSSEEvent) error {
 			helpRaw := append([]byte("event: "+event.Name+"\ndata: "), event.Data...)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, helpRaw)
-			line, _, errConvert := streamState.convert(event)
+			line, errConvert := streamState.Convert(event)
 			if errConvert != nil {
 				return errConvert
 			}
@@ -180,7 +180,7 @@ func (e *TraeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 			return nil
 		})
-		if errStream == nil && !streamState.Finished {
+		if errStream == nil && !streamState.IsFinished() {
 			errStream = fmt.Errorf("trae executor: raw chat stream closed before done event")
 		}
 		if errStream != nil {
@@ -542,4 +542,15 @@ func metadataStringFromJSON(payload []byte, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(anyString(value[key]))
+}
+
+func anyString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return ""
+	}
 }

--- a/internal/runtime/executor/trae_executor.go
+++ b/internal/runtime/executor/trae_executor.go
@@ -1,0 +1,545 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	traeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/trae"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/buildinfo"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
+)
+
+// TraeExecutor routes requests through an existing local Trae CLI account.
+type TraeExecutor struct {
+	cfg *config.Config
+}
+
+// NewTraeExecutor creates a Trae provider executor.
+func NewTraeExecutor(cfg *config.Config) *TraeExecutor { return &TraeExecutor{cfg: cfg} }
+
+// Identifier returns the executor provider key.
+func (e *TraeExecutor) Identifier() string { return traeauth.Provider }
+
+// RequestToFormat reports the OpenAI chat-completions shape used before Trae wrapping.
+func (e *TraeExecutor) RequestToFormat(_ cliproxyexecutor.Request, _ cliproxyexecutor.Options) sdktranslator.Format {
+	return sdktranslator.FormatOpenAI
+}
+
+// PrepareRequest reloads the local Trae access token and injects it into a request.
+func (e *TraeExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
+	if req == nil {
+		return nil
+	}
+	if auth == nil {
+		return fmt.Errorf("trae executor: auth is nil")
+	}
+	token, errToken := traeauth.AccessToken(auth.Metadata)
+	if errToken != nil {
+		return errToken
+	}
+	req.Header.Set("Authorization", "Cloud-CLI-JWT "+token)
+	util.ApplyCustomHeadersFromAttrs(req, auth.Attributes)
+	return nil
+}
+
+// HttpRequest executes an arbitrary HTTP request with the current Trae credential.
+func (e *TraeExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth, req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("trae executor: request is nil")
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+	httpReq := req.WithContext(ctx)
+	if errPrepare := e.PrepareRequest(httpReq, auth); errPrepare != nil {
+		return nil, errPrepare
+	}
+	return helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0).Do(httpReq)
+}
+
+// Execute performs a non-streaming request against Trae's raw chat SSE endpoint.
+func (e *TraeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	ctx = helps.EnsureSessionContext(ctx, opts, req.Payload)
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	body, errPrepare := e.prepareRequest(ctx, auth, req, opts)
+	if errPrepare != nil {
+		return resp, errPrepare
+	}
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+	httpResp, errDo := e.doRequest(ctx, auth, body, reporter)
+	if errDo != nil {
+		return resp, errDo
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("trae executor: close response body error: %v", errClose)
+		}
+	}()
+
+	accumulator := newTraeResponseAccumulator(req.Model)
+	errScan := scanTraeSSE(httpResp.Body, func(event traeSSEEvent) error {
+		helpRaw := append([]byte("event: "+event.Name+"\ndata: "), event.Data...)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, helpRaw)
+		return accumulator.consume(event)
+	})
+	if errScan != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+		return resp, errScan
+	}
+	if !accumulator.Finished {
+		return resp, fmt.Errorf("trae executor: raw chat stream closed before done event")
+	}
+
+	openAIResponse := accumulator.responseJSON()
+	reporter.Publish(ctx, helps.ParseOpenAIUsage(openAIResponse))
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	var param any
+	out := sdktranslator.TranslateNonStream(ctx, sdktranslator.FormatOpenAI, responseFormat, req.Model, opts.OriginalRequest, body, openAIResponse, &param)
+	if responseFormat == sdktranslator.FormatOpenAIResponse {
+		out = helps.EnsureResponsesUsageDetails(out)
+	}
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+// ExecuteStream performs a streaming Trae request and translates each event downstream.
+func (e *TraeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	ctx = helps.EnsureSessionContext(ctx, opts, req.Payload)
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	body, errPrepare := e.prepareRequest(ctx, auth, req, opts)
+	if errPrepare != nil {
+		return nil, errPrepare
+	}
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+	httpResp, errDo := e.doRequest(ctx, auth, body, reporter)
+	if errDo != nil {
+		return nil, errDo
+	}
+
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	streamState := newTraeStreamState(req.Model)
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("trae executor: close response body error: %v", errClose)
+			}
+		}()
+		originalPayload := opts.OriginalRequest
+		if len(originalPayload) == 0 {
+			originalPayload = req.Payload
+		}
+		claudeInputTokens := helps.NewClaudeInputTokenState(opts.SourceFormat, sdktranslator.FormatOpenAI, responseFormat, originalPayload)
+		var param any
+		var streamUsage helps.StreamUsageBuffer
+		defer streamUsage.Publish(ctx, reporter)
+		emitLine := func(line []byte) bool {
+			streamUsage.ObserveOpenAIStream(line)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, sdktranslator.FormatOpenAI, responseFormat, req.Model, opts.OriginalRequest, body, line, &param, claudeInputTokens)
+			for _, chunk := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunk}:
+				case <-ctx.Done():
+					return false
+				}
+			}
+			return true
+		}
+		errStream := scanTraeSSE(httpResp.Body, func(event traeSSEEvent) error {
+			helpRaw := append([]byte("event: "+event.Name+"\ndata: "), event.Data...)
+			helps.AppendAPIResponseChunk(ctx, e.cfg, helpRaw)
+			line, _, errConvert := streamState.convert(event)
+			if errConvert != nil {
+				return errConvert
+			}
+			if len(line) > 0 && !emitLine(line) {
+				return ctx.Err()
+			}
+			return nil
+		})
+		if errStream == nil && !streamState.Finished {
+			errStream = fmt.Errorf("trae executor: raw chat stream closed before done event")
+		}
+		if errStream != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errStream)
+			reporter.PublishFailure(ctx, errStream)
+			if ctx.Err() == nil {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Err: errStream}:
+				case <-ctx.Done():
+				}
+			}
+			return
+		}
+		_ = emitLine([]byte("[DONE]"))
+	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// CountTokens estimates tokens using the repository's OpenAI chat tokenizer.
+func (e *TraeExecutor) CountTokens(ctx context.Context, _ *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	from := opts.SourceFormat
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, sdktranslator.FormatOpenAI, baseModel, bytes.Clone(req.Payload), false)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, from.String(), sdktranslator.FormatOpenAI.String(), e.Identifier())
+	if errThinking != nil {
+		return cliproxyexecutor.Response{}, errThinking
+	}
+	enc, errTokenizer := helps.TokenizerForModel(baseModel)
+	if errTokenizer != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("trae executor: tokenizer init failed: %w", errTokenizer)
+	}
+	count, errCount := helps.CountOpenAIChatTokens(enc, body)
+	if errCount != nil {
+		return cliproxyexecutor.Response{}, fmt.Errorf("trae executor: token counting failed: %w", errCount)
+	}
+	usageJSON := helps.BuildOpenAIUsageJSON(count)
+	translated := sdktranslator.TranslateTokenCount(ctx, sdktranslator.FormatOpenAI, cliproxyexecutor.ResponseFormatOrSource(opts), count, usageJSON)
+	return cliproxyexecutor.Response{Payload: translated}, nil
+}
+
+// Refresh asks the local CLI to validate or renew its login, then reloads referenced state.
+func (e *TraeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	log.Debug("trae executor: refresh called")
+	if refreshed, handled, errHome := helps.RefreshAuthViaHome(ctx, e.cfg, auth); handled {
+		return refreshed, errHome
+	}
+	if auth == nil {
+		return nil, fmt.Errorf("trae executor: auth is nil")
+	}
+	cliPath := metadataString(auth.Metadata, "trae_cli_path")
+	authPath := metadataString(auth.Metadata, "trae_auth_path")
+	if cliPath == "" || authPath == "" {
+		return auth, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	refreshCtx, cancelRefresh := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelRefresh()
+	models, clientVersion, errModels := traeauth.FetchModels(refreshCtx, cliPath)
+	if errModels != nil {
+		return nil, fmt.Errorf("trae executor: refresh local CLI login: %w", errModels)
+	}
+	credentials, errLoad := traeauth.LoadCredentials(authPath)
+	if errLoad != nil {
+		return nil, errLoad
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["type"] = traeauth.Provider
+	auth.Metadata["user_id"] = credentials.UserID
+	auth.Metadata["region"] = credentials.Region
+	auth.Metadata["expires_at"] = credentials.ExpiresAt
+	auth.Metadata["expired"] = credentials.ExpiresAt
+	auth.Metadata["last_refresh"] = credentials.LastRefresh
+	auth.Metadata["models"] = models
+	if clientVersion != "" {
+		auth.Metadata["client_version"] = clientVersion
+	}
+	return auth, nil
+}
+
+func (e *TraeExecutor) prepareRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) ([]byte, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("trae executor: auth is nil")
+	}
+	from := opts.SourceFormat
+	to := sdktranslator.FormatOpenAI
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	originalPayload := opts.OriginalRequest
+	if len(originalPayload) == 0 {
+		originalPayload = req.Payload
+	}
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(originalPayload), false)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, bytes.Clone(req.Payload), false)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
+	if errThinking != nil {
+		return nil, errThinking
+	}
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
+
+	var translated map[string]any
+	if errUnmarshal := json.Unmarshal(body, &translated); errUnmarshal != nil {
+		return nil, fmt.Errorf("trae executor: parse translated request: %w", errUnmarshal)
+	}
+	model, found := traeauth.ModelFor(auth.Metadata, baseModel)
+	if !found {
+		model = traeauth.Model{Name: baseModel, ConfigName: baseModel, BackendModel: baseModel}
+		if !strings.HasSuffix(strings.ToLower(model.BackendModel), "__dev") {
+			model.BackendModel += "__dev"
+		}
+	}
+	conversationID := helps.ProviderSessionUUID(traeauth.Provider, req.Metadata, opts.Metadata)
+	if conversationID == "" {
+		conversationID = newTraeUUID()
+	}
+	sessionID := uuid.NewString()
+	maxTokens := intValue(translated["max_tokens"])
+	if maxTokens <= 0 {
+		maxTokens = intValue(translated["max_completion_tokens"])
+	}
+	if maxTokens <= 0 {
+		maxTokens = 32_000
+	}
+	parallelToolCalls := true
+	if configured, ok := translated["parallel_tool_calls"].(bool); ok {
+		parallelToolCalls = configured
+	}
+	messages := normalizeTraeMessages(translated["messages"])
+	requestPayload := map[string]any{
+		"access_type":         4,
+		"biz_context":         map[string]any{"repo_urls": []string{}},
+		"config_name":         model.ConfigName,
+		"conversation_id":     conversationID,
+		"is_preset":           true,
+		"max_tokens":          maxTokens,
+		"messages":            messages,
+		"model_name":          model.BackendModel,
+		"parallel_tool_calls": parallelToolCalls,
+		"reasoning_effort":    traeReasoningEffort(translated),
+		"session_id":          sessionID,
+		"tools":               []any{},
+		"user_input":          latestTraeUserInput(messages),
+	}
+	for _, key := range []string{"tools", "response_format"} {
+		if value, ok := translated[key]; ok && value != nil {
+			requestPayload[key] = value
+		}
+	}
+	encoded, errMarshal := json.Marshal(requestPayload)
+	if errMarshal != nil {
+		return nil, fmt.Errorf("trae executor: encode request: %w", errMarshal)
+	}
+	return encoded, nil
+}
+
+func (e *TraeExecutor) doRequest(ctx context.Context, auth *cliproxyauth.Auth, body []byte, reporter *helps.UsageReporter) (*http.Response, error) {
+	token, errToken := traeauth.AccessToken(auth.Metadata)
+	if errToken != nil {
+		return nil, errToken
+	}
+	baseURLs := traeauth.BaseURLs(auth.Metadata)
+	if len(baseURLs) == 0 {
+		return nil, fmt.Errorf("trae executor: no upstream endpoint is configured")
+	}
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	if reporter != nil {
+		httpClient = reporter.TrackHTTPClient(httpClient)
+	}
+	var lastErr error
+	for index, baseURL := range baseURLs {
+		url := strings.TrimSuffix(baseURL, "/") + traeauth.RawChatPath
+		httpReq, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if errRequest != nil {
+			return nil, errRequest
+		}
+		applyTraeHeaders(httpReq, auth, token)
+		httpReq.Header.Set("X-Flow-Traceparent", traeTraceparentForSession(metadataStringFromJSON(body, "session_id")))
+		var authID, authLabel, authType, authValue string
+		if auth != nil {
+			authID = auth.ID
+			authLabel = auth.Label
+			authType, authValue = auth.AccountInfo()
+		}
+		helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+			URL:       url,
+			Method:    http.MethodPost,
+			Headers:   httpReq.Header.Clone(),
+			Body:      body,
+			Provider:  e.Identifier(),
+			AuthID:    authID,
+			AuthLabel: authLabel,
+			AuthType:  authType,
+			AuthValue: authValue,
+		})
+		httpResp, errDo := httpClient.Do(httpReq)
+		if errDo != nil {
+			lastErr = errDo
+			helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+			continue
+		}
+		helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+		if httpResp.StatusCode >= 200 && httpResp.StatusCode < 300 {
+			return httpResp, nil
+		}
+		errorBody, _ := io.ReadAll(httpResp.Body)
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("trae executor: close rejected response body error: %v", errClose)
+		}
+		helps.AppendAPIResponseChunk(ctx, e.cfg, errorBody)
+		lastErr = statusErr{code: httpResp.StatusCode, msg: string(errorBody)}
+		if index+1 < len(baseURLs) && (httpResp.StatusCode == http.StatusNotFound || httpResp.StatusCode == http.StatusBadGateway || httpResp.StatusCode == http.StatusServiceUnavailable) {
+			continue
+		}
+		return nil, lastErr
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("trae executor: all upstream endpoint candidates failed")
+	}
+	return nil, lastErr
+}
+
+func applyTraeHeaders(request *http.Request, auth *cliproxyauth.Auth, token string) {
+	version := metadataString(auth.Metadata, "client_version")
+	if version == "" {
+		version = buildinfo.Version
+	}
+	if version == "" || version == "dev" {
+		version = "unknown"
+	}
+	request.Header.Set("Accept", "text/event-stream")
+	request.Header.Set("Authorization", "Cloud-CLI-JWT "+token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Originator", "codex_exec")
+	request.Header.Set("User-Agent", fmt.Sprintf("codex_exec/%s (%s; %s) dumb (codex_exec; %s)", version, traePlatformName(), runtime.GOARCH, version))
+	request.Header.Set("Version", version)
+	request.Header.Set("X-App-Id", traeauth.AppID)
+	request.Header.Set("X-Flow-Traceparent", newTraeTraceparent())
+	request.Header.Set("X-Ide-Function", "traecli_next")
+	request.Header.Set("X-Ide-Version-Code", time.Now().UTC().Format("20060102"))
+	if auth != nil {
+		util.ApplyCustomHeadersFromAttrs(request, auth.Attributes)
+	}
+}
+
+func normalizeTraeMessages(value any) []any {
+	messages, ok := value.([]any)
+	if !ok {
+		return []any{}
+	}
+	out := make([]any, 0, len(messages))
+	for _, rawMessage := range messages {
+		message, okMessage := rawMessage.(map[string]any)
+		if !okMessage {
+			continue
+		}
+		copyMessage := make(map[string]any, len(message))
+		for key, field := range message {
+			copyMessage[key] = field
+		}
+		if text, okText := copyMessage["content"].(string); okText {
+			copyMessage["content"] = []any{map[string]any{"type": "text", "text": text}}
+		}
+		out = append(out, copyMessage)
+	}
+	return out
+}
+
+func latestTraeUserInput(messages []any) string {
+	for index := len(messages) - 1; index >= 0; index-- {
+		message, ok := messages[index].(map[string]any)
+		if !ok || !strings.EqualFold(anyString(message["role"]), "user") {
+			continue
+		}
+		switch content := message["content"].(type) {
+		case string:
+			return content
+		case []any:
+			parts := make([]string, 0, len(content))
+			for _, rawPart := range content {
+				part, okPart := rawPart.(map[string]any)
+				if !okPart {
+					continue
+				}
+				text := anyString(part["text"])
+				if text == "" {
+					text = anyString(part["input_text"])
+				}
+				if text != "" {
+					parts = append(parts, text)
+				}
+			}
+			return strings.Join(parts, "\n")
+		}
+	}
+	return ""
+}
+
+func intValue(value any) int {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed)
+	case float32:
+		return int(typed)
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case json.Number:
+		parsed, _ := strconv.Atoi(typed.String())
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func traeReasoningEffort(payload map[string]any) string {
+	if effort := strings.TrimSpace(anyString(payload["reasoning_effort"])); effort != "" {
+		return effort
+	}
+	return "xhigh"
+}
+
+func traePlatformName() string {
+	switch runtime.GOOS {
+	case "linux":
+		return "Debian 10.0.0"
+	case "darwin":
+		return "Mac OS"
+	case "windows":
+		return "Windows"
+	default:
+		return runtime.GOOS
+	}
+}
+
+func newTraeUUID() string { return uuid.NewString() }
+
+func newTraeTraceparent() string {
+	return traeTraceparentForSession(uuid.NewString())
+}
+
+func traeTraceparentForSession(sessionID string) string {
+	traceID := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(sessionID), "-", ""))
+	if len(traceID) != 32 {
+		traceID = strings.ReplaceAll(uuid.NewString(), "-", "")
+	}
+	return "00-" + traceID + "-" + traceID[:16] + "-01"
+}
+
+func metadataStringFromJSON(payload []byte, key string) string {
+	var value map[string]any
+	if json.Unmarshal(payload, &value) != nil {
+		return ""
+	}
+	return strings.TrimSpace(anyString(value[key]))
+}

--- a/internal/runtime/executor/trae_executor.go
+++ b/internal/runtime/executor/trae_executor.go
@@ -242,12 +242,18 @@ func (e *TraeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 	refreshCtx, cancelRefresh := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelRefresh()
 	models, clientVersion, errModels := traeauth.FetchModels(refreshCtx, cliPath)
-	if errModels != nil {
-		return nil, fmt.Errorf("trae executor: refresh local CLI login: %w", errModels)
-	}
 	credentials, errLoad := traeauth.LoadCredentials(authPath)
 	if errLoad != nil {
 		return nil, errLoad
+	}
+	if errModels != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if !traeCredentialUsableAt(credentials, time.Now()) {
+			return nil, fmt.Errorf("trae executor: refresh local CLI login: %w", errModels)
+		}
+		log.Warn("trae executor: model catalog refresh failed; retaining unexpired local credential")
 	}
 	if auth.Metadata == nil {
 		auth.Metadata = make(map[string]any)
@@ -258,9 +264,11 @@ func (e *TraeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*c
 	auth.Metadata["expires_at"] = credentials.ExpiresAt
 	auth.Metadata["expired"] = credentials.ExpiresAt
 	auth.Metadata["last_refresh"] = credentials.LastRefresh
-	auth.Metadata["models"] = models
-	if clientVersion != "" {
-		auth.Metadata["client_version"] = clientVersion
+	if errModels == nil {
+		auth.Metadata["models"] = models
+		if clientVersion != "" {
+			auth.Metadata["client_version"] = clientVersion
+		}
 	}
 	return auth, nil
 }
@@ -330,7 +338,7 @@ func (e *TraeExecutor) prepareRequest(ctx context.Context, auth *cliproxyauth.Au
 		"tools":               []any{},
 		"user_input":          latestTraeUserInput(messages),
 	}
-	for _, key := range []string{"tools", "response_format"} {
+	for _, key := range []string{"tools", "tool_choice", "response_format"} {
 		if value, ok := translated[key]; ok && value != nil {
 			requestPayload[key] = value
 		}
@@ -542,6 +550,18 @@ func metadataStringFromJSON(payload []byte, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(anyString(value[key]))
+}
+
+func traeCredentialUsableAt(credentials traeauth.Credentials, now time.Time) bool {
+	if strings.TrimSpace(credentials.AccessToken) == "" {
+		return false
+	}
+	expiresAt := strings.TrimSpace(credentials.ExpiresAt)
+	if expiresAt == "" {
+		return true
+	}
+	expiry, errParse := time.Parse(time.RFC3339Nano, expiresAt)
+	return errParse == nil && expiry.After(now)
 }
 
 func anyString(value any) string {

--- a/internal/runtime/executor/trae_executor_test.go
+++ b/internal/runtime/executor/trae_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	traeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/trae"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -88,7 +89,9 @@ func TestTraeExecutorExecute(t *testing.T) {
 }
 
 func TestTraeExecutorExecuteStreamConvertsToolCalls(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		receivedBody = readTestBody(t, request)
 		writer.Header().Set("Content-Type", "text/event-stream")
 		_, _ = fmt.Fprint(writer, `event: metadata
 data: {"model":"gpt-5.6-sol","session_id":"session-2"}
@@ -116,7 +119,7 @@ data: {"finish_reason":"tool_calls"}
 	executor := NewTraeExecutor(&config.Config{})
 	req := cliproxyexecutor.Request{
 		Model:   "GPT-5.6-Sol",
-		Payload: []byte(`{"model":"GPT-5.6-Sol","messages":[{"role":"user","content":"look up x"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]}`),
+		Payload: []byte(`{"model":"GPT-5.6-Sol","messages":[{"role":"user","content":"look up x"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],"tool_choice":"required"}`),
 		Format:  sdktranslator.FormatOpenAI,
 	}
 	result, errExecute := executor.ExecuteStream(context.Background(), auth, req, cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAI, ResponseFormat: sdktranslator.FormatOpenAI})
@@ -147,6 +150,9 @@ data: {"finish_reason":"tool_calls"}
 	}
 	if got := arguments.String(); got != `{"q":"x"}` {
 		t.Fatalf("tool arguments = %q, stream = %s", got, stream)
+	}
+	if got := gjson.GetBytes(receivedBody, "tool_choice").String(); got != "required" {
+		t.Fatalf("tool_choice = %q, body = %s", got, receivedBody)
 	}
 	if !strings.Contains(stream, `"finish_reason":"tool_calls"`) || !strings.Contains(stream, "[DONE]") {
 		t.Fatalf("stream termination missing: %s", stream)
@@ -185,6 +191,56 @@ data: {"finish_reason":"tool_calls"}
 	}
 	if got := gjson.GetBytes(response.Payload, "choices.0.message.tool_calls.0.function.arguments").String(); got != `{"q":"x"}` {
 		t.Fatalf("tool arguments = %q, payload = %s", got, response.Payload)
+	}
+}
+
+func TestTraeExecutorRefreshCatalogFailureUsesUnexpiredReferencedCredential(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		wantErr   bool
+	}{
+		{name: "unexpired", expiresAt: time.Now().Add(time.Hour)},
+		{name: "expired", expiresAt: time.Now().Add(-time.Hour), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authPath := filepath.Join(t.TempDir(), "auth.json")
+			expiresAt := test.expiresAt.UTC().Format(time.RFC3339)
+			authJSON := fmt.Sprintf(`{"auth_mode":"trae","last_refresh":"2026-09-12T08:00:00Z","trae":{"access_token":"live-token","user_id":"test-user","expires_at":%q,"region":"CN"}}`, expiresAt)
+			if errWrite := os.WriteFile(authPath, []byte(authJSON), 0o600); errWrite != nil {
+				t.Fatal(errWrite)
+			}
+			models := []traeauth.Model{{
+				Name:          "GPT-5.6-Sol",
+				ConfigName:    "gpt-5.6-sol",
+				BackendModel:  "gpt-5.6-sol__dev",
+				Provider:      traeauth.Provider,
+				ContextWindow: 272000,
+			}}
+			auth := &cliproxyauth.Auth{
+				ID:       "trae-refresh-test.json",
+				Provider: traeauth.Provider,
+				Metadata: map[string]any{
+					"trae_cli_path":  filepath.Join(t.TempDir(), "missing-traecli"),
+					"trae_auth_path": authPath,
+					"models":         models,
+				},
+			}
+			refreshed, errRefresh := NewTraeExecutor(&config.Config{}).Refresh(context.Background(), auth)
+			if (errRefresh != nil) != test.wantErr {
+				t.Fatalf("Refresh() error = %v, wantErr %t", errRefresh, test.wantErr)
+			}
+			if test.wantErr {
+				return
+			}
+			if _, ok := traeauth.ModelFor(refreshed.Metadata, "GPT-5.6-Sol"); !ok {
+				t.Fatalf("Refresh() discarded cached model metadata: %+v", refreshed.Metadata)
+			}
+			if got := refreshed.Metadata["expires_at"]; got != expiresAt {
+				t.Fatalf("expires_at = %v, want %q", got, expiresAt)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/trae_executor_test.go
+++ b/internal/runtime/executor/trae_executor_test.go
@@ -1,0 +1,151 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	traeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/trae"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestTraeExecutorExecute(t *testing.T) {
+	var receivedBody []byte
+	var receivedTraceparent string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != traeauth.RawChatPath {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Cloud-CLI-JWT live-token" {
+			t.Fatalf("authorization = %q", request.Header.Get("Authorization"))
+		}
+		receivedTraceparent = request.Header.Get("X-Flow-Traceparent")
+		receivedBody = readTestBody(t, request)
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, "event: metadata\ndata: {\"model\":\"gpt-5.6-sol\",\"session_id\":\"session-1\"}\n\nevent: output\ndata: {\"response\":\"Hello\",\"reasoning_content\":\"brief thought\",\"tool_calls\":null}\n\nevent: token_usage\ndata: {\"prompt_tokens\":10,\"completion_tokens\":3,\"total_tokens\":13,\"cache_read_input_tokens\":4,\"reasoning_tokens\":1}\n\nevent: done\ndata: {\"finish_reason\":\"stop\"}\n\n")
+	}))
+	defer server.Close()
+
+	auth := testTraeAuth(t, server.URL)
+	executor := NewTraeExecutor(&config.Config{})
+	req := cliproxyexecutor.Request{
+		Model:   "GPT-5.6-Sol",
+		Payload: []byte(`{"model":"GPT-5.6-Sol","messages":[{"role":"user","content":"hello"}]}`),
+		Format:  sdktranslator.FormatOpenAI,
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, ResponseFormat: sdktranslator.FormatOpenAI}
+	response, errExecute := executor.Execute(context.Background(), auth, req, opts)
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	if got := gjson.GetBytes(response.Payload, "choices.0.message.content").String(); got != "Hello" {
+		t.Fatalf("content = %q, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "choices.0.message.reasoning_content").String(); got != "brief thought" {
+		t.Fatalf("reasoning = %q, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "usage.prompt_tokens").Int(); got != 10 {
+		t.Fatalf("prompt_tokens = %d, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(receivedBody, "config_name").String(); got != "gpt-5.6-sol" {
+		t.Fatalf("config_name = %q, body = %s", got, receivedBody)
+	}
+	if got := gjson.GetBytes(receivedBody, "model_name").String(); got != "gpt-5.6-sol__dev" {
+		t.Fatalf("model_name = %q, body = %s", got, receivedBody)
+	}
+	if got := gjson.GetBytes(receivedBody, "messages.0.content.0.text").String(); got != "hello" {
+		t.Fatalf("normalized message = %q, body = %s", got, receivedBody)
+	}
+	if !gjson.GetBytes(receivedBody, "is_preset").Bool() || gjson.GetBytes(receivedBody, "reasoning_effort").String() != "xhigh" {
+		t.Fatalf("Trae request defaults missing, body = %s", receivedBody)
+	}
+	sessionID := strings.ReplaceAll(gjson.GetBytes(receivedBody, "session_id").String(), "-", "")
+	if len(sessionID) != 32 {
+		t.Fatalf("session_id = %q, body = %s", sessionID, receivedBody)
+	}
+	if receivedTraceparent != "00-"+sessionID+"-"+sessionID[:16]+"-01" {
+		t.Fatalf("traceparent %q does not match session_id %q", receivedTraceparent, sessionID)
+	}
+}
+
+func TestTraeExecutorExecuteStreamConvertsToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, "event: metadata\ndata: {\"model\":\"gpt-5.6-sol\",\"session_id\":\"session-2\"}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function_call\":{\"name\":\"lookup\",\"arguments\":\"\"}}]}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"\",\"type\":\"\",\"function_call\":{\"name\":\"\",\"arguments\":\"{\\\"q\\\":\\\"x\\\"}\"}}]}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function_call\":{\"name\":\"lookup\",\"arguments\":\"\"}}]}\n\nevent: token_usage\ndata: {\"prompt_tokens\":8,\"completion_tokens\":4,\"total_tokens\":12}\n\nevent: done\ndata: {\"finish_reason\":\"tool_calls\"}\n\n")
+	}))
+	defer server.Close()
+
+	auth := testTraeAuth(t, server.URL)
+	executor := NewTraeExecutor(&config.Config{})
+	req := cliproxyexecutor.Request{
+		Model:   "GPT-5.6-Sol",
+		Payload: []byte(`{"model":"GPT-5.6-Sol","messages":[{"role":"user","content":"look up x"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]}`),
+		Format:  sdktranslator.FormatOpenAI,
+	}
+	result, errExecute := executor.ExecuteStream(context.Background(), auth, req, cliproxyexecutor.Options{Stream: true, SourceFormat: sdktranslator.FormatOpenAI, ResponseFormat: sdktranslator.FormatOpenAI})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	var output strings.Builder
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error = %v", chunk.Err)
+		}
+		output.Write(chunk.Payload)
+		output.WriteByte('\n')
+	}
+	stream := output.String()
+	if strings.Count(stream, `"name":"lookup"`) != 1 {
+		t.Fatalf("tool name was not emitted exactly once: %s", stream)
+	}
+	if !strings.Contains(stream, `"arguments":"{\\\"q\\\":\\\"x\\\"}"`) {
+		t.Fatalf("tool arguments missing: %s", stream)
+	}
+	if !strings.Contains(stream, `"finish_reason":"tool_calls"`) || !strings.Contains(stream, "[DONE]") {
+		t.Fatalf("stream termination missing: %s", stream)
+	}
+}
+
+func testTraeAuth(t *testing.T, baseURL string) *cliproxyauth.Auth {
+	t.Helper()
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if errWrite := os.WriteFile(authPath, []byte(`{"auth_mode":"trae","trae":{"access_token":"live-token","user_id":"test-user","region":"CN"}}`), 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	models := []traeauth.Model{{
+		Name:          "GPT-5.6-Sol",
+		ConfigName:    "gpt-5.6-sol",
+		BackendModel:  "gpt-5.6-sol__dev",
+		Provider:      traeauth.Provider,
+		ContextWindow: 272000,
+	}}
+	return &cliproxyauth.Auth{
+		ID:       "trae-test.json",
+		Provider: traeauth.Provider,
+		Metadata: map[string]any{
+			"trae_auth_path": authPath,
+			"base_url":       baseURL,
+			"client_version": "0.204.1",
+			"models":         models,
+		},
+	}
+}
+
+func readTestBody(t *testing.T, request *http.Request) []byte {
+	t.Helper()
+	raw, errRead := io.ReadAll(request.Body)
+	if errRead != nil {
+		t.Fatal(errRead)
+	}
+	return raw
+}

--- a/internal/runtime/executor/trae_executor_test.go
+++ b/internal/runtime/executor/trae_executor_test.go
@@ -32,7 +32,7 @@ func TestTraeExecutorExecute(t *testing.T) {
 		receivedTraceparent = request.Header.Get("X-Flow-Traceparent")
 		receivedBody = readTestBody(t, request)
 		writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(writer, "event: metadata\ndata: {\"model\":\"gpt-5.6-sol\",\"session_id\":\"session-1\"}\n\nevent: output\ndata: {\"response\":\"Hello\",\"reasoning_content\":\"brief thought\",\"tool_calls\":null}\n\nevent: token_usage\ndata: {\"prompt_tokens\":10,\"completion_tokens\":3,\"total_tokens\":13,\"cache_read_input_tokens\":4,\"reasoning_tokens\":1}\n\nevent: done\ndata: {\"finish_reason\":\"stop\"}\n\n")
+		_, _ = fmt.Fprint(writer, "event: metadata\ndata: {\"model\":\"gpt-5.6-sol\",\"session_id\":\"session-1\"}\n\nevent: output\ndata: {\"response\":\"Hello\",\"reasoning_content\":\"brief thought\",\"tool_calls\":null}\n\nevent: token_usage\ndata: {\"prompt_tokens\":10,\"completion_tokens\":3,\"total_tokens\":13,\"cache_creation_input_tokens_total\":2,\"cache_read_input_tokens_total\":4,\"reasoning_tokens_total\":1}\n\nevent: done\ndata: {\"finish_reason\":\"stop\"}\n\n")
 	}))
 	defer server.Close()
 
@@ -56,6 +56,15 @@ func TestTraeExecutorExecute(t *testing.T) {
 	}
 	if got := gjson.GetBytes(response.Payload, "usage.prompt_tokens").Int(); got != 10 {
 		t.Fatalf("prompt_tokens = %d, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "usage.prompt_tokens_details.cached_tokens").Int(); got != 4 {
+		t.Fatalf("cached_tokens = %d, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "usage.completion_tokens_details.reasoning_tokens").Int(); got != 1 {
+		t.Fatalf("reasoning_tokens = %d, payload = %s", got, response.Payload)
+	}
+	if got := gjson.GetBytes(response.Payload, "usage.cache_creation_input_tokens").Int(); got != 2 {
+		t.Fatalf("cache_creation_input_tokens = %d, payload = %s", got, response.Payload)
 	}
 	if got := gjson.GetBytes(receivedBody, "config_name").String(); got != "gpt-5.6-sol" {
 		t.Fatalf("config_name = %q, body = %s", got, receivedBody)
@@ -81,7 +90,25 @@ func TestTraeExecutorExecute(t *testing.T) {
 func TestTraeExecutorExecuteStreamConvertsToolCalls(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(writer, "event: metadata\ndata: {\"model\":\"gpt-5.6-sol\",\"session_id\":\"session-2\"}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function_call\":{\"name\":\"lookup\",\"arguments\":\"\"}}]}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"\",\"type\":\"\",\"function_call\":{\"name\":\"\",\"arguments\":\"{\\\"q\\\":\\\"x\\\"}\"}}]}\n\nevent: output\ndata: {\"response\":\"\",\"reasoning_content\":null,\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function_call\":{\"name\":\"lookup\",\"arguments\":\"\"}}]}\n\nevent: token_usage\ndata: {\"prompt_tokens\":8,\"completion_tokens\":4,\"total_tokens\":12}\n\nevent: done\ndata: {\"finish_reason\":\"tool_calls\"}\n\n")
+		_, _ = fmt.Fprint(writer, `event: metadata
+data: {"model":"gpt-5.6-sol","session_id":"session-2"}
+
+event: output
+data: {"response":"","reasoning_content":null,"tool_calls":[{"index":0,"id":"call_1","type":"function","function_call":{"name":"lookup","arguments":"","partial_arguments":"{"}}]}
+
+event: output
+data: {"response":"","reasoning_content":null,"tool_calls":[{"index":0,"id":"","type":"","function_call":{"name":"","arguments":"","partial_arguments":"\"q\":\"x\"}"}}]}
+
+event: output
+data: {"response":"","reasoning_content":null,"tool_calls":[{"index":0,"id":"call_1","type":"function","function_call":{"name":"lookup","arguments":""}}]}
+
+event: token_usage
+data: {"prompt_tokens":8,"completion_tokens":4,"total_tokens":12}
+
+event: done
+data: {"finish_reason":"tool_calls"}
+
+`)
 	}))
 	defer server.Close()
 
@@ -108,11 +135,56 @@ func TestTraeExecutorExecuteStreamConvertsToolCalls(t *testing.T) {
 	if strings.Count(stream, `"name":"lookup"`) != 1 {
 		t.Fatalf("tool name was not emitted exactly once: %s", stream)
 	}
-	if !strings.Contains(stream, `"arguments":"{\\\"q\\\":\\\"x\\\"}"`) {
-		t.Fatalf("tool arguments missing: %s", stream)
+	var arguments strings.Builder
+	for _, line := range strings.Split(stream, "\n") {
+		data := strings.TrimPrefix(line, "data: ")
+		if data == line {
+			continue
+		}
+		if fragment := gjson.Get(data, "choices.0.delta.tool_calls.0.function.arguments"); fragment.Exists() {
+			arguments.WriteString(fragment.String())
+		}
+	}
+	if got := arguments.String(); got != `{"q":"x"}` {
+		t.Fatalf("tool arguments = %q, stream = %s", got, stream)
 	}
 	if !strings.Contains(stream, `"finish_reason":"tool_calls"`) || !strings.Contains(stream, "[DONE]") {
 		t.Fatalf("stream termination missing: %s", stream)
+	}
+}
+
+func TestTraeExecutorExecuteAccumulatesPartialToolArguments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(writer, `event: metadata
+data: {"model":"gpt-5.6-sol","session_id":"session-3"}
+
+event: output
+data: {"tool_calls":[{"index":0,"id":"call_2","type":"function","function_call":{"name":"lookup","partial_arguments":"{"}}]}
+
+event: output
+data: {"tool_calls":[{"index":0,"function_call":{"partial_arguments":"\"q\":\"x\"}"}}]}
+
+event: done
+data: {"finish_reason":"tool_calls"}
+
+`)
+	}))
+	defer server.Close()
+
+	auth := testTraeAuth(t, server.URL)
+	executor := NewTraeExecutor(&config.Config{})
+	req := cliproxyexecutor.Request{
+		Model:   "GPT-5.6-Sol",
+		Payload: []byte(`{"model":"GPT-5.6-Sol","messages":[{"role":"user","content":"look up x"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]}`),
+		Format:  sdktranslator.FormatOpenAI,
+	}
+	response, errExecute := executor.Execute(context.Background(), auth, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI, ResponseFormat: sdktranslator.FormatOpenAI})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	if got := gjson.GetBytes(response.Payload, "choices.0.message.tool_calls.0.function.arguments").String(); got != `{"q":"x"}` {
+		t.Fatalf("tool arguments = %q, payload = %s", got, response.Payload)
 	}
 }
 

--- a/sdk/auth/refresh_registry.go
+++ b/sdk/auth/refresh_registry.go
@@ -11,6 +11,7 @@ func init() {
 	registerRefreshLead("claude", func() Authenticator { return NewClaudeAuthenticator() })
 	registerRefreshLead("antigravity", func() Authenticator { return NewAntigravityAuthenticator() })
 	registerRefreshLead("kimi", func() Authenticator { return NewKimiAuthenticator() })
+	registerRefreshLead("trae", func() Authenticator { return NewTraeAuthenticator() })
 	registerRefreshLead("xai", func() Authenticator { return NewXAIAuthenticator() })
 }
 

--- a/sdk/auth/refresh_registry_test.go
+++ b/sdk/auth/refresh_registry_test.go
@@ -15,6 +15,7 @@ func TestProviderRefreshLeads(t *testing.T) {
 		{name: "claude", authenticator: NewClaudeAuthenticator(), want: 4 * time.Hour},
 		{name: "antigravity", authenticator: NewAntigravityAuthenticator(), want: 30 * time.Minute},
 		{name: "kimi", authenticator: NewKimiAuthenticator(), want: 5 * time.Minute},
+		{name: "trae", authenticator: NewTraeAuthenticator(), want: 5 * time.Minute},
 		{name: "xai", authenticator: NewXAIAuthenticator(), want: 5 * time.Minute},
 	}
 

--- a/sdk/auth/trae.go
+++ b/sdk/auth/trae.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	traeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/trae"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+var unsafeTraeFileNameChars = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// TraeAuthenticator imports an existing local Trae CLI login without copying its access token.
+type TraeAuthenticator struct{}
+
+// NewTraeAuthenticator constructs a Trae CLI credential importer.
+func NewTraeAuthenticator() Authenticator { return &TraeAuthenticator{} }
+
+// Provider returns the Trae provider key.
+func (TraeAuthenticator) Provider() string { return traeauth.Provider }
+
+// RefreshLead refreshes the referenced Trae CLI state shortly before it expires.
+func (TraeAuthenticator) RefreshLead() *time.Duration {
+	lead := 5 * time.Minute
+	return &lead
+}
+
+// Login imports paths and model metadata from the already authenticated local Trae CLI.
+func (TraeAuthenticator) Login(ctx context.Context, cfg *config.Config, _ *LoginOptions) (*coreauth.Auth, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("cliproxy auth: configuration is required")
+	}
+	installation, errResolve := traeauth.ResolveInstallation()
+	if errResolve != nil {
+		return nil, errResolve
+	}
+	credentials, errLoad := traeauth.LoadCredentials(installation.AuthPath)
+	if errLoad != nil {
+		return nil, errLoad
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	modelCtx, cancelModels := context.WithTimeout(ctx, 30*time.Second)
+	models, clientVersion, errModels := traeauth.FetchModels(modelCtx, installation.CLIPath)
+	cancelModels()
+	if errModels != nil {
+		models, clientVersion, errModels = traeauth.LoadCachedModels(installation.ModelsPath)
+		if errModels != nil {
+			return nil, fmt.Errorf("trae: load model catalog: %w", errModels)
+		}
+	}
+
+	baseMetadata := map[string]any{"region": credentials.Region}
+	metadata := map[string]any{
+		"type":                 traeauth.Provider,
+		"auth_kind":            "oauth",
+		"trae_auth_path":       installation.AuthPath,
+		"trae_models_path":     installation.ModelsPath,
+		"trae_cli_path":        installation.CLIPath,
+		"trae_home":            installation.Home,
+		"user_id":              credentials.UserID,
+		"region":               credentials.Region,
+		"expires_at":           credentials.ExpiresAt,
+		"expired":              credentials.ExpiresAt,
+		"last_refresh":         credentials.LastRefresh,
+		"login_method":         credentials.LoginMethod,
+		"credential_kind":      credentials.CredentialKind,
+		"client_version":       clientVersion,
+		"base_urls":            traeauth.BaseURLs(baseMetadata),
+		"models":               models,
+		"credential_reference": true,
+	}
+	label := credentials.UserID
+	if label == "" {
+		label = "Trae CLI"
+	}
+	fileLabel := strings.Trim(unsafeTraeFileNameChars.ReplaceAllString(label, "_"), "._-")
+	if fileLabel == "" {
+		fileLabel = "local"
+	}
+	fileName := "trae-" + fileLabel + ".json"
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: traeauth.Provider,
+		FileName: fileName,
+		Label:    label,
+		Metadata: metadata,
+	}, nil
+}

--- a/sdk/auth/trae_test.go
+++ b/sdk/auth/trae_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestTraeAuthenticatorImportsCredentialReference(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	root := t.TempDir()
+	cliPath := filepath.Join(root, "traecli")
+	cli := []byte("#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  echo '[{\"name\":\"GPT-5.6-Sol\",\"config_name\":\"gpt-5.6-sol\",\"backend_model\":\"gpt-5.6-sol__dev\",\"provider\":\"trae\",\"context_window\":272000}]'\n  exit 0\nfi\nif [ \"$1\" = \"--version\" ]; then\n  echo 'traecli 0.204.1'\n  exit 0\nfi\nexit 1\n")
+	if errWrite := os.WriteFile(cliPath, cli, 0o700); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	authDir := filepath.Join(root, "cli")
+	if errMkdir := os.MkdirAll(authDir, 0o700); errMkdir != nil {
+		t.Fatal(errMkdir)
+	}
+	authPath := filepath.Join(authDir, "auth.json")
+	authJSON := map[string]any{
+		"auth_mode": "trae",
+		"trae": map[string]any{
+			"access_token": "must-not-be-copied",
+			"user_id":      "test-user",
+			"region":       "CN",
+		},
+	}
+	rawAuth, _ := json.Marshal(authJSON)
+	if errWrite := os.WriteFile(authPath, rawAuth, 0o600); errWrite != nil {
+		t.Fatal(errWrite)
+	}
+	t.Setenv("TRAECLI_PATH", cliPath)
+	t.Setenv("TRAE_HOME", root)
+	t.Setenv("TRAE_AUTH_PATH", authPath)
+	t.Setenv("TRAE_MODELS_PATH", filepath.Join(authDir, "models_cache.json"))
+
+	record, errLogin := (TraeAuthenticator{}).Login(context.Background(), &config.Config{}, nil)
+	if errLogin != nil {
+		t.Fatalf("Login() error = %v", errLogin)
+	}
+	if record.Provider != "trae" || record.Label != "test-user" {
+		t.Fatalf("Login() record = %+v", record)
+	}
+	if _, copied := record.Metadata["access_token"]; copied {
+		t.Fatal("Login() copied access_token into CLIProxyAPI metadata")
+	}
+	if record.Metadata["trae_auth_path"] != authPath || record.Metadata["client_version"] != "0.204.1" {
+		t.Fatalf("Login() metadata = %+v", record.Metadata)
+	}
+}

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -471,7 +471,7 @@ func modelAliasChannel(auth *Auth) string {
 // and auth kind. Returns empty string if the provider/authKind combination doesn't support
 // OAuth model alias (e.g., API key authentication).
 //
-// Built-in channels: vertex, aistudio, antigravity, claude, codex, kimi.
+// Built-in channels: vertex, aistudio, antigravity, claude, codex, kimi, trae.
 // Plugin OAuth providers use their normalized provider key as the channel.
 func OAuthModelAliasChannel(provider, authKind string) string {
 	provider = strings.ToLower(strings.TrimSpace(provider))

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -292,6 +292,8 @@ func (s *Service) registerExecutorForAuth(a *coreauth.Auth, forceReplace bool) {
 		s.coreManager.RegisterExecutor(executor.NewClaudeExecutor(cfg))
 	case "kimi":
 		s.coreManager.RegisterExecutor(executor.NewKimiExecutor(cfg))
+	case "trae":
+		s.coreManager.RegisterExecutor(executor.NewTraeExecutor(cfg))
 	case "xai":
 		if !forceReplace {
 			existingExecutor, hasExecutor := s.coreManager.Executor("xai")

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	traeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/trae"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -142,6 +143,9 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
 		models = registry.GetKimiModels()
+		models = applyExcludedModels(models, excluded)
+	case "trae":
+		models = traeauth.RegistryModels(a.Metadata)
 		models = applyExcludedModels(models, excluded)
 	case "xai":
 		models = registry.GetXAIModels()


### PR DESCRIPTION
## Summary

- add `--trae-login` to import an existing local Trae CLI session without copying its access token
- discover the account-specific Trae model catalog and register it dynamically
- add a native Trae executor with OpenAI request translation, streaming/non-streaming responses, tool calls, usage accounting, endpoint fallback, and proactive CLI-backed refresh
- document setup and supported environment overrides in the English and Chinese READMEs

## Security

CLIProxyAPI persists only paths and non-secret model/account metadata. The Trae token is re-read from the referenced local Trae auth file when a request is made and is never copied into the CLIProxyAPI auth record.

## Verification

- `go vet ./internal/auth/trae ./sdk/auth ./internal/runtime/executor ./sdk/cliproxy ./cmd/server`
- `go build -o /tmp/cli-proxy-api-trae ./cmd/server`
- imported the installed Trae CLI account and discovered 20 available models
- live non-streaming request returned `TRAE_PROXY_OK` with token usage
- live streaming request returned `TRAE_STREAM_OK` and a `[DONE]` terminator
- added focused tests for credential parsing/import, model registration, SSE translation, tool-call deltas, request authentication, and session/trace consistency

## Usage

```bash
traecli login status
./CLIProxyAPI --trae-login
./CLIProxyAPI --config config.yaml
```