### PR TITLE
fix(xai): send x-grok-conv-id for all models, not just composer

### DIFF
--- a/internal/runtime/executor/helps/derived_session.go
+++ b/internal/runtime/executor/helps/derived_session.go
@@ -64,3 +64,9 @@ func metadataString(metadata map[string]any, key string) string {
 	value, _ := metadata[key].(string)
 	return strings.TrimSpace(value)
 }
+
+// StableXAIConversationUUID maps a client conversation identity to a stable
+// UUID used as the xAI x-grok-conv-id header value.
+func StableXAIConversationUUID(identityValue string) string {
+	return stableProviderSessionUUID("xai", "client-conversation", identityValue)
+}

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -342,6 +343,15 @@ func xaiResolveComposerSessionID(ctx context.Context, req cliproxyexecutor.Reque
 	if sessionID := xaiExecutionSessionID(req, opts); sessionID != "" {
 		return sessionID, nil
 	}
+	// Derive a conversation ID from the client's own session headers so that
+	// x-grok-conv-id can be sent for every xAI model, not just composer ones.
+	// xAI routes requests sharing a conversation ID to the same server, and
+	// cache entries are stored per-server, so omitting the header scatters a
+	// conversation across servers and prevents prompt cache reuse. This matters
+	// most for large retained contexts, where a miss costs a full prefill.
+	if sessionID := xaiClientConversationID(ctx, opts); sessionID != "" {
+		return sessionID, nil
+	}
 	if !xaiRequiresIsolatedConversation(baseModel) {
 		return "", nil
 	}
@@ -368,6 +378,35 @@ func xaiExecutionSessionID(req cliproxyexecutor.Request, opts cliproxyexecutor.O
 		}
 	}
 	return helps.DerivedSessionUUID("xai", opts.Metadata, req.Metadata)
+}
+
+// xaiClientConversationID derives a stable conversation identifier from the
+// client's session headers, mirroring the sources the Codex executor already
+// uses. The value is hashed into a UUID so the upstream never sees raw client
+// identifiers, and it stays constant across turns of the same conversation.
+func xaiClientConversationID(ctx context.Context, opts cliproxyexecutor.Options) string {
+	headers := opts.Headers
+	if headers == nil {
+		if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+			headers = ginCtx.Request.Header
+		}
+	}
+	if headers == nil {
+		return ""
+	}
+	if turnMetadata := strings.TrimSpace(helps.HeaderValueCaseInsensitive(headers, "X-Codex-Turn-Metadata")); turnMetadata != "" {
+		for _, field := range []string{"prompt_cache_key", "thread_id", "session_id"} {
+			if value := strings.TrimSpace(gjson.Get(turnMetadata, field).String()); value != "" {
+				return helps.StableXAIConversationUUID(field + ":" + value)
+			}
+		}
+	}
+	for _, headerName := range []string{"Session-Id", "session_id", "Session_id", "Conversation_id"} {
+		if value := strings.TrimSpace(helps.HeaderValueCaseInsensitive(headers, headerName)); value != "" {
+			return helps.StableXAIConversationUUID("header:" + value)
+		}
+	}
+	return ""
 }
 
 func xaiRequiresIsolatedConversation(model string) bool {


### PR DESCRIPTION
## Problem

xAI routes requests sharing an `x-grok-conv-id` to the same server, and prompt cache entries are stored per-server. From the [xAI docs](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits):

> The `x-grok-conv-id` HTTP header routes requests with the same conversation ID to the same server. Since cache entries are stored per-server, this maximizes your cache hit rate.

`xaiResolveComposerSessionID` only produces a session ID when either:

1. an execution-session source already applies — `opts.Metadata` / `req.Metadata` keys, or a `prompt_cache_key` field in the payload, or
2. the model name starts with `grok-composer-`.

A Codex client talking to a non-composer model such as `grok-4.6` matches none of these: Codex sends the Responses protocol, which has no `prompt_cache_key` field, and the metadata keys are empty on this path. So `sessionID` is `""`, the header is never set, and each turn is scattered to a different server — paying a full prefill every time.

This is invisible on small prompts and severe on large retained contexts.

## Changes

Codex clients already send a stable conversation identity, in the very headers the Codex executor consumes today (`codex_executor_reasoning.go`):

```
Session-Id: 01a08920-82be-78c3-8dc9-2eca6f7f9655
X-Codex-Turn-Metadata: {"session_id":"01a08920-…","thread_id":"01a08920-…",
                        "turn_id":"…","window_number":154, …}
```

`thread_id` / `session_id` stay constant across turns of one conversation while `turn_id` and `window_number` change — exactly the grouping `x-grok-conv-id` wants.

`xaiClientConversationID` derives the ID from those headers when no execution-session source applies, trying `X-Codex-Turn-Metadata` (`prompt_cache_key` → `thread_id` → `session_id`), then `Session-Id` / `session_id` / `Session_id` / `Conversation_id`. The value goes through the existing `stableProviderSessionUUID` helper, so the upstream sees a UUID rather than raw client identifiers.

Ordering is deliberate: existing execution-session sources still win, and composer models keep their isolated-conversation path. When none of the headers are present the function returns `""` and behaviour is unchanged.

## Measurements

Codex Desktop → `grok-4.6`, ~160k-token context, the **same payload sent repeatedly** (first-token latency):

```
before   34.1s  34.2s  21.6s  15.0s  12.2s
after    18.0s  13.7s  22.3s   4.4s   2.7s   2.1s
```

Before, the floor sat around 12s and never settled — consistent with requests landing on different servers. After, once the conversation is pinned, it converges to ~2s.

Production traffic on the same deployment, 5-minute window (n=80): median first-token **5.1s**, 60% under 10s. Previously the median sat between 16s and 29s depending on the upstream.

For reference, a separate xAI account that happened to keep hitting the same server was already reaching ~2.0s before this change — so ~2s is the cache-hit baseline, not a new optimum.

## Correctness

Covered by a unit test exercising the properties that matter:

- same conversation, different turns (`turn_id` / `window_number` differ) → **same** ID
- different conversations → different IDs
- `Session-Id` fallback path, and repeat calls on it are stable
- no session headers → `""` (unchanged behaviour)
- output is a UUID, so raw client identifiers are not forwarded upstream

`go build ./...` and `go vet` are clean, and all xAI tests pass.

Note: `TestOpenAICompatExecutorToolResultContentByInputModalities` fails on this branch, but it **fails identically on an unmodified `dev`** (4 subtests, same assertions about image-modality tool results). It is unrelated to this change.
