### PR TITLE
fix(codex): stop retrying rejected refresh grants within a refresh operation

### DIFF
--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -328,12 +328,25 @@ func (o *CodexAuth) RefreshTokensWithRetry(ctx context.Context, refreshToken str
 	return nil, fmt.Errorf("token refresh failed after %d attempts: %w", maxRetries, lastErr)
 }
 
+// isNonRetryableRefreshErr reports rejected refresh grants that should stop
+// immediate replay within the current RefreshTokensWithRetry operation. It does
+// not change later scheduled refresh attempts or credential state.
 func isNonRetryableRefreshErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	raw := strings.ToLower(err.Error())
-	return strings.Contains(raw, "refresh_token_reused")
+	for _, terminal := range []string{
+		"refresh_token_reused",
+		"refresh_token_invalidated",
+		"token_invalidated",
+		"invalid_grant",
+	} {
+		if strings.Contains(raw, terminal) {
+			return true
+		}
+	}
+	return false
 }
 
 // UpdateTokenStorage updates an existing CodexTokenStorage with new token data.

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -2,6 +2,8 @@ package codex
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -67,31 +69,130 @@ func resetCodexRefreshGroupForTest() {
 	codexRefreshGroup = singleflight.Group{}
 }
 
-func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
-	var calls int32
-	auth := &CodexAuth{
-		httpClient: &http.Client{
-			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				atomic.AddInt32(&calls, 1)
-				return &http.Response{
-					StatusCode: http.StatusBadRequest,
-					Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_grant","code":"refresh_token_reused"}`)),
-					Header:     make(http.Header),
-					Request:    req,
-				}, nil
-			}),
+func TestIsNonRetryableRefreshErr(t *testing.T) {
+	// Terminal cases mirror how RefreshTokens formats a non-200 token endpoint
+	// response: "token refresh failed with status %d: %s".
+	refreshStatusErr := func(statusCode int, body string) error {
+		return fmt.Errorf("token refresh failed with status %d: %s", statusCode, body)
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "transport failure",
+			err:  errors.New(`Post "https://auth.openai.com/oauth/token": dial tcp: i/o timeout`),
+			want: false,
+		},
+		{
+			name: "server error",
+			err:  refreshStatusErr(http.StatusServiceUnavailable, `{"error":"server_error","error_description":"upstream unavailable"}`),
+			want: false,
+		},
+		{
+			name: "refresh token reused",
+			err:  refreshStatusErr(http.StatusBadRequest, `{"error":"invalid_request","code":"refresh_token_reused"}`),
+			want: true,
+		},
+		{
+			name: "refresh token invalidated",
+			err:  refreshStatusErr(http.StatusBadRequest, `{"error":"invalid_request","code":"refresh_token_invalidated"}`),
+			want: true,
+		},
+		{
+			name: "token invalidated",
+			err:  refreshStatusErr(http.StatusUnauthorized, `{"error":"unauthorized","code":"token_invalidated"}`),
+			want: true,
+		},
+		{
+			name: "invalid grant",
+			err:  refreshStatusErr(http.StatusUnauthorized, `{"error":"invalid_grant","error_description":"refresh token revoked"}`),
+			want: true,
+		},
+		{
+			name: "invalid grant uppercase",
+			err:  refreshStatusErr(http.StatusBadRequest, `{"error":"INVALID_GRANT","error_description":"Refresh token revoked"}`),
+			want: true,
 		},
 	}
 
-	_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token", 3)
-	if err == nil {
-		t.Fatalf("expected error for non-retryable refresh failure")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNonRetryableRefreshErr(tc.err); got != tc.want {
+				t.Fatalf("isNonRetryableRefreshErr(%v) = %t, want %t", tc.err, got, tc.want)
+			}
+		})
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "refresh_token_reused") {
-		t.Fatalf("expected refresh_token_reused in error, got: %v", err)
+}
+
+func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    string
+	}{
+		{
+			name:       "refresh_token_reused",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_grant","code":"refresh_token_reused"}`,
+			wantErr:    "refresh_token_reused",
+		},
+		{
+			name:       "refresh_token_invalidated",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"invalid_request","code":"refresh_token_invalidated"}`,
+			wantErr:    "refresh_token_invalidated",
+		},
+		{
+			name:       "token_invalidated",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"unauthorized","code":"token_invalidated"}`,
+			wantErr:    "token_invalidated",
+		},
+		{
+			name:       "invalid_grant",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":"invalid_grant","error_description":"refresh token revoked"}`,
+			wantErr:    "invalid_grant",
+		},
 	}
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Fatalf("expected 1 refresh attempt, got %d", got)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			auth := &CodexAuth{
+				httpClient: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						atomic.AddInt32(&calls, 1)
+						return &http.Response{
+							StatusCode: tc.statusCode,
+							Body:       io.NopCloser(strings.NewReader(tc.body)),
+							Header:     make(http.Header),
+							Request:    req,
+						}, nil
+					}),
+				},
+			}
+
+			_, err := auth.RefreshTokensWithRetry(context.Background(), "dummy_refresh_token_"+tc.name, 3)
+			if err == nil {
+				t.Fatalf("expected error for non-retryable refresh failure")
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.wantErr) {
+				t.Fatalf("expected %s in error, got: %v", tc.wantErr, err)
+			}
+			if got := atomic.LoadInt32(&calls); got != 1 {
+				t.Fatalf("expected 1 refresh attempt, got %d", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem and result

`RefreshTokensWithRetry` already stops retrying `refresh_token_reused`. This change treats `refresh_token_invalidated`, `token_invalidated`, and `invalid_grant` the same way, so a rejected refresh grant is not immediately replayed in the same refresh operation.

For example, a `400 invalid_grant` response with `maxRetries=3` now makes 1 HTTP request instead of 3.

## Scope

`invalid_grant` means the OAuth server rejected an expired, invalid, or otherwise unusable grant; it is not proof that an account was revoked. The existing string-matching strategy is retained.

This only changes duplicate attempts within one `RefreshTokensWithRetry` invocation. Background refresh scheduling and credential disable policy are unchanged, so later scheduled retries can still occur. Ordinary transient errors without these terminal markers keep their current retry behavior.

## Validation

- Added table coverage for the terminal markers and transient error strings.
- Added request-count coverage showing each terminal response makes one attempt.
- `go test ./internal/auth/codex -count=1`
- `go vet ./internal/auth/codex`
- `go build ./cmd/server`

Refs: openai/codex#39199, openai/codex#39189.

AI-assisted implementation and review.
