### PR TITLE
fix(wsrelay): reject incomplete responses and preserve status

### DIFF
--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -317,7 +317,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 				helps.RecordAPIResponseError(ctx, e.cfg, event.Err)
 				reporter.PublishFailure(ctx, event.Err)
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %v", event.Err)}:
+				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %w", event.Err)}:
 				case <-ctx.Done():
 				}
 				return false

--- a/internal/runtime/executor/aistudio_executor_test.go
+++ b/internal/runtime/executor/aistudio_executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -229,6 +230,83 @@ func TestAIStudioExecutorWithoutRelaySessionDoesNotMarkUpstreamAttempt(t *testin
 				t.Fatal("missing relay session was marked as an upstream attempt")
 			}
 		})
+	}
+}
+
+func TestAIStudioExecutorExecuteStreamPreservesRelayErrorStatus(t *testing.T) {
+	const authID = "aistudio-status-error"
+	connected := make(chan struct{}, 1)
+	relay := wsrelay.NewManager(wsrelay.Options{
+		ProviderFactory: func(*http.Request) (string, error) { return authID, nil },
+		OnConnected:     func(string) { connected <- struct{}{} },
+	})
+	server := httptest.NewServer(relay.Handler())
+	defer server.Close()
+	defer func() {
+		if errStop := relay.Stop(context.Background()); errStop != nil {
+			t.Errorf("relay stop error = %v", errStop)
+		}
+	}()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + relay.Path()
+	conn, _, errDial := websocket.DefaultDialer.Dial(wsURL, nil)
+	if errDial != nil {
+		t.Fatalf("dial websocket: %v", errDial)
+	}
+	defer func() {
+		if errClose := conn.Close(); errClose != nil {
+			t.Errorf("websocket close error = %v", errClose)
+		}
+	}()
+	select {
+	case <-connected:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for relay connection")
+	}
+
+	clientDone := make(chan error, 1)
+	go func() {
+		var request wsrelay.Message
+		if errRead := conn.ReadJSON(&request); errRead != nil {
+			clientDone <- errRead
+			return
+		}
+		clientDone <- conn.WriteJSON(wsrelay.Message{
+			ID:   request.ID,
+			Type: wsrelay.MessageTypeError,
+			Payload: map[string]any{
+				"error":  "invalid api key",
+				"status": http.StatusUnauthorized,
+			},
+		})
+	}()
+
+	exec := NewAIStudioExecutor(&config.Config{}, "aistudio", relay)
+	result, errExecute := exec.ExecuteStream(context.Background(), &cliproxyauth.Auth{ID: authID, Provider: "aistudio"}, cliproxyexecutor.Request{
+		Model:   "gemini-3.1-pro-preview",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	if result == nil {
+		t.Fatal("ExecuteStream() result is nil")
+	}
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("ExecuteStream() emitted no relay error")
+	}
+	var statusCoder interface{ StatusCode() int }
+	if !errors.As(streamErr, &statusCoder) || statusCoder.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("ExecuteStream() error = %v, want status %d", streamErr, http.StatusUnauthorized)
+	}
+	if errClient := <-clientDone; errClient != nil {
+		t.Fatalf("relay client error = %v", errClient)
 	}
 }
 

--- a/internal/wsrelay/http.go
+++ b/internal/wsrelay/http.go
@@ -35,6 +35,19 @@ type StreamEvent struct {
 	Err     error
 }
 
+type statusError struct {
+	message string
+	status  int
+}
+
+func (e statusError) Error() string {
+	return fmt.Sprintf("%s (status=%d)", e.message, e.status)
+}
+
+func (e statusError) StatusCode() int {
+	return e.status
+}
+
 // NonStream executes a non-streaming HTTP request using the websocket provider.
 func (m *Manager) NonStream(ctx context.Context, provider string, req *HTTPRequest) (*HTTPResponse, error) {
 	if req == nil {
@@ -45,6 +58,10 @@ func (m *Manager) NonStream(ctx context.Context, provider string, req *HTTPReque
 	if err != nil {
 		return nil, err
 	}
+	return receiveNonStream(ctx, respCh)
+}
+
+func receiveNonStream(ctx context.Context, respCh <-chan Message) (*HTTPResponse, error) {
 	var (
 		streamMode bool
 		streamResp *HTTPResponse
@@ -56,14 +73,8 @@ func (m *Manager) NonStream(ctx context.Context, provider string, req *HTTPReque
 			return nil, ctx.Err()
 		case msg, ok := <-respCh:
 			if !ok {
-				if streamMode {
-					if streamResp == nil {
-						streamResp = &HTTPResponse{Status: http.StatusOK, Headers: make(http.Header)}
-					} else if streamResp.Headers == nil {
-						streamResp.Headers = make(http.Header)
-					}
-					streamResp.Body = append(streamResp.Body[:0], streamBody.Bytes()...)
-					return streamResp, nil
+				if err := ctx.Err(); err != nil {
+					return nil, err
 				}
 				return nil, errors.New("wsrelay: connection closed during response")
 			}
@@ -237,12 +248,11 @@ func decodeError(payload map[string]any) error {
 		return errors.New("wsrelay: unknown error")
 	}
 	message, _ := payload["error"].(string)
-	status := 0
-	if v, ok := payload["status"].(float64); ok {
-		status = int(v)
-	}
 	if message == "" {
 		message = "wsrelay: upstream error"
 	}
-	return fmt.Errorf("%s (status=%d)", message, status)
+	if v, ok := payload["status"].(float64); ok && v >= http.StatusBadRequest && v <= 599 && v == float64(int(v)) {
+		return statusError{message: message, status: int(v)}
+	}
+	return errors.New(message)
 }

--- a/internal/wsrelay/http_test.go
+++ b/internal/wsrelay/http_test.go
@@ -1,0 +1,114 @@
+package wsrelay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestDecodeErrorStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     float64
+		wantStatus int
+	}{
+		{name: "upstream error", status: http.StatusUnauthorized, wantStatus: http.StatusUnauthorized},
+		{name: "lower error boundary", status: http.StatusBadRequest, wantStatus: http.StatusBadRequest},
+		{name: "upper error boundary", status: 599, wantStatus: 599},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := map[string]any{"error": "invalid api key", "status": test.status}
+			err := decodeError(payload)
+			var statusCoder interface{ StatusCode() int }
+			if !errors.As(err, &statusCoder) {
+				t.Fatalf("decodeError() does not expose status: %v", err)
+			}
+			if statusCoder.StatusCode() != test.wantStatus {
+				t.Fatalf("StatusCode() = %d, want %d", statusCoder.StatusCode(), test.wantStatus)
+			}
+			wantMessage := fmt.Sprintf("invalid api key (status=%d)", test.wantStatus)
+			if err.Error() != wantMessage {
+				t.Fatalf("Error() = %q, want %q", err.Error(), wantMessage)
+			}
+		})
+	}
+
+	withoutValidStatus := []struct {
+		name    string
+		payload map[string]any
+		want    string
+	}{
+		{name: "success", payload: map[string]any{"error": "invalid api key", "status": float64(http.StatusOK)}, want: "invalid api key"},
+		{name: "out of range", payload: map[string]any{"error": "invalid api key", "status": float64(600)}, want: "invalid api key"},
+		{name: "fractional", payload: map[string]any{"error": "invalid api key", "status": 401.5}, want: "invalid api key"},
+		{name: "missing", payload: map[string]any{"error": "invalid api key"}, want: "invalid api key"},
+		{name: "nil payload", want: "wsrelay: unknown error"},
+	}
+	for _, test := range withoutValidStatus {
+		t.Run(test.name, func(t *testing.T) {
+			err := decodeError(test.payload)
+			var statusCoder interface{ StatusCode() int }
+			if errors.As(err, &statusCoder) {
+				t.Fatalf("decodeError() unexpectedly exposes status %d", statusCoder.StatusCode())
+			}
+			if err.Error() != test.want {
+				t.Fatalf("Error() = %q, want %q", err.Error(), test.want)
+			}
+		})
+	}
+}
+
+func TestReceiveNonStreamRejectsRelayCloseBeforeTerminalEvent(t *testing.T) {
+	responses := make(chan Message, 2)
+	responses <- Message{Type: MessageTypeStreamStart, Payload: map[string]any{"status": float64(http.StatusOK)}}
+	responses <- Message{Type: MessageTypeStreamChunk, Payload: map[string]any{"data": "partial"}}
+	close(responses)
+
+	response, err := receiveNonStream(t.Context(), responses)
+	if err == nil {
+		t.Fatalf("receiveNonStream() response = %+v, want incomplete relay response failure", response)
+	}
+	if err.Error() != "wsrelay: connection closed during response" {
+		t.Fatalf("receiveNonStream() error = %q", err)
+	}
+	if response != nil {
+		t.Fatalf("receiveNonStream() response = %+v, want nil", response)
+	}
+}
+
+func TestReceiveNonStreamAcceptsExplicitTerminalEvent(t *testing.T) {
+	responses := make(chan Message, 3)
+	responses <- Message{Type: MessageTypeStreamStart, Payload: map[string]any{"status": float64(http.StatusAccepted)}}
+	responses <- Message{Type: MessageTypeStreamChunk, Payload: map[string]any{"data": "complete"}}
+	responses <- Message{Type: MessageTypeStreamEnd}
+	close(responses)
+
+	response, err := receiveNonStream(t.Context(), responses)
+	if err != nil {
+		t.Fatalf("receiveNonStream() error = %v", err)
+	}
+	if response.Status != http.StatusAccepted {
+		t.Fatalf("receiveNonStream() status = %d, want %d", response.Status, http.StatusAccepted)
+	}
+	if string(response.Body) != "complete" {
+		t.Fatalf("receiveNonStream() body = %q, want complete", response.Body)
+	}
+}
+
+func TestReceiveNonStreamReturnsCanceledContextWhenResponseCloses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	responses := make(chan Message)
+	close(responses)
+
+	response, err := receiveNonStream(ctx, responses)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("receiveNonStream() error = %v, want context.Canceled", err)
+	}
+	if response != nil {
+		t.Fatalf("receiveNonStream() response = %+v, want nil", response)
+	}
+}


### PR DESCRIPTION
WebSocket relay aggregation currently returns buffered stream bytes as a successful non-stream response when the relay closes before a terminal event. That exposes truncated upstream data as a complete response.

This requires an explicit `stream_end` or `http_response` before returning success. It also preserves valid 400–599 relay error statuses through AI Studio streaming while leaving status-less connection failures untyped so they do not trigger credential cooldowns.
