### PR TITLE
feat(api): add Responses input token count route

### DIFF
--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -76,6 +76,7 @@ func (s *Server) setupRoutes() {
 		v1.POST("/messages/count_tokens", claudeCodeHandlers.ClaudeCountTokens)
 		v1.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
+		v1.POST("/responses/input_tokens", openaiResponsesHandlers.InputTokens)
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		v1.POST("/alpha/search", s.codexAlphaSearch)
 		v1.POST("/live", s.codexLiveHandler.Handle)
@@ -113,6 +114,7 @@ func (s *Server) setupRoutes() {
 	{
 		codexDirect.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		codexDirect.POST("/responses", openaiResponsesHandlers.Responses)
+		codexDirect.POST("/responses/input_tokens", openaiResponsesHandlers.InputTokens)
 		codexDirect.POST("/responses/compact", openaiResponsesHandlers.Compact)
 		codexDirect.POST("/alpha/search", s.codexAlphaSearch)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -48,6 +48,8 @@ type codexSearchCaptureExecutor struct {
 	statuses     []int
 	refreshCalls int
 	httpCalls    int
+	countCalls   int
+	countPayload []byte
 	beforeReturn func()
 }
 
@@ -72,7 +74,11 @@ func (e *codexSearchCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*
 }
 
 func (e *codexSearchCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
-	return coreexecutor.Response{}, nil
+	e.countCalls++
+	if len(e.countPayload) > 0 {
+		return coreexecutor.Response{Payload: e.countPayload}, nil
+	}
+	return coreexecutor.Response{Payload: []byte(`{"response":{"usage":{"input_tokens":7,"output_tokens":0,"total_tokens":7}}}`)}, nil
 }
 
 func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.Auth) error {
@@ -630,6 +636,62 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	return NewServer(cfg, authManager, accessManager, configPath, opts...)
+}
+
+func TestResponsesInputTokensRoute(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{ID: "input-token-auth", Provider: "codex", Status: auth.StatusActive}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: "gpt-5.4"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", strings.NewReader(`{"model":"gpt-5.4","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.countCalls != 1 {
+		t.Fatalf("count calls = %d, want 1", executor.countCalls)
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != `{"object":"response.input_tokens","input_tokens":7}` {
+		t.Fatalf("body = %s", got)
+	}
+}
+
+func TestResponsesInputTokensRouteEstimatesPluginZeroCount(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{countPayload: []byte(`{"total_tokens":0}`)}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{ID: "input-token-estimate-auth", Provider: "codex", Status: auth.StatusActive}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, credential.Provider, []*registry.ModelInfo{{ID: "gpt-5.4"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", strings.NewReader(`{"model":"gpt-5.4","input":"hello"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var body struct {
+		InputTokens int64 `json:"input_tokens"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.InputTokens == 0 {
+		t.Fatalf("input_tokens = 0, want a local estimate; body=%s", rr.Body.String())
+	}
 }
 
 func TestHealthz(t *testing.T) {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"github.com/tiktoken-go/tokenizer"
 )
 
 func writeResponsesSSEChunk(w io.Writer, chunk []byte) {
@@ -609,6 +610,67 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()
+}
+
+func (h *OpenAIResponsesAPIHandler) InputTokens(c *gin.Context) {
+	rawJSON, err := handlers.ReadRequestBody(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{Message: fmt.Sprintf("Invalid request: %v", err), Type: "invalid_request_error"},
+		})
+		return
+	}
+
+	c.Header("Content-Type", "application/json")
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	resp, upstreamHeaders, errMsg := h.ExecuteCountWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		cliCancel(errMsg.Error)
+		return
+	}
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	if count, ok := responsesInputTokenCount(resp, rawJSON); ok {
+		_, _ = fmt.Fprintf(c.Writer, `{"object":"response.input_tokens","input_tokens":%d}`, count)
+		cliCancel()
+		return
+	}
+	h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("token count response did not include input_tokens")})
+	cliCancel()
+}
+
+func responsesInputTokenCount(response, request []byte) (int64, bool) {
+	var count int64
+	found := false
+	for _, path := range []string{"input_tokens", "response.input_tokens", "usage.input_tokens", "response.usage.input_tokens", "total_tokens"} {
+		if value := gjson.GetBytes(response, path); value.Exists() {
+			count, found = value.Int(), true
+			break
+		}
+	}
+	if count > 0 {
+		return count, true
+	}
+
+	parts := make([]string, 0, 4)
+	for _, path := range []string{"instructions", "input", "tools", "text.format"} {
+		if value := gjson.GetBytes(request, path); value.Exists() && value.Raw != "" && value.Raw != `""` && value.Raw != "[]" && value.Raw != "null" {
+			parts = append(parts, value.Raw)
+		}
+	}
+	if len(parts) == 0 {
+		return count, found
+	}
+	enc, err := tokenizer.Get(tokenizer.O200kBase)
+	if err != nil {
+		return count, found
+	}
+	estimate, err := enc.Count(strings.Join(parts, "\n"))
+	if err != nil {
+		return count, found
+	}
+	return int64(estimate), true
 }
 
 // handleNonStreamingResponse handles non-streaming chat completion responses


### PR DESCRIPTION
Adds the OpenAI-compatible `POST /v1/responses/input_tokens` route and delegates counting through the existing executor interface, including plugin executors. Responses are normalized to `response.input_tokens`; executors that explicitly return zero fall back to a local o200k estimate.\n\nThis is intentionally limited to the generic route/handler. It does not add provider-specific logic or Live/Realtime behavior.\n\nVerification:\n- `go test ./internal/api -run TestResponsesInputTokensRoute -count=1`\n- `go test ./sdk/api/handlers/openai -run TestResponses -count=1`\n- required server build