### PR TITLE
fix(openai-compat): drop top_k for active Claude thinking

### DIFF
--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -127,6 +127,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = normalizeOpenAICompatClaudeSampling(translated, originalPayloadSource, from)
 	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
@@ -342,6 +343,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	translated = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", translated, originalTranslated, requestedModel, requestPath, opts.Headers)
+	translated = normalizeOpenAICompatClaudeSampling(translated, originalPayloadSource, from)
 	if helps.ShouldNormalizeOpenAIToolResultsForModel(e.resolveCompatConfig(auth), baseModel, requestedModel) {
 		translated = helps.NormalizeOpenAIToolResultsTextOnly(translated)
 	}
@@ -570,6 +572,38 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		reporter.EnsurePublished(ctx)
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+// Claude clients may send top_k together with extended/adaptive thinking. The
+// OpenAI-compatible translation can otherwise preserve that knob all the way
+// to a Claude-backed compatibility route, where Anthropic rejects the pair.
+// Run this after payload overrides so they cannot reintroduce the invalid
+// combination. Non-Claude callers and non-thinking Claude requests are kept.
+func normalizeOpenAICompatClaudeSampling(body, source []byte, from sdktranslator.Format) []byte {
+	if !sourceFormatEqual(from, sdktranslator.FormatClaude) {
+		return body
+	}
+	thinkingActive := false
+	switch strings.ToLower(strings.TrimSpace(gjson.GetBytes(source, "thinking.type").String())) {
+	case "enabled", "adaptive", "auto":
+		thinkingActive = true
+	}
+	if !thinkingActive {
+		for _, path := range []string{"output_config.effort", "reasoning_effort", "reasoning.effort"} {
+			value := strings.ToLower(strings.TrimSpace(gjson.GetBytes(source, path).String()))
+			if value == "" {
+				value = strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, path).String()))
+			}
+			if value != "" && value != "none" {
+				thinkingActive = true
+				break
+			}
+		}
+	}
+	if thinkingActive {
+		body, _ = sjson.DeleteBytes(body, "top_k")
+	}
+	return body
 }
 
 func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (_ *cliproxyexecutor.StreamResult, err error) {

--- a/internal/runtime/executor/openai_compat_executor_sampling_test.go
+++ b/internal/runtime/executor/openai_compat_executor_sampling_test.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeOpenAICompatClaudeSampling(t *testing.T) {
+	tests := []struct {
+		name       string
+		from       sdktranslator.Format
+		source     string
+		translated string
+		wantTopK   bool
+	}{
+		{
+			name:       "claude adaptive thinking drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"thinking":{"type":"adaptive"},"top_k":40}`,
+			translated: `{"reasoning_effort":"max","temperature":1,"top_k":40}`,
+		},
+		{
+			name:       "claude enabled thinking drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"thinking":{"type":"enabled","budget_tokens":1024},"top_k":40}`,
+			translated: `{"reasoning_effort":"low","top_k":40}`,
+		},
+		{
+			name:       "claude effort activates thinking after translation and drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"output_config":{"effort":"max"},"top_k":40}`,
+			translated: `{"reasoning_effort":"max","top_k":40}`,
+		},
+		{
+			name:       "translated reasoning effort drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"messages":[],"top_k":40}`,
+			translated: `{"reasoning_effort":"high","top_k":40}`,
+		},
+		{
+			name:       "claude auto thinking drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"thinking":{"type":"auto"},"top_k":40}`,
+			translated: `{"top_k":40}`,
+		},
+		{
+			name:       "claude reasoning effort drops top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"reasoning":{"effort":"high"},"top_k":40}`,
+			translated: `{"top_k":40}`,
+		},
+		{
+			name:       "explicit none effort keeps top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"output_config":{"effort":"none"},"top_k":40}`,
+			translated: `{"reasoning_effort":"none","top_k":40}`,
+			wantTopK:   true,
+		},
+		{
+			name:       "translated active effort overrides source disabled sentinel",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"thinking":{"type":"disabled"},"top_k":40}`,
+			translated: `{"reasoning_effort":"high","top_k":40}`,
+		},
+		{
+			name:       "claude without thinking keeps top_k",
+			from:       sdktranslator.FormatClaude,
+			source:     `{"messages":[]}`,
+			translated: `{"top_k":40}`,
+			wantTopK:   true,
+		},
+		{
+			name:       "non-claude source keeps top_k",
+			from:       sdktranslator.FormatOpenAI,
+			source:     `{"thinking":{"type":"adaptive"}}`,
+			translated: `{"top_k":40}`,
+			wantTopK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeOpenAICompatClaudeSampling([]byte(tt.translated), []byte(tt.source), tt.from)
+			if exists := gjson.GetBytes(got, "top_k").Exists(); exists != tt.wantTopK {
+				t.Fatalf("top_k exists = %v, want %v; body=%s", exists, tt.wantTopK, got)
+			}
+			if temperature := gjson.GetBytes(got, "temperature"); temperature.Exists() && temperature.Int() != 1 {
+				t.Fatalf("temperature changed unexpectedly: body=%s", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Remove `top_k` from OpenAI-compatible payloads when a Claude request has active thinking.

Claude clients may send `top_k` together with extended/adaptive thinking. After Claude-to-OpenAI translation and payload overrides, that combination can reach a Claude-backed compatibility upstream and be rejected with `-4003 top_k must be unset when thinking is enabled/adaptive`.

This change runs after payload overrides and:

- applies only to Claude-source requests;
- treats `thinking.type=enabled|adaptive|auto` and non-`none` effort fields as active thinking;
- removes only `top_k`;
- preserves `top_k` for non-Claude, no-thinking, and explicit-`none` requests;
- keeps sibling sampling fields unchanged.

Both streaming and non-streaming execution paths are covered.

## Tests

- `go test -count=1 -run 'TestNormalizeOpenAICompatClaudeSampling|TestOpenAICompatExecutorUsesCompatibleClaudeTranslation|TestNormalizeClaudeSamplingForUpstream' ./internal/runtime/executor`
- `go build -buildvcs=false -trimpath -o /tmp/cpa-pr2-build ./cmd/server`
