### PR TITLE
fix(claude): forward caller betas the cloak does not manage

### DIFF
--- a/internal/runtime/executor/claude_executor_beta_passthrough_test.go
+++ b/internal/runtime/executor/claude_executor_beta_passthrough_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// fixtureAuth builds a cloaked direct-Anthropic API-key auth for header tests.
+// The key value is a placeholder that never reaches a real upstream.
+func fixtureAuth() *cliproxyauth.Auth {
+	attrs := map[string]string{}
+	attrs[cliproxyauth.AttributeAPIKey] = strings.Join([]string{"test", "fixture", "key"}, "-")
+	attrs["fingerprint_profile"] = "claude-code-cli"
+	return &cliproxyauth.Auth{Attributes: attrs}
+}
+
+// A caller the cloak does not recognize (a Claude Code newer than the pinned
+// profile) keeps betas the proxy does not manage: dropping them fails whole
+// turns whose features need the missing authorization, e.g. per-turn effort
+// directives with per-turn-control-2026-07-01 (#5738).
+func TestApplyClaudeHeaders_ForwardsUnmanagedCallerBetas(t *testing.T) {
+	t.Parallel()
+
+	auth := fixtureAuth()
+	req, errReq := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages?beta=true", nil)
+	if errReq != nil {
+		t.Fatalf("NewRequest() error = %v", errReq)
+	}
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", "per-turn-control-2026-07-01,mid-conversation-tool-changes-2026-07-01")
+	if errHeaders := applyClaudeHeaders(req, auth, auth.Attributes[cliproxyauth.AttributeAPIKey], false, nil, []byte(`{"model":"claude-fable-5-1"}`), &config.Config{}, incoming, false); errHeaders != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", errHeaders)
+	}
+	betas := req.Header.Get("Anthropic-Beta")
+	for _, want := range []string{"per-turn-control-2026-07-01", "mid-conversation-tool-changes-2026-07-01"} {
+		if !strings.Contains(betas, want) {
+			t.Fatalf("Anthropic-Beta = %q, want unmanaged caller beta %q forwarded", betas, want)
+		}
+	}
+}
+
+// Managed betas stay governed by the assembled baseline on direct Anthropic:
+// one whose gating excludes the request (effort on a Haiku model) is not
+// reinstated just because the caller asked for it.
+func TestApplyClaudeHeaders_StillGatesManagedCallerBetas(t *testing.T) {
+	t.Parallel()
+
+	auth := fixtureAuth()
+	req, errReq := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages?beta=true", nil)
+	if errReq != nil {
+		t.Fatalf("NewRequest() error = %v", errReq)
+	}
+	incoming := http.Header{}
+	incoming.Set("Anthropic-Beta", "effort-2025-11-24")
+	if errHeaders := applyClaudeHeaders(req, auth, auth.Attributes[cliproxyauth.AttributeAPIKey], false, nil, []byte(`{"model":"claude-haiku-4-5"}`), &config.Config{}, incoming, false); errHeaders != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", errHeaders)
+	}
+	if betas := req.Header.Get("Anthropic-Beta"); strings.Contains(betas, "effort-2025-11-24") {
+		t.Fatalf("Anthropic-Beta = %q, want gated effort beta kept off the Haiku request", betas)
+	}
+}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -76,6 +76,42 @@ var claudeCodeTrailingBetas = []string{
 	claudeStructuredOutputsBeta,
 }
 
+// claudeManagedBetaSet holds every beta the proxy itself assembles or gates.
+// Caller betas outside this set are unknown to the pinned Claude Code profile —
+// newer client releases ship betas past it — and are forwarded verbatim so
+// their features keep working (#5738).
+var claudeManagedBetaSet = func() map[string]bool {
+	managed := []string{
+		claudeTokenCountingBeta,
+		claudeFastModeBeta,
+		claudeOAuthBeta,
+		claudeCodeBeta,
+		claudeContext1MBeta,
+		claudeMidConvSystemBeta,
+		claudeAdvisorToolBeta,
+		claudeAdvancedToolUseBeta,
+		claudeEffortBeta,
+		claudeServerSideFallbackBeta,
+		claudeFallbackCreditBeta,
+		claudeStructuredOutputsBeta,
+		claudeThinkingDisplayUpdatesBeta,
+		claudeExtendedCacheTTLBeta,
+		claudeCacheDiagnosisBeta,
+		claudeRedactThinkingBeta,
+	}
+	managed = append(managed, claudeCodeCLIConstantBetas...)
+	managed = append(managed, claudeCodeTrailingBetas...)
+	set := make(map[string]bool, len(managed))
+	for _, beta := range managed {
+		set[beta] = true
+	}
+	return set
+}()
+
+func isManagedClaudeBeta(beta string) bool {
+	return claudeManagedBetaSet[strings.TrimSpace(beta)]
+}
+
 // claudeCodeCLIBetas assembles the Anthropic-Beta baseline the way Claude Code
 // 2.1.258 does: the list is per-request, not a fixed string. requested holds the
 // betas the caller asked for, which decide the capability flags below.
@@ -908,11 +944,22 @@ func applyClaudeHeadersWithNativeProfile(
 			appendBeta(beta)
 		}
 	} else {
-		// On direct Anthropic an unconfirmed CLI-profile caller's own betas are
-		// dropped: appending them to the measured baseline produces a shape real
-		// Claude Code never sends. Custom gateways keep caller extensions.
-		if !confirmedClaudeCode && incomingBetas != "" && !isAnthropicBase {
+		// On direct Anthropic an unconfirmed CLI-profile caller's managed betas
+		// are dropped: appending them to the measured baseline produces a shape
+		// real Claude Code never sends. Caller betas the proxy does not manage
+		// are newer-client features the pinned profile predates; dropping them
+		// fails those requests outright (per-turn effort directives need
+		// per-turn-control-2026-07-01), so they are forwarded (#5738). Custom
+		// gateways keep all caller extensions.
+		if !confirmedClaudeCode && incomingBetas != "" {
 			for _, beta := range strings.Split(incomingBetas, ",") {
+				beta = strings.TrimSpace(beta)
+				if beta == "" {
+					continue
+				}
+				if isManagedClaudeBeta(beta) && isAnthropicBase {
+					continue
+				}
 				appendBeta(beta)
 			}
 		}


### PR DESCRIPTION
## Summary

The cloaked header path dropped every caller-supplied `Anthropic-Beta` on direct Anthropic when CLI-profile detection did not confirm the caller. A genuine Claude Code newer than the pinned 2.1.258 profile sends betas that profile predates (`per-turn-control-2026-07-01`, `mid-conversation-tool-changes-2026-07-01`); dropping them makes upstream reject per-turn effort directives with a hard 400 `messages.N.output_config: Extra inputs are not permitted` (verified upstream-side in the issue: the directive-only system turn is legal when the beta is present).

Caller betas the proxy itself assembles or gates stay governed by the measured baseline (Haiku effort gating, subagent cache-ttl omissions, etc. are unchanged) via a new `claudeManagedBetaSet`. Only unmanaged caller betas are forwarded, appended after the baseline — the shape a real newer client actually sends. Custom gateways keep all caller extensions as before.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Unmanaged caller betas forwarded on direct Anthropic for an unconfirmed caller (fails before: absent from the assembled header, matching the issue's wire dump) | `go test -p 1 ./internal/runtime/executor/ -run TestApplyClaudeHeaders_ForwardsUnmanagedCallerBetas -v -count=1` | red before fix, green after |
| Managed betas keep their gating (effort stays off Haiku even when requested) | `go test -p 1 ./internal/runtime/executor/ -run TestApplyClaudeHeaders_StillGatesManagedCallerBetas -v -count=1` | pass |
| Existing beta/fingerprint contracts | `go test -p 1 ./internal/runtime/executor/ -count=1` | only the pre-existing xai Images/Videos combined-run flaky fails on this machine (single-run green, documented in prior PRs) |
| Build | `go build -o test-output ./cmd/server` | ok |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
- [ ] Behavior change: unconfirmed callers' unmanaged betas are now forwarded on direct Anthropic (see Summary); complements #5444's version-floor approach and stays valid whether or not that lands.
