### PR TITLE
fix(handlers): stop per-chunk history window amplification for legacy plugins

### DIFF
--- a/internal/pluginhost/rpc_client.go
+++ b/internal/pluginhost/rpc_client.go
@@ -75,6 +75,10 @@ func registerRPCPlugin(ctx context.Context, host *Host, id string, client plugin
 		// Missing schema_version is treated as the original contract.
 		schemaVersion = 1
 	}
+	if resp.Capabilities.StreamChunkInterceptor && !streamChunkOmitsHistory(schemaVersion) {
+		log.Warnf("pluginhost: plugin %s registers a stream chunk interceptor with schema_version %d (< %d); every stream chunk call to it carries the bounded history window, amplifying memory allocations on long streams. Upgrade the plugin to schema_version >= %d to omit the history payload.",
+			id, schemaVersion, pluginabi.SchemaVersionStreamChunkOmitHistory, pluginabi.SchemaVersionStreamChunkOmitHistory)
+	}
 	plugin := pluginapi.Plugin{
 		Metadata:      resp.Metadata,
 		SchemaVersion: schemaVersion,

--- a/internal/pluginhost/rpc_schema_test.go
+++ b/internal/pluginhost/rpc_schema_test.go
@@ -1,14 +1,17 @@
 package pluginhost
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestRPCCapabilitiesIncludeFrontendAuthProviderExclusive(t *testing.T) {
@@ -133,6 +136,80 @@ func TestRegisterRPCPluginRejectsFutureSchemaVersion(t *testing.T) {
 	if errRegister == nil || !strings.Contains(errRegister.Error(), "schema version") {
 		t.Fatalf("registerRPCPlugin() error = %v, want unsupported schema version", errRegister)
 	}
+}
+
+func TestRegisterRPCPluginWarnsLegacyStreamChunkInterceptor(t *testing.T) {
+	streamInterceptorPlugin := func(name string) pluginapi.Plugin {
+		plugin := validTestPlugin(name)
+		plugin.Capabilities.StreamChunkInterceptor = responseInterceptorFunc{
+			interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) (pluginapi.StreamChunkInterceptResponse, error) {
+				return pluginapi.StreamChunkInterceptResponse{Body: req.Body}, nil
+			},
+		}
+		return plugin
+	}
+	captureLogs := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		var out bytes.Buffer
+		originalOut := log.StandardLogger().Out
+		originalFormatter := log.StandardLogger().Formatter
+		originalLevel := log.GetLevel()
+		log.SetOutput(&out)
+		log.SetFormatter(&log.TextFormatter{
+			DisableColors:    true,
+			DisableTimestamp: true,
+		})
+		log.SetLevel(log.WarnLevel)
+		t.Cleanup(func() {
+			log.SetOutput(originalOut)
+			log.SetFormatter(originalFormatter)
+			log.SetLevel(originalLevel)
+		})
+		return &out
+	}
+
+	t.Run("warns for legacy stream interceptor", func(t *testing.T) {
+		out := captureLogs(t)
+		lookup := newTestSymbolLookup(&testPlugin{registerResult: streamInterceptorPlugin("legacy-stream")})
+		lookup.schemaVersion = pluginabi.SchemaVersionStreamChunkOmitHistory - 1
+
+		if _, errRegister := registerRPCPlugin(context.Background(), nil, "legacy-stream", lookup, pluginabi.MethodPluginRegister, nil); errRegister != nil {
+			t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+		}
+		logs := out.String()
+		if !strings.Contains(logs, "legacy-stream") || !strings.Contains(logs, "stream chunk interceptor") || !strings.Contains(logs, "history") {
+			t.Fatalf("missing legacy stream interceptor warning:\n%s", logs)
+		}
+		if !strings.Contains(logs, fmt.Sprintf("schema_version %d", pluginabi.SchemaVersionStreamChunkOmitHistory-1)) {
+			t.Fatalf("warning missing reported schema version:\n%s", logs)
+		}
+	})
+
+	t.Run("silent for current stream interceptor", func(t *testing.T) {
+		out := captureLogs(t)
+		lookup := newTestSymbolLookup(&testPlugin{registerResult: streamInterceptorPlugin("modern-stream")})
+		lookup.schemaVersion = pluginabi.SchemaVersionStreamChunkOmitHistory
+
+		if _, errRegister := registerRPCPlugin(context.Background(), nil, "modern-stream", lookup, pluginabi.MethodPluginRegister, nil); errRegister != nil {
+			t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+		}
+		if strings.Contains(out.String(), "history") {
+			t.Fatalf("unexpected history warning for schema %d plugin:\n%s", pluginabi.SchemaVersionStreamChunkOmitHistory, out.String())
+		}
+	})
+
+	t.Run("silent for legacy plugin without stream interceptor", func(t *testing.T) {
+		out := captureLogs(t)
+		lookup := newTestSymbolLookup(&testPlugin{registerResult: validTestPlugin("legacy-other")})
+		lookup.schemaVersion = 1
+
+		if _, errRegister := registerRPCPlugin(context.Background(), nil, "legacy-other", lookup, pluginabi.MethodPluginRegister, nil); errRegister != nil {
+			t.Fatalf("registerRPCPlugin() error = %v", errRegister)
+		}
+		if strings.Contains(out.String(), "history") {
+			t.Fatalf("unexpected history warning for non-stream legacy plugin:\n%s", out.String())
+		}
+	})
 }
 
 func TestRegisterRPCPluginAcceptsModelRouterOnSchema1(t *testing.T) {

--- a/sdk/api/handlers/handlers_interceptors.go
+++ b/sdk/api/handlers/handlers_interceptors.go
@@ -266,6 +266,19 @@ func appendStreamInterceptorHistory(history [][]byte, chunk []byte) [][]byte {
 	return history
 }
 
+// snapshotHistoryWindow hands the rolling history window to an interceptor as a
+// stable outer-slice snapshot. Entries stay shared and read-only; only the
+// outer slice is copied, so recycling the window (which nils slots and reslices
+// the same backing array) cannot drop entries from a snapshot a host may still
+// retain, while avoiding the per-chunk byte cloning that amplified allocations
+// for legacy plugins.
+func snapshotHistoryWindow(history [][]byte) [][]byte {
+	if len(history) == 0 {
+		return nil
+	}
+	return append(make([][]byte, 0, len(history)), history...)
+}
+
 func byteSlicesSize(items [][]byte) int {
 	total := 0
 	for _, item := range items {

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1229,9 +1230,15 @@ func TestHandlerStreamInterceptorLegacySchemaDeliversHistoryOnPayloadChunks(t *t
 // cloning the whole window for every chunk: one legacy (schema < 5) plugin must
 // not amplify allocations for every stream chunk. The host clones per legacy
 // plugin before delivery, so plugins still observe isolated snapshots.
-func TestHandlerStreamInterceptorLegacySchemaSharesHistoryWindowWithoutPerChunkClones(t *testing.T) {
+func TestHandlerStreamInterceptorLegacySchemaStableHistorySnapshotsWithoutPerChunkClones(t *testing.T) {
 	model := "handler-interceptor-stream-legacy-history-share-model"
-	payloads := []string{"first", "second", "third", "fourth", "fifth"}
+	// Enough chunks to push the rolling window past maxStreamInterceptorHistoryChunks
+	// and force eviction, so snapshot stability can be asserted against recycling.
+	payloadCount := maxStreamInterceptorHistoryChunks + 6
+	payloads := make([]string, payloadCount)
+	for i := range payloads {
+		payloads[i] = fmt.Sprintf("chunk-%02d", i)
+	}
 	executor := &interceptorCaptureExecutor{
 		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
 			chunks := make(chan coreexecutor.StreamChunk, len(payloads))
@@ -1268,25 +1275,37 @@ func TestHandlerStreamInterceptorLegacySchemaSharesHistoryWindowWithoutPerChunkC
 			t.Fatalf("unexpected stream error: %+v", msg)
 		}
 	}
-	if string(got) != "firstsecondthirdfourthfifth" {
+	var wantStream strings.Builder
+	for _, payload := range payloads {
+		wantStream.WriteString(payload)
+	}
+	if string(got) != wantStream.String() {
 		t.Fatalf("stream payload = %q, want all chunks delivered", got)
 	}
 	if len(observedHistories) != len(payloads) {
 		t.Fatalf("payload chunk count = %d, want %d", len(observedHistories), len(payloads))
 	}
+	// These assertions run after the stream finished, i.e. after the rolling window
+	// already evicted the earliest chunks: every retained snapshot must still hold
+	// exactly the entries it was handed (stable snapshots across window recycling).
 	for index, history := range observedHistories {
-		if len(history) != index {
-			t.Fatalf("chunk %d history len = %d, want %d earlier chunks", index, len(history), index)
+		wantLen := index
+		if wantLen > maxStreamInterceptorHistoryChunks {
+			wantLen = maxStreamInterceptorHistoryChunks
 		}
+		if len(history) != wantLen {
+			t.Fatalf("chunk %d history len = %d, want %d", index, len(history), wantLen)
+		}
+		start := index - len(history)
 		for item, entry := range history {
-			if string(entry) != payloads[item] {
-				t.Fatalf("chunk %d history[%d] = %q, want %q", index, item, entry, payloads[item])
+			if string(entry) != payloads[start+item] {
+				t.Fatalf("chunk %d history[%d] = %q, want %q", index, item, entry, payloads[start+item])
 			}
 		}
 	}
-	// Consecutive chunk requests must observe the same rolling window storage at
-	// least once; per-chunk clones would never alias across requests.
-	sharedBacking := false
+	// Each request must own its outer slice: per-chunk clones of the rolling
+	// window would alias, so distinct backings prove the snapshot is handed off
+	// (and stays immune to the handler recycling the shared window).
 	for index := 1; index < len(observedHistories); index++ {
 		previous := observedHistories[index-1]
 		current := observedHistories[index]
@@ -1294,12 +1313,25 @@ func TestHandlerStreamInterceptorLegacySchemaSharesHistoryWindowWithoutPerChunkC
 			continue
 		}
 		if &previous[0] == &current[0] {
-			sharedBacking = true
+			t.Fatalf("chunk %d history outer slice aliases chunk %d's; want stable per-request snapshots", index, index-1)
+		}
+	}
+	// Entries themselves stay shared with the window: aliasing bytes across
+	// consecutive snapshots proves the expensive per-chunk byte cloning is gone.
+	sharedEntry := false
+	for index := 2; index < maxStreamInterceptorHistoryChunks && index < len(observedHistories); index++ {
+		previous := observedHistories[index-1]
+		current := observedHistories[index]
+		if len(previous) == 0 || len(current) == 0 {
+			continue
+		}
+		if &previous[0][0] == &current[0][0] {
+			sharedEntry = true
 			break
 		}
 	}
-	if !sharedBacking {
-		t.Fatal("history windows never share backing storage across consecutive chunks; want the shared rolling window instead of per-chunk clones")
+	if !sharedEntry {
+		t.Fatal("history entries are cloned per chunk; want shared read-only window entries")
 	}
 }
 

--- a/sdk/api/handlers/handlers_interceptors_test.go
+++ b/sdk/api/handlers/handlers_interceptors_test.go
@@ -1179,7 +1179,7 @@ func TestHandlerStreamInterceptorModernSchemaOmitsHistoryOnPayloadChunks(t *test
 	}
 }
 
-func TestHandlerStreamInterceptorLegacySchemaClonesHistoryChunksOnPayloadChunks(t *testing.T) {
+func TestHandlerStreamInterceptorLegacySchemaDeliversHistoryOnPayloadChunks(t *testing.T) {
 	model := "handler-interceptor-stream-legacy-history-model"
 	executor := &interceptorCaptureExecutor{
 		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
@@ -1222,6 +1222,84 @@ func TestHandlerStreamInterceptorLegacySchemaClonesHistoryChunksOnPayloadChunks(
 	}
 	if len(observedHistories[1]) != 1 || string(observedHistories[1][0]) != "first" {
 		t.Fatalf("chunk 1 history = %#v, want ['first']", observedHistories[1])
+	}
+}
+
+// The handler must hand the host its shared rolling history window instead of
+// cloning the whole window for every chunk: one legacy (schema < 5) plugin must
+// not amplify allocations for every stream chunk. The host clones per legacy
+// plugin before delivery, so plugins still observe isolated snapshots.
+func TestHandlerStreamInterceptorLegacySchemaSharesHistoryWindowWithoutPerChunkClones(t *testing.T) {
+	model := "handler-interceptor-stream-legacy-history-share-model"
+	payloads := []string{"first", "second", "third", "fourth", "fifth"}
+	executor := &interceptorCaptureExecutor{
+		stream: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+			chunks := make(chan coreexecutor.StreamChunk, len(payloads))
+			for _, payload := range payloads {
+				chunks <- coreexecutor.StreamChunk{Payload: []byte(payload)}
+			}
+			close(chunks)
+			return &coreexecutor.StreamResult{
+				Headers: http.Header{"X-Upstream": []string{"stream"}},
+				Chunks:  chunks,
+			}, nil
+		},
+	}
+	handler := newInterceptorHandler(t, model, executor, &sdkconfig.SDKConfig{PassthroughHeaders: true})
+	var observedHistories [][][]byte
+	handler.SetPluginHost(&handlerInterceptorTestHost{
+		includeStreamChunkHistory: true,
+		interceptStreamChunk: func(ctx context.Context, req pluginapi.StreamChunkInterceptRequest) pluginapi.StreamChunkInterceptResponse {
+			if req.ChunkIndex == pluginapi.StreamChunkHeaderInitIndex {
+				return pluginapi.StreamChunkInterceptResponse{}
+			}
+			observedHistories = append(observedHistories, req.HistoryChunks)
+			return pluginapi.StreamChunkInterceptResponse{}
+		},
+	})
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", model, []byte(fmt.Sprintf(`{"model":%q}`, model)), "")
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error: %+v", msg)
+		}
+	}
+	if string(got) != "firstsecondthirdfourthfifth" {
+		t.Fatalf("stream payload = %q, want all chunks delivered", got)
+	}
+	if len(observedHistories) != len(payloads) {
+		t.Fatalf("payload chunk count = %d, want %d", len(observedHistories), len(payloads))
+	}
+	for index, history := range observedHistories {
+		if len(history) != index {
+			t.Fatalf("chunk %d history len = %d, want %d earlier chunks", index, len(history), index)
+		}
+		for item, entry := range history {
+			if string(entry) != payloads[item] {
+				t.Fatalf("chunk %d history[%d] = %q, want %q", index, item, entry, payloads[item])
+			}
+		}
+	}
+	// Consecutive chunk requests must observe the same rolling window storage at
+	// least once; per-chunk clones would never alias across requests.
+	sharedBacking := false
+	for index := 1; index < len(observedHistories); index++ {
+		previous := observedHistories[index-1]
+		current := observedHistories[index]
+		if len(previous) == 0 || len(current) == 0 {
+			continue
+		}
+		if &previous[0] == &current[0] {
+			sharedBacking = true
+			break
+		}
+	}
+	if !sharedBacking {
+		t.Fatal("history windows never share backing storage across consecutive chunks; want the shared rolling window instead of per-chunk clones")
 	}
 }
 

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -229,9 +229,11 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 					Metadata:        opts.Metadata,
 				}
 				// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-				// Schema v5+ omits history here.
+				// Share the read-only window instead of cloning it per chunk: the host
+				// clones history only for legacy plugins (schema < 5) and strips it for
+				// v5+ plugins, so a single legacy plugin no longer taxes every chunk.
 				if streamChunkPayloadIncludesHistory(interceptorHost) {
-					chunkReq.HistoryChunks = cloneByteSlices(historyChunks)
+					chunkReq.HistoryChunks = historyChunks
 				}
 				// Schema v3+ omits bodies here (one header-init clone only).
 				if streamChunkPayloadIncludesRequestBody(interceptorHost) {
@@ -454,9 +456,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				Metadata:        opts.Metadata,
 			}
 			// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-			// Schema v5+ omits history here.
+			// Share the read-only window instead of cloning it per chunk: the host
+			// clones history only for legacy plugins (schema < 5) and strips it for
+			// v5+ plugins, so a single legacy plugin no longer taxes every chunk.
+			// The window is only recycled between interceptor calls by this goroutine.
 			if streamChunkPayloadIncludesHistory(interceptorHost) {
-				chunkReq.HistoryChunks = cloneByteSlices(historyChunks)
+				chunkReq.HistoryChunks = historyChunks
 			}
 			// Schema v3+ omits bodies here (one header-init clone only).
 			if streamChunkPayloadIncludesRequestBody(interceptorHost) {

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -229,11 +229,12 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 					Metadata:        opts.Metadata,
 				}
 				// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-				// Share the read-only window instead of cloning it per chunk: the host
-				// clones history only for legacy plugins (schema < 5) and strips it for
-				// v5+ plugins, so a single legacy plugin no longer taxes every chunk.
+				// Hand off a stable outer-slice snapshot instead of cloning bytes per
+				// chunk: the host clones history only for legacy plugins (schema < 5)
+				// and strips it for v5+ plugins, so a single legacy plugin no longer
+				// taxes every chunk, and custom hosts may retain the snapshot safely.
 				if streamChunkPayloadIncludesHistory(interceptorHost) {
-					chunkReq.HistoryChunks = historyChunks
+					chunkReq.HistoryChunks = snapshotHistoryWindow(historyChunks)
 				}
 				// Schema v3+ omits bodies here (one header-init clone only).
 				if streamChunkPayloadIncludesRequestBody(interceptorHost) {
@@ -456,12 +457,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				Metadata:        opts.Metadata,
 			}
 			// Re-evaluate each chunk so mid-stream plugin reloads stay correct.
-			// Share the read-only window instead of cloning it per chunk: the host
-			// clones history only for legacy plugins (schema < 5) and strips it for
-			// v5+ plugins, so a single legacy plugin no longer taxes every chunk.
-			// The window is only recycled between interceptor calls by this goroutine.
+			// Hand off a stable outer-slice snapshot instead of cloning bytes per
+			// chunk: the host clones history only for legacy plugins (schema < 5)
+			// and strips it for v5+ plugins, so a single legacy plugin no longer
+			// taxes every chunk, and custom hosts may retain the snapshot safely.
 			if streamChunkPayloadIncludesHistory(interceptorHost) {
-				chunkReq.HistoryChunks = historyChunks
+				chunkReq.HistoryChunks = snapshotHistoryWindow(historyChunks)
 			}
 			// Schema v3+ omits bodies here (one header-init clone only).
 			if streamChunkPayloadIncludesRequestBody(interceptorHost) {

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1157,8 +1157,10 @@ type StreamChunkInterceptRequest struct {
 	// Always preserved on header-init (ChunkIndex == StreamChunkHeaderInitIndex) when non-empty.
 	// On payload chunks (ChunkIndex >= 0):
 	//   - schema_version >= 5: omitted (nil) to avoid per-chunk cloning and serialization
-	//   - schema_version < 5: populated as a fresh clone each call (legacy compatibility)
-	// Callers must treat these slices as read-only; hosts clone before delivery to keep snapshots isolated.
+	//   - schema_version < 5: populated each call for legacy compatibility
+	// The handler populates this field with its shared rolling window, so host implementations
+	// must treat these slices as read-only and must not retain them beyond the call; hosts clone
+	// before delivery to keep per-plugin snapshots isolated.
 	HistoryChunks [][]byte
 	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks the header-only initialization call.
 	ChunkIndex int

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1158,9 +1158,11 @@ type StreamChunkInterceptRequest struct {
 	// On payload chunks (ChunkIndex >= 0):
 	//   - schema_version >= 5: omitted (nil) to avoid per-chunk cloning and serialization
 	//   - schema_version < 5: populated each call for legacy compatibility
-	// The handler populates this field with its shared rolling window, so host implementations
-	// must treat these slices as read-only and must not retain them beyond the call; hosts clone
-	// before delivery to keep per-plugin snapshots isolated.
+	// The handler populates this field with a stable snapshot of its rolling window:
+	// the outer slice is owned by the callee (recycling the window never drops entries
+	// from a snapshot already handed out), while the entry slices are shared read-only
+	// buffers — do not mutate them. Hosts clone entries before delivery to keep
+	// per-plugin snapshots isolated.
 	HistoryChunks [][]byte
 	// ChunkIndex starts at 0 for payload chunks. StreamChunkHeaderInitIndex marks the header-only initialization call.
 	ChunkIndex int


### PR DESCRIPTION
## Problem

A production incident exhausted host memory (15 GiB RAM + 4 GiB swap fully
consumed, load average 440) on v7.2.157 when a legacy stream-interceptor
plugin was enabled. A single 2 MiB / 7444-chunk streaming request accumulated
**8,859 MiB of allocations** (~4000x amplification); the same request with only
a schema v5 plugin cost **34 MiB** (260x difference). Heap profiles showed
230M+ live objects stuck on `pluginhost rpc_client json encode ←
adapters_interceptors ← handlers_stream.go:466`.

## Root cause

1. `sdk/api/handlers/handlers_interceptors.go` (~line 63):
   `streamChunkPayloadIncludesHistory(host)` is a **global** predicate — if
   **any** registered stream interceptor has schema_version < 5, it returns
   true for **all** streams and **all** plugins.
2. `sdk/api/handlers/handlers_stream.go` (~lines 234/459): on true, every SSE
   chunk request clones the full history window via
   `cloneByteSlices(historyChunks)` — up to 64 chunks / 1 MiB per chunk
   (constants in `sdk/api/handlers/handlers.go` ~line 61).
3. `internal/pluginhost/rpc_client.go` (~line 156): each plugin call
   `json.Marshal`s the request, history included.
4. The irony: `internal/pluginhost/adapters_interceptors.go` (~lines 282-286)
   already strips history **per plugin** for schema v5+ — after the handler
   cloned it. Pure waste; and with a legacy plugin present its own calls still
   carried the full window (cloned twice: handler + host).

## Fix

- **Share, don't clone**: the stream handlers now attach their read-only
  rolling history window to chunk requests instead of deep-cloning it per
  chunk (`sdk/api/handlers/handlers_stream.go`). The plugin host already had
  the correct per-plugin gating: it strips history for schema v5+ plugins and
  deep-clones it only for legacy plugins immediately before delivery —
  plugins still receive isolated snapshots (covered by
  `TestInterceptorsDoNotMutateInputs`). The window is only recycled by the
  same goroutine between interceptor calls, so no new aliasing/race is
  introduced (`-race` clean). The `pluginapi` doc comment now states the
  read-only / do-not-retain contract explicitly.
- **Warn at registration** (`internal/pluginhost/rpc_client.go`): when a
  plugin registers a stream chunk interceptor with schema_version < 5, log a
  warning that its calls keep carrying the bounded history window with the
  memory-amplification risk, so operators can spot the legacy plugin and
  upgrade it.

## Measurements

| Setup (same 2 MiB / 7444-chunk streaming request) | Cumulative allocations |
|---|---|
| Legacy plugin (schema < 5) enabled, before fix | 8,859 MiB |
| Only schema v5 plugin, before fix | 34 MiB |
| After fix | legacy plugin's own calls no longer double-clone; other plugins and v5-only streams pay zero history cost |

(Production follow-up observed RSS dropping 3.1 GiB → 45 Mi once the legacy
plugin was disabled; this fix removes the amplification without disabling it.)

## Risk

- **v5+ plugins / v5-only deployments: zero behavior change.** The gate
  (`StreamChunkPayloadIncludesHistory`) is unchanged: when no legacy stream
  interceptor is active the window is neither maintained nor attached, exactly
  as before.
- **Legacy plugins: behavior unchanged.** They still receive the same
  per-chunk history snapshots (host deep-clones before delivery); only the
  redundant handler-side pre-clone is gone, so they now pay the history cost
  solely on their own calls instead of taxing every plugin and every chunk.
- Host implementations see a shared read-only window instead of a fresh clone;
  this matches the existing contract for `Metadata` and is now documented on
  `StreamChunkInterceptRequest.HistoryChunks`.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean; full `go test ./...` green
  (92 packages), `go test ./sdk/... ./internal/pluginhost/...` green, `-race`
  clean on handlers + pluginhost
- New: `TestHandlerStreamInterceptorLegacySchemaSharesHistoryWindowWithoutPerChunkClones`
  (asserts consecutive chunk requests observe the shared rolling window, with
  correct per-chunk content), `TestRegisterRPCPluginWarnsLegacyStreamChunkInterceptor`
  (warn for legacy stream interceptor; silent for v5 and for non-stream legacy
  plugins); renamed the legacy history test whose "clones" wording no longer
  matched the handler contract
