### PR TITLE
fix(executor): redact sensitive websocket log data

### DIFF
--- a/internal/client/codex/live/live_test.go
+++ b/internal/client/codex/live/live_test.go
@@ -1066,8 +1066,8 @@ func TestHandleSidebandDialErrorPreservesBodyReturnedWithReadError(t *testing.T)
 	}
 	rawTimeline, okTimeline := c.Get("API_WEBSOCKET_TIMELINE")
 	timeline, _ := rawTimeline.([]byte)
-	if !okTimeline || !strings.Contains(string(timeline), upstreamError) {
-		t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want original upstream error", timeline)
+	if !okTimeline || strings.Contains(string(timeline), upstreamError) || !strings.Contains(string(timeline), "Details: redacted") {
+		t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want redacted upstream error", timeline)
 	}
 }
 
@@ -1093,8 +1093,8 @@ func TestHandleSidebandDialErrorDoesNotForwardNonUnauthorizedBody(t *testing.T) 
 	}
 	rawTimeline, okTimeline := c.Get("API_WEBSOCKET_TIMELINE")
 	timeline, _ := rawTimeline.([]byte)
-	if !okTimeline || !strings.Contains(string(timeline), upstreamError) {
-		t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want original upstream error", timeline)
+	if !okTimeline || strings.Contains(string(timeline), upstreamError) || !strings.Contains(string(timeline), "Details: redacted") {
+		t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want redacted upstream error", timeline)
 	}
 }
 

--- a/internal/client/codex/live/websocket_test.go
+++ b/internal/client/codex/live/websocket_test.go
@@ -110,8 +110,8 @@ func TestHandleDirectWebsocketForwardsUnauthorizedHomeHandshakeWithoutRefresh(t 
 			if tc.truncatedResponse {
 				select {
 				case timeline := <-timelineCapture:
-					if !strings.Contains(string(timeline), tc.upstreamBody) {
-						t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want original upstream error", timeline)
+					if strings.Contains(string(timeline), tc.upstreamBody) || !strings.Contains(string(timeline), "Details: redacted") {
+						t.Fatalf("API_WEBSOCKET_TIMELINE = %q, want redacted upstream error", timeline)
 					}
 				case <-time.After(time.Second):
 					t.Fatal("timed out waiting for websocket request-log timeline")

--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -49,17 +49,13 @@ func (e *CodexWebsocketsExecutor) dialCodexWebsocket(ctx context.Context, auth *
 
 func writeWebsocketPayloadMessage(provider string, sess *codexWebsocketSession, conn *websocket.Conn, payload []byte) error {
 	provider = strings.TrimSpace(provider)
-	if provider == "" {
+	if provider != "xai" {
 		provider = "codex"
-	}
-	sessionID := ""
-	if sess != nil {
-		sessionID = sess.sessionID
 	}
 	sessionKind := sessionObjectKind(sess)
 	payloadBytes := len(payload)
 	start := time.Now()
-	log.Debugf("%s websockets: write payload started session=%s session_object=%s bytes=%d", provider, sessionID, sessionKind, payloadBytes)
+	log.WithFields(log.Fields{"provider": provider, "session_object": sessionKind, "bytes": payloadBytes}).Debug("websockets: write payload started")
 	var errSend error
 	if sess != nil {
 		errSend = sess.writeMessage(conn, websocket.TextMessage, payload)
@@ -69,9 +65,9 @@ func writeWebsocketPayloadMessage(provider string, sess *codexWebsocketSession, 
 		errSend = conn.WriteMessage(websocket.TextMessage, payload)
 	}
 	if errSend != nil {
-		log.Warnf("%s websockets: write payload failed session=%s session_object=%s bytes=%d duration=%v err=%v", provider, sessionID, sessionKind, payloadBytes, time.Since(start), errSend)
+		log.WithFields(log.Fields{"provider": provider, "session_object": sessionKind, "bytes": payloadBytes, "duration": time.Since(start), "diagnostic": helps.SafeWebsocketErrorDiagnostic(errSend)}).Warn("websockets: write payload failed")
 	} else {
-		log.Debugf("%s websockets: write payload completed session=%s session_object=%s bytes=%d duration=%v", provider, sessionID, sessionKind, payloadBytes, time.Since(start))
+		log.WithFields(log.Fields{"provider": provider, "session_object": sessionKind, "bytes": payloadBytes, "duration": time.Since(start)}).Debug("websockets: write payload completed")
 	}
 	return errSend
 }

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -253,21 +254,17 @@ func (s *codexWebsocketSession) configureConn(conn *websocket.Conn) {
 	}
 	s.resetUpstreamDisconnectError(conn)
 	conn.SetPingHandler(func(appData string) error {
-		sessionID := ""
-		if s != nil {
-			sessionID = s.sessionID
-		}
 		sessionKind := sessionObjectKind(s)
-		log.Debugf("codex websockets: upstream ping received session=%s session_object=%s ping_bytes=%d", sessionID, sessionKind, len(appData))
-		log.Debugf("codex websockets: upstream pong write started session=%s session_object=%s", sessionID, sessionKind)
+		log.WithFields(log.Fields{"provider": "codex", "session_object": sessionKind, "ping_bytes": len(appData)}).Debug("codex websockets: upstream ping received")
+		log.WithFields(log.Fields{"provider": "codex", "session_object": sessionKind}).Debug("codex websockets: upstream pong write started")
 		start := time.Now()
 		// Gorilla websocket allows concurrent WriteControl with WriteMessage.
 		// Avoid writeMu here so keepalive pongs are not starved by long payload writes.
 		errPong := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
 		if errPong != nil {
-			log.Warnf("codex websockets: upstream pong write failed session=%s session_object=%s duration=%v err=%v", sessionID, sessionKind, time.Since(start), errPong)
+			log.WithFields(log.Fields{"provider": "codex", "session_object": sessionKind, "duration": time.Since(start), "diagnostic": helps.SafeWebsocketErrorDiagnostic(errPong)}).Warn("codex websockets: upstream pong write failed")
 		} else {
-			log.Debugf("codex websockets: upstream pong replied session=%s session_object=%s duration=%v", sessionID, sessionKind, time.Since(start))
+			log.WithFields(log.Fields{"provider": "codex", "session_object": sessionKind, "duration": time.Since(start)}).Debug("codex websockets: upstream pong replied")
 		}
 		return errPong
 	})
@@ -435,14 +432,14 @@ func configureRawCodexWebsocketConn(conn *websocket.Conn, authID string, wsURL s
 		return
 	}
 	conn.SetPingHandler(func(appData string) error {
-		log.Debugf("codex websockets: upstream ping received session= session_object=none ping_bytes=%d", len(appData))
-		log.Debugf("codex websockets: upstream pong write started session= session_object=none")
+		log.WithFields(log.Fields{"provider": "codex", "session_object": "none", "ping_bytes": len(appData)}).Debug("codex websockets: upstream ping received")
+		log.WithFields(log.Fields{"provider": "codex", "session_object": "none"}).Debug("codex websockets: upstream pong write started")
 		start := time.Now()
 		errPong := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
 		if errPong != nil {
-			log.Warnf("codex websockets: upstream pong write failed session= session_object=none duration=%v err=%v", time.Since(start), errPong)
+			log.WithFields(log.Fields{"provider": "codex", "session_object": "none", "duration": time.Since(start), "diagnostic": helps.SafeWebsocketErrorDiagnostic(errPong)}).Warn("codex websockets: upstream pong write failed")
 		} else {
-			log.Debugf("codex websockets: upstream pong replied session= session_object=none duration=%v", time.Since(start))
+			log.WithFields(log.Fields{"provider": "codex", "session_object": "none", "duration": time.Since(start)}).Debug("codex websockets: upstream pong replied")
 		}
 		return errPong
 	})
@@ -636,7 +633,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 		previousCloser := sess.connCloser
 		sess.connMu.Unlock()
 		if errClose := closer.Close(); errClose != nil {
-			log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+			logCodexWebsocketCloseFailure("duplicate", errClose)
 		}
 		logCodexWebsocketConnectedWithReused(sess, sess.sessionID, authID, wsURL, true)
 		return previous, previousCloser, nil, nil
@@ -762,7 +759,7 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWe
 	}
 	if closer != nil {
 		if errClose := closer.Close(); errClose != nil {
-			log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+			logCodexWebsocketCloseFailure("active", errClose)
 		}
 	}
 	if lifecycle != nil {
@@ -854,7 +851,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 		logCodexWebsocketDisconnectedWithLastEvent(sess, sessionID, authID, wsURL, reason, lastEvent, nil)
 		if closer != nil {
 			if errClose := closer.Close(); errClose != nil {
-				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+				logCodexWebsocketCloseFailure("session_close", errClose)
 			}
 		}
 	}
@@ -877,14 +874,12 @@ func logCodexWebsocketConnected(sessionID string, authID string, wsURL string) {
 	logCodexWebsocketConnectedWithReused(nil, sessionID, authID, wsURL, false)
 }
 
-func logCodexWebsocketConnectedWithReused(sess *codexWebsocketSession, sessionID string, authID string, wsURL string, reused bool) {
-	sessionStr := strings.TrimSpace(sessionID)
-	sessionKind := sessionObjectKind(sess)
-	if reused {
-		log.Infof("codex websockets: upstream connected session=%s auth=%s url=%s session_object=%s reused=true", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind)
-		return
-	}
-	log.Infof("codex websockets: upstream connected session=%s auth=%s url=%s session_object=%s reused=false", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind)
+func logCodexWebsocketConnectedWithReused(sess *codexWebsocketSession, _ string, _ string, _ string, reused bool) {
+	log.WithFields(log.Fields{
+		"provider":       "codex",
+		"session_object": sessionObjectKind(sess),
+		"reused":         reused,
+	}).Info("codex websockets: upstream connected")
 }
 
 func logCodexWebsocketDisconnected(sessionID string, authID string, wsURL string, reason string, err error) {
@@ -900,23 +895,38 @@ func isTerminalEvent(eventType string) bool {
 	}
 }
 
-func logCodexWebsocketDisconnectedWithLastEvent(sess *codexWebsocketSession, sessionID string, authID string, wsURL string, reason string, lastEvent string, err error) {
-	sessionStr := strings.TrimSpace(sessionID)
-	sessionKind := sessionObjectKind(sess)
-	terminalStatus := isTerminalEvent(lastEvent)
+func logCodexWebsocketDisconnectedWithLastEvent(sess *codexWebsocketSession, _ string, _ string, _ string, reason string, lastEvent string, err error) {
+	status := "ok"
 	if err != nil {
-		if lastEvent != "" {
-			log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s last_event=%s is_terminal=%t err=%v", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), lastEvent, terminalStatus, err)
-			return
-		}
-		log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s is_terminal=false err=%v", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), err)
-		return
+		status = "error"
 	}
-	if lastEvent != "" {
-		log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s last_event=%s is_terminal=%t", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), lastEvent, terminalStatus)
-		return
+	fields := log.Fields{
+		"provider":       "codex",
+		"session_object": sessionObjectKind(sess),
+		"reason":         helps.SafeWebsocketLifecycleReason(reason),
+		"status":         status,
+		"diagnostic":     helps.SafeWebsocketErrorDiagnostic(err),
+		"is_terminal":    isTerminalEvent(lastEvent),
 	}
-	log.Infof("codex websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s is_terminal=false", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason))
+	if strings.TrimSpace(lastEvent) != "" {
+		fields["last_event"] = helps.SafeWebsocketEventType(lastEvent)
+	}
+	log.WithFields(fields).Info("codex websockets: upstream disconnected")
+}
+
+func logCodexWebsocketStreamStart(model string) {
+	log.WithFields(log.Fields{
+		"provider": "codex",
+		"model":    helps.SafeWebsocketModel("codex", model),
+	}).Debug("codex websockets: executing stream request")
+}
+
+func logCodexWebsocketCloseFailure(stage string, err error) {
+	log.WithFields(log.Fields{
+		"provider":   "codex",
+		"stage":      helps.SafeWebsocketCloseStage(stage),
+		"diagnostic": helps.SafeWebsocketErrorDiagnostic(err),
+	}).Error("codex websockets: close upstream connection failed")
 }
 
 // CloseCodexWebsocketSessionsForAuthID closes all active Codex upstream websocket sessions

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -14,12 +14,11 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
-	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
 func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
-	log.Debugf("Executing Codex Websockets stream request with auth ID: %s, model: %s", auth.ID, req.Model)
+	logCodexWebsocketStreamStart(req.Model)
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -513,7 +512,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		} else {
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "completed", nil)
 			if errClose := closer.Close(); errClose != nil {
-				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+				logCodexWebsocketCloseFailure("stream", errClose)
 			}
 		}
 		close(out)
@@ -536,7 +535,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, terminateReason, terminateErr)
 			if errClose := closer.Close(); errClose != nil {
-				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+				logCodexWebsocketCloseFailure("stream_teardown", errClose)
 			}
 		}()
 

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -298,22 +298,15 @@ func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info Ups
 	builder := &strings.Builder{}
 	builder.WriteString(fmt.Sprintf("Timestamp: %s\n", time.Now().Format(time.RFC3339Nano)))
 	builder.WriteString("Event: api.websocket.request\n")
-	if info.URL != "" {
-		builder.WriteString(fmt.Sprintf("Upstream URL: %s\n", info.URL))
+	// WebSocket request details can contain credentials, session identifiers,
+	// URLs with query secrets, and user content. Keep only structural metadata.
+	if provider := strings.TrimSpace(info.Provider); provider != "" {
+		builder.WriteString(fmt.Sprintf("Provider: %s\n", provider))
 	}
-	if auth := formatAuthInfo(info); auth != "" {
-		builder.WriteString(fmt.Sprintf("Auth: %s\n", auth))
+	if method := strings.TrimSpace(info.Method); method != "" {
+		builder.WriteString(fmt.Sprintf("Method: %s\n", method))
 	}
-	builder.WriteString("Headers:\n")
-	writeHeaders(builder, info.Headers)
-	builder.WriteString("\nBody:\n")
-	if len(info.Body) > 0 {
-		builder.Write(info.Body)
-	} else {
-		builder.WriteString("<empty>")
-	}
-	builder.WriteString("\n")
-
+	builder.WriteString("Details: redacted\n")
 	appendAPIWebsocketTimeline(ginCtx, []byte(builder.String()))
 }
 
@@ -352,9 +345,12 @@ func RecordAPIWebsocketUpgradeRejection(ctx context.Context, cfg *config.Config,
 		return
 	}
 
-	RecordAPIRequest(ctx, cfg, info)
-	RecordAPIResponseMetadata(ctx, cfg, status, headers)
-	AppendAPIResponseChunk(ctx, cfg, body)
+	// Keep rejected websocket handshakes on the redacted timeline path. The
+	// response headers and body may contain provider identifiers or raw errors.
+	RecordAPIWebsocketRequest(ctx, cfg, info)
+	RecordAPIResponseMetadata(ctx, cfg, status, nil)
+	_ = headers
+	_ = body
 }
 
 // WebsocketUpgradeRequestURL converts a websocket URL back to its HTTP handshake URL for logging.
@@ -394,8 +390,7 @@ func AppendAPIWebsocketResponse(ctx context.Context, cfg *config.Config, payload
 	builder := &strings.Builder{}
 	builder.WriteString(fmt.Sprintf("Timestamp: %s\n", time.Now().Format(time.RFC3339Nano)))
 	builder.WriteString("Event: api.websocket.response\n")
-	builder.Write(data)
-	builder.WriteString("\n")
+	builder.WriteString("Details: redacted\n")
 
 	appendAPIWebsocketTimeline(ginCtx, []byte(builder.String()))
 }
@@ -424,7 +419,7 @@ func RecordAPIWebsocketError(ctx context.Context, cfg *config.Config, stage stri
 	if trimmed := strings.TrimSpace(stage); trimmed != "" {
 		builder.WriteString(fmt.Sprintf("Stage: %s\n", trimmed))
 	}
-	builder.WriteString(fmt.Sprintf("Error: %s\n", err.Error()))
+	builder.WriteString("Error: upstream websocket operation failed\n")
 
 	appendAPIWebsocketTimeline(ginCtx, []byte(builder.String()))
 }

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -345,9 +345,10 @@ func RecordAPIWebsocketUpgradeRejection(ctx context.Context, cfg *config.Config,
 		return
 	}
 
-	// Keep rejected websocket handshakes on the redacted timeline path. The
-	// response headers and body may contain provider identifiers or raw errors.
-	RecordAPIWebsocketRequest(ctx, cfg, info)
+	// Preserve a normal API request/response attempt, but strip every sensitive
+	// websocket field before handing it to the generic request logger.
+	safeInfo := UpstreamRequestLog{Method: http.MethodGet, Provider: info.Provider}
+	RecordAPIRequest(ctx, cfg, safeInfo)
 	RecordAPIResponseMetadata(ctx, cfg, status, nil)
 	_ = headers
 	_ = body

--- a/internal/runtime/executor/helps/websocket_log_redaction.go
+++ b/internal/runtime/executor/helps/websocket_log_redaction.go
@@ -1,4 +1,4 @@
-package executor
+package helps
 
 import (
 	"context"
@@ -87,8 +87,8 @@ var safeWebsocketCloseStages = []string{
 	"stream_teardown",
 }
 
-// safeWebsocketCloseStage maps a close stage onto the allowlist.
-func safeWebsocketCloseStage(stage string) string {
+// SafeWebsocketCloseStage maps a close stage onto the allowlist.
+func SafeWebsocketCloseStage(stage string) string {
 	trimmed := strings.TrimSpace(stage)
 	if trimmed == "" {
 		return absentLogPlaceholder
@@ -111,8 +111,8 @@ func matchSafeLogLiteral(allowlist []string, value string) string {
 	return ""
 }
 
-// safeWebsocketLifecycleReason maps a lifecycle reason onto the allowlist.
-func safeWebsocketLifecycleReason(reason string) string {
+// SafeWebsocketLifecycleReason maps a lifecycle reason onto the allowlist.
+func SafeWebsocketLifecycleReason(reason string) string {
 	trimmed := strings.TrimSpace(reason)
 	if trimmed == "" {
 		return absentLogPlaceholder
@@ -123,8 +123,8 @@ func safeWebsocketLifecycleReason(reason string) string {
 	return unknownLogPlaceholder
 }
 
-// safeWebsocketEventType maps an upstream event type onto the allowlist.
-func safeWebsocketEventType(eventType string) string {
+// SafeWebsocketEventType maps an upstream event type onto the allowlist.
+func SafeWebsocketEventType(eventType string) string {
 	trimmed := strings.TrimSpace(eventType)
 	if trimmed == "" {
 		return absentLogPlaceholder
@@ -135,12 +135,12 @@ func safeWebsocketEventType(eventType string) string {
 	return unknownLogPlaceholder
 }
 
-// safeWebsocketModel resolves a requested model name to the matching model ID
+// SafeWebsocketModel resolves a requested model name to the matching model ID
 // held in the embedded model catalogue. The returned string is a
 // catalogue-owned literal rather than the client-supplied request value. An
 // unrecognised or dynamically discovered model is reported as
 // unknownLogPlaceholder.
-func safeWebsocketModel(provider string, model string) string {
+func SafeWebsocketModel(provider string, model string) string {
 	trimmed := strings.TrimSpace(model)
 	if trimmed == "" {
 		return absentLogPlaceholder
@@ -173,14 +173,14 @@ func safeWebsocketModel(provider string, model string) string {
 	return unknownLogPlaceholder
 }
 
-// safeWebsocketErrorDiagnostic converts an error into a diagnostic built only
+// SafeWebsocketErrorDiagnostic converts an error into a diagnostic built only
 // from structural properties of the error: sentinel identity, the net.Error
 // timeout flag, the numeric websocket close code and the numeric HTTP status.
 //
 // The error's own message is never read, so provider wording that embeds
 // tokens, account identifiers or URLs cannot reach the log. Numeric codes are
 // rendered from integers rather than from any part of the error string.
-func safeWebsocketErrorDiagnostic(err error) string {
+func SafeWebsocketErrorDiagnostic(err error) string {
 	if err == nil {
 		return absentLogPlaceholder
 	}

--- a/internal/runtime/executor/helps/websocket_logging_redaction_test.go
+++ b/internal/runtime/executor/helps/websocket_logging_redaction_test.go
@@ -1,0 +1,40 @@
+package helps
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestWebsocketRequestTimelineRedactsSensitiveData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
+	sentinels := []string{"secret-query", "secret-auth", "secret-session", "secret-body", "secret-response", "secret-error"}
+
+	RecordAPIWebsocketRequest(ctx, cfg, UpstreamRequestLog{
+		URL: "wss://provider.example/ws?token=secret-query", Method: "WEBSOCKET",
+		Headers: http.Header{"Authorization": []string{"Bearer secret-auth"}, "X-Session": []string{"secret-session"}},
+		Body:    []byte(`{"input":"secret-body"}`), Provider: "xai", AuthID: "secret-auth",
+	})
+	AppendAPIWebsocketResponse(ctx, cfg, []byte(`{"output":"secret-response"}`))
+	RecordAPIWebsocketError(ctx, cfg, "read", errors.New("secret-error"))
+
+	raw, _ := ginCtx.Get(apiWebsocketTimelineKey)
+	timeline, _ := raw.([]byte)
+	for _, sentinel := range sentinels {
+		if strings.Contains(string(timeline), sentinel) {
+			t.Fatalf("websocket timeline leaked %q: %s", sentinel, timeline)
+		}
+	}
+	if !strings.Contains(string(timeline), "Details: redacted") || !strings.Contains(string(timeline), "upstream websocket operation failed") {
+		t.Fatalf("timeline lacks structural redaction markers: %s", timeline)
+	}
+}

--- a/internal/runtime/executor/helps/websocket_logging_redaction_test.go
+++ b/internal/runtime/executor/helps/websocket_logging_redaction_test.go
@@ -38,3 +38,45 @@ func TestWebsocketRequestTimelineRedactsSensitiveData(t *testing.T) {
 		t.Fatalf("timeline lacks structural redaction markers: %s", timeline)
 	}
 }
+
+func TestWebsocketUpgradeRejectionCreatesRedactedRequestAttempt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
+	const sentinel = "upgrade-rejection-secret"
+
+	RecordAPIWebsocketUpgradeRejection(ctx, cfg, UpstreamRequestLog{
+		URL:       "wss://provider.example/ws?token=" + sentinel,
+		Method:    "WEBSOCKET",
+		Headers:   http.Header{"Authorization": []string{"Bearer " + sentinel}},
+		Body:      []byte(`{"input":"` + sentinel + `"}`),
+		Provider:  "xai",
+		AuthID:    sentinel,
+		AuthValue: sentinel,
+	}, http.StatusUnauthorized, http.Header{"X-Upstream-ID": []string{sentinel}}, []byte(`{"error":"`+sentinel+`"}`))
+
+	rawRequest, okRequest := ginCtx.Get(apiRequestKey)
+	requestLog, _ := rawRequest.([]byte)
+	if !okRequest || len(requestLog) == 0 {
+		t.Fatal("websocket rejection did not create an API request attempt")
+	}
+	if strings.Contains(string(requestLog), "<missing>") {
+		t.Fatalf("websocket rejection created placeholder request attempt: %s", requestLog)
+	}
+	if strings.Contains(string(requestLog), sentinel) {
+		t.Fatalf("websocket rejection request attempt leaked sentinel: %s", requestLog)
+	}
+	if !strings.Contains(string(requestLog), "=== API REQUEST 1 ===") || !strings.Contains(string(requestLog), "HTTP Method: GET") {
+		t.Fatalf("websocket rejection request attempt lacks structural metadata: %s", requestLog)
+	}
+
+	rawResponse, okResponse := ginCtx.Get(apiResponseKey)
+	responseLog, _ := rawResponse.([]byte)
+	if !okResponse || !strings.Contains(string(responseLog), "Status: 401") {
+		t.Fatalf("websocket rejection response was not linked to request attempt: %s", responseLog)
+	}
+	if strings.Contains(string(responseLog), sentinel) {
+		t.Fatalf("websocket rejection response leaked sentinel: %s", responseLog)
+	}
+}

--- a/internal/runtime/executor/websocket_log_redaction.go
+++ b/internal/runtime/executor/websocket_log_redaction.go
@@ -1,0 +1,245 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+)
+
+// This file centralises the log-safe projection of websocket lifecycle values.
+//
+// Codex and xAI websocket lifecycle logs previously interpolated session IDs,
+// auth IDs, full upstream URLs (including query strings that can carry
+// credentials) and raw provider errors. Those values originate from
+// client-supplied request headers, stored credentials and upstream responses,
+// so they must never reach an application log.
+//
+// Every helper here converts an untrusted input into a value drawn from a
+// closed set of in-repository literals, or into a fixed placeholder. No helper
+// returns a substring of its argument, so a caller cannot reintroduce a leak by
+// forwarding the result to a log call.
+
+const (
+	// redactedLogPlaceholder marks a value that was present but withheld.
+	redactedLogPlaceholder = "[redacted]"
+	// absentLogPlaceholder marks a value that was empty at the call site.
+	absentLogPlaceholder = "none"
+	// unknownLogPlaceholder marks a value that is neither empty nor allowlisted.
+	unknownLogPlaceholder = "other"
+)
+
+// safeWebsocketLifecycleReasons is the closed set of lifecycle reason codes
+// produced inside this repository. Reasons come from our own control flow
+// rather than from a provider or a client, but they are still funnelled through
+// an allowlist so a future caller cannot pass an upstream string through
+// without also updating this list.
+var safeWebsocketLifecycleReasons = []string{
+	"auth_removed",
+	"completed",
+	"connection_closed",
+	"context_done",
+	"error",
+	"executor_shutdown",
+	"invalidated",
+	"read_error",
+	"send_error",
+	"session_closed",
+	"target_changed",
+	"terminal_empty_incomplete",
+	"terminal_failure",
+	"test_invalidate",
+	"unexpected_binary",
+	"upstream_disconnected",
+	"upstream_error",
+}
+
+// safeWebsocketEventTypes is the closed set of upstream event types that may be
+// named in a log line. Event types arrive inside provider payloads, so an
+// unlisted value is reported as unknownLogPlaceholder instead of being echoed.
+var safeWebsocketEventTypes = []string{
+	"error",
+	"response.append",
+	"response.completed",
+	"response.create",
+	"response.created",
+	"response.done",
+	"response.failed",
+	"response.incomplete",
+	"response.output_item.done",
+}
+
+// safeWebsocketCloseStages names the close call sites that may appear in a log
+// line. Stages are in-repository literals chosen at each call site.
+var safeWebsocketCloseStages = []string{
+	"active",
+	"duplicate",
+	"lifecycle_bind_failure",
+	"session_close",
+	"stale",
+	"stream",
+	"stream_teardown",
+}
+
+// safeWebsocketCloseStage maps a close stage onto the allowlist.
+func safeWebsocketCloseStage(stage string) string {
+	trimmed := strings.TrimSpace(stage)
+	if trimmed == "" {
+		return absentLogPlaceholder
+	}
+	if matched := matchSafeLogLiteral(safeWebsocketCloseStages, trimmed); matched != "" {
+		return matched
+	}
+	return unknownLogPlaceholder
+}
+
+// matchSafeLogLiteral returns the allowlist entry equal to value, or "" when
+// there is no match. The returned string is the allowlist literal itself, never
+// a slice of value, which is what keeps the caller's value out of the log.
+func matchSafeLogLiteral(allowlist []string, value string) string {
+	for i := range allowlist {
+		if allowlist[i] == value {
+			return allowlist[i]
+		}
+	}
+	return ""
+}
+
+// safeWebsocketLifecycleReason maps a lifecycle reason onto the allowlist.
+func safeWebsocketLifecycleReason(reason string) string {
+	trimmed := strings.TrimSpace(reason)
+	if trimmed == "" {
+		return absentLogPlaceholder
+	}
+	if matched := matchSafeLogLiteral(safeWebsocketLifecycleReasons, trimmed); matched != "" {
+		return matched
+	}
+	return unknownLogPlaceholder
+}
+
+// safeWebsocketEventType maps an upstream event type onto the allowlist.
+func safeWebsocketEventType(eventType string) string {
+	trimmed := strings.TrimSpace(eventType)
+	if trimmed == "" {
+		return absentLogPlaceholder
+	}
+	if matched := matchSafeLogLiteral(safeWebsocketEventTypes, trimmed); matched != "" {
+		return matched
+	}
+	return unknownLogPlaceholder
+}
+
+// safeWebsocketModel resolves a requested model name to the matching model ID
+// held in the embedded model catalogue. The returned string is a
+// catalogue-owned literal rather than the client-supplied request value. An
+// unrecognised or dynamically discovered model is reported as
+// unknownLogPlaceholder.
+func safeWebsocketModel(provider string, model string) string {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return absentLogPlaceholder
+	}
+	baseModel := strings.TrimSpace(thinking.ParseSuffix(trimmed).ModelName)
+	if baseModel == "" {
+		return unknownLogPlaceholder
+	}
+	var candidates []*registry.ModelInfo
+	switch strings.TrimSpace(provider) {
+	case "codex":
+		candidates = append(candidates, registry.GetCodexFreeModels()...)
+		candidates = append(candidates, registry.GetCodexTeamModels()...)
+		candidates = append(candidates, registry.GetCodexPlusModels()...)
+		candidates = append(candidates, registry.GetCodexProModels()...)
+	case "xai":
+		candidates = registry.GetXAIModels()
+	default:
+		return unknownLogPlaceholder
+	}
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		catalogueID := strings.TrimSpace(candidate.ID)
+		if catalogueID != "" && catalogueID == baseModel {
+			return catalogueID
+		}
+	}
+	return unknownLogPlaceholder
+}
+
+// safeWebsocketErrorDiagnostic converts an error into a diagnostic built only
+// from structural properties of the error: sentinel identity, the net.Error
+// timeout flag, the numeric websocket close code and the numeric HTTP status.
+//
+// The error's own message is never read, so provider wording that embeds
+// tokens, account identifiers or URLs cannot reach the log. Numeric codes are
+// rendered from integers rather than from any part of the error string.
+func safeWebsocketErrorDiagnostic(err error) string {
+	if err == nil {
+		return absentLogPlaceholder
+	}
+
+	signals := make([]string, 0, 4)
+	appendSignal := func(signal string) {
+		if signal == "" {
+			return
+		}
+		for i := range signals {
+			if signals[i] == signal {
+				return
+			}
+		}
+		signals = append(signals, signal)
+	}
+
+	switch {
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		appendSignal("unexpected_eof")
+	case errors.Is(err, io.EOF):
+		appendSignal("eof")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		appendSignal("timeout")
+	}
+	if errors.Is(err, context.Canceled) {
+		appendSignal("canceled")
+	}
+	if errors.Is(err, net.ErrClosed) {
+		appendSignal("connection_closed")
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr != nil && netErr.Timeout() {
+		appendSignal("timeout")
+	}
+	var closeErr *websocket.CloseError
+	if errors.As(err, &closeErr) && closeErr != nil {
+		// Only the numeric close code is reported. closeErr.Text is provider
+		// controlled and is deliberately dropped.
+		appendSignal("close_code=" + safeNumericCode(closeErr.Code, 1000, 4999))
+	}
+	var statusProvider interface{ StatusCode() int }
+	if errors.As(err, &statusProvider) && statusProvider != nil {
+		appendSignal("status=" + safeNumericCode(statusProvider.StatusCode(), 100, 599))
+	}
+
+	if len(signals) == 0 {
+		return redactedLogPlaceholder
+	}
+	return strings.Join(signals, ",")
+}
+
+// safeNumericCode renders an integer code that falls inside the supplied
+// inclusive range. Out-of-range codes collapse to a placeholder so a hostile
+// value cannot widen the log line.
+func safeNumericCode(code int, minCode int, maxCode int) string {
+	if code < minCode || code > maxCode {
+		return unknownLogPlaceholder
+	}
+	return strconv.Itoa(code)
+}

--- a/internal/runtime/executor/websocket_log_redaction_test.go
+++ b/internal/runtime/executor/websocket_log_redaction_test.go
@@ -1,0 +1,283 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+)
+
+// sentinelWebsocketLogValues holds values that must never appear in an emitted
+// log record. Each sentinel stands in for a class of data that the Codex and
+// xAI websocket lifecycle logs used to interpolate directly.
+const (
+	sentinelSessionID          = "sess-SENSITIVE-SESSION-ID"
+	sentinelAuthID             = "auth-SENSITIVE-AUTH-ID"
+	sentinelAccessToken        = "SENSITIVE-ACCESS-TOKEN"
+	sentinelResponseID         = "resp-SENSITIVE-RESPONSE-ID"
+	sentinelPreviousResponseID = "resp-SENSITIVE-PREVIOUS-RESPONSE-ID"
+	sentinelProviderMessage    = "SENSITIVE-PROVIDER-ERROR-DETAIL"
+)
+
+// sentinelWebsocketURL embeds a credential in the query string, mirroring the
+// signed upstream URLs that these executors dial.
+var sentinelWebsocketURL = "wss://chatgpt.com/backend-api/codex/responses?access_token=" + sentinelAccessToken + "&session=" + sentinelSessionID
+
+// forbiddenWebsocketLogValues lists every substring that must be absent from
+// captured log output.
+var forbiddenWebsocketLogValues = []string{
+	sentinelSessionID,
+	sentinelAuthID,
+	sentinelAccessToken,
+	sentinelResponseID,
+	sentinelPreviousResponseID,
+	sentinelProviderMessage,
+	"access_token",
+	"backend-api",
+	"/responses",
+}
+
+// captureWebsocketLogs runs emit with a local logrus hook installed at debug
+// level and returns the rendered entries.
+func captureWebsocketLogs(t *testing.T, emit func()) []string {
+	t.Helper()
+
+	logger := log.StandardLogger()
+	previousLevel := logger.GetLevel()
+	logger.SetLevel(log.DebugLevel)
+	hook := logtest.NewLocal(logger)
+	t.Cleanup(func() {
+		hook.Reset()
+		logger.SetLevel(previousLevel)
+	})
+
+	emit()
+
+	entries := hook.AllEntries()
+	rendered := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		formatted, errFormat := entry.String()
+		if errFormat != nil {
+			formatted = ""
+		}
+		rendered = append(rendered, strings.Join([]string{entry.Message, formatted, fmt.Sprint(entry.Data)}, " "))
+	}
+	return rendered
+}
+
+// assertNoSentinelLeak fails the test if any captured record contains a
+// sentinel value.
+func assertNoSentinelLeak(t *testing.T, records []string) {
+	t.Helper()
+	if len(records) == 0 {
+		t.Fatal("expected at least one websocket lifecycle log record")
+	}
+	for _, record := range records {
+		for _, forbidden := range forbiddenWebsocketLogValues {
+			if strings.Contains(record, forbidden) {
+				t.Errorf("websocket lifecycle log leaked %q: %s", forbidden, record)
+			}
+		}
+		// The acceptance criteria require identifiers and complete URLs to be
+		// omitted, not merely masked. These field names must therefore be
+		// absent from the formatted record as well as their sentinel values.
+		for _, forbiddenField := range []string{
+			" session=",
+			" auth=",
+			" endpoint=",
+			" response_id=",
+			" previous_response_id=",
+		} {
+			if strings.Contains(record, forbiddenField) {
+				t.Errorf("websocket lifecycle log included forbidden field %q: %s", forbiddenField, record)
+			}
+		}
+	}
+}
+
+// sentinelStatusError carries an HTTP status alongside provider text, matching
+// the terminal failures produced by both executors.
+type sentinelStatusError struct{}
+
+func (sentinelStatusError) Error() string   { return "upstream refused: " + sentinelProviderMessage }
+func (sentinelStatusError) StatusCode() int { return http.StatusUnauthorized }
+
+func TestCodexWebsocketLifecycleLogsOmitSensitiveValues(t *testing.T) {
+	records := captureWebsocketLogs(t, func() {
+		logCodexWebsocketStreamStart("gpt-5-codex-" + sentinelSessionID)
+		logCodexWebsocketConnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL)
+		for _, reason := range []string{"read_error", "send_error", "upstream_error", sentinelProviderMessage} {
+			logCodexWebsocketDisconnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, reason, errors.New(sentinelProviderMessage))
+			logCodexWebsocketDisconnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, reason, nil)
+		}
+		logCodexWebsocketDisconnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, "terminal_failure", sentinelStatusError{})
+		logCodexWebsocketCloseFailure("stream", errors.New(sentinelProviderMessage))
+		logCodexWebsocketCloseFailure(sentinelProviderMessage, nil)
+	})
+
+	assertNoSentinelLeak(t, records)
+
+	joined := strings.Join(records, "\n")
+	for _, expected := range []string{"upstream connected", "upstream disconnected", "executing stream request"} {
+		if !strings.Contains(joined, expected) {
+			t.Errorf("expected Codex lifecycle log containing %q, got:\n%s", expected, joined)
+		}
+	}
+	// Operational metadata must survive redaction, otherwise the logs lose
+	// their diagnostic value.
+	for _, expected := range []string{"reason=read_error", "status=error", "status=ok"} {
+		if !strings.Contains(joined, expected) {
+			t.Errorf("expected Codex lifecycle log field %q, got:\n%s", expected, joined)
+		}
+	}
+}
+
+func TestXAIWebsocketLifecycleLogsOmitSensitiveValues(t *testing.T) {
+	requestPayload := []byte(fmt.Sprintf(
+		`{"type":"response.create","previous_response_id":%q,"generate":true,"input":[{"role":"user"},{"role":"user"}],"authorization":"Bearer %s"}`,
+		sentinelPreviousResponseID, sentinelAccessToken,
+	))
+	terminalPayload := []byte(fmt.Sprintf(
+		`{"type":"response.completed","response":{"id":%q,"previous_response_id":%q}}`,
+		sentinelResponseID, sentinelPreviousResponseID,
+	))
+
+	records := captureWebsocketLogs(t, func() {
+		logXAIWebsocketConnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL)
+		logXAIWebsocketRequest(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, requestPayload)
+		logXAIWebsocketRequest(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, nil)
+		logXAIWebsocketWarmupCompleted(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, terminalPayload)
+		logXAIWebsocketTerminalResponse(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, "response.completed", terminalPayload)
+		logXAIWebsocketTerminalResponse(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, sentinelProviderMessage, terminalPayload)
+		logXAIWebsocketDisconnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, "read_error", errors.New(sentinelProviderMessage))
+		logXAIWebsocketDisconnected(sentinelSessionID, sentinelAuthID, sentinelWebsocketURL, "completed", nil)
+		logXAIWebsocketCompactFallback(sentinelSessionID, sentinelAuthID, 3, true)
+		logXAIWebsocketCloseFailure("session_close", errors.New(sentinelProviderMessage))
+	})
+
+	assertNoSentinelLeak(t, records)
+
+	joined := strings.Join(records, "\n")
+	for _, expected := range []string{
+		"upstream connected",
+		"upstream request sent",
+		"upstream warmup completed",
+		"upstream terminal response",
+		"upstream disconnected",
+		"compact fallback",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Errorf("expected xAI lifecycle log containing %q, got:\n%s", expected, joined)
+		}
+	}
+	for _, expected := range []string{"event=response.create", "input_items=2", "generate=true"} {
+		if !strings.Contains(joined, expected) {
+			t.Errorf("expected xAI lifecycle log field %q, got:\n%s", expected, joined)
+		}
+	}
+}
+
+func TestSafeWebsocketLifecycleReasonRejectsUnlistedValues(t *testing.T) {
+	if got := safeWebsocketLifecycleReason("read_error"); got != "read_error" {
+		t.Fatalf("safeWebsocketLifecycleReason(read_error) = %q, want read_error", got)
+	}
+	if got := safeWebsocketLifecycleReason(""); got != absentLogPlaceholder {
+		t.Fatalf("safeWebsocketLifecycleReason(empty) = %q, want %q", got, absentLogPlaceholder)
+	}
+	if got := safeWebsocketLifecycleReason(sentinelProviderMessage); got != unknownLogPlaceholder {
+		t.Fatalf("safeWebsocketLifecycleReason(sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	}
+}
+
+func TestSafeWebsocketEventTypeRejectsUnlistedValues(t *testing.T) {
+	if got := safeWebsocketEventType("response.completed"); got != "response.completed" {
+		t.Fatalf("safeWebsocketEventType(response.completed) = %q, want response.completed", got)
+	}
+	if got := safeWebsocketEventType(sentinelProviderMessage); got != unknownLogPlaceholder {
+		t.Fatalf("safeWebsocketEventType(sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	}
+}
+
+func TestSafeWebsocketErrorDiagnosticReportsStructureOnly(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: absentLogPlaceholder},
+		{name: "opaque", err: errors.New(sentinelProviderMessage), want: redactedLogPlaceholder},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "net closed", err: net.ErrClosed, want: "connection_closed"},
+		{name: "status", err: sentinelStatusError{}, want: "status=401"},
+		{
+			name: "close code",
+			err:  &websocket.CloseError{Code: websocket.CloseAbnormalClosure, Text: sentinelProviderMessage},
+			want: "close_code=1006",
+		},
+		{
+			name: "out of range close code",
+			err:  &websocket.CloseError{Code: 17, Text: sentinelProviderMessage},
+			want: "close_code=" + unknownLogPlaceholder,
+		},
+		{
+			name: "wrapped status",
+			err:  fmt.Errorf("wrapped %s: %w", sentinelProviderMessage, sentinelStatusError{}),
+			want: "status=401",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := safeWebsocketErrorDiagnostic(testCase.err)
+			if got != testCase.want {
+				t.Fatalf("safeWebsocketErrorDiagnostic() = %q, want %q", got, testCase.want)
+			}
+			if strings.Contains(got, sentinelProviderMessage) {
+				t.Fatalf("safeWebsocketErrorDiagnostic() leaked provider text: %q", got)
+			}
+		})
+	}
+}
+
+func TestSafeWebsocketModelResolvesThroughRegistry(t *testing.T) {
+	if got := safeWebsocketModel("codex", ""); got != absentLogPlaceholder {
+		t.Fatalf("safeWebsocketModel(codex, empty) = %q, want %q", got, absentLogPlaceholder)
+	}
+	if got := safeWebsocketModel("codex", sentinelSessionID); got != unknownLogPlaceholder {
+		t.Fatalf("safeWebsocketModel(codex, sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	}
+	if got := safeWebsocketModel("codex", "gpt-5-codex"); strings.Contains(got, sentinelSessionID) {
+		t.Fatalf("safeWebsocketModel() leaked sentinel: %q", got)
+	}
+}
+
+func TestSafeXAIGenerateModeReportsFixedLiterals(t *testing.T) {
+	testCases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{name: "absent", payload: `{}`, want: "default"},
+		{name: "true", payload: `{"generate":true}`, want: "true"},
+		{name: "false", payload: `{"generate":false}`, want: "false"},
+		{name: "string", payload: fmt.Sprintf(`{"generate":%q}`, sentinelAccessToken), want: unknownLogPlaceholder},
+		{name: "object", payload: fmt.Sprintf(`{"generate":{"token":%q}}`, sentinelAccessToken), want: unknownLogPlaceholder},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := safeXAIGenerateMode([]byte(testCase.payload)); got != testCase.want {
+				t.Fatalf("safeXAIGenerateMode(%s) = %q, want %q", testCase.payload, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/websocket_log_redaction_test.go
+++ b/internal/runtime/executor/websocket_log_redaction_test.go
@@ -188,6 +188,14 @@ func TestXAIWebsocketLifecycleLogsOmitSensitiveValues(t *testing.T) {
 	}
 }
 
+func TestWebsocketWriteLogsOmitSessionAndErrorDetails(t *testing.T) {
+	records := captureWebsocketLogs(t, func() {
+		sess := &codexWebsocketSession{sessionID: sentinelSessionID}
+		_ = writeWebsocketPayloadMessage("codex", sess, nil, []byte(sentinelAccessToken))
+	})
+	assertNoSentinelLeak(t, records)
+}
+
 func TestSafeWebsocketLifecycleReasonRejectsUnlistedValues(t *testing.T) {
 	if got := helps.SafeWebsocketLifecycleReason("read_error"); got != "read_error" {
 		t.Fatalf("helps.SafeWebsocketLifecycleReason(read_error) = %q, want read_error", got)

--- a/internal/runtime/executor/websocket_log_redaction_test.go
+++ b/internal/runtime/executor/websocket_log_redaction_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	log "github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -188,23 +189,23 @@ func TestXAIWebsocketLifecycleLogsOmitSensitiveValues(t *testing.T) {
 }
 
 func TestSafeWebsocketLifecycleReasonRejectsUnlistedValues(t *testing.T) {
-	if got := safeWebsocketLifecycleReason("read_error"); got != "read_error" {
-		t.Fatalf("safeWebsocketLifecycleReason(read_error) = %q, want read_error", got)
+	if got := helps.SafeWebsocketLifecycleReason("read_error"); got != "read_error" {
+		t.Fatalf("helps.SafeWebsocketLifecycleReason(read_error) = %q, want read_error", got)
 	}
-	if got := safeWebsocketLifecycleReason(""); got != absentLogPlaceholder {
-		t.Fatalf("safeWebsocketLifecycleReason(empty) = %q, want %q", got, absentLogPlaceholder)
+	if got := helps.SafeWebsocketLifecycleReason(""); got != "none" {
+		t.Fatalf("helps.SafeWebsocketLifecycleReason(empty) = %q, want %q", got, "none")
 	}
-	if got := safeWebsocketLifecycleReason(sentinelProviderMessage); got != unknownLogPlaceholder {
-		t.Fatalf("safeWebsocketLifecycleReason(sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	if got := helps.SafeWebsocketLifecycleReason(sentinelProviderMessage); got != "other" {
+		t.Fatalf("helps.SafeWebsocketLifecycleReason(sentinel) = %q, want %q", got, "other")
 	}
 }
 
 func TestSafeWebsocketEventTypeRejectsUnlistedValues(t *testing.T) {
-	if got := safeWebsocketEventType("response.completed"); got != "response.completed" {
-		t.Fatalf("safeWebsocketEventType(response.completed) = %q, want response.completed", got)
+	if got := helps.SafeWebsocketEventType("response.completed"); got != "response.completed" {
+		t.Fatalf("helps.SafeWebsocketEventType(response.completed) = %q, want response.completed", got)
 	}
-	if got := safeWebsocketEventType(sentinelProviderMessage); got != unknownLogPlaceholder {
-		t.Fatalf("safeWebsocketEventType(sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	if got := helps.SafeWebsocketEventType(sentinelProviderMessage); got != "other" {
+		t.Fatalf("helps.SafeWebsocketEventType(sentinel) = %q, want %q", got, "other")
 	}
 }
 
@@ -214,8 +215,8 @@ func TestSafeWebsocketErrorDiagnosticReportsStructureOnly(t *testing.T) {
 		err  error
 		want string
 	}{
-		{name: "nil", err: nil, want: absentLogPlaceholder},
-		{name: "opaque", err: errors.New(sentinelProviderMessage), want: redactedLogPlaceholder},
+		{name: "nil", err: nil, want: "none"},
+		{name: "opaque", err: errors.New(sentinelProviderMessage), want: "[redacted]"},
 		{name: "canceled", err: context.Canceled, want: "canceled"},
 		{name: "deadline", err: context.DeadlineExceeded, want: "timeout"},
 		{name: "net closed", err: net.ErrClosed, want: "connection_closed"},
@@ -228,7 +229,7 @@ func TestSafeWebsocketErrorDiagnosticReportsStructureOnly(t *testing.T) {
 		{
 			name: "out of range close code",
 			err:  &websocket.CloseError{Code: 17, Text: sentinelProviderMessage},
-			want: "close_code=" + unknownLogPlaceholder,
+			want: "close_code=" + "other",
 		},
 		{
 			name: "wrapped status",
@@ -238,26 +239,26 @@ func TestSafeWebsocketErrorDiagnosticReportsStructureOnly(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := safeWebsocketErrorDiagnostic(testCase.err)
+			got := helps.SafeWebsocketErrorDiagnostic(testCase.err)
 			if got != testCase.want {
-				t.Fatalf("safeWebsocketErrorDiagnostic() = %q, want %q", got, testCase.want)
+				t.Fatalf("helps.SafeWebsocketErrorDiagnostic() = %q, want %q", got, testCase.want)
 			}
 			if strings.Contains(got, sentinelProviderMessage) {
-				t.Fatalf("safeWebsocketErrorDiagnostic() leaked provider text: %q", got)
+				t.Fatalf("helps.SafeWebsocketErrorDiagnostic() leaked provider text: %q", got)
 			}
 		})
 	}
 }
 
 func TestSafeWebsocketModelResolvesThroughRegistry(t *testing.T) {
-	if got := safeWebsocketModel("codex", ""); got != absentLogPlaceholder {
-		t.Fatalf("safeWebsocketModel(codex, empty) = %q, want %q", got, absentLogPlaceholder)
+	if got := helps.SafeWebsocketModel("codex", ""); got != "none" {
+		t.Fatalf("helps.SafeWebsocketModel(codex, empty) = %q, want %q", got, "none")
 	}
-	if got := safeWebsocketModel("codex", sentinelSessionID); got != unknownLogPlaceholder {
-		t.Fatalf("safeWebsocketModel(codex, sentinel) = %q, want %q", got, unknownLogPlaceholder)
+	if got := helps.SafeWebsocketModel("codex", sentinelSessionID); got != "other" {
+		t.Fatalf("helps.SafeWebsocketModel(codex, sentinel) = %q, want %q", got, "other")
 	}
-	if got := safeWebsocketModel("codex", "gpt-5-codex"); strings.Contains(got, sentinelSessionID) {
-		t.Fatalf("safeWebsocketModel() leaked sentinel: %q", got)
+	if got := helps.SafeWebsocketModel("codex", "gpt-5-codex"); strings.Contains(got, sentinelSessionID) {
+		t.Fatalf("helps.SafeWebsocketModel() leaked sentinel: %q", got)
 	}
 }
 
@@ -270,8 +271,8 @@ func TestSafeXAIGenerateModeReportsFixedLiterals(t *testing.T) {
 		{name: "absent", payload: `{}`, want: "default"},
 		{name: "true", payload: `{"generate":true}`, want: "true"},
 		{name: "false", payload: `{"generate":false}`, want: "false"},
-		{name: "string", payload: fmt.Sprintf(`{"generate":%q}`, sentinelAccessToken), want: unknownLogPlaceholder},
-		{name: "object", payload: fmt.Sprintf(`{"generate":{"token":%q}}`, sentinelAccessToken), want: unknownLogPlaceholder},
+		{name: "string", payload: fmt.Sprintf(`{"generate":%q}`, sentinelAccessToken), want: "other"},
+		{name: "object", payload: fmt.Sprintf(`{"generate":{"token":%q}}`, sentinelAccessToken), want: "other"},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -663,7 +663,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 			} else {
 				logXAIWebsocketDisconnected(executionSessionID, authID, wsURL, "send_error", errSend)
 				if errClose := closer.Close(); errClose != nil {
-					log.Errorf("xai websockets executor: close websocket error: %v", errClose)
+					logXAIWebsocketCloseFailure("stream", errClose)
 				}
 			}
 			return nil, errSend
@@ -693,7 +693,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 			}
 			logXAIWebsocketDisconnected(executionSessionID, authID, wsURL, terminateReason, terminateErr)
 			if errClose := closer.Close(); errClose != nil {
-				log.Errorf("xai websockets executor: close websocket error: %v", errClose)
+				logXAIWebsocketCloseFailure("stream_teardown", errClose)
 			}
 		}()
 
@@ -923,13 +923,7 @@ func (e *XAIWebsocketsExecutor) executeCompactionTriggerFromWebsocketContext(ctx
 	if auth != nil {
 		authID = auth.ID
 	}
-	log.Infof(
-		"xai websockets: compact fallback session=%s auth=%s input_items=%d keep_previous_response_id=%t",
-		xaiExecutionSessionID(req, opts),
-		strings.TrimSpace(authID),
-		inputItemsCount,
-		keepPreviousResponseID,
-	)
+	logXAIWebsocketCompactFallback(xaiExecutionSessionID(req, opts), authID, inputItemsCount, keepPreviousResponseID)
 	compactReq := req
 	compactReq.Payload = compactPayload
 
@@ -1185,7 +1179,7 @@ func (e *XAIWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cl
 		previousCloser := sess.connCloser
 		sess.connMu.Unlock()
 		if errClose := closer.Close(); errClose != nil {
-			log.Errorf("xai websockets executor: close websocket error: %v", errClose)
+			logXAIWebsocketCloseFailure("duplicate", errClose)
 		}
 		logXAIWebsocketConnectedWithReused(sess, sess.sessionID, authID, wsURL, true)
 		return previous, previousCloser, nil, nil
@@ -1209,21 +1203,17 @@ func configureXAIWebsocketConn(sess *codexWebsocketSession, conn *websocket.Conn
 	}
 	sess.resetUpstreamDisconnectError(conn)
 	conn.SetPingHandler(func(appData string) error {
-		sessionID := ""
-		if sess != nil {
-			sessionID = sess.sessionID
-		}
 		sessionKind := sessionObjectKind(sess)
-		log.Debugf("xai websockets: upstream ping received session=%s session_object=%s ping_bytes=%d", sessionID, sessionKind, len(appData))
-		log.Debugf("xai websockets: upstream pong write started session=%s session_object=%s", sessionID, sessionKind)
+		log.WithFields(log.Fields{"provider": "xai", "session_object": sessionKind, "ping_bytes": len(appData)}).Debug("xai websockets: upstream ping received")
+		log.WithFields(log.Fields{"provider": "xai", "session_object": sessionKind}).Debug("xai websockets: upstream pong write started")
 		start := time.Now()
 		// Gorilla websocket allows concurrent WriteControl with WriteMessage.
 		// Avoid writeMu here so keepalive pongs are not starved by long payload writes.
 		errPong := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Time{})
 		if errPong != nil {
-			log.Warnf("xai websockets: upstream pong write failed session=%s session_object=%s duration=%v err=%v", sessionID, sessionKind, time.Since(start), errPong)
+			log.WithFields(log.Fields{"provider": "xai", "session_object": sessionKind, "duration": time.Since(start), "diagnostic": helps.SafeWebsocketErrorDiagnostic(errPong)}).Warn("xai websockets: upstream pong write failed")
 		} else {
-			log.Debugf("xai websockets: upstream pong replied session=%s session_object=%s duration=%v", sessionID, sessionKind, time.Since(start))
+			log.WithFields(log.Fields{"provider": "xai", "session_object": sessionKind, "duration": time.Since(start)}).Debug("xai websockets: upstream pong replied")
 		}
 		return errPong
 	})
@@ -1387,7 +1377,7 @@ func (e *XAIWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWebs
 	}
 	if closer != nil {
 		if errClose := closer.Close(); errClose != nil {
-			log.Errorf("xai websockets executor: close websocket error: %v", errClose)
+			logXAIWebsocketCloseFailure("active", errClose)
 		}
 	}
 	if lifecycle != nil {
@@ -1474,7 +1464,7 @@ func closeXAIWebsocketSession(sess *codexWebsocketSession, reason string) {
 		logXAIWebsocketDisconnectedWithLastEvent(sess, sessionID, authID, wsURL, reason, lastEvent, nil)
 		if closer != nil {
 			if errClose := closer.Close(); errClose != nil {
-				log.Errorf("xai websockets executor: close websocket error: %v", errClose)
+				logXAIWebsocketCloseFailure("session_close", errClose)
 			}
 		}
 	}
@@ -1546,84 +1536,92 @@ func applyXAIWebsocketHeaders(ctx context.Context, headers http.Header, auth *cl
 	return headers
 }
 
-func logXAIWebsocketRequest(sessionID string, authID string, wsURL string, payload []byte) {
+func logXAIWebsocketRequest(_ string, _ string, _ string, payload []byte) {
+	fields := log.Fields{"provider": "xai"}
 	if len(payload) == 0 {
-		log.Infof("xai websockets: upstream request sent session=%s auth=%s url=%s", strings.TrimSpace(sessionID), strings.TrimSpace(authID), strings.TrimSpace(wsURL))
+		log.WithFields(fields).Info("xai websockets: upstream request sent")
 		return
 	}
-	generateValue := "default"
-	if generate := gjson.GetBytes(payload, "generate"); generate.Exists() {
-		generateValue = strings.TrimSpace(generate.Raw)
-	}
-	log.Infof(
-		"xai websockets: upstream request sent session=%s auth=%s url=%s event=%s previous_response_id=%s generate=%s input_items=%d",
-		strings.TrimSpace(sessionID),
-		strings.TrimSpace(authID),
-		strings.TrimSpace(wsURL),
-		strings.TrimSpace(gjson.GetBytes(payload, "type").String()),
-		strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()),
-		generateValue,
-		len(gjson.GetBytes(payload, "input").Array()),
-	)
+	fields["event"] = helps.SafeWebsocketEventType(gjson.GetBytes(payload, "type").String())
+	fields["generate"] = safeXAIGenerateMode(payload)
+	fields["input_items"] = len(gjson.GetBytes(payload, "input").Array())
+	log.WithFields(fields).Info("xai websockets: upstream request sent")
 }
 
-func logXAIWebsocketWarmupCompleted(sessionID string, authID string, wsURL string, payload []byte) {
-	log.Infof(
-		"xai websockets: upstream warmup completed session=%s auth=%s url=%s response_id=%s",
-		strings.TrimSpace(sessionID),
-		strings.TrimSpace(authID),
-		strings.TrimSpace(wsURL),
-		strings.TrimSpace(gjson.GetBytes(payload, "response.id").String()),
-	)
+func logXAIWebsocketWarmupCompleted(_ string, _ string, _ string, _ []byte) {
+	log.WithField("provider", "xai").Info("xai websockets: upstream warmup completed")
 }
 
-func logXAIWebsocketTerminalResponse(sessionID string, authID string, wsURL string, eventType string, payload []byte) {
-	log.Infof(
-		"xai websockets: upstream terminal response session=%s auth=%s url=%s event=%s response_id=%s previous_response_id=%s",
-		strings.TrimSpace(sessionID),
-		strings.TrimSpace(authID),
-		strings.TrimSpace(wsURL),
-		strings.TrimSpace(eventType),
-		strings.TrimSpace(gjson.GetBytes(payload, "response.id").String()),
-		strings.TrimSpace(gjson.GetBytes(payload, "response.previous_response_id").String()),
-	)
+func logXAIWebsocketTerminalResponse(_ string, _ string, _ string, eventType string, _ []byte) {
+	log.WithFields(log.Fields{
+		"provider": "xai",
+		"event":    helps.SafeWebsocketEventType(eventType),
+	}).Info("xai websockets: upstream terminal response")
 }
 
 func logXAIWebsocketConnected(sessionID string, authID string, wsURL string) {
 	logXAIWebsocketConnectedWithReused(nil, sessionID, authID, wsURL, false)
 }
 
-func logXAIWebsocketConnectedWithReused(sess *codexWebsocketSession, sessionID string, authID string, wsURL string, reused bool) {
-	sessionStr := strings.TrimSpace(sessionID)
-	sessionKind := sessionObjectKind(sess)
-	if reused {
-		log.Infof("xai websockets: upstream connected session=%s auth=%s url=%s session_object=%s reused=true", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind)
-		return
-	}
-	log.Infof("xai websockets: upstream connected session=%s auth=%s url=%s session_object=%s reused=false", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind)
+func logXAIWebsocketConnectedWithReused(sess *codexWebsocketSession, _ string, _ string, _ string, reused bool) {
+	log.WithFields(log.Fields{
+		"provider":       "xai",
+		"session_object": sessionObjectKind(sess),
+		"reused":         reused,
+	}).Info("xai websockets: upstream connected")
 }
 
 func logXAIWebsocketDisconnected(sessionID string, authID string, wsURL string, reason string, err error) {
 	logXAIWebsocketDisconnectedWithLastEvent(nil, sessionID, authID, wsURL, reason, "", err)
 }
 
-func logXAIWebsocketDisconnectedWithLastEvent(sess *codexWebsocketSession, sessionID string, authID string, wsURL string, reason string, lastEvent string, err error) {
-	sessionStr := strings.TrimSpace(sessionID)
-	sessionKind := sessionObjectKind(sess)
-	terminalStatus := isTerminalEvent(lastEvent)
+func logXAIWebsocketDisconnectedWithLastEvent(sess *codexWebsocketSession, _ string, _ string, _ string, reason string, lastEvent string, err error) {
+	status := "ok"
 	if err != nil {
-		if lastEvent != "" {
-			log.Infof("xai websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s last_event=%s is_terminal=%t err=%v", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), lastEvent, terminalStatus, err)
-			return
+		status = "error"
+	}
+	fields := log.Fields{
+		"provider":       "xai",
+		"session_object": sessionObjectKind(sess),
+		"reason":         helps.SafeWebsocketLifecycleReason(reason),
+		"status":         status,
+		"diagnostic":     helps.SafeWebsocketErrorDiagnostic(err),
+		"is_terminal":    isTerminalEvent(lastEvent),
+	}
+	if strings.TrimSpace(lastEvent) != "" {
+		fields["last_event"] = helps.SafeWebsocketEventType(lastEvent)
+	}
+	log.WithFields(fields).Info("xai websockets: upstream disconnected")
+}
+
+func logXAIWebsocketCompactFallback(_ string, _ string, inputItemsCount int, keepPreviousResponseID bool) {
+	log.WithFields(log.Fields{
+		"provider":                  "xai",
+		"input_items":               inputItemsCount,
+		"keep_previous_response_id": keepPreviousResponseID,
+	}).Info("xai websockets: compact fallback")
+}
+
+func logXAIWebsocketCloseFailure(stage string, err error) {
+	log.WithFields(log.Fields{
+		"provider":   "xai",
+		"stage":      helps.SafeWebsocketCloseStage(stage),
+		"diagnostic": helps.SafeWebsocketErrorDiagnostic(err),
+	}).Error("xai websockets: close upstream connection failed")
+}
+
+func safeXAIGenerateMode(payload []byte) string {
+	generate := gjson.GetBytes(payload, "generate")
+	if !generate.Exists() {
+		return "default"
+	}
+	if generate.Type == gjson.True || generate.Type == gjson.False {
+		if generate.Bool() {
+			return "true"
 		}
-		log.Infof("xai websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s is_terminal=false err=%v", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), err)
-		return
+		return "false"
 	}
-	if lastEvent != "" {
-		log.Infof("xai websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s last_event=%s is_terminal=%t", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason), lastEvent, terminalStatus)
-		return
-	}
-	log.Infof("xai websockets: upstream disconnected session=%s auth=%s url=%s session_object=%s reason=%s is_terminal=false", sessionStr, strings.TrimSpace(authID), strings.TrimSpace(wsURL), sessionKind, strings.TrimSpace(reason))
+	return "other"
 }
 
 // CloseXAIWebsocketSessionsForAuthID closes all active xAI upstream websocket sessions


### PR DESCRIPTION
## Summary
- omit session IDs, auth IDs, signed upstream URLs, and response IDs from Codex/xAI WebSocket lifecycle logs
- reduce provider-controlled errors and event fields to allowlisted diagnostics
- redact deferred WebSocket request timelines consistently

## Why core
These log calls are inside the built-in Codex/xAI WebSocket executors and the shared request logger; the plugin API cannot intercept them.

## Tests
Includes regression tests that inject sentinel credentials and assert they never appear in logs.