### PR TITLE
feat(plugins): forward per-login metadata to auth provider StartLogin

### DIFF
--- a/internal/api/handlers/management/auth_files_oauth_callback.go
+++ b/internal/api/handlers/management/auth_files_oauth_callback.go
@@ -168,6 +168,32 @@ func pluginAuthProviderFromPath(path string) (string, bool) {
 	return provider, true
 }
 
+// pluginLoginMetadata turns the auth-url query string into per-login metadata
+// for the plugin, so a single provider can be logged in several times with
+// different settings (for example one account per region or organization
+// portal) without editing the plugin's global config between logins. The
+// management key is read from headers only, so no credential is carried here.
+func pluginLoginMetadata(c *gin.Context) map[string]any {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return nil
+	}
+	query := c.Request.URL.Query()
+	if len(query) == 0 {
+		return nil
+	}
+	metadata := make(map[string]any, len(query))
+	for key, values := range query {
+		if len(values) == 0 {
+			continue
+		}
+		metadata[key] = values[0]
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
 func (h *Handler) ServePluginAuthURL(c *gin.Context) bool {
 	if h == nil || c == nil || c.Request == nil || c.Request.URL == nil {
 		return false
@@ -190,7 +216,7 @@ func (h *Handler) ServePluginAuthURL(c *gin.Context) bool {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate authorization url"})
 		return true
 	}
-	resp, handled, errStart := host.StartLogin(ctx, provider, baseURL)
+	resp, handled, errStart := host.StartLogin(ctx, provider, baseURL, pluginLoginMetadata(c))
 	if !handled {
 		return false
 	}

--- a/internal/pluginhost/auth_provider.go
+++ b/internal/pluginhost/auth_provider.go
@@ -255,15 +255,23 @@ func pluginAuthParseResponseAuths(resp pluginapi.AuthParseResponse) []pluginapi.
 	return []pluginapi.AuthData{resp.Auth}
 }
 
-func (h *Host) StartLogin(ctx context.Context, provider string, baseURL string) (pluginapi.AuthLoginStartResponse, bool, error) {
+// StartLogin starts a provider login flow. The optional metadata carries
+// per-login context (for example the account or region a plugin should log in
+// to) and reaches the plugin as AuthLoginStartRequest.Metadata, mirroring how
+// PollLogin already forwards metadata.
+func (h *Host) StartLogin(ctx context.Context, provider string, baseURL string, metadata ...map[string]any) (pluginapi.AuthLoginStartResponse, bool, error) {
 	record := h.authProviderRecord(provider)
 	if record == nil {
 		return pluginapi.AuthLoginStartResponse{}, false, nil
 	}
-	return h.callStartLogin(ctx, *record, provider, baseURL)
+	var startMetadata map[string]any
+	if len(metadata) > 0 {
+		startMetadata = metadata[0]
+	}
+	return h.callStartLogin(ctx, *record, provider, baseURL, startMetadata)
 }
 
-func (h *Host) callStartLogin(ctx context.Context, record capabilityRecord, provider string, baseURL string) (resp pluginapi.AuthLoginStartResponse, handled bool, err error) {
+func (h *Host) callStartLogin(ctx context.Context, record capabilityRecord, provider string, baseURL string, metadata map[string]any) (resp pluginapi.AuthLoginStartResponse, handled bool, err error) {
 	authProvider := record.plugin.Capabilities.AuthProvider
 	if h == nil || authProvider == nil || h.isPluginFused(record.id) || !h.recordCurrent(record) {
 		return pluginapi.AuthLoginStartResponse{}, false, nil
@@ -281,6 +289,7 @@ func (h *Host) callStartLogin(ctx context.Context, record capabilityRecord, prov
 		BaseURL:    strings.TrimSpace(baseURL),
 		Host:       h.hostConfigSummary(),
 		HTTPClient: h.newHTTPClient(nil),
+		Metadata:   cloneAnyMap(metadata),
 	}
 	resp, errStart := authProvider.StartLogin(ctx, req)
 	if errStart != nil {

--- a/internal/pluginhost/auth_provider_test.go
+++ b/internal/pluginhost/auth_provider_test.go
@@ -215,6 +215,48 @@ func TestStartLoginPassesProviderBaseURLHostAndHTTPClient(t *testing.T) {
 	}
 }
 
+func TestStartLoginForwardsPerLoginMetadata(t *testing.T) {
+	var gotMetadata map[string]any
+	host := newHostWithRecords(capabilityRecord{
+		id: "auth-plugin",
+		plugin: pluginapi.Plugin{
+			Capabilities: pluginapi.Capabilities{
+				AuthProvider: fakeAuthProvider{
+					identifier: "plugin-provider",
+					startLogin: func(ctx context.Context, req pluginapi.AuthLoginStartRequest) (pluginapi.AuthLoginStartResponse, error) {
+						gotMetadata = req.Metadata
+						return pluginapi.AuthLoginStartResponse{Provider: req.Provider, State: "state-1"}, nil
+					},
+				},
+			},
+		},
+	})
+	host.runtimeConfig = &config.Config{AuthDir: t.TempDir()}
+
+	metadata := map[string]any{"idc_start_url": "https://d-abc.awsapps.com/start", "idc_region": "eu-west-1"}
+	if _, handled, errStart := host.StartLogin(context.Background(), "plugin-provider", "http://localhost:8080/login", metadata); errStart != nil || !handled {
+		t.Fatalf("StartLogin() handled=%t error=%v, want handled call", handled, errStart)
+	}
+	if gotMetadata["idc_start_url"] != "https://d-abc.awsapps.com/start" || gotMetadata["idc_region"] != "eu-west-1" {
+		t.Fatalf("StartLogin metadata = %#v, want the per-login values", gotMetadata)
+	}
+
+	// The plugin must receive a copy: mutating its metadata cannot reach the caller.
+	gotMetadata["idc_region"] = "mutated"
+	if metadata["idc_region"] != "eu-west-1" {
+		t.Fatalf("caller metadata mutated by plugin: %#v", metadata)
+	}
+
+	// Omitting metadata keeps the previous behavior (nil, not an empty map).
+	gotMetadata = map[string]any{"stale": true}
+	if _, handled, errStart := host.StartLogin(context.Background(), "plugin-provider", "http://localhost:8080/login"); errStart != nil || !handled {
+		t.Fatalf("StartLogin() without metadata handled=%t error=%v", handled, errStart)
+	}
+	if gotMetadata != nil {
+		t.Fatalf("StartLogin metadata = %#v, want nil when no metadata is passed", gotMetadata)
+	}
+}
+
 func TestPollLoginPassesProviderStateHostAndHTTPClient(t *testing.T) {
 	authDir := t.TempDir()
 	called := false

--- a/sdk/pluginhost/host.go
+++ b/sdk/pluginhost/host.go
@@ -161,11 +161,12 @@ func (h *Host) HasAuthProvider(provider string) bool {
 }
 
 // StartLogin starts a provider login flow through an active auth-provider plugin.
-func (h *Host) StartLogin(ctx context.Context, provider string, baseURL string) (pluginapi.AuthLoginStartResponse, bool, error) {
+// The optional metadata is forwarded to the plugin as per-login context.
+func (h *Host) StartLogin(ctx context.Context, provider string, baseURL string, metadata ...map[string]any) (pluginapi.AuthLoginStartResponse, bool, error) {
 	if h == nil || h.inner == nil {
 		return pluginapi.AuthLoginStartResponse{}, false, nil
 	}
-	return h.inner.StartLogin(ctx, provider, baseURL)
+	return h.inner.StartLogin(ctx, provider, baseURL, metadata...)
 }
 
 // PollLogin polls a provider login flow through an active auth-provider plugin.


### PR DESCRIPTION
Closes #5760.

### Problem

`pluginapi.AuthLoginStartRequest` declares a `Metadata` field ("plugin-defined login context"), but the host never populates it, so an auth-provider plugin receives identical input on every login and can only read its own global config. Logging one provider in several times with different settings (one account per region, per organization SSO portal) therefore requires editing plugin config between logins, even though the resulting credentials are independent and coexist fine afterwards.

`PollLogin` already accepts `metadata ...map[string]any`; `StartLogin` had no equivalent.

### Change

- `Host.StartLogin` takes optional metadata, mirroring the existing `PollLogin(ctx, provider, state, metadata...)` signature, and forwards a clone to the plugin as `AuthLoginStartRequest.Metadata`.
- `ServePluginAuthURL` turns the auth-url query string into that metadata, so `GET /v0/management/<provider>-auth-url?idc_region=eu-west-1` reaches the plugin as login context.
- `sdk/pluginhost.Host.StartLogin` passes the variadic argument through.

### Compatibility and safety

- The parameter is variadic, so every existing caller and plugin is unaffected. With no metadata the plugin receives `nil`, not an empty map — asserted in the test.
- Metadata is cloned via `cloneAnyMap`, so a plugin cannot mutate the caller's map — also asserted.
- The management key is accepted only via `Authorization` / `X-Management-Key` headers, so forwarding the query string carries no credential.

### Testing

- `TestStartLoginForwardsPerLoginMetadata` covers forwarding, the defensive copy, and the nil-when-omitted case. Verified by mutation: removing the `Metadata:` line fails the test.
- `go test ./internal/pluginhost/ ./sdk/pluginhost/` passes.
- `go build -o test-output ./cmd/server` passes; `gofmt` clean on touched files. (`internal/pluginhost/host.go` is gofmt-dirty on `main` already and was left untouched.)

Happy to narrow the shape if you'd prefer something tighter than forwarding the whole query — a dedicated field, a nested `oauth_flow_config` object, or an explicit allow-list of forwarded keys.