### PR TITLE
test(codex): cover hot credential replacement and team plan synthesis

### DIFF
--- a/internal/watcher/synthesizer/synth_codex_plan_test.go
+++ b/internal/watcher/synthesizer/synth_codex_plan_test.go
@@ -1,0 +1,39 @@
+package synthesizer
+
+import (
+	"encoding/base64"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+// A replaced codex auth file carries its plan in the id_token JWT; the
+// synthesizer must extract chatgpt_plan_type so the model catalog registers
+// the right plan tier (team/pro/free) after a credential swap (#5736).
+func TestSynthesizeAuthFileCodexExtractsPlanType(t *testing.T) {
+	b64 := func(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+	header := b64(`{"alg":"none"}`)
+	payload := b64(`{"email":"t@example.com","exp":9999999999,"https://api.openai.com/auth":{"chatgpt_plan_type":"team","chatgpt_account_id":"acc-1"}}`)
+	jwt := header + "." + payload + ".sig"
+
+	tempDir := t.TempDir()
+	fullPath := filepath.Join(tempDir, "codex-team.json")
+	raw := []byte(`{"type":"codex","access_token":"at","id_token":"` + jwt + `"}`)
+
+	auths, errSynthesize := SynthesizeAuthFile(&SynthesisContext{
+		Config:  &config.Config{},
+		AuthDir: tempDir,
+		Now:     time.Now(),
+	}, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auths = %d, want 1", len(auths))
+	}
+	if got := auths[0].Attributes["plan_type"]; got != "team" {
+		t.Fatalf("plan_type = %q, want team", got)
+	}
+}

--- a/sdk/cliproxy/codex_hot_replacement_models_test.go
+++ b/sdk/cliproxy/codex_hot_replacement_models_test.go
@@ -1,0 +1,76 @@
+package cliproxy
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// Replacing an invalidated Codex OAuth credential through the hot-update path
+// must restore the same state a fresh start would: the auth becomes available
+// again, the full plan catalog stays registered, and no model remains
+// suspended in the registry (#5736).
+func TestCodexHotReplacementRestoresModelsAndAvailability(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	svc := &Service{cfg: &config.Config{}, coreManager: coreauth.NewManager(nil, nil, nil)}
+	ctx := context.Background()
+
+	teamAuth := &coreauth.Auth{
+		ID:       "codex-team-5736",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"plan_type": "team",
+		},
+	}
+	if _, errRegister := svc.coreManager.Register(ctx, teamAuth); errRegister != nil {
+		t.Fatalf("register: %v", errRegister)
+	}
+	svc.registerModelsForAuth(ctx, teamAuth)
+
+	// Credential invalidated upstream.
+	svc.coreManager.MarkResult(ctx, coreauth.Result{
+		AuthID: teamAuth.ID, Provider: teamAuth.Provider, Model: "",
+		Success: false,
+		Error:   &coreauth.Error{HTTPStatus: http.StatusUnauthorized, Message: "Encountered invalidated oauth token: REDACTED"},
+	})
+
+	// The credential is replaced with a fresh one under the same auth ID.
+	fresh := &coreauth.Auth{
+		ID:       "codex-team-5736",
+		Provider: "codex",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"plan_type": "team",
+		},
+	}
+	svc.applyCoreAuthAddOrUpdate(ctx, fresh)
+
+	updated, ok := svc.coreManager.GetByID(teamAuth.ID)
+	if !ok || updated == nil {
+		t.Fatal("auth missing after replacement")
+	}
+	if updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("replaced auth still carries the invalidated-credential cooldown: Unavailable=%v NextRetryAfter=%v", updated.Unavailable, updated.NextRetryAfter)
+	}
+
+	registered := reg.GetModelsForClient(teamAuth.ID)
+	teamModels := registry.GetCodexTeamModels()
+	if len(registered) != len(teamModels) {
+		ids := make([]string, 0, len(registered))
+		for _, m := range registered {
+			ids = append(ids, m.ID)
+		}
+		t.Fatalf("registered models = %v, want the full team catalog (%d models)", ids, len(teamModels))
+	}
+	for _, model := range teamModels {
+		if reg.IsModelSuspendedForClient(teamAuth.ID, model.ID) {
+			t.Fatalf("team model %q suspended after credential replacement", model.ID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Tests-only follow-up for #5736. The reported sequence was re-run against current dev (post `d1702fdf` / `8f23ad02` / `60e5b8bd`) and behaves correctly, so no product change is proposed — these tests lock the corrected behavior so a regression cannot sneak back in:

1. `TestCodexHotReplacementRestoresModelsAndAvailability` — registers a team-plan Codex OAuth auth, fails it with an invalidated-token error, replaces the credential through the hot-update path, and asserts the auth is available again, the full team catalog stays registered, and no team model is suspended in the registry.
2. `TestSynthesizeAuthFileCodexExtractsPlanType` — a replaced auth file whose `id_token` carries `chatgpt_plan_type: team` synthesizes the matching `plan_type` attribute, so the catalog registers the right plan tier after a credential swap.

## Verification

| Claim | Command | Result |
| --- | --- | --- |
| Hot replacement restores availability and the full team catalog, nothing suspended | `go test -p 1 ./sdk/cliproxy/ -run TestCodexHotReplacementRestoresModelsAndAvailability -v -count=1` | pass |
| Synthesis extracts plan_type from the replaced file's id_token | `go test ./internal/watcher/synthesizer/ -run TestSynthesizeAuthFileCodexExtractsPlanType -v -count=1` | pass |
| Packages | `go test -p 1 ./sdk/cliproxy/ ./internal/watcher/synthesizer/ -count=1` | ok |
| Build | `go build -o test-output ./cmd/server` | ok |

## AI use

Implemented with GLM-5.3-Flash (ZCode); all verification commands run locally, outputs quoted above.

## Checklist

- [x] Tests added/updated for the change
